### PR TITLE
fixed https://github.com/NuGet/Home/issues/1017

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -479,8 +479,14 @@ namespace NuGet.Configuration
                     if (ReadProtocolVersion(existingSetting) == source.ProtocolVersion)
                     {
                         // Update the source value of all settings with the same protocol version.
-                        existingSetting.Value = source.Source;
                         foundSettingWithSourcePriority = true;
+
+                        // if the existing source changed, update the setting value
+                        if (!existingSetting.Value.Equals(source.Source))
+                        {
+                            existingSetting.Value = source.Source;
+                            existingSetting.OriginalValue = source.Source;
+                        }
                     }
                     sourceSettings.Add(existingSetting);
                 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
@@ -15,35 +15,45 @@ namespace NuGet.Configuration
         public SettingValue(string key, 
                             string value, 
                             bool isMachineWide, 
-                            int priority = 0, 
-                            bool isRelativePath = false, 
-                            string originValue = null)
+                            int priority = 0)
             : this(key, 
                   value, 
                   origin: null, 
-                  isMachineWide: isMachineWide, 
-                  priority: priority, 
-                  isRelativePath : isRelativePath, 
-                  originValue: originValue)
+                  isMachineWide: isMachineWide,
+                  originalValue: value,
+                  priority: priority)
+        { }
+
+        public SettingValue(string key,
+                            string value,
+                            ISettings origin,
+                            bool isMachineWide,
+                            int priority = 0) 
+            : this(key,
+                   value,
+                   origin: origin,
+                   isMachineWide : isMachineWide,
+                   originalValue : value,
+                   priority: priority)
         { }
 
         public SettingValue(string key, 
                             string value, 
                             ISettings origin, 
-                            bool isMachineWide, 
-                            int priority = 0, 
-                            bool isRelativePath = false, 
-                            string originValue = null)
+                            bool isMachineWide,
+                            string originalValue,
+                            int priority = 0)
         {
             Key = key;
             Value = value;
             Origin = origin;
             IsMachineWide = isMachineWide;
             Priority = priority;
-            IsRelativePath = isRelativePath;
-            OriginValue = originValue;
+            OriginalValue = originalValue;
             AdditionalData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
+
+        
 
         /// <summary>
         /// Represents the key of the setting
@@ -105,14 +115,10 @@ namespace NuGet.Configuration
         {
             return Tuple.Create(Key, Value, IsMachineWide).GetHashCode();
         }
+
        /// <summary>
        /// relative path source value in NuGet.Config
        /// </summary>
-        public string OriginValue { get; }
-
-        /// <summary>
-        /// return true when this settingvalue is a relative path package source
-        /// </summary>
-        public bool IsRelativePath { get; }
+        public string OriginalValue { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
@@ -12,17 +12,36 @@ namespace NuGet.Configuration
     /// </summary>
     public class SettingValue
     {
-        public SettingValue(string key, string value, bool isMachineWide, int priority = 0)
-            : this(key, value, origin: null, isMachineWide: isMachineWide, priority: priority)
+        public SettingValue(string key, 
+                            string value, 
+                            bool isMachineWide, 
+                            int priority = 0, 
+                            bool isRelativePath = false, 
+                            string originValue = null)
+            : this(key, 
+                  value, 
+                  origin: null, 
+                  isMachineWide: isMachineWide, 
+                  priority: priority, 
+                  isRelativePath : isRelativePath, 
+                  originValue: originValue)
         { }
 
-        public SettingValue(string key, string value, ISettings origin, bool isMachineWide, int priority = 0)
+        public SettingValue(string key, 
+                            string value, 
+                            ISettings origin, 
+                            bool isMachineWide, 
+                            int priority = 0, 
+                            bool isRelativePath = false, 
+                            string originValue = null)
         {
             Key = key;
             Value = value;
             Origin = origin;
             IsMachineWide = isMachineWide;
             Priority = priority;
+            IsRelativePath = isRelativePath;
+            OriginValue = originValue;
             AdditionalData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
@@ -86,5 +105,14 @@ namespace NuGet.Configuration
         {
             return Tuple.Create(Key, Value, IsMachineWide).GetHashCode();
         }
+       /// <summary>
+       /// relative path source value in NuGet.Config
+       /// </summary>
+        public string OriginValue { get; }
+
+        /// <summary>
+        /// return true when this settingvalue is a relative path package source
+        /// </summary>
+        public bool IsRelativePath { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -494,14 +494,7 @@ namespace NuGet.Configuration
             foreach (var value in valuesToWrite)
             {
                 var element = new XElement("add");
-                if (value.IsRelativePath)
-                {
-                    SetElementValues(element, value.Key, value.OriginValue, value.AdditionalData);
-                }
-                else
-                {
-                    SetElementValues(element, value.Key, value.Value, value.AdditionalData);
-                }
+                SetElementValues(element, value.Key, value.OriginalValue, value.AdditionalData);
                 XElementUtility.AddIndented(sectionElement, element);
             }
 
@@ -823,25 +816,21 @@ namespace NuGet.Configuration
             }
 
             var value = valueAttribute.Value;
-            string originValue = null;
-            bool isRelative = false;
+            var originalValue = valueAttribute.Value;
             Uri uri;
 
             if (isPath && Uri.TryCreate(value, UriKind.Relative, out uri))
             {
                 var configDirectory = Path.GetDirectoryName(ConfigFilePath);
-                originValue = value;
-                isRelative = true;
                 value = Path.Combine(Root, Path.Combine(configDirectory, value));
             }
 
             var settingValue = new SettingValue(keyAttribute.Value, 
                                                 value, 
                                                 origin: this, 
-                                                isMachineWide: IsMachineWideSettings, 
-                                                priority: _priority, 
-                                                isRelativePath: isRelative, 
-                                                originValue: originValue);
+                                                isMachineWide: IsMachineWideSettings,
+                                                originalValue: originalValue,
+                                                priority: _priority);
             foreach (var attribute in element.Attributes())
             {
                 // Add all attributes other than ConfigurationContants.KeyAttribute and ConfigurationContants.ValueAttribute to AdditionalValues

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -659,6 +659,94 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void SavePackageSourcesWithRelativePath()
+        {
+            using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" /> 
+    </packageSources>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"), configContents);
+
+                var rootPath = Path.Combine(mockBaseDirectory.Path, Path.GetRandomFileName());
+                
+                var settings = Settings.LoadDefaultSettings(rootPath,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: false);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
+                
+                // Act
+                packageSourceProvider.SavePackageSources(packageSourceList);
+
+                // Assert
+                Assert.Equal(
+                       @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+    </packageSources>
+</configuration>
+".Replace("\r\n", "\n"),
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
+        public void SavePackageSourcesWithRelativePathAndAddNewSource()
+        {
+            using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" /> 
+    </packageSources>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"), configContents);
+
+                var rootPath = Path.Combine(mockBaseDirectory.Path, Path.GetRandomFileName());
+
+                var settings = Settings.LoadDefaultSettings(rootPath,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: false);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+                var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Act
+                packageSourceList.Add(new PackageSource("https://test3.net", "test3"));
+                packageSourceProvider.SavePackageSources(packageSourceList);
+
+                // Assert
+                Assert.Equal(
+                       @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+        <add key=""nuget.org"" value=""https://nuget.org"" />
+        <add key=""test.org"" value=""Packages"" />
+        <add key=""test3"" value=""https://test3.net"" />
+    </packageSources>
+</configuration>
+".Replace("\r\n", "\n"),
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
         public void SavePackageSourcesWithOneClear()
         {
             using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1017
the bug is when Settings.ReadSection() reads package Source section from Nuget.config, it converts relative package source paths to absolute paths. Then when settings.updateSection() write all settingsValue to NuGet.config, it will overwrite the relative path to absolute path in config file.

the fix here is during reading config file, if the setting Value is relative path, mark it and save the relative path. Then during writing config file, check the setting value is relative or not, if yes, write saved relative path to config file, else write absolute path to config file.
