### PR TITLE
ContentModel fix for RID agnostic package items

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -201,6 +201,8 @@ namespace NuGet.Client
 
             public SelectionCriteria ForFrameworkAndRuntime(NuGetFramework framework, string runtimeIdentifier)
             {
+                // Both criteria must specify a RID
+
                 var builder = new SelectionCriteriaBuilder(_conventions.Properties);
                 if (!string.IsNullOrEmpty(runtimeIdentifier))
                 {
@@ -211,7 +213,7 @@ namespace NuGet.Client
 
                 // Then try runtime-agnostic
                 builder = builder
-                    .Add[PropertyNames.TargetFrameworkMoniker, framework];
+                    .Add[PropertyNames.TargetFrameworkMoniker, framework][PropertyNames.RuntimeIdentifier, value: null];
 
                 return builder.Criteria;
             }

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
@@ -12,6 +12,54 @@ namespace NuGet.Client.Test
     public class ContentModelLibTests
     {
         [Fact]
+        public void ContentModel_RuntimeAgnosticFallback()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/aot/lib/netcore50/System.Reflection.Emit.dll",
+                "lib/netcore50/System.Reflection.Emit.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("netcore50"));
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal("lib/netcore50/System.Reflection.Emit.dll", group.Items.Single().Path);
+        }
+
+        [Fact]
+        public void ContentModel_RuntimeAgnosticFallbackReverse()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/netcore50/System.Reflection.Emit.dll",
+                "runtimes/aot/lib/netcore50/System.Reflection.Emit.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("netcore50"));
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal("lib/netcore50/System.Reflection.Emit.dll", group.Items.Single().Path);
+        }
+
+        [Fact]
         public void ContentModel_LibNoFilesAtRootNoAnyGroup()
         {
             // Arrange


### PR DESCRIPTION
This fix adds runtime=null as a criteria when searching for a runtime agnostic option. 

As mentioned in the bug order does matter here. The reverse test will pass without the fix, but the other fails.

https://github.com/NuGet/Home/issues/1457

//cc @ericstj @yishaigalatzer @deepakaravindr @MeniZalzman @feiling 
