### PR TITLE
fixed https://github.com/NuGet/Home/issues/1196

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -147,7 +147,7 @@ namespace NuGet.PackageManagement.UI
             return null;
         }
 
-        private void SetSelectedDepencyBehavior(DependencyBehavior? dependencyBehavior)
+        private void SetSelectedDepencyBehavior(DependencyBehavior dependencyBehavior)
         {
             var selectedDependencyBehavior = _detailModel.Options.DependencyBehaviors
                 .FirstOrDefault(d => d.Behavior == dependencyBehavior);
@@ -166,7 +166,7 @@ namespace NuGet.PackageManagement.UI
             UserSettings settings,
             Configuration.ISettings nugetSettings)
         {
-            var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings) ?? settings.DependencyBehavior;
+            var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings);
             if (settings == null)
             {
                 if (nugetSettings == null)
@@ -174,8 +174,8 @@ namespace NuGet.PackageManagement.UI
                     return;
                 }
 
-                // set depency behavior to the value from nugetSettings  
-                SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings));
+                // set depency behavior to the value from nugetSettings
+                SetSelectedDepencyBehavior(dependencySetting ?? DependencyBehavior.Lowest);
                 return;
             }
 
@@ -184,7 +184,7 @@ namespace NuGet.PackageManagement.UI
             _detailModel.Options.ForceRemove = settings.ForceRemove;
             _topPanel.CheckboxPrerelease.IsChecked = settings.IncludePrerelease;
 
-            SetSelectedDepencyBehavior(dependencySetting);
+            SetSelectedDepencyBehavior(dependencySetting ?? settings.DependencyBehavior);
 
             var selectedFileConflictAction = _detailModel.Options.FileConflictActions.
                 FirstOrDefault(a => a.Action == settings.FileConflictAction);

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -136,17 +136,15 @@ namespace NuGet.PackageManagement.UI
         protected static DependencyBehavior? GetDependencyBehaviorFromConfig(
             Configuration.ISettings nugetSettings)
         {
-            if (nugetSettings == null)
+            if (nugetSettings != null)
             {
-                return null;
-            }
-
-            var dependencySetting = nugetSettings.GetValue("config", "dependencyversion");
-            DependencyBehavior behavior;
-            var success = Enum.TryParse(dependencySetting, true, out behavior);
-            if (success)
-            {
-                return behavior;
+                var dependencySetting = nugetSettings.GetValue("config", "dependencyversion");
+                DependencyBehavior behavior;
+                var success = Enum.TryParse(dependencySetting, true, out behavior);
+                if (success)
+                {
+                    return behavior;
+                }
             }
 
             return null;
@@ -174,11 +172,6 @@ namespace NuGet.PackageManagement.UI
             var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings);
             if (settings == null)
             {
-                if (nugetSettings == null)
-                {
-                    return;
-                }
-
                 // set depency behavior to the value from nugetSettings
                 SetSelectedDepencyBehavior(dependencySetting ?? DependencyBehavior.Lowest);
                 return;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -166,12 +166,18 @@ namespace NuGet.PackageManagement.UI
             UserSettings settings,
             Configuration.ISettings nugetSettings)
         {
+            if (settings == null || nugetSettings == null)
+            {
+                return;
+            }
+
             _detailModel.Options.ShowPreviewWindow = settings.ShowPreviewWindow;
             _detailModel.Options.RemoveDependencies = settings.RemoveDependencies;
             _detailModel.Options.ForceRemove = settings.ForceRemove;
             _topPanel.CheckboxPrerelease.IsChecked = settings.IncludePrerelease;
 
-            SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings)?? settings.DependencyBehavior);
+            var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings) ?? settings.DependencyBehavior;
+            SetSelectedDepencyBehavior(dependencySetting);
 
             var selectedFileConflictAction = _detailModel.Options.FileConflictActions.
                 FirstOrDefault(a => a.Action == settings.FileConflictAction);

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -166,9 +166,16 @@ namespace NuGet.PackageManagement.UI
             UserSettings settings,
             Configuration.ISettings nugetSettings)
         {
-            if (settings == null || nugetSettings == null)
+            var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings) ?? settings.DependencyBehavior;
+            if (settings == null)
             {
-                return;
+                if (nugetSettings == null)
+                {
+                    return;
+                }
+
+                // set depency behavior to the value from nugetSettings  
+                SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings));
             }
 
             _detailModel.Options.ShowPreviewWindow = settings.ShowPreviewWindow;
@@ -176,7 +183,6 @@ namespace NuGet.PackageManagement.UI
             _detailModel.Options.ForceRemove = settings.ForceRemove;
             _topPanel.CheckboxPrerelease.IsChecked = settings.IncludePrerelease;
 
-            var dependencySetting = GetDependencyBehaviorFromConfig(nugetSettings) ?? settings.DependencyBehavior;
             SetSelectedDepencyBehavior(dependencySetting);
 
             var selectedFileConflictAction = _detailModel.Options.FileConflictActions.

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -143,7 +143,7 @@ namespace NuGet.PackageManagement.UI
             {
                 return behavior;
             }
-            
+
             return null;
         }
 
@@ -176,6 +176,7 @@ namespace NuGet.PackageManagement.UI
 
                 // set depency behavior to the value from nugetSettings  
                 SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings));
+                return;
             }
 
             _detailModel.Options.ShowPreviewWindow = settings.ShowPreviewWindow;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -136,6 +136,11 @@ namespace NuGet.PackageManagement.UI
         protected static DependencyBehavior? GetDependencyBehaviorFromConfig(
             Configuration.ISettings nugetSettings)
         {
+            if (nugetSettings == null)
+            {
+                return null;
+            }
+
             var dependencySetting = nugetSettings.GetValue("config", "dependencyversion");
             DependencyBehavior behavior;
             var success = Enum.TryParse(dependencySetting, true, out behavior);

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -133,7 +133,7 @@ namespace NuGet.PackageManagement.UI
             return RegistrySettingUtility.GetBooleanSetting(Constants.SuppressUIDisclaimerRegistryName);
         }
 
-        protected static DependencyBehavior GetDependencyBehaviorFromConfig(
+        protected static DependencyBehavior? GetDependencyBehaviorFromConfig(
             Configuration.ISettings nugetSettings)
         {
             var dependencySetting = nugetSettings.GetValue("config", "dependencyversion");
@@ -143,11 +143,11 @@ namespace NuGet.PackageManagement.UI
             {
                 return behavior;
             }
-            // Default to Lowest
-            return DependencyBehavior.Lowest;
+            
+            return null;
         }
 
-        private void SetSelectedDepencyBehavior(DependencyBehavior dependencyBehavior)
+        private void SetSelectedDepencyBehavior(DependencyBehavior? dependencyBehavior)
         {
             var selectedDependencyBehavior = _detailModel.Options.DependencyBehaviors
                 .FirstOrDefault(d => d.Behavior == dependencyBehavior);
@@ -166,24 +166,12 @@ namespace NuGet.PackageManagement.UI
             UserSettings settings,
             Configuration.ISettings nugetSettings)
         {
-            if (settings == null)
-            {
-                if (nugetSettings == null)
-                {
-                    return;
-                }
-
-                // set depency behavior to the value from nugetSettings
-                SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings));
-                return;
-            }
-
             _detailModel.Options.ShowPreviewWindow = settings.ShowPreviewWindow;
             _detailModel.Options.RemoveDependencies = settings.RemoveDependencies;
             _detailModel.Options.ForceRemove = settings.ForceRemove;
             _topPanel.CheckboxPrerelease.IsChecked = settings.IncludePrerelease;
 
-            SetSelectedDepencyBehavior(settings.DependencyBehavior);
+            SetSelectedDepencyBehavior(GetDependencyBehaviorFromConfig(nugetSettings)?? settings.DependencyBehavior);
 
             var selectedFileConflictAction = _detailModel.Options.FileConflictActions.
                 FirstOrDefault(a => a.Action == settings.FileConflictAction);


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1196

the bug is UI don't show the value of DependencyVersion in config as default.

the fix is during UI loading, it will check DependencyVersion in config, if there is a config setting there, use that as dependency Behavior value.
