### PR TITLE
After packages are installed/uninstalled in one package manager, othe…

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -211,8 +211,8 @@ namespace NuGet.PackageManagement.UI
                     // execute the actions
                     await executeActionsAsync(actions);
 
-                    // update
-                    uiService.RefreshPackageStatus();
+                    // fires ActionsExecuted event to update the UI
+                    uiService.OnActionsExecuted(actions);
                 }
             }
             catch (System.Net.Http.HttpRequestException ex)

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
@@ -72,7 +72,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Actions\ResolvedAction.cs" />
     <Compile Include="Actions\UIActionEngine.cs" />
     <Compile Include="Actions\ProjectContext.cs" />
     <Compile Include="Actions\UpdatePreviewResult.cs" />

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
@@ -69,9 +69,10 @@ namespace NuGet.PackageManagement.UI
         FileConflictAction FileConflictAction { get; }
 
         /// <summary>
-        /// Refreshes the package details and installed status icons
+        /// Fires SolutionManager.ActionsExecuted event so that the UI will get 
+        /// refreshed.
         /// </summary>
-        void RefreshPackageStatus();
+        void OnActionsExecuted(IEnumerable<ResolvedAction> actions);
 
         SourceRepository ActiveSource { get; }
 

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.UI
 
         IOptionsPageActivator OptionsPageActivator { get; }
 
-        IEnumerable<NuGetProject> Projects { get; }
+        IEnumerable<NuGetProject> Projects { get; set; }
 
         void AddSettings(string key, UserSettings settings);
 

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -163,17 +163,9 @@ namespace NuGet.PackageManagement.UI
 
         public PackageIdentity SelectedPackage { get; set; }
 
-        public void RefreshPackageStatus()
+        public void OnActionsExecuted(IEnumerable<ResolvedAction> actions)
         {
-            if (PackageManagerControl != null)
-            {
-                UIDispatcher.Invoke(() => { PackageManagerControl.UpdatePackageStatus(); });
-            }
-
-            if (_detailControl != null)
-            {
-                UIDispatcher.Invoke(() => { _detailControl.Refresh(); });
-            }
+            this._context.SolutionManager.OnActionsExecuted(actions);
         }
 
         public SourceRepository ActiveSource

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
@@ -14,7 +14,7 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     public abstract class NuGetUIContextBase : INuGetUIContext
     {
-        private readonly NuGetProject[] _projects;
+        private NuGetProject[] _projects;
 
         protected NuGetUIContextBase(
             ISourceRepositoryProvider sourceProvider,
@@ -52,6 +52,10 @@ namespace NuGet.PackageManagement.UI
         public IEnumerable<NuGetProject> Projects
         {
             get { return _projects; }
+            set
+            {
+                _projects = value.ToArray();
+            }
         }
 
         public abstract void AddSettings(string key, UserSettings settings);

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
@@ -148,6 +148,10 @@ namespace NuGet.PackageManagement.UI
             {
                 _self.Visibility = Visibility.Collapsed;
             }
+            else
+            {
+                _self.Visibility = Visibility.Visible;
+            }
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -54,8 +54,12 @@ namespace NuGet.PackageManagement.UI
 
         public void Refresh()
         {
-            var model = DataContext as DetailControlModel;
-            model?.Refresh();
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var model = DataContext as DetailControlModel;
+                model?.Refresh();
+            });
         }
 
         private void ProjectInstallButtonClicked(object sender, EventArgs e)

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml
@@ -16,103 +16,7 @@
       <local:InstalledVersionsCountConverter
         x:Key="InstalledVersionsCountConverter" />
 
-      <!-- style of the list view headers
-      <Style x:Key="GridViewColumnHeaderGripper" TargetType="{x:Type Thumb}">
-        <Setter Property="Canvas.Right" Value="-9" />
-        <Setter Property="Width" Value="18" />
-        <Setter Property="Height" Value="{Binding ActualHeight, RelativeSource={RelativeSource TemplatedParent}}" />
-        <Setter Property="Padding" Value="0" />
-        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" />
-        <Setter Property="Template">
-          <Setter.Value>
-            <ControlTemplate TargetType="{x:Type Thumb}">
-              <Border Background="Transparent" Padding="{TemplateBinding Padding}">
-                <Rectangle Fill="{TemplateBinding Background}" HorizontalAlignment="Center" Width="1" />
-              </Border>
-            </ControlTemplate>
-          </Setter.Value>
-        </Setter>
-      </Style>
-      <Style x:Key="GridViewColumnHeaderStyle1" TargetType="{x:Type GridViewColumnHeader}">
-        <Setter Property="HorizontalContentAlignment" Value="Center" />
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Background" Value="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}" />
-        <Setter Property="BorderBrush" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Padding" Value="4,0,4,4" />
-        <Setter Property="Margin" Value="0" />
-        <Setter Property="Foreground" Value="{DynamicResource {x:Static local:Brushes.UIText}}" />
-        <Setter Property="Template">
-          <Setter.Value>
-            <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
-              <Grid SnapsToDevicePixels="true">
-                <Border
-                  x:Name="HeaderBorder"
-                  BorderThickness="0"
-                  Background="{TemplateBinding Background}"
-                  Padding="{TemplateBinding Padding}">
-                  <ContentPresenter x:Name="HeaderContent" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="0,0,0,1" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                </Border>
-                <Canvas>
-                  <Thumb x:Name="PART_HeaderGripper" Style="{StaticResource GridViewColumnHeaderGripper}" />
-                </Canvas>
-              </Grid>
-              <ControlTemplate.Triggers>
-                <Trigger Property="IsMouseOver" Value="true">
-                  <Setter Property="Background" TargetName="HeaderBorder" Value="{DynamicResource {x:Static local:Brushes.ContentMouseOverBrushKey}}" />
-                  <Setter
-                    Property="TextBlock.Foreground"
-                    Value="{DynamicResource {x:Static local:Brushes.ContentMouseOverTextBrushKey}}" />
-                </Trigger>
-                <Trigger Property="IsPressed" Value="true">
-                  <Setter Property="Background" TargetName="HeaderBorder" Value="{DynamicResource {x:Static local:Brushes.ContentSelectedBrushKey}}" />
-                  <Setter
-                    Property="TextBlock.Foreground"
-                    Value="{DynamicResource {x:Static local:Brushes.ContentSelectedTextBrushKey}}" />
-                  <Setter Property="Visibility" TargetName="PART_HeaderGripper" Value="Hidden" />
-                  <Setter Property="Margin" TargetName="HeaderContent" Value="1,1,0,0" />
-                </Trigger>
-                <Trigger Property="Height" Value="Auto">
-                  <Setter Property="MinHeight" Value="20" />
-                </Trigger>
-              </ControlTemplate.Triggers>
-            </ControlTemplate>
-          </Setter.Value>
-        </Setter>
-        <Style.Triggers>
-          <Trigger Property="Role" Value="Floating">
-            <Setter Property="Opacity" Value="0.4082" />
-            <Setter Property="Template">
-              <Setter.Value>
-                <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
-                  <Canvas x:Name="PART_FloatingHeaderCanvas">
-                    <Rectangle Fill="#FF000000" Height="{TemplateBinding ActualHeight}" Opacity="0.4697" Width="{TemplateBinding ActualWidth}" />
-                  </Canvas>
-                </ControlTemplate>
-              </Setter.Value>
-            </Setter>
-          </Trigger>
-          <Trigger Property="Role" Value="Padding">
-            <Setter Property="Template">
-              <Setter.Value>
-                <ControlTemplate TargetType="{x:Type GridViewColumnHeader}">
-                  <Border
-                    x:Name="HeaderBorder"
-                    Background="{TemplateBinding Background}" />
-                  <ControlTemplate.Triggers>
-                    <Trigger Property="Height" Value="Auto">
-                      <Setter Property="MinHeight" Value="20" />
-                    </Trigger>
-                  </ControlTemplate.Triggers>
-                </ControlTemplate>
-              </Setter.Value>
-            </Setter>
-          </Trigger>
-        </Style.Triggers>
-      </Style>
-
-      -->
-
+      <!-- style of the list view headers -->      
       <Style x:Uid="Style_1" x:Key="GridViewColumnHeaderGripper" TargetType="{x:Type Thumb}">
         <Setter x:Uid="Setter_1" Property="Canvas.Right" Value="-8.5" />
         <Setter x:Uid="Setter_2" Property="Width" Value="18" />
@@ -260,8 +164,7 @@
       Margin="0,8,0,0"
       ItemsSource="{Binding Projects}"
       Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
-      Foreground="{DynamicResource {x:Static local:Brushes.UIText}}"      
-      SizeChanged="ListView_SizeChanged">
+      Foreground="{DynamicResource {x:Static local:Brushes.UIText}}" >
       <ListView.View>
         <GridView ColumnHeaderContainerStyle="{StaticResource GridViewColumnHeaderStyle}">
 

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml.cs
@@ -27,6 +27,8 @@ namespace NuGet.PackageManagement.UI
         {
             InitializeComponent();
 
+            _projectList.SizeChanged += ListView_SizeChanged;
+
             _sortableColumns = new List<GridViewColumnHeader> {
                 _projectColumnHeader,
                 _versionColumnHeader
@@ -192,6 +194,9 @@ namespace NuGet.PackageManagement.UI
 
             var newWidth = _projectColumnHeader.ActualWidth + width;
             _projectColumn.Width = newWidth;
+
+            // this width adjustment is only done once.
+            _projectList.SizeChanged -= ListView_SizeChanged;
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -77,6 +77,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public event EventHandler SolutionOpening;
 
+        public event EventHandler<ActionsExecutedEventArgs> ActionsExecuted;
+
         public VSSolutionManager()
         {
             _dte = ServiceLocator.GetInstance<DTE>();
@@ -709,6 +711,14 @@ namespace NuGet.PackageManagement.VisualStudio
         public int OnSelectionChanged(IVsHierarchy pHierOld, uint itemidOld, IVsMultiItemSelect pMISOld, ISelectionContainer pSCOld, IVsHierarchy pHierNew, uint itemidNew, IVsMultiItemSelect pMISNew, ISelectionContainer pSCNew)
         {
             return VSConstants.S_OK;
+        }
+
+        public void OnActionsExecuted(IEnumerable<ResolvedAction> actions)
+        {
+            if (ActionsExecuted != null)
+            {
+                ActionsExecuted(this, new ActionsExecutedEventArgs(actions));
+            }
         }
 
         #endregion IVsSelectionEvents implementation

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ActionsExecutedEventArgs.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ActionsExecutedEventArgs.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// The event args of the ActionsExecuted event.
+    /// </summary>
+    public class ActionsExecutedEventArgs : EventArgs
+    {
+        public ActionsExecutedEventArgs(IEnumerable<ResolvedAction> actions)
+        {
+            Actions = actions;
+        }
+
+        /// <summary>
+        /// The list of actions that are executed.
+        /// </summary>
+        public IEnumerable<ResolvedAction> Actions { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -10,12 +10,23 @@ namespace NuGet.PackageManagement
     public interface ISolutionManager
     {
         event EventHandler SolutionOpening;
+
         event EventHandler SolutionOpened;
+
         event EventHandler SolutionClosing;
+
         event EventHandler SolutionClosed;
+
         event EventHandler<NuGetProjectEventArgs> NuGetProjectAdded;
+
         event EventHandler<NuGetProjectEventArgs> NuGetProjectRemoved;
+
         event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
+
+        /// <summary>
+        /// Event raised after user actions are executed.
+        /// </summary>
+        event EventHandler<ActionsExecutedEventArgs> ActionsExecuted;
 
         /// <summary>
         /// Gets the current open solution directory, can only be called from the main UI thread.
@@ -71,6 +82,12 @@ namespace NuGet.PackageManagement
         /// passed in.
         /// </returns>
         NuGetProject GetNuGetProject(string nuGetProjectSafeName);
+
+        /// <summary>
+        /// Fires ActionsExecuted event.
+        /// </summary>
+        /// <param name="actions"></param>
+        void OnActionsExecuted(IEnumerable<ResolvedAction> actions);
     }
 
     public class NuGetProjectEventArgs : EventArgs

--- a/src/NuGet.Core/NuGet.PackageManagement/ResolvedAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ResolvedAction.cs
@@ -3,7 +3,7 @@
 
 using NuGet.ProjectManagement;
 
-namespace NuGet.PackageManagement.UI
+namespace NuGet.PackageManagement
 {
     public class ResolvedAction
     {

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -163,6 +163,15 @@ namespace Test.Utility
 
         public event EventHandler SolutionOpened;
         public event EventHandler SolutionOpening;
+        public event EventHandler<ActionsExecutedEventArgs> ActionsExecuted;
+
+        public void OnActionsExecuted(IEnumerable<ResolvedAction> actions)
+        {
+            if (ActionsExecuted != null)
+            {
+                ActionsExecuted(this, new ActionsExecutedEventArgs(actions));
+            }
+        }
 
 #pragma warning restore 0067
     }


### PR DESCRIPTION
…r package manager windows now get refreshed too.

Other changes:
- Fix a crash problem when user adjusts list column header's width.
- Fix a bug in AuthorAndDownloadCount control.

The fix of UI update:
- Added event ActionsExecuted to SolutionManager. It's fired after actions are executed.
- Package Manager windows listen to this event. When the event is triggered, the windows will refresh themselves.

Note that action execution in powershell won't trigger this event. We'll try to fix this in another changeset.

@emgarten @deepakaravindr @yishaigalatzer @MeniZalzman @zhili1208 
