### PR TITLE
TargetFrameworkName_NearestCompareTest fix for equal frameworks

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -162,20 +162,24 @@ namespace NuGet.Client
                 && availableFrameworkName != null
                 && projectFrameworkName != null)
             {
-                var reducer = new FrameworkReducer();
-                var frameworks = new NuGetFramework[] { criteriaFrameworkName, availableFrameworkName };
-
-                // Find the nearest compatible framework to the project framework.
-                var nearest = reducer.GetNearest(projectFrameworkName, frameworks);
-
-                if (criteriaFrameworkName.Equals(nearest))
+                // If the frameworks are the same this can be skipped
+                if (!criteriaFrameworkName.Equals(availableFrameworkName))
                 {
-                    return -1;
-                }
+                    var reducer = new FrameworkReducer();
+                    var frameworks = new NuGetFramework[] { criteriaFrameworkName, availableFrameworkName };
 
-                if (availableFrameworkName.Equals(nearest))
-                {
-                    return 1;
+                    // Find the nearest compatible framework to the project framework.
+                    var nearest = reducer.GetNearest(projectFrameworkName, frameworks);
+
+                    if (criteriaFrameworkName.Equals(nearest))
+                    {
+                        return -1;
+                    }
+
+                    if (availableFrameworkName.Equals(nearest))
+                    {
+                        return 1;
+                    }
                 }
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
@@ -131,5 +131,73 @@ namespace NuGet.Client.Test
             Assert.Equal(1, group.Items.Count);
             Assert.Equal("lib/net46/a.dll", group.Items[0].Path);
         }
+
+        [Fact]
+        public void ContentModel_GetNearestRIDAndTFM()
+        {
+            // Arrange
+            var runtimes = new List<RuntimeDescription>()
+            {
+                new RuntimeDescription("a"),
+                new RuntimeDescription("b", new string[] { "a" }),
+                new RuntimeDescription("c", new string[] { "b" }),
+                new RuntimeDescription("d", new string[] { "c" }),
+            };
+
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    runtimes,
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") }));
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("netcore50"), "d");
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/a/lib/netcore50/assembly.dll",
+                "runtimes/b/lib/netcore50/assembly.dll",
+                "runtimes/c/lib/netcore50/assembly.dll",
+            });
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal("runtimes/c/lib/netcore50/assembly.dll", group.Items.Single().Path);
+        }
+
+        [Fact]
+        public void ContentModel_GetNearestRIDAndTFMReverse()
+        {
+            // Arrange
+            var runtimes = new List<RuntimeDescription>()
+            {
+                new RuntimeDescription("a"),
+                new RuntimeDescription("b", new string[] { "a" }),
+                new RuntimeDescription("c", new string[] { "b" }),
+                new RuntimeDescription("d", new string[] { "c" }),
+            };
+
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    runtimes,
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") }));
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("netcore50"), "d");
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/c/lib/netcore50/assembly.dll",
+                "runtimes/b/lib/netcore50/assembly.dll",
+                "runtimes/a/lib/netcore50/assembly.dll",
+            });
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.RuntimeAssemblies);
+
+            // Assert
+            Assert.Equal("runtimes/c/lib/netcore50/assembly.dll", group.Items.Single().Path);
+        }
     }
 }


### PR DESCRIPTION
This is a fix for the ContentModel in how it compares TxMs. Without a runtime only unique TxMs are passed in. With a runtime there can be duplicates since the unique key is made up of both the TxM and RID. 

The change here updates TargetFrameworkName_NearestCompareTest to handle equal frameworks instead of favoring the existing one over the other.

https://github.com/NuGet/Home/issues/1676

//cc @ericstj @yishaigalatzer @MeniZalzman @deepakaravindr @feiling 
