### PR TITLE
Fix https://github.com/NuGet/Home/Issues/1408

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
@@ -41,7 +41,8 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             string root;
             if (SolutionManager == null
-                || !SolutionManager.IsSolutionOpen)
+                || !SolutionManager.IsSolutionOpen
+                || string.IsNullOrEmpty(SolutionManager.SolutionDirectory))
             {
                 root = null;
             }


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/1408

The fix is about making vssettings not throw if the solution doesn't have a folder attached to it.
This happens when there is no solution open, but there is a single file open, which creates s misc files solution.

Also see:
https://github.com/NuGet/NuGet.VisualStudioExtension/commit/ba0a129278318917e4007542c099bd1048b856e7
