### PR TITLE
Fix issue NuGet/Home#1608: NuGet is creating lots of temp files in %T…

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -423,19 +423,29 @@ namespace NuGet.CommandLine
                 do
                 {
                     _filePath = Path.Combine(directory, Path.GetRandomFileName() + extension);
+
+                    if (!File.Exists(_filePath))
+                    {
+                        try
+                        {
+                            // create an empty file
+                            using (var filestream = File.Open(_filePath, FileMode.CreateNew))
+                            {
+                            }
+
+                            // file is created successfully.
+                            return;
+                        }
+                        catch
+                        {
+                        }
+                    }
+
                     count++;
                 }
-                while (File.Exists(_filePath) && count < 3);
-
-                if (count == 3)
-                {
-                    throw new InvalidOperationException("Failed to create a random file.");
-                }
-
-                // create an empty file
-                using (var filestream = File.Open(_filePath, FileMode.CreateNew))
-                {
-                }
+                while (count < 3);
+                
+                throw new InvalidOperationException("Failed to create a random file.");                
             }
 
             public static implicit operator string(TempFile f)


### PR DESCRIPTION
…EMP%, which eventually fails after there is 65,536 of them.

The fix uses Path.GetRandomFileName() instead of Path.GetTempFileName().

Yishai will fix temp file generation in nuget.core.

@yishaigalatzer @MeniZalzman @emgarten @deepakaravindr 
