### PR TITLE
Update prerelease bugs

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -311,7 +311,17 @@ namespace NuGet.PackageManagement {
                 return ResourceManager.GetString("ParameterCannotBeZeroOrNegative", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Resolution was successful but resulted in no action.
+        /// </summary>
+        internal static string ResolutionSuccessfulNoAction
+        {
+            get {
+                return ResourceManager.GetString("ResolutionSuccessfulNoAction", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Resolved actions to install package &apos;{0}&apos;.
         /// </summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -258,4 +258,7 @@
   <data name="UnsupportedPackageFeature" xml:space="preserve">
     <value>Package '{0}' uses features that are not supported by the current version of NuGet. To upgrade NuGet, see http://docs.nuget.org/consume/installing-nuget.</value>
   </data>
+  <data name="ResolutionSuccessfulNoAction" xml:space="preserve">
+    <value>Resolution was successful but resulted in no action</value>
+  </data>
 </root>

--- a/test/EndToEnd/tests/update.ps1
+++ b/test/EndToEnd/tests/update.ps1
@@ -1023,7 +1023,7 @@ function Test-UpdatePackageFailsIfNewVersionLessThanInstalledPrereleaseVersion {
     # Act
     $p | Install-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage -Version 1.0.1-a -Prerelease
     Assert-Package $p 'PreReleaseTestPackage' 1.0.1-a
-    Assert-Throws { $p | Update-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage } "Already referencing a newer version of 'PreReleaseTestPackage'.."
+    $p | Update-Package -Source $context.RepositoryRoot -Id PreReleaseTestPackage
 
     # Assert
     Assert-Package $p PreReleaseTestPackage 1.0.1-a


### PR DESCRIPTION
- couple of bugs on Update-Package with prerelease packages in the project
- new "multi" api for PackageManagement whereby the caller can give a set of PackageIdentities to resolve
