### PR TITLE
fix https://github.com/NuGet/Home/issues/998

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -999,7 +999,8 @@ namespace NuGet.Configuration
                 }
             }
         }
-
+        
+        // Compare two config file path, return true if two path are the same.
         private static bool ConfigPathComparer(string path1, string path2)
         {
             if (path1 == null && path2 == null)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -153,7 +153,8 @@ namespace NuGet.Configuration
                     validSettingFiles.AddRange(
                         GetSettingsFileNames(root)
                             .Select(f => ReadSettings(root, f))
-                            .Where(f => f != null));
+                            .Where(f => f != null 
+                            && !f.ConfigFilePath.Equals(Path.GetFullPath(Path.Combine(root, configFileName ?? "")))));
                 }
 
                 if (loadAppDataSettings)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -154,7 +154,7 @@ namespace NuGet.Configuration
                         GetSettingsFileNames(root)
                             .Select(f => ReadSettings(root, f))
                             .Where(f => f != null 
-                            && !f.ConfigFilePath.Equals(Path.GetFullPath(Path.Combine(root, configFileName ?? "")))));
+                            && !f.ConfigFilePath.Equals(Path.GetFullPath(Path.Combine(root, configFileName ?? "")), StringComparison.OrdinalIgnoreCase)));
                 }
 
                 if (loadAppDataSettings)

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -166,12 +166,9 @@ namespace NuGet.Configuration
 
                 if (machineWideSettings != null)
                 {
-                    // In order to avoid duplicate settings
-                    // Exclude specified configFile from machine wide config files
                     validSettingFiles.AddRange(
                         machineWideSettings.Settings.Select(
-                            s => new Settings(s.Root, s.ConfigFileName, s.IsMachineWideSettings))
-                            .Where(f => !ConfigPathComparer(f.ConfigFilePath, Path.Combine(root, configFileName?? string.Empty))));
+                            s => new Settings(s.Root, s.ConfigFileName, s.IsMachineWideSettings)));
                 }
 
                 if (validSettingFiles == null

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -147,6 +147,8 @@ namespace NuGet.Configuration
         {
             {
                 // Walk up the tree to find a config file; also look in .nuget subdirectories
+                // In order to avoid duplicate settings
+                // Exclude specified configeFile from hierarchy Config
                 var validSettingFiles = new List<Settings>();
                 if (root != null)
                 {
@@ -154,7 +156,7 @@ namespace NuGet.Configuration
                         GetSettingsFileNames(root)
                             .Select(f => ReadSettings(root, f))
                             .Where(f => f != null 
-                            && !f.ConfigFilePath.Equals(Path.GetFullPath(Path.Combine(root, configFileName ?? "")), StringComparison.OrdinalIgnoreCase)));
+                            && !f.ConfigFilePath.Equals(Path.Combine(root, configFileName ?? "").ToString(), StringComparison.OrdinalIgnoreCase)));
                 }
 
                 if (loadAppDataSettings)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1913,51 +1913,6 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void AddPackageSourcesWithMachineWideConfigFile()
-        {
-
-            using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())
-            {
-                // Arrange
-                var configContents =
-                     @"<?xml version=""1.0""?>
-<configuration>
-<packageSources>
-    <add key='NuGet.org' value='https://NuGet.org' />
-</packageSources>
-</configuration>
-";
-                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"), configContents);
-                var machineWideSetting = new Settings(mockBaseDirectory.Path, "NuGet.config", true);
-                var m = new Mock<IMachineWideSettings>();
-                m.SetupGet(obj => obj.Settings).Returns(new List<Settings> { machineWideSetting });
-
-                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
-                   configFileName: "NuGet.config",
-                   machineWideSettings: m.Object,
-                   loadAppDataSettings: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
-
-                // Act
-                List<PackageSource> sources = packageSourceProvider.LoadPackageSources().ToList();
-                sources.Add(new PackageSource("https://test.org", "test"));
-                packageSourceProvider.SavePackageSources(sources);
-
-                // Assert
-                Assert.Equal(
-                      @"<?xml version=""1.0"" encoding=""utf-8""?>
-<configuration>
-<packageSources>
- <add key=""NuGet.org"" value=""https://NuGet.org"" />
- <add key=""test"" value=""https://test.org"" />
-</packageSources>
-</configuration>
-".Replace("\r\n", "\n"),
-                  File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")).Replace("\r\n", "\n"));
-            }
-        }
-
-        [Fact]
         public void SavePackageSources_AddDisabledSourceToTheConfigContainingSource()
         {
             using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1913,6 +1913,51 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void AddPackageSourcesWithMachineWideConfigFile()
+        {
+
+            using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0""?>
+<configuration>
+<packageSources>
+    <add key='NuGet.org' value='https://NuGet.org' />
+</packageSources>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"), configContents);
+                var machineWideSetting = new Settings(mockBaseDirectory.Path, "NuGet.config", true);
+                var m = new Mock<IMachineWideSettings>();
+                m.SetupGet(obj => obj.Settings).Returns(new List<Settings> { machineWideSetting });
+
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                   configFileName: "NuGet.config",
+                   machineWideSettings: m.Object,
+                   loadAppDataSettings: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                List<PackageSource> sources = packageSourceProvider.LoadPackageSources().ToList();
+                sources.Add(new PackageSource("https://test.org", "test"));
+                packageSourceProvider.SavePackageSources(sources);
+
+                // Assert
+                Assert.Equal(
+                      @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+<packageSources>
+ <add key=""NuGet.org"" value=""https://NuGet.org"" />
+ <add key=""test"" value=""https://test.org"" />
+</packageSources>
+</configuration>
+".Replace("\r\n", "\n"),
+                  File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config")).Replace("\r\n", "\n"));
+            }
+        }
+
+        [Fact]
         public void SavePackageSources_AddDisabledSourceToTheConfigContainingSource()
         {
             using (var mockBaseDirectory = TestFilesystemUtility.CreateRandomTestFolder())


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/998
the root casue of this bug is settings loaded same config file twice.
 when user use nuget.exe sources add command to add source to local config file by using -ConfigFile,
 and if config file name is NuGet.config, loadAppDataConfig and hierarchy Config search will add same config file to settings twice.(also exist in 2.8.6)
 in this case, when we add a new source to the config file, for first setting, it will add source and save, for second setting, no new source and save. becasue they are same config file, so the second one overwrite the first one.

the fix is never add user speficific config to settings during hierarchy config search.
