### PR TITLE
Fix issue 1664: empty dropdown for 'update' leads to NullReferenceException

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/NotNullToBooleanConverter.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/NotNullToBooleanConverter.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// Converts not null to true, null to false.
+    /// </summary>
+    internal class NotNullToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value != null ? true : false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            // no op
+            Debug.Fail("Not Implemented");
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Models\PackageItemListViewModel.cs" />
     <Compile Include="Models\PackageStatus.cs" />
     <Compile Include="Models\SearchResult.cs" />
+    <Compile Include="NotNullToBooleanConverter.cs" />
     <Compile Include="PackageInstallationInfo.cs" />
     <Compile Include="PackageLoaderOptions.cs" />
     <Compile Include="PackageSolutionDetailControlModel.cs" />

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -61,6 +61,12 @@ namespace NuGet.PackageManagement.UI
         private void ProjectInstallButtonClicked(object sender, EventArgs e)
         {
             var model = (DetailControlModel)DataContext;
+
+            if (model.SelectedVersion == null)
+            {
+                return;
+            }
+
             var userAction = UserAction.CreateInstallAction(
                 model.Id,
                 model.SelectedVersion.Version);

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
@@ -14,6 +14,8 @@
         <ResourceDictionary
           Source="Resources.xaml" />
       </ResourceDictionary.MergedDictionaries>
+      <local:NotNullToBooleanConverter
+        x:Key="NotNullToBooleanConverter" />
       <ControlTemplate
         x:Key="SeparatorControlTemplate">
         <Separator
@@ -112,6 +114,7 @@
       AutomationProperties.AutomationId="Project_Button_Update"
       Click="InstallButton_Clicked"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}}"
+      IsEnabled="{Binding SelectedVersion,Converter={StaticResource NotNullToBooleanConverter}}"
       Content="{x:Static local:Resources.Button_Update}" />
   </Grid>
 </UserControl>


### PR DESCRIPTION
The update button should only be enabled if there is a selected version in the project package manager.

@yishaigalatzer @MeniZalzman @emgarten @deepakaravindr 
