### PR TITLE
fixed https://github.com/NuGet/Home/issues/1244

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml
@@ -16,6 +16,7 @@
   mc:Ignorable="d"
   ShowInTaskbar="False"
   WindowStartupLocation="CenterOwner"
+  KeyDown="OnButtonKeyDown"
   Title="{x:Static resx:Resources.WindowTitle_LicenseAcceptance}"
   d:DesignHeight="300"
   d:DesignWidth="300">

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
@@ -3,6 +3,7 @@
 
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Input;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -39,6 +40,19 @@ namespace NuGet.PackageManagement.UI
         private void OnAcceptButtonClick(object sender, RoutedEventArgs e)
         {
             DialogResult = true;
+        }
+
+        private void OnButtonKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Y)
+            {
+                DialogResult = true;
+            }
+
+            else if (e.Key == Key.N)
+            {
+                DialogResult = false;
+            }
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/LicenseAcceptanceWindow.xaml.cs
@@ -44,12 +44,12 @@ namespace NuGet.PackageManagement.UI
 
         private void OnButtonKeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Y)
+            if (e.Key == Key.A)
             {
                 DialogResult = true;
             }
 
-            else if (e.Key == Key.N)
+            else if (e.Key == Key.D)
             {
                 DialogResult = false;
             }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1244

added keyboard accelerators "Y" and "N" for License acceptance dialog
