### PR TITLE
Fixes the issue where lib folder with file '_._' is ignored

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/FrameworkSpecificGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/FrameworkSpecificGroup.cs
@@ -59,10 +59,7 @@ namespace NuGet.Packaging
             get { return _items; }
         }
 
-        public bool HasEmptyFolder
-        {
-            get;
-        }
+        public bool HasEmptyFolder { get; }
 
         public bool Equals(FrameworkSpecificGroup other)
         {

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/FrameworkSpecificGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/FrameworkSpecificGroup.cs
@@ -14,7 +14,7 @@ namespace NuGet.Packaging
     /// </summary>
     public class FrameworkSpecificGroup : IEquatable<FrameworkSpecificGroup>, IFrameworkSpecific
     {
-        private const string EmptyFolder = "/_._";
+        public readonly static string EmptyFolder = "/_._";
         private readonly NuGetFramework _targetFramework;
         private readonly string[] _items;
 
@@ -37,6 +37,8 @@ namespace NuGet.Packaging
 
             _targetFramework = targetFramework;
 
+            HasEmptyFolder = items.Any(item => item.EndsWith(EmptyFolder, StringComparison.Ordinal));
+
             // Remove empty folder markers here
             _items = items.Where(item => !item.EndsWith(EmptyFolder, StringComparison.Ordinal)).ToArray();
         }
@@ -55,6 +57,11 @@ namespace NuGet.Packaging
         public IEnumerable<string> Items
         {
             get { return _items; }
+        }
+
+        public bool HasEmptyFolder
+        {
+            get;
         }
 
         public bool Equals(FrameworkSpecificGroup other)

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -185,6 +185,19 @@ namespace NuGet.ProjectManagement
             var compatibleToolItemsGroup =
                 MSBuildNuGetProjectSystemUtility.GetMostCompatibleGroup(MSBuildNuGetProjectSystem.TargetFramework, toolItemGroups);
 
+            compatibleLibItemsGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleLibItemsGroup);
+            compatibleReferenceItemsGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleReferenceItemsGroup);
+            compatibleFrameworkReferencesGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleFrameworkReferencesGroup);
+            compatibleContentFilesGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleContentFilesGroup);
+            compatibleBuildFilesGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleBuildFilesGroup);
+            compatibleToolItemsGroup
+                = MSBuildNuGetProjectSystemUtility.Normalize(compatibleToolItemsGroup);
+
             hasCompatibleProjectLevelContent = MSBuildNuGetProjectSystemUtility.IsValid(compatibleLibItemsGroup) ||
                                                MSBuildNuGetProjectSystemUtility.IsValid(compatibleFrameworkReferencesGroup) ||
                                                MSBuildNuGetProjectSystemUtility.IsValid(compatibleContentFilesGroup) ||
@@ -400,6 +413,7 @@ namespace NuGet.ProjectManagement
                 var toolItemGroups = packageReader.GetToolItems();
                 var compatibleToolItemsGroup = MSBuildNuGetProjectSystemUtility
                     .GetMostCompatibleGroup(packageTargetFramework, toolItemGroups);
+                compatibleToolItemsGroup = MSBuildNuGetProjectSystemUtility.Normalize(compatibleToolItemsGroup);
 
                 if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleToolItemsGroup))
                 {
@@ -429,6 +443,13 @@ namespace NuGet.ProjectManagement
 
                 var compatibleBuildFilesGroup =
                     MSBuildNuGetProjectSystemUtility.GetMostCompatibleGroup(packageTargetFramework, buildFileGroups);
+
+                compatibleReferenceItemsGroup
+                    = MSBuildNuGetProjectSystemUtility.Normalize(compatibleReferenceItemsGroup);
+                compatibleContentFilesGroup
+                    = MSBuildNuGetProjectSystemUtility.Normalize(compatibleContentFilesGroup);
+                compatibleBuildFilesGroup
+                    = MSBuildNuGetProjectSystemUtility.Normalize(compatibleBuildFilesGroup);
 
                 // Step-5: Remove package reference from packages.config
                 await PackagesConfigNuGetProject.UninstallPackageAsync(packageIdentity, nuGetProjectContext, token);

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -57,10 +57,14 @@ namespace NuGet.ProjectManagement
 
         internal static bool IsValid(FrameworkSpecificGroup frameworkSpecificGroup)
         {
-            return (frameworkSpecificGroup != null
-                && (frameworkSpecificGroup.HasEmptyFolder
-                    || frameworkSpecificGroup.Items.Any()
-                    || !frameworkSpecificGroup.TargetFramework.Equals(NuGetFramework.AnyFramework)));
+            if (frameworkSpecificGroup != null)
+            {
+                return (frameworkSpecificGroup.HasEmptyFolder
+                     || frameworkSpecificGroup.Items.Any()
+                     || !frameworkSpecificGroup.TargetFramework.Equals(NuGetFramework.AnyFramework));
+            }
+
+            return false;
         }
 
         internal static void TryAddFile(IMSBuildNuGetProjectSystem msBuildNuGetProjectSystem, string path, Func<Stream> content)

--- a/src/NuGet.Core/Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/Test.Utility/TestPackages.cs
@@ -72,6 +72,28 @@ namespace Test.Utility
                 });
         }
 
+        public static FileInfo GetNet45TestPackageWithDummyFile(string path,
+            string packageId = "packageA",
+            string packageVersion = "2.0.3")
+        {
+            return GeneratePackage(path, packageId, packageVersion,
+                new[]
+                {
+                    "lib/net45/_._"
+                });
+        }
+
+        public static FileInfo GetTestPackageWithDummyFile(string path,
+            string packageId = "packageA",
+            string packageVersion = "2.0.3")
+        {
+            return GeneratePackage(path, packageId, packageVersion,
+                new[]
+                {
+                    "lib/_._"
+                });
+        }
+
         public static FileInfo GetMixedPackage(string path, string baseName, string packageId, string packageVersion)
         {
             return GeneratePackage(path, packageId, packageVersion,


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1021.

The issue is that lib folder with just the file '_._' is not considered as
a valid 'any' framework. That is, lib/_._ is being ignored. However,
lib/net45/_._ or lib/net45 will be considered as valid.

Added a property to FrameworkSpecificGroup which says whether there was
an empty folder represented by file '_._'.

Even after this change, an empty folder of lib without the '_._' file
is not a valid empty directory and will be ignored.

@yishaigalatzer @emgarten @MeniZalzman @feiling 
