### PR TITLE
Fixes the ArgumentOutofRangeException issue on powershell console

### DIFF
--- a/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
@@ -178,10 +178,13 @@ namespace NuGetConsole.Implementation.Console
                     // snapshot's length could be lower than spanStart + spanLength,
                     // and if so, SnapshotSpan constructor will throw ArgumentOutOfRangeException.
                     // We compute fixedLength to overcome this problem.
-                    var fixedLength
-                        = spanStart + spanLength > snapshot.Length ? snapshot.Length - spanStart : spanLength;
+                    int constrainedLength = spanLength;
+                    if (spanStart + spanLength > snapshot.Length)
+                    {
+                        constrainedLength = snapshot.Length - spanStart;
+                    }
 
-                    var snapshotSpan = new SnapshotSpan(snapshot, spanStart, fixedLength);
+                    var snapshotSpan = new SnapshotSpan(snapshot, spanStart, constrainedLength);
                     classificationSpans.Add(new ClassificationSpan(
                         snapshotSpan, classificationType));
                 }

--- a/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
@@ -171,8 +171,19 @@ namespace NuGetConsole.Implementation.Console
                 // Check color spans
                 foreach (var t in _colorSpans.Overlap(span))
                 {
+                    var spanStart = t.Item1.Start;
+                    var spanLength = t.Item1.Length;
+                    var classificationType = t.Item2;
+
+                    // snapshot's length could be lower than spanStart + spanLength,
+                    // and if so, SnapshotSpan constructor will throw ArgumentOutOfRangeException.
+                    // We compute fixedLength to overcome this problem.
+                    var fixedLength
+                        = spanStart + spanLength > snapshot.Length ? snapshot.Length - spanStart : spanLength;
+
+                    var snapshotSpan = new SnapshotSpan(snapshot, spanStart, fixedLength);
                     classificationSpans.Add(new ClassificationSpan(
-                        new SnapshotSpan(snapshot, t.Item1), t.Item2));
+                        snapshotSpan, classificationType));
                 }
             }
             return classificationSpans;

--- a/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Console/WpfConsoleClassifier.cs
@@ -177,7 +177,7 @@ namespace NuGetConsole.Implementation.Console
 
                     // snapshot's length could be lower than spanStart + spanLength,
                     // and if so, SnapshotSpan constructor will throw ArgumentOutOfRangeException.
-                    // We compute fixedLength to overcome this problem.
+                    // We compute constrainedLength to overcome this problem.
                     int constrainedLength = spanLength;
                     if (spanStart + spanLength > snapshot.Length)
                     {


### PR DESCRIPTION
Fixes NuGet/Home#555
1. In WpfConsoleClassifier, Snapshotspan created with an overlapping
   color span must restricted to the length of the current snapshot. Otherwise,
   it throws ArgumentOutOfRangeException
2. Did not add tests since it will require using
   InternalsVisibleTo attribute. Tests that use InternalsVisibleTo can be found at
   https://github.com/NuGet/NuGet.Client/commit/c32ca0d81b3118fa7b7904787c210c054e2a8bef

@yishaigalatzer @emgarten @MeniZalzman
