### PR TITLE
Build folder fixes for project.json restore

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -102,6 +102,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.ProjectManagement.Tes
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Test.Utility", "src\NuGet.Core\Test.Utility\Test.Utility.xproj", "{CA285053-F013-45CC-A2EA-7581A37585D4}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Client.Test", "test\NuGet.Core.Tests\NuGet.Client.Test\NuGet.Client.Test.xproj", "{9DE7F262-F1AC-48F1-A446-0E1ED9938748}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -288,6 +290,10 @@ Global
 		{CA285053-F013-45CC-A2EA-7581A37585D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA285053-F013-45CC-A2EA-7581A37585D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA285053-F013-45CC-A2EA-7581A37585D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DE7F262-F1AC-48F1-A446-0E1ED9938748}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DE7F262-F1AC-48F1-A446-0E1ED9938748}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DE7F262-F1AC-48F1-A446-0E1ED9938748}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DE7F262-F1AC-48F1-A446-0E1ED9938748}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -338,5 +344,6 @@ Global
 		{118222E0-C4A0-4141-9637-5D9EFE79D7C4} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{22FAED52-0AD6-493B-8091-6404EF3B255B} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{CA285053-F013-45CC-A2EA-7581A37585D4} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
+		{9DE7F262-F1AC-48F1-A446-0E1ED9938748} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -326,10 +326,10 @@ namespace NuGet.Client
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                        "build/{tfm}/{any?}",
-                        new PatternDefinition("build/{any?}", defaults: new Dictionary<string, object>
+                        "build/{tfm}/{msbuild?}",
+                        new PatternDefinition("build/{msbuild?}", defaults: new Dictionary<string, object>
                         {
-                            { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                            { "tfm", NuGetFramework.AnyFramework }
                         })
                     },
                     pathPatterns: new PatternDefinition[]
@@ -337,7 +337,7 @@ namespace NuGet.Client
                         "build/{tfm}/{msbuild}",
                         new PatternDefinition("build/{msbuild}", defaults: new Dictionary<string, object>
                         {
-                            { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                            { "tfm", NuGetFramework.AnyFramework }
                         })
                     });
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -1315,6 +1315,75 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void RestoreProjectJson_GenerateTargetsForRootBuildFolderIgnoreSubFolders()
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var guid = Guid.NewGuid();
+            var workingPath = Path.Combine(tempPath, guid.ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            _dirs.TryAdd(workingPath, false);
+
+            Util.CreateDirectory(workingPath);
+            Util.CreateDirectory(repositoryPath);
+            Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
+            var packageA = Util.CreateTestPackageBuilder("packageA", "3.1.0");
+
+            var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+            var targetA = Util.CreatePackageFile("build/net45/packageA.targets", targetContent);
+            var targetARoot = Util.CreatePackageFile("build/packageA.targets", targetContent);
+
+            packageA.Files.Add(targetA);
+            packageA.Files.Add(targetARoot);
+
+            Util.CreateTestPackage(packageA, repositoryPath);
+
+            Util.CreateFile(workingPath, "project.json",
+                                            @"{
+                                            'dependencies': {
+                                            'packageA': '3.1.0',
+                                            },
+                                            'frameworks': {
+                                                        'uap10.0': { }
+                                                    }
+                                            }");
+
+            string[] args = new string[] {
+                "restore",
+                "-Source",
+                repositoryPath,
+                "-solutionDir",
+                workingPath,
+                "project.json"
+            };
+
+            var targetFilePath = Path.Combine(workingPath, $"{guid}.nuget.targets");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(targetFilePath));
+
+            var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+            // Verify the target was added
+            Assert.True(targetsFile.IndexOf(@"build\packageA.targets") > -1);
+
+            // Verify sub directories were not used
+            Assert.True(targetsFile.IndexOf(@"build\net45\packageA.targets") < 0);
+        }
+
+        [Fact]
         public void RestoreProjectJson_GenerateTargetsPersistsWithMultipleRestores()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelBuildTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelBuildTests.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.Client.Test
+{
+    public class ContentModelBuildTests
+    {
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelBuildTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelBuildTests.cs
@@ -2,10 +2,157 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+using Xunit;
 
 namespace NuGet.Client.Test
 {
     public class ContentModelBuildTests
     {
+        [Fact]
+        public void ContentModel_BuildRootFolderAndTFM()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.AnyFramework);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/packageA.targets",
+                "build/packageA.props",
+                "build/config.xml",
+                "build/net45/task.dll",
+                "build/net45/task.targets",
+                "build/net45/task.props",
+            });
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.MSBuildFiles);
+            var items = group.Items.OrderBy(item => item.Path).ToList();
+
+            // Assert
+            Assert.Equal(2, items.Count);
+            Assert.Equal("build/packageA.props", items[0].Path);
+            Assert.Equal("build/packageA.targets", items[1].Path);
+        }
+
+        [Fact]
+        public void ContentModel_BuildRootFolderRandomFiles()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/config.xml",
+                "build/net45/task.dll",
+                "build/net45/task.targets",
+                "build/net45/task.props",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.MSBuildFiles);
+
+            // Assert
+            Assert.Equal(1, groups.Count());
+            Assert.Equal(NuGetFramework.Parse("net45"), groups.First().Properties["tfm"] as NuGetFramework);
+        }
+
+        [Fact]
+        public void ContentModel_BuildNoFilesAtRoot()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/net46/packageA.targets",
+                "build/net45/packageA.targets",
+                "build/net35/packageA.targets",
+                "build/net20/packageA.targets",
+                "build/uap10.0/packageA.targets",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.MSBuildFiles)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(5, groups.Count());
+            Assert.Equal(NuGetFramework.Parse("net20"), groups[0].Properties["tfm"] as NuGetFramework);
+            Assert.Equal(NuGetFramework.Parse("net35"), groups[1].Properties["tfm"] as NuGetFramework);
+            Assert.Equal(NuGetFramework.Parse("net45"), groups[2].Properties["tfm"] as NuGetFramework);
+            Assert.Equal(NuGetFramework.Parse("net46"), groups[3].Properties["tfm"] as NuGetFramework);
+            Assert.Equal(NuGetFramework.Parse("uap10.0"), groups[4].Properties["tfm"] as NuGetFramework);
+
+            Assert.Equal("build/net20/packageA.targets", groups[0].Items.Single().Path);
+            Assert.Equal("build/net35/packageA.targets", groups[1].Items.Single().Path);
+            Assert.Equal("build/net45/packageA.targets", groups[2].Items.Single().Path);
+            Assert.Equal("build/net46/packageA.targets", groups[3].Items.Single().Path);
+            Assert.Equal("build/uap10.0/packageA.targets", groups[4].Items.Single().Path);
+        }
+
+        [Fact]
+        public void ContentModel_BuildNoFilesAtRootNoAnyGroup()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/net46/packageA.targets",
+                "build/net45/packageA.targets",
+                "build/net35/packageA.targets",
+                "build/net20/packageA.targets",
+                "build/uap10.0/packageA.targets",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.MSBuildFiles)
+                .Select(group => ((NuGetFramework)group.Properties["tfm"]))
+                .ToList();
+
+            // Assert
+            Assert.Equal(0, groups.Count(framework => framework == NuGetFramework.AnyFramework));
+        }
+
+        [Fact]
+        public void ContentModel_BuildAnyFolderTreatedAsDotNet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/any/packageA.targets"
+            });
+
+            // Act
+            var framework = collection.FindItemGroups(conventions.Patterns.MSBuildFiles)
+                .Select(group => ((NuGetFramework)group.Properties["tfm"]))
+                .Single();
+
+            // Assert
+            Assert.Equal(".NETPlatform", framework.Framework);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+using Xunit;
+
+namespace NuGet.Client.Test
+{
+    public class ContentModelLibTests
+    {
+        [Fact]
+        public void ContentModel_LibNoFilesAtRootNoAnyGroup()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/net46/a.dll",
+                "lib/uap10.0/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
+                .Select(group => ((NuGetFramework)group.Properties["tfm"]))
+                .ToList();
+
+            // Assert
+            Assert.Equal(0, groups.Count(framework => framework == NuGetFramework.AnyFramework));
+        }
+
+        [Fact]
+        public void ContentModel_LibRootFolderOnly()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/a.dll"
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies).ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(NuGetFramework.Parse("net"), groups[0].Properties["tfm"]);
+        }
+
+        [Fact]
+        public void ContentModel_LibRootAndTFM()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/net46/a.dll",
+                "lib/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(2, groups.Count);
+            Assert.Equal(NuGetFramework.Parse("net"), groups[0].Properties["tfm"]);
+            Assert.Equal(NuGetFramework.Parse("net46"), groups[1].Properties["tfm"]);
+        }
+
+        [Fact]
+        public void ContentModel_LibRootIgnoreSubFolder()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/a.dll",
+                "lib/x86/b.dll"
+            });
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("net46"));
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal(1, group.Items.Count());
+        }
+
+        [Fact]
+        public void ContentModel_LibNet46WithSubFoldersAreIgnored()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("net46"));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/net46/a.dll",
+                "lib/net46/sub/a.dll",
+            });
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal(1, group.Items.Count);
+            Assert.Equal("lib/net46/a.dll", group.Items[0].Path);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/NuGet.Client.Test.xproj
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/NuGet.Client.Test.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9de7f262-f1ac-48f1-a446-0e1ed9938748</ProjectGuid>
+    <RootNamespace>NuGet.Client.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/NuGet.Client.Test.xproj
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/NuGet.Client.Test.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>9de7f262-f1ac-48f1-a446-0e1ed9938748</ProjectGuid>
@@ -12,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -1,0 +1,21 @@
+﻿{
+  "version": "3.3.0-*",
+  "dependencies": {
+    "NuGet.Client": "3.3.0-*",
+    "NuGet.Test.Utility": "3.3.0-*",
+    "xunit": "2.1.0-rc1-build3168",
+    "xunit.runner.dnx": "2.1.0-beta5-build169",
+    "Microsoft.Framework.Runtime": "1.0.0-beta6"
+  },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.0.10-beta-*"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Updated the ContentModel pattern for MSBuild files so that sub folders will be ignored
- Added ContentModel tests
- Updated RestoreCommand to allow the Any group

https://github.com/NuGet/Home/issues/1461
https://github.com/NuGet/Home/issues/965

//cc @deepakaravindr @yishaigalatzer @MeniZalzman @feiling 
