### PR TITLE
nuget.exe: Fix the strings for add and init commands once the docs PR is signed-off

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -70,7 +70,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the fileSourceFolder to which the nupkg will be added. http sources are not supported..
+        ///   Looks up a localized string similar to Specifies the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported..
         /// </summary>
         internal static string AddCommandSourceDescription {
             get {
@@ -79,7 +79,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specify the path to the package to be added to the specified file source..
+        ///   Looks up a localized string similar to Specifies the path to the package to be added and the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported..
         /// </summary>
         internal static string AddCommandUsageDescription {
             get {
@@ -99,7 +99,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;packagePath&gt; -Source &lt;fileSourceFolder&gt; [options].
+        ///   Looks up a localized string similar to &lt;packagePath&gt; -Source &lt;folderBasedPackageSource&gt; [options].
         /// </summary>
         internal static string AddCommandUsageSummary {
             get {
@@ -3159,7 +3159,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adds all the packages from the &lt;srcFeed&gt; to the hierarchical &lt;destFeed&gt;. http feeds are not supported. For more info, goto https://docs.nuget.org/consume/command-line-reference#init-command..
+        ///   Looks up a localized string similar to Adds all the packages from the &lt;srcPackageSourcePath&gt; to the hierarchical &lt;destPackageSourcePath&gt;. http feeds are not supported. For more info, goto https://docs.nuget.org/consume/command-line-reference#init-command..
         /// </summary>
         internal static string InitCommandDescription {
             get {
@@ -3168,16 +3168,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the fileSourceFolder. Cannot be an http source..
-        /// </summary>
-        internal static string InitCommandSourceDescription {
-            get {
-                return ResourceManager.GetString("InitCommandSourceDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Specify the path to the feed to be added to the specified destination feed.
+        ///   Looks up a localized string similar to Specify the path to source package source to be copied from and the path to the destination package source to be copied to..
         /// </summary>
         internal static string InitCommandUsageDescription {
             get {
@@ -3188,7 +3179,7 @@ namespace NuGet.CommandLine {
         /// <summary>
         ///   Looks up a localized string similar to nuget init c:\foo c:\bar
         ///
-        ///nuget add \\foo\packages \\bar\packages.
+        ///nuget init \\foo\packages \\bar\packages.
         /// </summary>
         internal static string InitCommandUsageExamples {
             get {
@@ -3197,7 +3188,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;srcFeedPath&gt; &lt;destFeedPath&gt; [options].
+        ///   Looks up a localized string similar to &lt;srcPackageSourcePath&gt; &lt;destPackageSourcePath&gt; [options].
         /// </summary>
         internal static string InitCommandUsageSummary {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5249,7 +5249,7 @@ nuget update -Self</value>
     <value>Adds the given package to a hierarchical source. http sources are not supported. For more info, goto https://docs.nuget.org/consume/command-line-reference#add-command.</value>
   </data>
   <data name="AddCommandUsageDescription" xml:space="preserve">
-    <value>Specify the path to the package to be added to the specified file source.</value>
+    <value>Specifies the path to the package to be added and the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported.</value>
   </data>
   <data name="AddCommandUsageExamples" xml:space="preserve">
     <value>nuget add foo.nupkg  -Source c:\bar\
@@ -5257,27 +5257,24 @@ nuget update -Self</value>
 nuget add foo.nupkg -Source \\bar\packages\</value>
   </data>
   <data name="AddCommandUsageSummary" xml:space="preserve">
-    <value>&lt;packagePath&gt; -Source &lt;fileSourceFolder&gt; [options]</value>
+    <value>&lt;packagePath&gt; -Source &lt;folderBasedPackageSource&gt; [options]</value>
   </data>
   <data name="AddCommandSourceDescription" xml:space="preserve">
-    <value>Specifies the fileSourceFolder to which the nupkg will be added. http sources are not supported.</value>
+    <value>Specifies the package source, which is a folder or UNC share, to which the nupkg will be added. Http sources are not supported.</value>
   </data>
   <data name="InitCommandDescription" xml:space="preserve">
-    <value>Adds all the packages from the &lt;srcFeed&gt; to the hierarchical &lt;destFeed&gt;. http feeds are not supported. For more info, goto https://docs.nuget.org/consume/command-line-reference#init-command.</value>
-  </data>
-  <data name="InitCommandSourceDescription" xml:space="preserve">
-    <value>Specifies the fileSourceFolder. Cannot be an http source.</value>
+    <value>Adds all the packages from the &lt;srcPackageSourcePath&gt; to the hierarchical &lt;destPackageSourcePath&gt;. http feeds are not supported. For more info, goto https://docs.nuget.org/consume/command-line-reference#init-command.</value>
   </data>
   <data name="InitCommandUsageDescription" xml:space="preserve">
-    <value>Specify the path to the feed to be added to the specified destination feed</value>
+    <value>Specify the path to source package source to be copied from and the path to the destination package source to be copied to.</value>
   </data>
   <data name="InitCommandUsageExamples" xml:space="preserve">
     <value>nuget init c:\foo c:\bar
 
-nuget add \\foo\packages \\bar\packages</value>
+nuget init \\foo\packages \\bar\packages</value>
   </data>
   <data name="InitCommandUsageSummary" xml:space="preserve">
-    <value>&lt;srcFeedPath&gt; &lt;destFeedPath&gt; [options]</value>
+    <value>&lt;srcPackageSourcePath&gt; &lt;destPackageSourcePath&gt; [options]</value>
   </data>
   <data name="ExpandDescription" xml:space="preserve">
     <value>If provided, a package added to offline feed is also expanded.</value>


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1736

This updates the nuget.exe strings based on comments from the
Docs PR: https://github.com/NuGet/NuGetDocs/pull/387/files

@emgarten @csharpfritz @yishaigalatzer 
