### PR TITLE
Replace backslashes with Path.DirectorySeparatorChar in SettingsUtility

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -11,8 +11,8 @@ namespace NuGet.Configuration
         public const string ConfigSection = "config";
         public const string GlobalPackagesFolderKey = "globalPackagesFolder";
         public const string GlobalPackagesFolderEnvironmentKey = "NUGET_PACKAGES";
-        public const string DefaultGlobalPackagesFolderPath = ".nuget\\packages\\";
         public const string RepositoryPathKey = "repositoryPath";
+        public static readonly string DefaultGlobalPackagesFolderPath = Path.Combine(".nuget", "packages") + Path.DirectorySeparatorChar;
 
         public static string GetRepositoryPath(ISettings settings)
         {


### PR DESCRIPTION
NuGet would create a folder `~/.nuget\packages\` on non-Windows machines before.

Fixes https://github.com/NuGet/Home/issues/1517
