### PR TITLE
Improve empty nupkg folder handling

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -39,15 +39,15 @@ namespace NuGet.ProjectManagement
         /// Filter out invalid package items and replace the directory separator with the correct slash for the 
         /// current OS.
         /// </summary>
-        /// <remarks>If the group is null or contains _._ this method will return the same group.</remarks>
+        /// <remarks>If the group is null or contains only only _._ this method will return the same group.</remarks>
         internal static FrameworkSpecificGroup Normalize(FrameworkSpecificGroup group)
         {
             // Default to returning the same group
             var result = group;
 
-            // If the group is null or contains only _._ then this is a no-op.
+            // If the group is null or it does not contain any items besides _._ then this is a no-op.
             // If it does have items create a new normalized group to replace it with.
-            if (group?.HasEmptyFolder == false)
+            if (group?.Items.Any() == true)
             {
                 // Filter out invalid files
                 var normalizedItems = GetValidPackageItems(group.Items)

--- a/src/NuGet.Core/Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/Test.Utility/TestPackages.cs
@@ -179,6 +179,17 @@ namespace Test.Utility
                 });
         }
 
+        public static FileInfo GetPackageWithEmptyFolders(string path, string packageId, string packageVersion)
+        {
+            return GeneratePackage(path, packageId, packageVersion,
+                new[]
+                {
+                    "build/net45/_._",
+                    "lib/net45/_._",
+                    "content/_._"
+                });
+        }
+
         public static FileInfo GetPackageWithFrameworkReference(string path,
             string packageId = "packageA",
             string packageVersion = "2.0.3")

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -1,3 +1,24 @@
+# Verify Xunit 2.1.0 can be installed into a net45 project.
+# https://github.com/NuGet/Home/issues/1711
+function Test-InstallXunit210WithEmptyBuildFolderSucceeds
+{
+    param($context)
+
+    # Arrange
+    $p = New-ClassLibrary
+
+    # Act
+    $p | Install-Package xunit -version 2.1.0
+
+    # Assert
+    Assert-Package $p xunit 2.1.0
+    Assert-Package $p xunit.core 2.1.0
+    Assert-Package $p xunit.assert 2.1.0
+    Assert-Package $p xunit.extensibility.core 2.1.0
+    Assert-Package $p xunit.extensibility.execution 2.1.0
+    Assert-Package $p xunit.abstractions 2.0.0
+}
+
 function Test-SinglePackageInstallIntoSingleProject {
     # Arrange
     $project = New-ConsoleApplication

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
@@ -20,6 +20,63 @@ namespace ProjectManagement.Test
 {
     public class MSBuildNuGetProjectTests
     {
+        [Fact]
+        public async Task TestMSBuildNuGetProjectEmptyPackageFoldersAreNotAdded()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+            var randomTestPackageSourcePath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomPackagesFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomPackagesConfigFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomPackagesConfigPath = Path.Combine(randomPackagesConfigFolderPath, "packages.config");
+            var token = CancellationToken.None;
+
+            var projectTargetFramework = NuGetFramework.Parse("net45");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework, 
+                testNuGetProjectContext);
+
+            var msBuildNuGetProject = new MSBuildNuGetProject(
+                msBuildNuGetProjectSystem, 
+                randomPackagesFolderPath, 
+                randomPackagesConfigFolderPath);
+
+            var packageFileInfo = TestPackages.GetPackageWithEmptyFolders(randomTestPackageSourcePath,
+                packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
+            using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+            {
+                // Act
+                await msBuildNuGetProject.InstallPackageAsync(
+                    packageIdentity, 
+                    packageStream, 
+                    testNuGetProjectContext, 
+                    token);
+            }
+
+            var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject
+                .GetInstalledPackagesAsync(token))
+                .ToList();
+
+            var projectFiles = msBuildNuGetProjectSystem.Files.Where(file => file != "packages.config").ToList();
+
+            // Assert
+            Assert.Equal(1, packagesInPackagesConfig.Count);
+            Assert.Equal(packageIdentity, packagesInPackagesConfig[0].PackageIdentity);
+            Assert.Equal(projectTargetFramework, packagesInPackagesConfig[0].TargetFramework);
+
+            // Check that no files were added
+            Assert.Equal(0, msBuildNuGetProjectSystem.Imports.Count);
+            Assert.Equal(0, projectFiles.Count);
+            Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(
+                randomTestPackageSourcePath, 
+                randomPackagesFolderPath, 
+                randomPackagesConfigFolderPath);
+        }
+
         #region Assembly references tests
 
         [Fact]


### PR DESCRIPTION
Inside a nupkg an empty folder can be created by adding a file named: `_._`. This is needed since the OPC does not allow actual empty folders.

XUnit.Core contains one of these folders to clear out the msbuild targets for the net45 framework. `build/net45/_._` without it the portable library folder would be used.

In NuGet 3.3.0 this behavior was regressed and instead of ignoring the `_._` file it was added as a target incorrectly. This results in NuGet attempting to add _._ as an import to the project which fails.

The fix for this is to avoid adding in `_._` to the targets group, and instead return the same empty group during the normalization method since it is already set up and has the `_._` file ignored. 

https://github.com/NuGet/Home/issues/1711

//cc @yishaigalatzer @deepakaravindr @feiling @MeniZalzman 
