### PR TITLE
fixed https://github.com/NuGet/Home/issues/796

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
@@ -16,7 +16,7 @@ namespace NuGet.Packaging
 {
     public static class PackageHelper
     {
-        private static readonly string[] ExcludePaths = new[] { "_rels", "package" };
+        private static readonly string[] ExcludePaths = new[] { "_rels", "package", "[Content_Types].xml" };
         private static readonly string[] ExcludeExtension = new[] { ".nupkg.sha512" };
 
         public static bool IsManifest(string path)

--- a/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
@@ -439,5 +439,32 @@ namespace NuGet.Test.Utility
 
             return result;
         }
+
+        public static Stream GetTestPackageWithContentXmlFile()
+        {
+            var stream = new MemoryStream();
+
+            using (var zip = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                zip.AddEntry("lib/a.dll", new byte[] { 0 });
+                zip.AddEntry("[Content_Types].xml", new byte[] { 0 });
+                zip.AddEntry("content/[Content_Types].xml", new byte[] { 0 });
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata>
+                                <id>packageA</id>
+                                <version>2.0.3</version>
+                                <authors>Author1, author2</authors>
+                                <description>Sample description</description>
+                                <language>en-US</language>
+                                <projectUrl>http://www.nuget.org/</projectUrl>
+                                <licenseUrl>http://www.nuget.org/license</licenseUrl>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return stream;
+        }
     }
 }

--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -330,6 +330,31 @@ function Test-PackageRestore-AllSourcesAreUsed {
     }
 }
 
+# Test unneeded file are not created during restore
+function Test-PackageRestore-NoContent_TypesXml {
+    param($context)
+
+    # Arrange
+    $p1 = New-ClassLibrary	
+    $p1 | Install-Package jquery -version 2.1.4
+    
+    # delete the packages folder
+    $packagesDir = Get-PackagesDir
+    RemoveDirectory $packagesDir
+    Assert-False (Test-Path $packagesDir)
+
+    # Act
+    Build-Solution
+
+    # Assert
+	$thisPackageDir = Join-Path $packagesDir ("jQuery" + "." + "2.1.4")
+	$Content_xmlPath = Join-Path $thisPackageDir "[Content_Types].xml" 
+    Assert-True (Test-Path $packagesDir)
+	Assert-True (Test-Path $thisPackageDir)
+    Assert-Package $p1 jquery
+	Assert-False (Test-Path $Content_xmlPath)  
+}
+
 # Create a test package 
 function CreateTestPackage {
     param(

--- a/test/EndToEnd/tests/PackageRestoreTest.ps1
+++ b/test/EndToEnd/tests/PackageRestoreTest.ps1
@@ -330,31 +330,6 @@ function Test-PackageRestore-AllSourcesAreUsed {
     }
 }
 
-# Test unneeded file are not created during restore
-function Test-PackageRestore-NoContent_TypesXml {
-    param($context)
-
-    # Arrange
-    $p1 = New-ClassLibrary	
-    $p1 | Install-Package jquery -version 2.1.4
-    
-    # delete the packages folder
-    $packagesDir = Get-PackagesDir
-    RemoveDirectory $packagesDir
-    Assert-False (Test-Path $packagesDir)
-
-    # Act
-    Build-Solution
-
-    # Assert
-	$thisPackageDir = Join-Path $packagesDir ("jQuery" + "." + "2.1.4")
-	$Content_xmlPath = Join-Path $thisPackageDir "[Content_Types].xml" 
-    Assert-True (Test-Path $packagesDir)
-	Assert-True (Test-Path $thisPackageDir)
-    Assert-Package $p1 jquery
-	Assert-False (Test-Path $Content_xmlPath)  
-}
-
 # Create a test package 
 function CreateTestPackage {
     param(

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -10,21 +10,21 @@ using Xunit;
 
 namespace NuGet.Packaging.Test
 {
-    public class PackageExtractorTests : IDisposable
+    public class PackageExtractorTests
     {
         [Fact]
         void PackageExtractor_withContentXmlFile()
         {
             // Arrange
             var packageStream = TestPackages.GetTestPackageWithContentXmlFile();
-            var root = GetTempDir();
+            var root = TestFileSystemUtility.CreateRandomTestFolder();
             var packageReader = new PackageReader(packageStream);
-            var packagePath = Path.Combine(root.FullName, "packageA.2.0.3");
+            var packagePath = Path.Combine(root, "packageA.2.0.3");
             
             // Act
             var files = PackageExtractor.ExtractPackageAsync(packageReader, 
                                                              packageStream, 
-                                                             new PackagePathResolver(root.FullName), 
+                                                             new PackagePathResolver(root), 
                                                              null, 
                                                              PackageSaveModes.Nupkg, 
                                                              CancellationToken.None).Result;
@@ -32,40 +32,9 @@ namespace NuGet.Packaging.Test
             Assert.False(files.Contains(Path.Combine(packagePath + "[Content_Types].xml")));
             var test = Path.Combine(packagePath, "content/[Content_Types].xml");
             Assert.True(files.Contains(Path.Combine(packagePath,"content/[Content_Types].xml")));
-        }
 
-        private DirectoryInfo GetTempDir()
-        {
-            var workingDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + "/"));
-            workingDir.Create();
-            _path.Add(workingDir.FullName);
-
-            return workingDir;
-        }
-
-        private ConcurrentBag<string> _path = new ConcurrentBag<string>();
-
-        public void Dispose()
-        {
-            foreach (var path in _path)
-            {
-                try
-                {
-                    if (File.Exists(path))
-                    {
-                        File.Delete(path);
-                    }
-
-                    if (Directory.Exists(path))
-                    {
-                        Directory.Delete(path, true);
-                    }
-                }
-                catch
-                {
-
-                }
-            }
-        }
+            // Clean
+            TestFileSystemUtility.DeleteRandomTestFolders(root);
+        }   
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class PackageExtractorTests : IDisposable
+    {
+        [Fact]
+        void PackageExtractor_withContentXmlFile()
+        {
+            // Arrange
+            var packageStream = TestPackages.GetTestPackageWithContentXmlFile();
+            var root = GetTempDir();
+            var packageReader = new PackageReader(packageStream);
+            var packagePath = Path.Combine(root.FullName, "packageA.2.0.3");
+            
+            // Act
+            var files = PackageExtractor.ExtractPackageAsync(packageReader, 
+                                                             packageStream, 
+                                                             new PackagePathResolver(root.FullName), 
+                                                             null, 
+                                                             PackageSaveModes.Nupkg, 
+                                                             CancellationToken.None).Result;
+            // Assert
+            Assert.False(files.Contains(Path.Combine(packagePath + "[Content_Types].xml")));
+            var test = Path.Combine(packagePath, "content/[Content_Types].xml");
+            Assert.True(files.Contains(Path.Combine(packagePath,"content/[Content_Types].xml")));
+        }
+
+        private DirectoryInfo GetTempDir()
+        {
+            var workingDir = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + "/"));
+            workingDir.Create();
+            _path.Add(workingDir.FullName);
+
+            return workingDir;
+        }
+
+        private ConcurrentBag<string> _path = new ConcurrentBag<string>();
+
+        public void Dispose()
+        {
+            foreach (var path in _path)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+
+                    if (Directory.Exists(path))
+                    {
+                        Directory.Delete(path, true);
+                    }
+                }
+                catch
+                {
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/796
the bug is unneeded file [Content_Types].xml are created during restore.
the fix is filter [Content_Types].xml in PackageExtraction.
