### PR TITLE
Fixes "Disabled feed "Microsoft and .NET" gets enabled after running nuget.exe"

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -530,6 +530,18 @@ namespace NuGet.Configuration
                 sourcesToDisable.Add(new SettingValue(source.Name, "true", origin: null, isMachineWide: true, priority: 0));
             }
 
+            // add entries to the disablePackageSource for disabled package sources that are not in loaded 'sources'
+            foreach (var setting in existingDisabledSources)
+            {
+                if (!sourcesToDisable.Any(
+                    s => s.Key == setting.Key
+                    && s.Priority == setting.Priority
+                    && s.IsMachineWide == setting.IsMachineWide))
+                {
+                    sourcesToDisable.Add(setting);
+                }
+            }
+
             // Write the updates to the nearest settings file.
             Settings.UpdateSections(ConfigurationContants.PackageSources, sourceSettings);
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1374

Disabled Machine wide package sources specific to VS, get enabled when
running nuget.exe sources add.

Reason: Machine wide package sources specific to Visual Studio
do not get loaded in the context of nuget.exe. However, they may be
disabled on the NuGet.Config at %APPDATA%. When saving package sources,
only sources that are loaded in the context of the client, are eligible for
being disable. This is incorrect

Fix: Every disabled package source element in a nuget.config
should be added back whether or not it is a loaded package source
in the context of the current client

Added a new unit test for this scenario. Tested it manually. And, tested
that all the existing tests run successfully.

@yishaigalatzer @emgarten @feiling @zhili1208 
