### PR TITLE
Fix Nuget Update command to respect repositoryPath in nuget.config

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -324,10 +325,15 @@ namespace NuGet.CommandLine
         {
             string packagesDir = RepositoryPath;
 
-            if (String.IsNullOrEmpty(packagesDir) &&
-                !String.IsNullOrEmpty(solutionDir))
+            if (String.IsNullOrEmpty(packagesDir))
             {
-                packagesDir = Path.Combine(solutionDir, CommandLineConstants.PackagesDirectoryName);
+                // Try and get the packages folder from the nuget.config file otherwise full back to assuming it's <solution>\'packages'.
+                packagesDir = SettingsUtility.GetRepositoryPath(Settings);
+                if (String.IsNullOrEmpty(packagesDir) &&
+                    !String.IsNullOrEmpty(solutionDir))
+                {
+                    packagesDir = Path.Combine(solutionDir, CommandLineConstants.PackagesDirectoryName);
+                }
             }
 
             return GetPackagesDirectory(packagesDir);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -418,6 +418,19 @@ namespace NuGet.CommandLine.Test
             doc.Save(existingConfig);
         }
 
+        public static void CreateNuGetConfig(string workingPath, List<string> sources, string packagesPath)
+        {
+            CreateNuGetConfig(workingPath, sources);
+            var existingConfig = Path.Combine(workingPath, "NuGet.Config");
+
+            var doc = XDocument.Load(existingConfig);
+            var config = doc.Descendants(XName.Get("config")).FirstOrDefault();
+            var repositoryPath = config.Descendants().First(x => x.Name == "add" && x.Attribute("key").Value == "repositoryPath").Attribute("value");
+            repositoryPath.SetValue(packagesPath);
+
+            doc.Save(existingConfig);
+        }
+
         /// <summary>
         /// Create a simple package with a lib folder. This package should install everywhere.
         /// The package will be removed from the machine cache upon creation


### PR DESCRIPTION
Executing the following command line:

```
nuget update mysolution.sln
```

will update all the packages in a solution.  However, if there is custom `repositoryPath` specified in a nuget.config, it will error with `Unable to locate the packages folder. Try specifying it using the repositoryPath switch`.  Updating a single package (with a project file) works as expected.

This Pull Request is a simple update to ensure that a custom `packages` folder is respected.  It will fallback to assuming `SolutionDir+"\packages"` if no config file is present.
