### PR TITLE
Update xunit to 2.1.0

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
-  <package id="xunit.runner.msbuild" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.msbuild" version="2.1.0" targetFramework="net45" />
   <package id="NuGet.MsBuild.Integration" version="3.1.0-beta-001" targetFramework="net45" />
 </packages>

--- a/build/test.targets
+++ b/build/test.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<UsingTask AssemblyFile="$(MsBuildThisFileDirectory)..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-<Target Name="RunTests">
+<UsingTask AssemblyFile="$(MsBuildThisFileDirectory)..\packages\xunit.runner.msbuild.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
+<Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' " >
 	<ItemGroup>
 		<Line Include="&lt;configuration&gt;&lt;appSettings&gt;
 &lt;add key=&quot;TargetDir&quot; value=&quot;$(TargetDir)&quot;/&gt;
@@ -11,11 +11,7 @@
 		Lines="@(Line)"			
 		Overwrite="true"
 		/>
-
-		<Message Text="Running tests synchronously for $(TargetDir)$(AssemblyName).dll" Importance="high" />
-		<xunit Assemblies="$(TargetDir)$(AssemblyName).dll" MaxParallelThreads="1" Condition=" $(XUnitDisableRunInParallel) == 'true' " />
-		
-		<Message Text="Running tests in parallel for $(TargetDir)$(AssemblyName).dll" Importance="high" />
-		<xunit Assemblies="$(TargetDir)$(AssemblyName).dll" MaxParallelThreads="4" Condition=" $(XUnitDisableRunInParallel) == '' OR $(XUnitDisableRunInParallel) == 'false' " />
+		<Message Text="Running tests for $(TargetDir)$(AssemblyName).dll" Importance="high" />
+		<xunit Assemblies="$(TargetDir)$(AssemblyName).dll" />
 </Target>
 </Project>

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -4,7 +4,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "xunit": "2.1.0-rc1-build3168"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -8,7 +8,7 @@
     "NuGet.ProjectManagement": "3.3.0-*",
     "NuGet.Protocol.VisualStudio": "3.3.0-*",
     "Microsoft.VisualStudio.ProjectSystem.Interop": "",
-    "xunit": "2.1.0-rc1-build3168",
+    "xunit": "2.1.0",
     "NuGet.Test.Utility": "3.3.0-*"
   },
   "frameworks": {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
-    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -50,6 +49,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -108,16 +110,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\test.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
-  <UsingTask AssemblyFile="..\..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-  <Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' ">
-    <xunit Assemblies="bin\$(Configuration)\$(AssemblyName).dll" MaxParallelThreads="1" ParallelizeTestCollections="false" />
-  </Target>
   <PropertyGroup>
     <PostBuildEvent>xcopy /diy $(SolutionDir)test\TestExtensions\TestablePluginCredentialProvider\$(OutDir). $(TargetDir)TestableCredentialProvider</PostBuildEvent>
   </PropertyGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/xunit.runner.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "maxParallelThreads": 1
+}

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
-    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -73,14 +72,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\sign.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
-  <UsingTask AssemblyFile="..\..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-  <Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' ">
-    <xunit Assemblies="bin\$(Configuration)\$(AssemblyName).dll" MaxParallelThreads="1" ParallelizeTestCollections="false" />
-  </Target>
+  <Import Project="..\..\..\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerProvider.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerProvider.Test.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
-    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -73,14 +72,4 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\test.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
-  <UsingTask AssemblyFile="..\..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-  <Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' ">
-    <xunit Assemblies="bin\$(Configuration)\$(AssemblyName).dll" MaxParallelThreads="1" ParallelizeTestCollections="false" />
-  </Target>
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/NuGet.VsExtension.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/NuGet.VsExtension.Test.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
-    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -81,14 +80,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\sign.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
-  <UsingTask AssemblyFile="..\..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-  <Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' ">
-    <xunit Assemblies="bin\$(Configuration)\$(AssemblyName).dll" MaxParallelThreads="1" ParallelizeTestCollections="false" />
-  </Target>
+  <Import Project="..\..\..\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/PackageManagement.UI.Test/PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/PackageManagement.UI.Test/PackageManagement.UI.Test.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
-    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -62,14 +61,4 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\test.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(PackagesPath)\xunit.core\2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
-  </Target>
-  <UsingTask AssemblyFile="..\..\..\packages\xunit.runner.msbuild.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
-  <Target Name="RunTests" AfterTargets="Build" Condition=" '$(RunTests)' == 'true' ">
-    <xunit Assemblies="bin\$(Configuration)\$(AssemblyName).dll" MaxParallelThreads="1" ParallelizeTestCollections="false" />
-  </Target>
 </Project>

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "NuGet.Client": "3.3.0-*",
     "NuGet.Test.Utility": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191",
     "Microsoft.Framework.Runtime": "1.0.0-beta6"
   },
   "commands": {

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -4,18 +4,13 @@
     "NuGet.Client": "3.3.0-*",
     "NuGet.Test.Utility": "3.3.0-*",
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-beta6-build191",
-    "Microsoft.Framework.Runtime": "1.0.0-beta6"
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "dnx451": { },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Runtime.Serialization.Primitives": "4.0.10-beta-23109"
-      }
-    }
+    "dnxcore50": { }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -4,18 +4,13 @@
     "NuGet.Commands": "3.3.0-*",
     "NuGet.Test.Utility": "3.3.0-*",
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-beta6-build191",
-    "Microsoft.Framework.Runtime": "1.0.0-beta6"
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "dnx451": {},
-    "dnxcore50": {
-      "dependencies": {
-        "System.Runtime.Serialization.Primitives": "4.0.10-beta-23109"
-      }
-    }
+    "dnxcore50": {}
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "NuGet.Commands": "3.3.0-*",
     "NuGet.Test.Utility": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191",
     "Microsoft.Framework.Runtime": "1.0.0-beta6"
   },
   "commands": {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "NuGet.Configuration": "3.3.0-*",
     "Moq": "4.2.1409.1722",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -2,8 +2,8 @@
   "version": "1.0.0-*",
   "dependencies": {
     "NuGet.DependencyResolver.Core": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -2,8 +2,8 @@
   "version": "1.0.0-*",
   "dependencies": {
     "NuGet.DependencyResolver": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "NuGet.Frameworks": "3.3.0-*",
     "NuGet.Packaging": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
 	"NuGet.PackageManagement": "3.3.0-*",
     "Test.Utility": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -2,8 +2,8 @@
   "version": "3.3.0-*",
   "dependencies": {
     "NuGet.Packaging.Core": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageFolderReaderTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.Test
             {
                 // Assert
                 Assert.NotNull(nuspec);
-                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+                Assert.Equal(5, nuspec.Length);
             }
         }
 
@@ -71,7 +71,7 @@ namespace NuGet.Packaging.Test
             {
                 // Assert
                 Assert.NotNull(nuspec);
-                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+                Assert.Equal(5, nuspec.Length);
             }
         }
 
@@ -253,7 +253,7 @@ namespace NuGet.Packaging.Test
             {
                 // Assert
                 Assert.NotNull(nuspec);
-                Assert.Equal(5, nuspec.ReadAllBytes().Count());
+                Assert.Equal(5, nuspec.Length);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -30,11 +30,11 @@ namespace NuGet.Packaging.Test
             var reader = new PackageReader(stream);
 
             // Act
-            var nuspec = reader.GetNuspec();
+            var nuspec = new BinaryReader(reader.GetNuspec());
 
             // Assert
             Assert.NotNull(nuspec);
-            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            Assert.Equal(5, nuspec.ReadBytes(4096).Length);
         }
 
         [Fact]
@@ -52,11 +52,11 @@ namespace NuGet.Packaging.Test
             var reader = new PackageReader(stream);
 
             // Act
-            var nuspec = reader.GetNuspec();
+            var nuspec = new BinaryReader(reader.GetNuspec());
 
             // Assert
             Assert.NotNull(nuspec);
-            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            Assert.Equal(5, nuspec.ReadBytes(4096).Length);
         }
 
         [Fact]
@@ -189,11 +189,11 @@ namespace NuGet.Packaging.Test
             var reader = new PackageReader(stream);
 
             // Act
-            var nuspec = reader.GetNuspec();
+            var nuspec = new BinaryReader(reader.GetNuspec());
 
             // Assert
             Assert.NotNull(nuspec);
-            Assert.Equal(5, nuspec.ReadAllBytes().Count());
+            Assert.Equal(5, nuspec.ReadBytes(4096).Length);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "NuGet.Packaging": "3.3.0-*",
     "NuGet.Test.Utility": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -2,8 +2,8 @@
   "version": "3.3.0-*",
   "dependencies": {
 	"NuGet.ProjectManagement": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191",
     "Test.Utility": "3.3.0-*"
   },
   "commands": {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -2,8 +2,8 @@
   "version": "3.3.0-*",
   "dependencies": {
     "NuGet.ProjectModel": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191",
     "Microsoft.Framework.Runtime": "1.0.0-beta6"
   },
   "commands": {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -3,18 +3,13 @@
   "dependencies": {
     "NuGet.ProjectModel": "3.3.0-*",
     "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-beta6-build191",
-    "Microsoft.Framework.Runtime": "1.0.0-beta6"
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
     "dnx451": {},
-    "dnxcore50": {
-      "dependencies": {
-        "System.Runtime.Serialization.Primitives": "4.0.10-beta-23109"
-      }
-    }
+    "dnxcore50": {}
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v2.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v2.Tests/project.json
@@ -3,8 +3,8 @@
     "Moq": "4.2.1408.0717",
     "NuGet.Protocol.Core.v2": "3.3.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -3,8 +3,8 @@
     "Moq": "4.2.1408.0717",
     "NuGet.Protocol.Core.v3": "3.3.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -3,8 +3,8 @@
   "dependencies": {
     "NuGet.Protocol.VisualStudio": "3.3.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -2,8 +2,8 @@
   "version": "3.3.0-*",
   "dependencies": {
     "NuGet.Resolver": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -2,8 +2,8 @@
   "version": "3.3.0-*",
   "dependencies": {
     "NuGet.RuntimeModel": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
     "NuGet.Versioning": "3.3.0-*",
-    "xunit": "2.1.0-rc1-build3168",
-    "xunit.runner.dnx": "2.1.0-beta5-build169"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-beta6-build191"
   },
   "commands": {
     "test": "xunit.runner.dnx"


### PR DESCRIPTION
Update from the prerelease version of xunit to xunit 2.1.0 stable.

I've removed the msbuild properties around disabling parallel tests and replaced it with xunit.runner.json for the command line. The others were running synchronously but can run in parallel.

Everything now uses test.targets so that the reference to xunit is in one file.

This change also fixes: https://github.com/NuGet/Home/issues/1070
