### PR TITLE
Fix issue 1551: restore project.json does not work with NTLM.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
@@ -66,6 +66,10 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                     {
                         handlerResource.ClientHandler.Credentials = credentials;
                     }
+                    else
+                    {
+                        handlerResource.ClientHandler.UseDefaultCredentials = true;
+                    }
 
                     var request = new HttpRequestMessage(HttpMethod.Get, uri);
                     STSAuthHelper.PrepareSTSRequest(_baseUri, CredentialStore.Instance, request);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/ServiceIndexResourceV3Provider.cs
@@ -52,6 +52,10 @@ namespace NuGet.Protocol.Core.v3
                 {
                     messageHandlerResource.ClientHandler.Credentials = credentials;
                 }
+                else
+                {
+                    messageHandlerResource.ClientHandler.UseDefaultCredentials = true;
+                }
 
                 using (var client = new DataClient(messageHandlerResource))
                 {


### PR DESCRIPTION
The fix is simple: we just need to set HttpClientHandler.UseDefaultCredentials to true (see https://msdn.microsoft.com/en-us/library/system.net.http.httpclienthandler.usedefaultcredentials(v=vs.118).aspx) when there are no user provided credentials. This is how nuget 2.x works.
