### PR TITLE
Modify MsBuildUtility to get project closure for multiple projects.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.target
+++ b/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.target
@@ -3,36 +3,32 @@
             DependsOnTargets="_SplitProjectReferencesByFileExistence"
             Returns="@(_ProjectReferencingProjectJsonFile)">
 
+        <PropertyGroup>
+            <EntryPointProject Condition=" '$(EntryPointProject)' == '' ">$(MsBuildProjectFullPath)</EntryPointProject>
+        </PropertyGroup>
+
         <ItemGroup>
             <_ProjectReferencingProjectJsonFile
+                Include="#:$(MSBuildProjectFullPath)"
+                Condition=" '$(MSBuildProjectFullPath)' == '$(EntryPointProject)' " />
+            <_ProjectReferencingProjectJsonFile
                 Include="$(MSBuildProjectFullPath)"
-                Condition=" Exists('$(MsBuildProjectDirectory)\project.json') " />
+                Condition=" '$(MSBuildProjectFullPath)' != '$(EntryPointProject)' " />
         </ItemGroup>
 
         <MSBuild
           Projects="@(ProjectReference)"
           Targets="_NuGet_GetProjectsReferencingProjectJsonInternal"
           BuildInParallel="$(BuildInParallel)"
-          Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform);"
+          Properties="
+            %(_MSBuildProjectReferenceExistent.SetConfiguration);
+            %(_MSBuildProjectReferenceExistent.SetPlatform);
+            EntryPointProject=$(EntryPointProject)"
           RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
             <Output
                 TaskParameter="TargetOutputs"
                 ItemName="_ProjectReferencingProjectJsonFile" />
         </MSBuild>
-    </Target>
-
-    <Target Name="NuGet_GetProjectsReferencingProjectJson">
-        <CallTarget
-            Targets="_NuGet_GetProjectsReferencingProjectJsonInternal">
-            <Output
-                ItemName="_ProjectReferencingProjectJsonFile"
-                TaskParameter="TargetOutputs" />
-        </CallTarget>
-
-        <WriteLinesToFile
-            File="$(ResultsFile)"
-            Lines="@(_ProjectReferencingProjectJsonFile)"
-            Overwrite="true" />
     </Target>
 </Project>

--- a/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFilesEntryPoint.target
+++ b/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFilesEntryPoint.target
@@ -1,0 +1,26 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="NuGet_GetProjectsReferencingProjectJson">
+        <ItemGroup>
+            <NuGet_ProjectReferenceToResolveItems Include="$(NuGet_ProjectReferenceToResolve)" />
+        </ItemGroup>
+        <MsBuild
+            Projects="@(NuGet_ProjectReferenceToResolveItems)"
+            Targets="_NuGet_GetProjectsReferencingProjectJsonInternal"
+            BuildInParallel="$(BuildInParalel)"
+            Properties="
+                %(_MSBuildProjectReferenceExistent.SetConfiguration);
+                %(_MSBuildProjectReferenceExistent.SetPlatform);
+                CustomAfterMicrosoftCommonTargets=$(NuGetCustomAfterBuildTargetPath)"
+            RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+         
+            <Output
+                TaskParameter="TargetOutputs"
+                ItemName="_ProjectReferencingProjectJsonFile" />
+        </MsBuild>
+        
+        <WriteLinesToFile
+            File="$(ResultsFile)"
+            Lines="@(_ProjectReferencingProjectJsonFile)"
+            Overwrite="true" />
+    </Target>
+</Project>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="GetProjectsReferencingProjectJsonFiles.target" />
+    <EmbeddedResource Include="GetProjectsReferencingProjectJsonFilesEntryPoint.target" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AnalysisResources.Designer.cs">
@@ -152,6 +153,7 @@
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.Composition.Registration" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>


### PR DESCRIPTION
Filter out projects with project.json \ projectname.project.json in code instead of MSBuild target.

Fixes #1690
