### PR TITLE
Fix a case where  An entry with the same key already exists is throws during installation

### DIFF
--- a/src/NuGet.Core/NuGet.Resolver/Properties/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Resolver/Properties/Strings.Designer.cs
@@ -186,6 +186,22 @@ namespace NuGet.Resolver
             return string.Format(CultureInfo.CurrentCulture, GetString("VersionIsNotCompatible"), p0, p1);
         }
 
+        /// <summary>
+        /// The package '{0}' version '{1}' declared a duplicate dependency '{2}'. This might mean the package is corrupt or the server metadata for the package is corrupt.
+        /// </summary>
+        internal static string DuplicateDependencyIdsError
+        {
+            get { return GetString("DuplicateDependencyIdsError"); }
+        }
+
+        /// <summary>
+        /// The package '{0}' version '{1}' declared a duplicate dependency '{2}'. This might mean the package is corrupt or the server metadata for the package is corrupt.
+        /// </summary>
+        internal static string FormatDuplicateDependencyIdsError(object p0, object p1, object p2)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateDependencyIdsError"), p0, p1, p2);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/NuGet.Core/NuGet.Resolver/ResolverPackage.cs
+++ b/src/NuGet.Core/NuGet.Resolver/ResolverPackage.cs
@@ -44,6 +44,11 @@ namespace NuGet.Resolver
                 _dependencyIds = new SortedDictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase);
                 foreach (var dependency in dependencies)
                 {
+                    if (_dependencyIds.ContainsKey(dependency.Id))
+                    {
+                        throw new InvalidOperationException(Strings.FormatDuplicateDependencyIdsError(id, version, dependency.Id));
+                    }
+
                     _dependencyIds.Add(dependency.Id, dependency.VersionRange == null ? VersionRange.All : dependency.VersionRange);
                 }
             }

--- a/src/NuGet.Core/NuGet.Resolver/Strings.resx
+++ b/src/NuGet.Core/NuGet.Resolver/Strings.resx
@@ -123,6 +123,9 @@
   <data name="DependencyConstraint" xml:space="preserve">
     <value>constraint</value>
   </data>
+  <data name="DuplicateDependencyIdsError" xml:space="preserve">
+    <value>The package '{0}' version '{1}' declared a duplicate dependency '{2}'. This might mean the package is corrupt or the server metadata for the package is corrupt.</value>
+  </data>
   <data name="FatalError" xml:space="preserve">
     <value>A fatal error occured while resolving dependencies.</value>
   </data>


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/1412

A server (or package) might incorrectly return multiple dependencies in the same package.
Although this can be ignored using distinct. It indicates that something is very wrong with the package.

We know of at least one server that combines dependencies, which leads to unrelated dependencies and versions in the same dependency group.

Hence the fix is to throw a better error message.
