### PR TITLE
Clear the local package cache after installing packages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -332,6 +332,9 @@ namespace NuGet.Commands
                     _request.MaxDegreeOfConcurrency,
                     token);
 
+            // Clear the local cache for newly installed packages
+            localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
+
             // Resolve runtime dependencies
             var runtimeGraphs = new List<RestoreTargetGraph>();
             if (runtimesByFramework.Count > 0)
@@ -375,6 +378,9 @@ namespace NuGet.Commands
                     allInstalledPackages,
                     _request.MaxDegreeOfConcurrency,
                     token);
+
+                // Clear the local cache for newly installed packages
+                localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
             }
 
             return Tuple.Create(true, graphs, allRuntimes);

--- a/src/NuGet.Core/NuGet.Repositories/NuGetv3LocalRepository.cs
+++ b/src/NuGet.Core/NuGet.Repositories/NuGetv3LocalRepository.cs
@@ -76,6 +76,21 @@ namespace NuGet.Repositories
                 });
         }
 
+        /// <summary>
+        /// Remove cached results for the given ids. This is needed
+        /// after installing a new package.
+        /// </summary>
+        public void ClearCacheForIds(IEnumerable<string> packageIds)
+        {
+            lock (_cache)
+            {
+                foreach (var packageId in packageIds)
+                {
+                    _cache.Remove(packageId);
+                }
+            }
+        }
+
         private IEnumerable<LocalPackageInfo> GetOrAdd(string packageId, Func<string, List<LocalPackageInfo>> factory)
         {
             lock (_cache)


### PR DESCRIPTION
The restore command keeps a local repository with an in memory cache of the global packages folder to avoid hitting the disk over and over. When new packages are installed and a package with the same id is already in the global folder the cache will hold onto the older version and not find the new package.

https://github.com/NuGet/Home/issues/1663

//cc @yishaigalatzer @deepakaravindr @MeniZalzman @zhili1208 @feiling 
