### PR TITLE
Fix the issue that AddBindingRedirectsAsync() overflows when there is…

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -963,16 +963,17 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             assemblies = new HashSet<string>(PathComparer.Default);
+            visitedProjects.Add(envDTEProject.UniqueName, assemblies);
+
             var localProjectAssemblies = GetLocalProjectAssemblies(envDTEProject);
             CollectionsUtility.AddRange(assemblies, localProjectAssemblies);
+            
             var referencedProjects = GetReferencedProjects(envDTEProject);
             foreach (var project in referencedProjects)
             {
                 var assemblyClosure = GetAssemblyClosure(project, visitedProjects);
                 CollectionsUtility.AddRange(assemblies, assemblyClosure);
             }
-
-            visitedProjects.Add(envDTEProject.UniqueName, assemblies);
 
             return assemblies;
         }


### PR DESCRIPTION
… circular reference.

This is a further fix of issue NuGet/Home#1332.

@yishaigalatzer @MeniZalzman @emgarten @deepakaravindr 
