### PR TITLE
Fix issue 1506

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -528,10 +528,9 @@ namespace NuGet.PackageManagement.VisualStudio
             EnvDTEProjectName oldEnvDTEProjectName;
             _nuGetAndEnvDTEProjectCache.TryGetProjectNameByShortName(EnvDTEProjectUtility.GetName(envDTEProject), out oldEnvDTEProjectName);
 
-            EnvDTEProjectName newEnvDTEProjectName = _nuGetAndEnvDTEProjectCache.AddProject(envDTEProject, GetProjectFactory());
+            var newEnvDTEProjectName = _nuGetAndEnvDTEProjectCache.AddProject(envDTEProject, GetProjectFactory());
 
-            if (String.IsNullOrEmpty(DefaultNuGetProjectName)
-                ||
+            if (string.IsNullOrEmpty(DefaultNuGetProjectName) ||
                 newEnvDTEProjectName.ShortName.Equals(DefaultNuGetProjectName, StringComparison.OrdinalIgnoreCase))
             {
                 DefaultNuGetProjectName = oldEnvDTEProjectName != null ?

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
@@ -327,7 +326,7 @@ namespace NuGetVSExtension
 
             ProjectRetargetingHandler = new ProjectRetargetingHandler(_dte, SolutionManager, this);
             ProjectUpgradeHandler = new ProjectUpgradeHandler(this, SolutionManager);
-            
+
             LoadNuGetSettings();
         }
 
@@ -640,6 +639,13 @@ namespace NuGetVSExtension
             }
 
             var nugetProject = solutionManager.GetNuGetProject(EnvDTEProjectUtility.GetCustomUniqueName(project));
+
+            // If we failed to generate a cache entry in the solution manager something went wrong.
+            if (nugetProject == null)
+            {
+                throw new InvalidOperationException(
+                    string.Format(Resources.ProjectHasAnInvalidNuGetConfiguration, project.Name));
+            }
 
             // load packages.config. This makes sure that an exception will get thrown if there
             // are problems with packages.config, such as duplicate packages. When an exception

--- a/src/NuGet.Clients/VsExtension/Resources.Designer.cs
+++ b/src/NuGet.Clients/VsExtension/Resources.Designer.cs
@@ -262,6 +262,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} nuget configuration is invalid..
+        /// </summary>
+        internal static string ProjectHasAnInvalidNuGetConfiguration {
+            get {
+                return ResourceManager.GetString("ProjectHasAnInvalidNuGetConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Some NuGet packages were installed using a target framework different from the current target framework and may need to be reinstalled. Visit http://docs.nuget.org/docs/workflows/reinstalling-packages for more information.  Packages affected: {0}.
         /// </summary>
         internal static string ProjectUpgradeAndRetargetErrorMessage {

--- a/src/NuGet.Clients/VsExtension/Resources.resx
+++ b/src/NuGet.Clients/VsExtension/Resources.resx
@@ -186,6 +186,9 @@ Missing packages: {0}</value>
     <value>Restoring NuGet packages...
 To prevent NuGet from restoring packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck 'Allow NuGet to download missing packages during build.'</value>
   </data>
+  <data name="ProjectHasAnInvalidNuGetConfiguration" xml:space="preserve">
+    <value>{0} nuget configuration is invalid.</value>
+  </data>
   <data name="ProjectUpgradeAndRetargetErrorMessage" xml:space="preserve">
     <value>Some NuGet packages were installed using a target framework different from the current target framework and may need to be reinstalled. Visit http://docs.nuget.org/docs/workflows/reinstalling-packages for more information.  Packages affected: {0}</value>
   </data>


### PR DESCRIPTION
Fix issue https://github.com/nuget/home/issues/1506

Primary:
Make BuildIntegratedNugetProject constructor fail gracefully when the project.json file is corrupt
Throw meaningful exception when reading the json file fails

Secondary
Ignore failures when constructing any nuget project, and handling gracefully (this is more of a defensive programming, not the real fix)
