### PR TITLE
Fixes https://github.com/NuGet/Home/issues/1566

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
@@ -207,14 +207,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     try
                     {
-                        using (var stream = FileSystemUtility.GetFileStream(packagesConfigFullPath))
+                        using (var writer = new PackagesConfigWriter(packagesConfigFullPath, createNew: false))
                         {
-                            var writer = new PackagesConfigWriter(stream, createNew: false);
                             foreach (var entry in packageReferencesToUpdateReinstall)
                             {
                                 writer.UpdatePackageEntry(entry.Key, entry.Value);
                             }
-                            writer.Close();
                         }
                     }
                     catch (Exception ex)

--- a/src/NuGet.Core/NuGet.Packaging/Exceptions/PackagesConfigReaderException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Exceptions/PackagesConfigReaderException.cs
@@ -1,14 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
 {
-    public sealed class PackagesConfigReaderException : PackagingException
+    public class PackagesConfigReaderException : PackagingException
     {
         public PackagesConfigReaderException(string message)
             : base(message)
+        {
+        }
+
+        public PackagesConfigReaderException(string message, Exception innerException)
+            : base(message, innerException)
         {
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/Exceptions/PackagesConfigWriterException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Exceptions/PackagesConfigWriterException.cs
@@ -2,20 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGet.Packaging.Core;
 
-namespace NuGet.Packaging.Core
+namespace NuGet.Packaging
 {
-    /// <summary>
-    /// Generic packaging exception.
-    /// </summary>
-    public class PackagingException : Exception
+    public class PackagesConfigWriterException : PackagingException
     {
-        public PackagingException(string message)
+        public PackagesConfigWriterException(string message)
             : base(message)
         {
         }
 
-        public PackagingException(string message, Exception innerException)
+        public PackagesConfigWriterException(string message, Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/NuGet.Core/NuGet.Packaging/Properties/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Properties/Strings.Designer.cs
@@ -115,11 +115,19 @@ namespace NuGet.Packaging
         }
 
         /// <summary>
-        /// Fail to load packages.config as XML file. Please check it. 
+        /// Fail to write packages.config as XML file while accessing {0}: {1} 
         /// </summary>
-        internal static string FormatFailToLoadPackagesConfig()
+        internal static string FailToWritePackagesConfig
         {
-            return GetString("FailToLoadPackagesConfig");
+            get { return GetString("FailToWritePackagesConfig"); }
+        }
+
+        /// <summary>
+        /// Fail to write packages.config as XML file while accessing {0}: {1} 
+        /// </summary>
+        internal static string FormatFailToWritePackagesConfig(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("FailToWritePackagesConfig"), p0, p1);
         }
 
         /// <summary>
@@ -184,6 +192,22 @@ namespace NuGet.Packaging
         internal static string FormatPackageEntryNotExist(object p0, object p1)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("PackageEntryNotExist"), p0, p1);
+        }
+
+        /// <summary>
+        /// Packages node does not exists in packages.config at {0}.
+        /// </summary>
+        internal static string PackagesNodeNotExist
+        {
+            get { return GetString("PackagesNodeNotExist"); }
+        }
+
+        /// <summary>
+        /// Packages node does not exists in packages.config at {0}.
+        /// </summary>
+        internal static string FormatPackagesNodeNotExist(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PackagesNodeNotExist"), p0);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -165,4 +165,10 @@
   <data name="InvalidNuspecEntry" xml:space="preserve">
     <value>The nuspec contains an invalid entry '{0}' in package '{1}' .</value>
   </data>
+  <data name="FailToWritePackagesConfig" xml:space="preserve">
+    <value>Fail to write packages.config as XML file while accessing {0}: {1}</value>
+  </data>
+  <data name="PackagesNodeNotExist" xml:space="preserve">
+    <value>Packages node does not exists in packages.config at {0}.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.ProjectManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Strings.Designer.cs
@@ -275,7 +275,18 @@ namespace NuGet.ProjectManagement {
                 return ResourceManager.GetString("ErrorLoadingPackagesConfig", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while writing file &apos;{0}&apos;: {1}.
+        /// </summary>
+        public static string ErrorWritingPackagesConfig
+        {
+            get
+            {
+                return ResourceManager.GetString("ErrorWritingPackagesConfig", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to File &apos;{0}&apos; already exists in project &apos;{1}&apos;. Do you want to overwrite it?.
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Strings.resx
@@ -189,6 +189,9 @@
   <data name="ErrorLoadingPackagesConfig" xml:space="preserve">
     <value>An error occurred while reading file '{0}': {1}</value>
   </data>
+  <data name="ErrorWritingPackagesConfig" xml:space="preserve">
+    <value>An error occurred while writing file '{0}': {1}</value>
+  </data>
   <data name="FileConflictMessage" xml:space="preserve">
     <value>File '{0}' already exists in project '{1}'. Do you want to overwrite it?</value>
   </data>


### PR DESCRIPTION
Fix the potential packages.config corrupt issue, by save XDocument to a temporary file and overwrite the original packages.config file (when it already exists).
