### PR TITLE
Select the nearest TxM on a per codeLanguage basis

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
@@ -83,27 +83,39 @@ namespace NuGet.Commands
         {
             var groups = new List<ContentItemGroup>();
 
-            // Find all unique frameworks
-            var frameworks = contentGroups.Select(
-                group =>
-                    (NuGetFramework)group.Properties[ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker])
-                .Distinct()
-                .ToList();
+            // Find all unique code languages
+            Dictionary<string, List<ContentItemGroup>> groupsByLanguage 
+                = new Dictionary<string, List<ContentItemGroup>>(StringComparer.OrdinalIgnoreCase);
 
-            // Find the best framework
-            var nearestFramework =
-                NuGetFrameworkUtility.GetNearest<NuGetFramework>(frameworks, framework, item => item);
-
-            // If a compatible framework exists get all groups with that framework
-            if (nearestFramework != null)
+            // Index groups by their code language
+            foreach (var group in contentGroups)
             {
-                var contentFilesGroupsWithSameFramework = contentGroups.Where(
-                    group =>
-                    nearestFramework.Equals(
-                        (NuGetFramework)group.Properties[ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker])
-                    );
+                var codeLanguage = (string)group.Properties[ManagedCodeConventions.PropertyNames.CodeLanguage];
 
-                groups.AddRange(contentFilesGroupsWithSameFramework);
+                List<ContentItemGroup> index;
+                if (!groupsByLanguage.TryGetValue(codeLanguage, out index))
+                {
+                    index = new List<ContentItemGroup>(1);
+                    groupsByLanguage.Add(codeLanguage, index);
+                }
+
+                index.Add(group);
+            }
+
+            // Find the nearest TxM within each language
+            foreach (var codeLanguagePair in groupsByLanguage)
+            {
+                var languageGroups = codeLanguagePair.Value;
+
+                var nearestGroup = NuGetFrameworkUtility.GetNearest<ContentItemGroup>(languageGroups, framework, 
+                    group =>
+                       (NuGetFramework)group.Properties[ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker]);
+
+                // If a compatible group exists within the code language add it to the results
+                if (nearestGroup != null)
+                {
+                    groups.Add(nearestGroup);
+                }
             }
 
             return groups;

--- a/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
@@ -83,11 +83,9 @@ namespace NuGet.Commands
         {
             var groups = new List<ContentItemGroup>();
 
-            // Find all unique code languages
-            Dictionary<string, List<ContentItemGroup>> groupsByLanguage 
-                = new Dictionary<string, List<ContentItemGroup>>(StringComparer.OrdinalIgnoreCase);
+            // Group by content by code language and find the nearest TxM under each language.
+            var groupsByLanguage = new Dictionary<string, List<ContentItemGroup>>(StringComparer.OrdinalIgnoreCase);
 
-            // Index groups by their code language
             foreach (var group in contentGroups)
             {
                 var codeLanguage = (string)group.Properties[ManagedCodeConventions.PropertyNames.CodeLanguage];


### PR DESCRIPTION
This change allows the nearest compatible TxM for a language into the lock file, even if it isn't the same TxM that another language selected.

Example:

```
vb/net45/code.vb
cs/net40/code.cs
cs/net46/code.cs

net45 selects: 
vb/net45/code.vb
cs/net40/code.cs
```

Previously net45 would be selected and cs would have zero items in the group.

//cc @yishaigalatzer @deepakaravindr @MeniZalzman @zhili1208 
