### PR TITLE
Fix https://github.com/NuGet/Home/issues/1649

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Runtime/BindingRedirectManager.cs
@@ -268,8 +268,8 @@ namespace NuGet.PackageManagement.VisualStudio
             // Since we've successfully parsed this node, it has to be valid and this child must exist.
             if (existingBindingRedirectElement != null)
             {
-                existingBindingRedirectElement.Attribute("oldVersion").SetValue(newBindingRedirect.OldVersion);
-                existingBindingRedirectElement.Attribute("newVersion").SetValue(newBindingRedirect.NewVersion);
+                existingBindingRedirectElement.SetAttributeValue(XName.Get("oldVersion"), newBindingRedirect.OldVersion);
+                existingBindingRedirectElement.SetAttributeValue(XName.Get("newVersion"), newBindingRedirect.NewVersion);
             }
             else
             {


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/1649

This will make missing elements in binding redirects be ignored, in many cases it will create a good binding redirect and in cases where an attribute is missing it will not break or warn (e.g. missing culture attribute), just do a best effort to add the new version.
