### PR TITLE
RemoteV2FindPackageByIdResource filters out unlisted packages. Fixed that

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -212,17 +212,6 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             var properties = element.Element(_xnameProperties);
             var idElement = properties.Element(_xnameId);
 
-            var publishElement = properties.Element(_xnamePublish);
-            if (publishElement != null)
-            {
-                DateTime publishDate;
-                if (DateTime.TryParse(publishElement.Value, out publishDate)
-                    && (publishDate == _unlistedPublishedTime))
-                {
-                    return null;
-                }
-            }
-
             return new PackageInfo
             {
                 // Use the given Id as final fallback if all elements above don't exist

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1158,7 +1158,7 @@ namespace NuGet.Test
             TestFilesystemUtility.DeleteRandomTestFolders(testSolutionManager.SolutionDirectory, randomProjectFolderPath);
         }
 
-        [Fact(Skip = "Tracked by github issue: https://github.com/NuGet/Home/issues/1612")]
+        [Fact]
         public async Task TestPacManBuildIntegratedInstallPackageWithInitPS1()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1612

RemoteV2FindPackageByIdResource filters out unlisted packages. This is not
true with RemoteV3FindPackageByIdResource. Unlisted packages should not be
filtered out.

Re-enabled the functional (xunit) test that was failing due to this issue.
Tested that the issue has been fixed after cleaning up the global packages
folder as well.

@yishaigalatzer @emgarten @feiling @zhili1208 @MeniZalzman 
