### PR TITLE
Respect ReferenceOutputAssembly when packing a CSPROJ

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -514,6 +514,16 @@ namespace NuGet.CommandLine.Test
             string[] references = null,
             string[] contentFiles = null)
         {
+            var project = CreateProjFileXmlContent(projectName, targetFrameworkVersion, references, contentFiles);
+            return project.ToString();
+        }
+
+        public static XElement CreateProjFileXmlContent(
+            string projectName = "proj1",
+            string targetFrameworkVersion = "v4.5",
+            string[] references = null,
+            string[] contentFiles = null)
+        {
             XNamespace msbuild = "http://schemas.microsoft.com/developer/msbuild/2003";
 
             var project = new XElement(msbuild + "Project",
@@ -539,7 +549,7 @@ namespace NuGet.CommandLine.Test
             project.Add(new XElement(msbuild + "Import",
                 new XAttribute("Project", @"$(MSBuildToolsPath)\Microsoft.CSharp.targets")));
 
-            return project.ToString();
+            return project;
         }
 
         public static string CreateSolutionFileContent()


### PR DESCRIPTION
[from @chandramouleswaran. PR and the text below. I have fixed the tests to use XElement and existing Util helper methods]

This PR addresses - NuGet/Home#1540

Basically, we do not want to include assemblies of project references which are only used to help resolving build dependencies.

For example: I might have a .proj file which does say VHD creation but I do not want its output to be a part of the package.

This can be done using ReferenceOutputAssembly being false which is a standard now. I have also added tests for the same.

@yishaigalatzer @emgarten @zhili1208 
