### PR TITLE
LockFileFormat slash fix

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
@@ -376,7 +376,7 @@ namespace NuGet.ProjectModel
 
         private static IList<string> ReadPathArray(JArray json, Func<JToken, string> readItem)
         {
-            return ReadArray(json, readItem).Select(f => GetPathWithDirectorySeparator(f)).ToList();
+            return ReadArray(json, readItem).Select(f => GetPathWithForwardSlashes(f)).ToList();
         }
 
         private static void WriteArray<TItem>(JToken json, string property, IEnumerable<TItem> items, Func<TItem, JToken> writeItem)
@@ -504,18 +504,6 @@ namespace NuGet.ProjectModel
         private static string GetPathWithBackSlashes(string path)
         {
             return path.Replace('/', '\\');
-        }
-
-        private static string GetPathWithDirectorySeparator(string path)
-        {
-            if (Path.DirectorySeparatorChar == '/')
-            {
-                return GetPathWithForwardSlashes(path);
-            }
-            else
-            {
-                return GetPathWithBackSlashes(path);
-            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -575,6 +575,10 @@ namespace NuGet.Commands.Test
             var previousLockFile = result.LockFile;
             request.ExistingLockFile = result.LockFile;
 
+            // Act 2 
+            // Read the file from disk to verify the reader
+            var fromDisk = lockFileFormat.Read(lockFilePath);
+
             // wait half a second to make sure the time difference can be picked up
             await Task.Delay(500);
 
@@ -590,9 +594,11 @@ namespace NuGet.Commands.Test
 
             // Verify the files are equal
             Assert.True(previousLockFile.Equals(result.LockFile));
+            Assert.True(fromDisk.Equals(result.LockFile));
 
             // Verify the hash codes are the same
             Assert.Equal(previousLockFile.GetHashCode(), result.LockFile.GetHashCode());
+            Assert.Equal(fromDisk.GetHashCode(), result.LockFile.GetHashCode());
         }
 
         [Fact]


### PR DESCRIPTION
LockFileFormat incorrectly replaces all forward slashes with back slashes for library file paths. When the lock file is created forward slashes are used, it is only when reading the file back in from disk that this replace happens.

With the slashes replaced the lock file will be written to disk even when there are no changes, and this can trigger visual studio to reload intellisense unnecessarily.

//cc @deepakaravindr @yishaigalatzer @MeniZalzman @zhili1208 
