### PR TITLE
Fix https://github.com/NuGet/Home/issues/1397

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -17,8 +17,8 @@ namespace NuGet.Common
         private readonly string _projectDirectory;
 
         public MSBuildProjectSystem(
-            string msbuildDirectory, 
-            string projectFullPath, 
+            string msbuildDirectory,
+            string projectFullPath,
             INuGetProjectContext projectContext)
         {
             LoadAssemblies(msbuildDirectory);
@@ -135,19 +135,24 @@ namespace NuGet.Common
                 new[] { new KeyValuePair<string, string>("HintPath", relativePath) });
         }
 
-        public void BeginProcessing(IEnumerable<string> files)
+        public void BeginProcessing()
         {
-            // No-op
+            // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
+        }
+
+        public void RegisterProcessedFiles(IEnumerable<string> files)
+        {
+            // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
+        }
+
+        public void EndProcessing()
+        {
+            // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
         }
 
         public void DeleteDirectory(string path, bool recursive)
         {
             FileSystemUtility.DeleteDirectory(path, recursive, NuGetProjectContext);
-        }
-
-        public void EndProcessing()
-        {
-            // No-op
         }
 
         public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -746,9 +746,14 @@ namespace NuGet.PackageManagement.VisualStudio
             return Task.FromResult(false);
         }
 
-        public virtual void BeginProcessing(IEnumerable<string> files)
+        public virtual void BeginProcessing()
         {
             ProjectBuildSystem?.StartBatchEdit();
+        }
+
+        public virtual void RegisterProcessedFiles(IEnumerable<string> files)
+        {
+            // No-op, this is implemented in other project systems, like website.
         }
 
         public virtual void EndProcessing()

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     // Remove the reference via DTE.
                     RemoveDTEReference(name);
 
-                    // For GACed binaries, VS would not clear the refresh files for us since it assumes the reference exists in web.config. 
+                    // For GACed binaries, VS would not clear the refresh files for us since it assumes the reference exists in web.config.
                     // We'll clean up any remaining .refresh files.
                     var refreshFilePath = Path.Combine("bin", Path.GetFileName(name) + ".refresh");
                     var refreshFileFullPath = FileSystemUtility.GetFullPath(ProjectFullPath, refreshFilePath);
@@ -117,7 +117,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 if (reference != null
                     && reference.ReferenceKind == AssemblyReferenceType.AssemblyReferenceConfig)
                 {
-                    // Bug 2319: Strong named assembly references are specified via config and may be specified in the root web.config. Attempting to remove these 
+                    // Bug 2319: Strong named assembly references are specified via config and may be specified in the root web.config. Attempting to remove these
                     // references always throws and there isn't an easy way to identify this. Instead, we'll attempt to lower the level of the message so it doesn't
                     // appear as readily.
 
@@ -193,9 +193,13 @@ namespace NuGet.PackageManagement.VisualStudio
             return base.GetDirectories(path);
         }
 
-        public override void BeginProcessing(IEnumerable<string> files)
+        public override void BeginProcessing()
         {
-            // Need NOT be on the UI thread
+        }
+
+        public override void RegisterProcessedFiles(IEnumerable<string> files)
+        {
+            // Need NOT be on the UI thread (but not thread safe)
 
             var orderedFiles = files.OrderBy(path => path)
                 .ToList();
@@ -209,8 +213,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         continue;
                     }
 
-                    if (path1.StartsWith(path2, StringComparison.OrdinalIgnoreCase)
-                        &&
+                    if (path1.StartsWith(path2, StringComparison.OrdinalIgnoreCase) &&
                         IsSourceFile(path1))
                     {
                         _excludedCodeFiles.Add(path1);

--- a/src/NuGet.Core/NuGet.ProjectManagement/FileModifiers/IPackageFileTransformer.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/FileModifiers/IPackageFileTransformer.cs
@@ -12,11 +12,18 @@ namespace NuGet.ProjectManagement
         /// <summary>
         /// Transforms the file
         /// </summary>
-        void TransformFile(Func<Stream> fileStreamFactory, string targetPath, IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem);
+        void TransformFile(Func<Stream> fileStreamFactory, string targetPath, IMSBuildNuGetProjectSystem projectSystem);
 
         /// <summary>
-        /// Reverses the transform
+        /// Reverses the transform on the targetPath, using all the potential source of change
         /// </summary>
-        void RevertFile(Func<Stream> fileStreamFactory, string targetPath, IEnumerable<InternalZipFileInfo> matchingFiles, IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem);
+        /// <param name="fileStreamFactory">A factory for accessing the file to be reverted from the nupkg being uninstalled.</param>
+        /// <param name="targetPath">A path to the file to be reverted.</param>
+        /// <param name="matchingFiles">Other files in other packages that may have changed the <paramref name="targetPath"/>.</param>
+        /// <param name="projectSystem">The project where this change is taking place.</param>
+        void RevertFile(Func<Stream> fileStreamFactory,
+            string targetPath,
+            IEnumerable<InternalZipFileInfo> matchingFiles,
+            IMSBuildNuGetProjectSystem projectSystem);
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectManagement/FileModifiers/XmlTransformer.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/FileModifiers/XmlTransformer.cs
@@ -32,12 +32,18 @@ namespace NuGet.ProjectManagement
             MSBuildNuGetProjectSystemUtility.AddFile(msBuildNuGetProjectSystem, targetPath, transformDocument.Save);
         }
 
-        public void RevertFile(Func<Stream> fileStreamFactory, string targetPath, IEnumerable<InternalZipFileInfo> matchingFiles, IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem)
+        public void RevertFile(Func<Stream> fileStreamFactory,
+            string targetPath,
+            IEnumerable<InternalZipFileInfo> matchingFiles,
+            IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem)
         {
             // Get the xml snippet
             var xmlFragment = GetXml(fileStreamFactory, msBuildNuGetProjectSystem);
 
-            var document = XmlUtility.GetOrCreateDocument(xmlFragment.Name, msBuildNuGetProjectSystem.ProjectFullPath, targetPath, msBuildNuGetProjectSystem.NuGetProjectContext);
+            var document = XmlUtility.GetOrCreateDocument(xmlFragment.Name,
+                msBuildNuGetProjectSystem.ProjectFullPath,
+                targetPath,
+                msBuildNuGetProjectSystem.NuGetProjectContext);
 
             // Merge the other xml elements into one element within this xml hierarchy (matching the config file path)
             var mergedFragments = matchingFiles.Select(f => GetXml(f, msBuildNuGetProjectSystem))

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
@@ -45,7 +45,12 @@ namespace NuGet.ProjectManagement
         bool IsSupportedFile(string path);
         void AddBindingRedirects();
         Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure);
-        void BeginProcessing(IEnumerable<string> files);
+        void BeginProcessing();
+        /// <summary>
+        /// This method can be called multiple times during a batch operation in between a single BeginProcessing/EndProcessing calls.
+        /// </summary>
+        /// <param name="files">a list of files being changed.</param>
+        void RegisterProcessedFiles(IEnumerable<string> files);
         void EndProcessing();
 
         void DeleteDirectory(string path, bool recursive);

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -131,7 +131,7 @@ namespace NuGet.ProjectManagement
         private static bool IsBindingRedirectsDisabled(INuGetProjectContext nuGetProjectContext)
         {
             var msBuildNuGetProjectContext = nuGetProjectContext as IMSBuildNuGetProjectContext;
-            return msBuildNuGetProjectContext!= null && msBuildNuGetProjectContext.BindingRedirectsDisabled;
+            return msBuildNuGetProjectContext != null && msBuildNuGetProjectContext.BindingRedirectsDisabled;
         }
 
         private static bool IsSkipAssemblyReferences(INuGetProjectContext nuGetProjectContext)
@@ -178,7 +178,7 @@ namespace NuGet.ProjectManagement
                 return false;
             }
 
-            // Step-2: Create PackageReader using the PackageStream and obtain the various item groups            
+            // Step-2: Create PackageReader using the PackageStream and obtain the various item groups
             downloadResourceResult.PackageStream.Seek(0, SeekOrigin.Begin);
             var packageReader = downloadResourceResult.PackageReader;
             if (packageReader == null)
@@ -279,7 +279,7 @@ namespace NuGet.ProjectManagement
             }
             PackageEventsProvider.Instance.NotifyInstalling(packageEventArgs);
 
-            // Step-6: Install package to FolderNuGetProject     
+            // Step-6: Install package to FolderNuGetProject
             await FolderNuGetProject.InstallPackageAsync(packageIdentity, downloadResourceResult, nuGetProjectContext, token);
 
             // Step-7: Raise PackageInstalled event
@@ -466,6 +466,7 @@ namespace NuGet.ProjectManagement
                 {
                     var packagesPaths = (await GetInstalledPackagesAsync(token))
                         .Select(pr => FolderNuGetProject.GetInstalledPackageFilePath(pr.PackageIdentity));
+
                     MSBuildNuGetProjectSystemUtility.DeleteFiles(MSBuildNuGetProjectSystem,
                         zipArchive,
                         packagesPaths,

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -332,6 +332,7 @@ namespace NuGet.ProjectManagement
             PerformSafeAction(() => DeleteDirectory(projectSystem, path), projectSystem.NuGetProjectContext);
         }
 
+        // Deletes an empty folder from disk and the project
         private static void DeleteDirectory(IMSBuildNuGetProjectSystem projectSystem, string path)
         {
             var fullPath = Path.Combine(projectSystem.ProjectFullPath, path);
@@ -341,7 +342,7 @@ namespace NuGet.ProjectManagement
             }
 
             // Only delete this folder if it is empty and we didn't specify that we want to recurse
-            if (GetFiles(projectSystem, path, "*.*", recursive).Any() || GetDirectories(projectSystem, path).Any())
+            if (GetFiles(projectSystem, path, "*.*", recursive: false).Any() || GetDirectories(projectSystem, path).Any())
             {
                 projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_DirectoryNotEmpty, path);
                 return;

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -77,7 +77,7 @@ namespace NuGet.ProjectManagement
             IDictionary<FileTransformExtensions, IPackageFileTransformer> fileTransformers)
         {
             var packageTargetFramework = frameworkSpecificGroup.TargetFramework;
-            
+
             var packageItemListAsArchiveEntryNames = frameworkSpecificGroup.Items.ToList();
             packageItemListAsArchiveEntryNames.Sort(new PackageItemComparer());
             try
@@ -87,7 +87,9 @@ namespace NuGet.ProjectManagement
                     var paths = packageItemListAsArchiveEntryNames.Select(file => ResolvePath(fileTransformers, fte => fte.InstallExtension,
                         GetEffectivePathForContentFile(packageTargetFramework, file)));
                     paths = paths.Where(p => !string.IsNullOrEmpty(p));
-                    msBuildNuGetProjectSystem.BeginProcessing(paths);
+
+                    msBuildNuGetProjectSystem.BeginProcessing();
+                    msBuildNuGetProjectSystem.RegisterProcessedFiles(paths);
                 }
                 catch (Exception)
                 {
@@ -137,114 +139,130 @@ namespace NuGet.ProjectManagement
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
-        internal static void DeleteFiles(IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem,
+        internal static void DeleteFiles(IMSBuildNuGetProjectSystem projectSystem,
             ZipArchive zipArchive,
             IEnumerable<string> otherPackagesPath,
             FrameworkSpecificGroup frameworkSpecificGroup,
             IDictionary<FileTransformExtensions, IPackageFileTransformer> fileTransformers)
         {
-            var packageTargetFramework = frameworkSpecificGroup.TargetFramework;
-            IPackageFileTransformer transformer;
-            var directoryLookup = frameworkSpecificGroup.Items.ToLookup(
-                p => Path.GetDirectoryName(ResolveTargetPath(msBuildNuGetProjectSystem,
-                    fileTransformers,
-                    fte => fte.UninstallExtension,
-                    GetEffectivePathForContentFile(packageTargetFramework, p),
-                    out transformer)));
-
-            // Get all directories that this package may have added
-            var directories = from grouping in directoryLookup
-                from directory in FileSystemUtility.GetDirectories(grouping.Key, altDirectorySeparator: false)
-                orderby directory.Length descending
-                select directory;
-
-            // Remove files from every directory
-            foreach (var directory in directories)
+            try
             {
-                var directoryFiles = directoryLookup.Contains(directory) ? directoryLookup[directory] : Enumerable.Empty<string>();
+                projectSystem.BeginProcessing();
 
-                if (!Directory.Exists(Path.Combine(msBuildNuGetProjectSystem.ProjectFullPath, directory)))
-                {
-                    continue;
-                }
+                var packageTargetFramework = frameworkSpecificGroup.TargetFramework;
 
-                foreach (var file in directoryFiles)
+                IPackageFileTransformer transformer;
+
+                var directoryLookup = frameworkSpecificGroup.Items.ToLookup(
+                    p => Path.GetDirectoryName(ResolveTargetPath(projectSystem,
+                        fileTransformers,
+                        fte => fte.UninstallExtension,
+                        GetEffectivePathForContentFile(packageTargetFramework, p),
+                        out transformer)));
+
+                // Get all directories that this package may have added
+                var directories = from grouping in directoryLookup
+                                  from directory in FileSystemUtility.GetDirectories(grouping.Key, altDirectorySeparator: false)
+                                  orderby directory.Length descending
+                                  select directory;
+
+                string projectFullPath = projectSystem.ProjectFullPath;
+
+                // Remove files from every directory
+                foreach (var directory in directories)
                 {
-                    if (IsEmptyFolder(file))
+                    var directoryFiles = directoryLookup.Contains(directory) ? directoryLookup[directory] : Enumerable.Empty<string>();
+
+                    if (!Directory.Exists(Path.Combine(projectFullPath, directory)))
                     {
                         continue;
                     }
 
-                    // Resolve the path
-                    var path = ResolveTargetPath(msBuildNuGetProjectSystem,
-                        fileTransformers,
-                        fte => fte.UninstallExtension,
-                        GetEffectivePathForContentFile(packageTargetFramework, file),
-                        out transformer);
-
-                    if (msBuildNuGetProjectSystem.IsSupportedFile(path))
+                    foreach (var file in directoryFiles)
                     {
-                        if (transformer != null)
+                        if (IsEmptyFolder(file))
                         {
-                            // TODO: use the framework from packages.config instead of the current framework
-                            // which may have changed during re-targeting
-                            var projectFramework = msBuildNuGetProjectSystem.TargetFramework;
+                            continue;
+                        }
 
-                            var matchingFiles = new List<InternalZipFileInfo>();
-                            foreach (var otherPackagePath in otherPackagesPath)
+                        // Resolve the path
+                        var path = ResolveTargetPath(projectSystem,
+                            fileTransformers,
+                            fte => fte.UninstallExtension,
+                            GetEffectivePathForContentFile(packageTargetFramework, file),
+                            out transformer);
+
+                        if (projectSystem.IsSupportedFile(path))
+                        {
+                            // Register the file being uninstalled (used by web site project system).
+                            projectSystem.RegisterProcessedFiles(new[] { path });
+
+                            if (transformer != null)
                             {
-                                using (var otherPackageStream = File.OpenRead(otherPackagePath))
-                                {
-                                    var otherPackageZipArchive = new ZipArchive(otherPackageStream);
-                                    var otherPackageZipReader = new PackageReader(otherPackageZipArchive);
+                                // TODO: use the framework from packages.config instead of the current framework
+                                // which may have changed during re-targeting
+                                var projectFramework = projectSystem.TargetFramework;
 
-                                    // use the project framework to find the group that would have been installed
-                                    var mostCompatibleContentFilesGroup = GetMostCompatibleGroup(projectFramework, otherPackageZipReader.GetContentItems(), altDirSeparator: true);
-                                    if (mostCompatibleContentFilesGroup != null
-                                        && IsValid(mostCompatibleContentFilesGroup))
+                                var matchingFiles = new List<InternalZipFileInfo>();
+                                foreach (var otherPackagePath in otherPackagesPath)
+                                {
+                                    using (var otherPackageStream = File.OpenRead(otherPackagePath))
                                     {
-                                        foreach (var otherPackageItem in mostCompatibleContentFilesGroup.Items)
+                                        var otherPackageZipArchive = new ZipArchive(otherPackageStream);
+                                        var otherPackageZipReader = new PackageReader(otherPackageZipArchive);
+
+                                        // use the project framework to find the group that would have been installed
+                                        var mostCompatibleContentFilesGroup = GetMostCompatibleGroup(projectFramework, otherPackageZipReader.GetContentItems(), altDirSeparator: true);
+                                        if (mostCompatibleContentFilesGroup != null
+                                            && IsValid(mostCompatibleContentFilesGroup))
                                         {
-                                            if (GetEffectivePathForContentFile(packageTargetFramework, otherPackageItem)
-                                                .Equals(GetEffectivePathForContentFile(packageTargetFramework, file), StringComparison.OrdinalIgnoreCase))
+                                            foreach (var otherPackageItem in mostCompatibleContentFilesGroup.Items)
                                             {
-                                                matchingFiles.Add(new InternalZipFileInfo(otherPackagePath, otherPackageItem));
+                                                if (GetEffectivePathForContentFile(packageTargetFramework, otherPackageItem)
+                                                    .Equals(GetEffectivePathForContentFile(packageTargetFramework, file), StringComparison.OrdinalIgnoreCase))
+                                                {
+                                                    matchingFiles.Add(new InternalZipFileInfo(otherPackagePath, otherPackageItem));
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
 
-                            try
+                                try
+                                {
+                                    var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
+                                    if (zipArchiveFileEntry != null)
+                                    {
+                                        transformer.RevertFile(zipArchiveFileEntry.Open, path, matchingFiles, projectSystem);
+                                    }
+                                }
+                                catch (Exception e)
+                                {
+                                    projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
+                                }
+                            }
+                            else
                             {
                                 var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
                                 if (zipArchiveFileEntry != null)
                                 {
-                                    transformer.RevertFile(zipArchiveFileEntry.Open, path, matchingFiles, msBuildNuGetProjectSystem);
+                                    DeleteFileSafe(path, zipArchiveFileEntry.Open, projectSystem);
                                 }
-                            }
-                            catch (Exception e)
-                            {
-                                msBuildNuGetProjectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
-                            }
-                        }
-                        else
-                        {
-                            var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
-                            if (zipArchiveFileEntry != null)
-                            {
-                                DeleteFileSafe(path, zipArchiveFileEntry.Open, msBuildNuGetProjectSystem);
                             }
                         }
                     }
-                }
 
-                // If the directory is empty then delete it
-                if (!GetFilesSafe(msBuildNuGetProjectSystem, directory).Any()
-                    && !GetDirectoriesSafe(msBuildNuGetProjectSystem, directory).Any())
-                {
-                    DeleteDirectorySafe(msBuildNuGetProjectSystem, directory, recursive: false);
+                    // If the directory is empty then delete it
+                    if (!GetFilesSafe(projectSystem, directory).Any()
+                        && !GetDirectoriesSafe(projectSystem, directory).Any())
+                    {
+                        DeleteDirectorySafe(projectSystem, directory);
+                    }
                 }
+            }
+            finally
+            {
+                projectSystem.EndProcessing();
             }
         }
 
@@ -309,30 +327,32 @@ namespace NuGet.ProjectManagement
             return msBuildNuGetProjectSystem.GetDirectories(path);
         }
 
-        internal static void DeleteDirectorySafe(IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem, string path, bool recursive)
+        internal static void DeleteDirectorySafe(IMSBuildNuGetProjectSystem projectSystem, string path)
         {
-            PerformSafeAction(() => DeleteDirectory(msBuildNuGetProjectSystem, path, recursive), msBuildNuGetProjectSystem.NuGetProjectContext);
+            PerformSafeAction(() => DeleteDirectory(projectSystem, path), projectSystem.NuGetProjectContext);
         }
 
-        internal static void DeleteDirectory(IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem, string path, bool recursive)
+        private static void DeleteDirectory(IMSBuildNuGetProjectSystem projectSystem, string path)
         {
-            var fullPath = Path.Combine(msBuildNuGetProjectSystem.ProjectFullPath, path);
+            var fullPath = Path.Combine(projectSystem.ProjectFullPath, path);
             if (!Directory.Exists(fullPath))
             {
                 return;
             }
 
             // Only delete this folder if it is empty and we didn't specify that we want to recurse
-            if (!recursive
-                && (GetFiles(msBuildNuGetProjectSystem, path, "*.*", recursive).Any() || GetDirectories(msBuildNuGetProjectSystem, path).Any()))
+            if (GetFiles(projectSystem, path, "*.*", recursive).Any() || GetDirectories(projectSystem, path).Any())
             {
-                msBuildNuGetProjectSystem.NuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_DirectoryNotEmpty, path);
+                projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, Strings.Warning_DirectoryNotEmpty, path);
                 return;
             }
-            msBuildNuGetProjectSystem.DeleteDirectory(path, recursive);
+
+            projectSystem.RegisterProcessedFiles(new[] { path });
+
+            projectSystem.DeleteDirectory(path, recursive: false);
 
             // Workaround for update-package TFS issue. If we're bound to TFS, do not try and delete directories.
-            var sourceControlManager = SourceControlUtility.GetSourceControlManager(msBuildNuGetProjectSystem.NuGetProjectContext);
+            var sourceControlManager = SourceControlUtility.GetSourceControlManager(projectSystem.NuGetProjectContext);
             if (sourceControlManager != null)
             {
                 // Source control bound, do not delete
@@ -341,7 +361,7 @@ namespace NuGet.ProjectManagement
 
             try
             {
-                Directory.Delete(fullPath, recursive);
+                Directory.Delete(fullPath, recursive: false);
 
                 // The directory is not guaranteed to be gone since there could be
                 // other open handles. Wait, up to half a second, until the directory is gone.
@@ -349,9 +369,10 @@ namespace NuGet.ProjectManagement
                 {
                     Thread.Sleep(100);
                 }
-                msBuildNuGetProjectSystem.RemoveFile(path);
+                projectSystem.RegisterProcessedFiles(new[] { path });
+                projectSystem.RemoveFile(path);
 
-                msBuildNuGetProjectSystem.NuGetProjectContext.Log(MessageLevel.Debug, Strings.Debug_RemovedFolder, fullPath);
+                projectSystem.NuGetProjectContext.Log(MessageLevel.Debug, Strings.Debug_RemovedFolder, fullPath);
             }
             catch (DirectoryNotFoundException)
             {

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -174,9 +174,21 @@ namespace Test.Utility
             return Task.FromResult(0);
         }
 
-        public void BeginProcessing(IEnumerable<string> files)
+        public void BeginProcessing()
         {
-            FilesInProcessing = new HashSet<string>(files);
+        }
+
+        public void RegisterProcessedFiles(IEnumerable<string> files)
+        {
+            if (FilesInProcessing == null)
+            {
+                FilesInProcessing = new HashSet<string>(files);
+            }
+
+            foreach (var file in files)
+            {
+                FilesInProcessing.Add(file);
+            }
         }
 
         public void EndProcessing()

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
@@ -174,9 +173,21 @@ namespace Test.Utility
             return Task.FromResult(0);
         }
 
-        public void BeginProcessing(IEnumerable<string> files)
+        public void BeginProcessing()
         {
-            FilesInProcessing = new HashSet<string>(files);
+        }
+
+        public void RegisterProcessedFiles(IEnumerable<string> files)
+        {
+            if (FilesInProcessing == null)
+            {
+                FilesInProcessing = new HashSet<string>(files);
+            }
+
+            foreach (var file in files)
+            {
+                FilesInProcessing.Add(file);
+            }
         }
 
         public void EndProcessing()


### PR DESCRIPTION
This is probably a first step in a series of possible improvements to uninstall/update.
This change adds a batch operation around removing files, and modifies the batch operation to be more friendly to not require finding out what files change ahead of time

On my laptop I measured the improvement on KendoUICore uninstall from 350 seconds to 120 seconds.
