### PR TITLE
NuGet.exe: Fixes the issue where invalid config file specified by user via -ConfigFile switch are ignored

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Properties/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Properties/Resources.Designer.cs
@@ -131,6 +131,14 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
+        /// Unable to parse config file '{0}'. Error Message: {1}.
+        /// </summary>
+        internal static string UserSettings_UnableToParseConfigFile_ErrorMessage
+        {
+            get { return GetString("UserSettings_UnableToParseConfigFile_ErrorMessage"); }
+        }
+
+        /// <summary>
         /// Unable to parse config file '{0}'.
         /// </summary>
         internal static string FormatUserSettings_UnableToParseConfigFile(object p0)

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -141,4 +141,7 @@
   <data name="UserSettings_UnableToParseConfigFile" xml:space="preserve">
     <value>Unable to parse config file '{0}'.</value>
   </data>
+  <data name="UserSettings_UnableToParseConfigFile_ErrorMessage" xml:space="preserve">
+    <value>Unable to parse config file '{0}'. Error Message: {1}.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -1760,6 +1760,39 @@ namespace NuGet.Configuration.Test
             Assert.Equal(String.Format(@"File '{0}' does not exist.", Path.Combine(mockBaseDirectory, "user.config")), ex.Message);
         }
 
+        // Tests that when configFileName is not null, the specified
+        // file must exist and it must be valid.
+        [Fact]
+        public void UserSpecifiedConfigFileMustBeValid()
+        {
+            // Arrange
+            var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            var config = @"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+    <packageSources>
+        <add key='key1' value='value1'/>
+    </packageSources>
+    <solution>
+        <solution>
+    <add key='disableSourceControlIntegration' value='true' />
+  </solution>
+</configuration>";
+
+            TestFilesystemUtility.CreateConfigurationFile("user.config", mockBaseDirectory, config);
+
+            // Act and assert
+            Exception ex = Record.Exception(() => Settings.LoadDefaultSettings(
+                mockBaseDirectory,
+                configFileName: "user.config",
+                machineWideSettings: null));
+            Assert.NotNull(ex);
+            var tex = Assert.IsAssignableFrom<InvalidOperationException>(ex);
+            Assert.True(ex.Message.Contains(
+                string.Format(@"Unable to parse config file '{0}'. Error Message:",
+                Path.Combine(mockBaseDirectory, "user.config"))), "Error message is not as expected");
+        }
+
         // Tests the scenario where there are two user settings, both created
         // with the same machine wide settings.
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/388.
Also, fixes https://github.com/NuGet/Home/issues/1068 and https://github.com/NuGet/Home/issues/1302

Private method Settings.ReadSettings eats up the XmlException. Changed it
to throw with meaningful error message ONLY when loading user settings
that is not the global appdata config file.

1) Added unit tests
2) Manually tested the scenario

@yishaigalatzer @emgarten @MeniZalzman 
