### PR TITLE
Fix of issue NuGet/Home#1332: VS 2015 crashes when adding/removing Nu…

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1088,10 +1088,14 @@ namespace NuGet.PackageManagement.VisualStudio
                     var reference3 = reference as Reference3;
 
                     // Get the referenced project from the reference if any
-                    // C++ projects will throw on reference.SourceProject if reference3.Resolved is false
+                    // C++ projects will throw on reference.SourceProject if reference3.Resolved is false.
+                    // It's also possible that the referenced project is the project itself 
+                    // for C++ projects. In this case this reference should be skipped to avoid circular
+                    // references.
                     if (reference3 != null
                         && reference3.Resolved
-                        && reference.SourceProject != null)
+                        && reference.SourceProject != null
+                        && reference.SourceProject != envDTEProject)
                     {
                         envDTEProjects.Add(reference.SourceProject);
                     }


### PR DESCRIPTION
…Get package to a Windows Phone 8.1 project.

The cause is that the referenced project of one C++ project in the solution is
the project itself, i.e. a circular reference. This causes the stack overflow and the crash.

@emgarten @yishaigalatzer @MeniZalzman @deepakaravindr 
