### PR TITLE
skip preview changes dialog when there are no actions to preview

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -84,7 +84,9 @@ namespace NuGet.PackageManagement.UI
         {
             var result = false;
 
-            UIDispatcher.Invoke(() =>
+            if (actions.Any())
+            {
+                UIDispatcher.Invoke(() =>
                 {
                     var w = new PreviewWindow(_context);
                     w.DataContext = new PreviewWindowModel(actions);
@@ -98,6 +100,11 @@ namespace NuGet.PackageManagement.UI
 
                     result = w.ShowModal() == true;
                 });
+            }
+            else
+            {
+                return true;
+            }
 
             return result;
         }


### PR DESCRIPTION
Relates to NuGet/Home/issues/961 and NuGet/Home/issues/843

This change ensures the client won't bring up an empty preview changes dialog when there are no actions to preview.
Instead, it will just continue the flow (and fail fast by showing the errors in the error list with details logged to the output window).
