### PR TITLE
short name aesthetics

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -81,15 +81,15 @@ namespace NuGet.Test
         }
 
         [Theory]
-        [InlineData("uap10.0", "portable-aspnetcore5+net45+win8+wp8+wpa81")]
-        [InlineData("netcore50", "portable-aspnetcore5+net45+win8+wp8+wpa81")]
+        [InlineData("uap10.0", "portable-aspnetcore50+net45+win8+wp8+wpa81")]
+        [InlineData("netcore50", "portable-aspnetcore50+net45+win8+wp8+wpa81")]
         [InlineData("dnx452", "net45")]
-        [InlineData("dnxcore50", "portable-aspnetcore5+net45+win8+wp8+wpa81")]
-        [InlineData("net20", "net2")]
+        [InlineData("dnxcore50", "portable-aspnetcore50+net45+win8+wp8+wpa81")]
+        [InlineData("net20", "net20")]
         [InlineData("net451", "net45")]
-        [InlineData("sl5", "portable-net4+sl5+win8+wp8+wpa81")]
-        [InlineData("wp81", "portable-aspnetcore5+net45+win8+wp8+wpa81")]
-        [InlineData("win81", "portable-aspnetcore5+net45+win8+wp8+wpa81")]
+        [InlineData("sl5", "portable-net40+sl5+win8+wp8+wpa81")]
+        [InlineData("wp81", "portable-aspnetcore50+net45+win8+wp8+wpa81")]
+        [InlineData("win81", "portable-aspnetcore50+net45+win8+wp8+wpa81")]
         public void FrameworkReducer_JsonNetGetNearestLibGroup(string projectFramework, string expectedFramework)
         {
             // Arrange
@@ -234,12 +234,12 @@ namespace NuGet.Test
         }
 
         [Theory]
-        [InlineData("dnx452", "aspnet5")]
-        [InlineData("dnx451", "aspnet5")]
-        [InlineData("dnx45", "aspnet5")]
-        [InlineData("net45", "net4")]
-        [InlineData("dnxcore5", "aspnetcore5")]
-        [InlineData("win8", "portable-net4+sl5+win8+wp8")]
+        [InlineData("dnx452", "aspnet50")]
+        [InlineData("dnx451", "aspnet50")]
+        [InlineData("dnx45", "aspnet50")]
+        [InlineData("net45", "net40")]
+        [InlineData("dnxcore5", "aspnetcore50")]
+        [InlineData("win8", "portable-net40+sl5+win8+wp8")]
         [InlineData("MonoAndroid40", "monoandroid")]
         [InlineData("win81", "win81")]
         [InlineData("wpa81", "wpa81")]
@@ -931,7 +931,7 @@ namespace NuGet.Test
 
             var result = reducer.GetNearest(projectFramework, frameworks);
 
-            Assert.Equal("net4", result.GetShortFolderName());
+            Assert.Equal("net40", result.GetShortFolderName());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -39,15 +39,15 @@ namespace NuGet.Test
 
         [Theory]
         [InlineData("45", "net45")]
-        [InlineData("40", "net4")]
+        [InlineData("40", "net40")]
         [InlineData("35", "net35")]
-        [InlineData("20", "net2")]
+        [InlineData("20", "net20")]
         [InlineData("4.5", "net45")]
-        [InlineData("4", "net4")]
-        [InlineData("4.0", "net4")]
+        [InlineData("4", "net40")]
+        [InlineData("4.0", "net40")]
         [InlineData("3.5", "net35")]
-        [InlineData("2", "net2")]
-        [InlineData("2.0", "net2")]
+        [InlineData("2", "net20")]
+        [InlineData("2.0", "net20")]
         public void NuGetFramework_Numeric(string input, string expected)
         {
             string actual = NuGetFramework.Parse(input).GetShortFolderName();
@@ -182,11 +182,11 @@ namespace NuGet.Test
 
         [Theory]
         [InlineData("net45", ".NETFramework,Version=v4.5")]
-        [InlineData("net2", ".NETFramework,Version=v2.0")]
-        [InlineData("net4", ".NETFramework,Version=v4.0")]
+        [InlineData("net20", ".NETFramework,Version=v2.0")]
+        [InlineData("net40", ".NETFramework,Version=v4.0")]
         [InlineData("net35", ".NETFramework,Version=v3.5")]
-        [InlineData("net4", ".NETFramework,Version=v4.0")]
-        [InlineData("net4-client", ".NETFramework,Version=v4.0,Profile=Client")]
+        [InlineData("net40", ".NETFramework,Version=v4.0")]
+        [InlineData("net40-client", ".NETFramework,Version=v4.0,Profile=Client")]
         [InlineData("net", ".NETFramework,Version=v0.0")]
         [InlineData("net10.1.2.3", ".NETFramework,Version=v10.1.2.3")]
         [InlineData("net45-cf", ".NETFramework,Version=v4.5,Profile=CompactFramework")]
@@ -258,7 +258,7 @@ namespace NuGet.Test
         {
             var fw = NuGetFramework.Parse("portable-net40%2Bsl5%2Bwp80%2Bwin8%2Bwpa81");
 
-            Assert.Equal("portable-net4+sl5+win8+wp8+wpa81", fw.GetShortFolderName());
+            Assert.Equal("portable-net40+sl5+win8+wp8+wpa81", fw.GetShortFolderName());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -124,7 +124,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("1", packages.Count().ToString());
             Assert.Equal("packageA", packages[0].PackageIdentity.Id);
             Assert.Equal("3.0.1", packages[0].PackageIdentity.Version.ToNormalizedString());
-            Assert.Equal("dnxcore5", packages[0].TargetFramework.GetShortFolderName());
+            Assert.Equal("dnxcore50", packages[0].TargetFramework.GetShortFolderName());
 
             // Verify allowedVersions attribute is kept after package update.
             Assert.Equal("[0.5.0, )", packages[0].AllowedVersions.ToNormalizedString());
@@ -173,7 +173,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal("1", packages.Count().ToString());
             Assert.Equal("packageA", packages[0].PackageIdentity.Id);
             Assert.Equal("3.0.1", packages[0].PackageIdentity.Version.ToNormalizedString());
-            Assert.Equal("dnxcore5", packages[0].TargetFramework.GetShortFolderName());
+            Assert.Equal("dnxcore50", packages[0].TargetFramework.GetShortFolderName());
 
             // Verify allowedVersions attribute is kept after package update.
             Assert.Equal("[0.5.0, )", packages[0].AllowedVersions.ToNormalizedString());

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/JsonConfigUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/JsonConfigUtilityTests.cs
@@ -105,7 +105,7 @@ namespace ProjectManagement.Test
             var frameworks = JsonConfigUtility.GetFrameworks(json);
 
             // Assert
-            Assert.Equal("netcore5", frameworks.Single().GetShortFolderName());
+            Assert.Equal("netcore50", frameworks.Single().GetShortFolderName());
         }
 
         [Fact]


### PR DESCRIPTION
This will write out all framework short names with a minimum of two digits for all frameworks by default. Win, WP, and SL will be allowed to have a single digit as they did in the past, this helps keep portable folder name lengths down also.

https://github.com/NuGet/Home/issues/1568

//cc @yishaigalatzer @deepakaravindr @MeniZalzman
