### PR TITLE
Fix https://github.com/NuGet/Home/issues/1570

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <RestoreNuGetPackages>true</RestoreNuGetPackages>
     <PlatformTarget>$(Platform)</PlatformTarget>
-	<AssemblyOriginatorKeyFile>$(MS_PFX_PATH)</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MS_PFX_PATH)</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -118,6 +118,7 @@
     <Compile Include="Rules\MisplacedTransformFileRule.cs" />
     <Compile Include="Rules\MissingSummaryRule.cs" />
     <Compile Include="Rules\WinRTNameIsObsoleteRule.cs" />
+    <Compile Include="SafeAssemblyCatalog.cs" />
     <Compile Include="SettingsCredentialProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SettingsToLegacySettings.cs" />

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -1735,7 +1735,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to der Symbolserver.
+        ///   Looks up a localized string similar to Symbolserver.
         /// </summary>
         public static string DefaultSymbolServer_deu {
             get {
@@ -3540,6 +3540,24 @@ namespace NuGet.CommandLine {
         public static string FailedToBuildProject_trk {
             get {
                 return ResourceManager.GetString("FailedToBuildProject_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load {0}, if this extension was downloaded from the internet please make sure it got unblocked (right click, properties, unblock)..
+        /// </summary>
+        public static string FailedToLoadExtension {
+            get {
+                return ResourceManager.GetString("FailedToLoadExtension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load {0}{1}.
+        /// </summary>
+        public static string FailedToLoadExtensionDuringMefComposition {
+            get {
+                return ResourceManager.GetString("FailedToLoadExtensionDuringMefComposition", resourceCulture);
             }
         }
         
@@ -5614,7 +5632,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to der NuGet-Katalog.
+        ///   Looks up a localized string similar to NuGet-Katalog.
         /// </summary>
         public static string LiveFeed_deu {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6067,4 +6067,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_MSBuildNotInstalled" xml:space="preserve">
     <value>MSBuild is not installed.</value>
   </data>
+  <data name="FailedToLoadExtension" xml:space="preserve">
+    <value>Failed to load {0}, if this extension was downloaded from the internet please make sure it got unblocked (right click, properties, unblock).</value>
+  </data>
+  <data name="FailedToLoadExtensionDuringMefComposition" xml:space="preserve">
+    <value>Failed to load {0}{1}</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/SafeAssemblyCatalog.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/SafeAssemblyCatalog.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.ComponentModel.Composition.Hosting;
+using System.ComponentModel.Composition.Primitives;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using NuGet.Common;
+
+namespace NuGet.CommandLine
+{
+    internal class SafeAssemblyCatalog : ComposablePartCatalog
+    {
+        private ComposablePartCatalog _innerCatalog;
+
+        private readonly string _assemblyPath;
+        private readonly IConsole _console;
+
+        public SafeAssemblyCatalog(string assemblyPath, IConsole console)
+            : base()
+        {
+            _assemblyPath = assemblyPath;
+            _console = console;
+        }
+
+        public override IQueryable<ComposablePartDefinition> Parts
+        {
+            get
+            {
+                IQueryable<ComposablePartDefinition> parts = null;
+                if (_innerCatalog == null)
+                {
+                    ComposablePartCatalog tempCatalog = null;
+                    try
+                    {
+                        tempCatalog = new AssemblyCatalog(_assemblyPath);
+                        parts = tempCatalog.Parts;
+
+                        var assembly = Assembly.LoadFile(_assemblyPath);
+                        assembly.GetTypes();
+                    }
+                    catch (Exception ex)
+                    {
+                        // dispose old tempCatalog
+                        if (tempCatalog != null)
+                        {
+                            tempCatalog.Dispose();
+                            tempCatalog = null;
+                        }
+
+                        try
+                        {
+                            tempCatalog = new EmptyCatalog();
+                            HandleException(ex, _assemblyPath);
+                            parts = tempCatalog.Parts;
+                        }
+                        catch
+                        {
+                            if (tempCatalog != null)
+                            {
+                                tempCatalog.Dispose();
+                                throw;
+                            }
+                        }
+                    }
+
+                    _innerCatalog = tempCatalog;
+                }
+                else
+                {
+                    parts = _innerCatalog.Parts;
+                }
+
+                return parts;
+            }
+        }
+
+        private void HandleException(Exception ex, string assemblyPath)
+        {
+            var rex = ex as ReflectionTypeLoadException;
+
+            if (rex == null)
+            {
+                throw ex;
+            }
+
+            var resource =
+                LocalizedResourceManager.GetString(nameof(NuGetResources.FailedToLoadExtensionDuringMefComposition));
+
+            var perAssemblyError = string.Empty;
+
+            if (rex?.LoaderExceptions.Length > 0)
+            {
+                var builder = new StringBuilder();
+
+                builder.AppendLine(string.Empty);
+
+                var errors = rex.LoaderExceptions.Select(e => e.Message).Distinct(StringComparer.Ordinal);
+
+                foreach (var error in errors)
+                {
+                    builder.AppendLine(error);
+                }
+
+                perAssemblyError = builder.ToString();
+            }
+
+            var warning = string.Format(resource, _assemblyPath, perAssemblyError);
+
+            _console.WriteWarning(warning);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                using (_innerCatalog)
+                {
+                }
+
+                _innerCatalog = null;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private class EmptyCatalog : ComposablePartCatalog
+        {
+            private readonly ComposablePartDefinition[] _empty = new ComposablePartDefinition[0];
+
+            public override IQueryable<ComposablePartDefinition> Parts
+            {
+                get
+                {
+                    return Queryable.AsQueryable(_empty);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/1570
1. Capture errors coming from mark of the web
2. Capture errors coming from types failing to load (all types must load from the extension, or else we throw). These are attached to the offending extension through the SafeAssemblyCatalog class
3. Attempt auto "binding redirect" through AssemblyResolved event
