### PR TITLE
outputPath fix for pp files

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
@@ -250,6 +250,11 @@ namespace NuGet.Commands
                 lockFileItem.Properties.Add(BuildAction, normalizedAction);
                 lockFileItem.Properties.Add(CopyToOutput, copyToOutput.ToString());
 
+                // Check if this is a .pp transform. If the filename is ".pp" ignore it since it will
+                // have no file name after the transform.
+                var isPP = lockFileItem.Path.EndsWith(".pp", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrEmpty(Path.GetFileNameWithoutExtension(lockFileItem.Path));
+
                 if (copyToOutput)
                 {
                     string destination = null;
@@ -265,11 +270,17 @@ namespace NuGet.Commands
                         destination = GetContentFileFolderRelativeToFramework(file);
                     }
 
+                    if (isPP)
+                    {
+                        // Remove .pp from the output file path
+                        destination = destination.Substring(0, destination.Length - 3);
+                    }
+
                     lockFileItem.Properties.Add("outputPath", destination);
                 }
 
                 // Add the pp transform file if one exists
-                if (lockFileItem.Path.EndsWith(".pp", StringComparison.OrdinalIgnoreCase))
+                if (isPP)
                 {
                     var destination = lockFileItem.Path.Substring(0, lockFileItem.Path.Length - 3);
                     destination = GetContentFileFolderRelativeToFramework(destination);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -18,6 +18,145 @@ namespace NuGet.Commands.Test
     public class ContentFilesTests : IDisposable
     {
         [Fact]
+        public async Task ContentFiles_VerifyLockFileContainsCorrectPPOutputPath()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var framework = "net46";
+
+            var workingDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(workingDir);
+
+            var repository = Path.Combine(workingDir, "repository");
+            Directory.CreateDirectory(repository);
+            var projectDir = Path.Combine(workingDir, "project");
+            Directory.CreateDirectory(projectDir);
+            var packagesDir = Path.Combine(workingDir, "packages");
+            Directory.CreateDirectory(packagesDir);
+
+            var file = new FileInfo(Path.Combine(repository, "packageA.1.0.0.nupkg"));
+
+            using (var zip = new ZipArchive(File.Create(file.FullName), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("contentFiles/any/any/a/code.cs.pp", new byte[] { 0 });
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
+                        <metadata>
+                            <id>packageA</id>
+                            <version>1.0.0</version>
+                            <title />
+                            <contentFiles>
+                                <files include=""**/*.*"" copyToOutput=""TRUE"" flatten=""true"" />
+                            </contentFiles>
+                        </metadata>
+                        </package>", Encoding.UTF8);
+            }
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource(repository));
+
+            var configJson = JObject.Parse(@"{
+                ""dependencies"": {
+                ""packageA"": ""1.0.0""
+                },
+                ""frameworks"": {
+                ""_FRAMEWORK_"": {}
+                }
+            }".Replace("_FRAMEWORK_", framework));
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var command = new RestoreCommand(logger, request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+            result.Commit(logger);
+
+            var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
+
+            var helperCsItem = target.Libraries.Single().ContentFiles
+                .Single(item => item.Path == "contentFiles/any/any/a/code.cs.pp");
+
+            // Assert
+            Assert.Equal("code.cs", helperCsItem.Properties["outputPath"]);
+        }
+
+        [Fact]
+        public async Task ContentFiles_InvalidPPFileName()
+        {
+            // Arrange
+            var logger = new TestLogger();
+            var framework = "net46";
+
+            var workingDir = TestFileSystemUtility.CreateRandomTestFolder();
+            _testFolders.Add(workingDir);
+
+            var repository = Path.Combine(workingDir, "repository");
+            Directory.CreateDirectory(repository);
+            var projectDir = Path.Combine(workingDir, "project");
+            Directory.CreateDirectory(projectDir);
+            var packagesDir = Path.Combine(workingDir, "packages");
+            Directory.CreateDirectory(packagesDir);
+
+            var file = new FileInfo(Path.Combine(repository, "packageA.1.0.0.nupkg"));
+
+            using (var zip = new ZipArchive(File.Create(file.FullName), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("contentFiles/any/any/a/.pp", new byte[] { 0 });
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
+                        <metadata>
+                            <id>packageA</id>
+                            <version>1.0.0</version>
+                            <title />
+                            <contentFiles>
+                                <files include=""**/*"" copyToOutput=""TRUE"" flatten=""true"" />
+                            </contentFiles>
+                        </metadata>
+                        </package>", Encoding.UTF8);
+            }
+
+            var sources = new List<PackageSource>();
+            sources.Add(new PackageSource(repository));
+
+            var configJson = JObject.Parse(@"{
+                ""dependencies"": {
+                ""packageA"": ""1.0.0""
+                },
+                ""frameworks"": {
+                ""_FRAMEWORK_"": {}
+                }
+            }".Replace("_FRAMEWORK_", framework));
+
+            var specPath = Path.Combine(projectDir, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+
+            var request = new RestoreRequest(spec, sources, packagesDir);
+            request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+
+            var command = new RestoreCommand(logger, request);
+
+            // Act
+            var result = await command.ExecuteAsync();
+            result.Commit(logger);
+
+            var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
+
+            var helperCsItem = target.Libraries.Single().ContentFiles
+                .Single(item => item.Path == "contentFiles/any/any/a/.pp");
+
+            // Assert
+            Assert.Equal(".pp", helperCsItem.Properties["outputPath"]);
+            Assert.False(helperCsItem.Properties.ContainsKey("ppOutputPath"));
+        }
+
+        [Fact]
         public async Task ContentFiles_VerifyLockFileChange_Changed()
         {
             // Arrange


### PR DESCRIPTION
This fix removes the .pp extension from the outputPath property in the lock file. 

The scenario here could be that a user has a config.xml.pp file that they need to copy to the output directory. The file is expected to end up as config.xml.

//cc @yishaigalatzer @deepakaravindr @zhili1208 @feiling @MeniZalzman
