### PR TITLE
Fixes "NuGet -verbosity quiet doesn't show errors and warnings"

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -79,7 +79,7 @@ namespace NuGet.Common
 
         private TextWriter Out
         {
-            get { return System.Console.Out; }
+            get { return Verbosity == Verbosity.Quiet ? TextWriter.Null : System.Console.Out; }
         }
 
         public void Write(object value)
@@ -183,7 +183,7 @@ namespace NuGet.Common
                                  ? String.Format(CultureInfo.CurrentCulture, LocalizedResourceManager.GetString("CommandLine_Warning"), value)
                                  : value;
 
-            WriteColor(Out, ConsoleColor.Yellow, message, args);
+            WriteColor(System.Console.Out, ConsoleColor.Yellow, message, args);
         }
 
         public void WriteLine(ConsoleColor color, string value, params object[] args)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -79,7 +79,7 @@ namespace NuGet.Common
 
         private TextWriter Out
         {
-            get { return Verbosity == Verbosity.Quiet ? TextWriter.Null : System.Console.Out; }
+            get { return System.Console.Out; }
         }
 
         public void Write(object value)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
@@ -179,6 +179,29 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Fact]
+        public void TestVerbosityQuiet_ShowsWarnings()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            var args = new string[] {
+                    "config",
+                    "nonExistentKey",
+                    "-Verbosity",
+                    "Quiet"
+            };
+
+            // Act
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert
+            Util.VerifyResultSuccess(result, "WARNING: Key 'nonExistentKey' not found.");
+        }
+
         private void AssertEqualCollections(IList<Configuration.SettingValue> actual, string[] expected)
         {
             Assert.Equal(actual.Count, expected.Length / 2);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -86,6 +86,45 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void TestVerbosityQuiet_ShowsErrorMessages()
+        {
+            var randomTestFolder = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var nugetexe = Util.GetNuGetExePath();
+                var solutionPath = Path.Combine(randomTestFolder, "solution.sln");
+
+                var args = new string[]
+                {
+                    "restore",
+                    solutionPath,
+                    "-PackagesDirectory",
+                    randomTestFolder,
+                    "-Verbosity",
+                    "Quiet"
+                };
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                // Assert
+                Assert.NotEqual(0, r.Item1);
+                var error = r.Item3;
+                Assert.Contains("could not find a part of the path", r.Item3, StringComparison.OrdinalIgnoreCase);
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(randomTestFolder);
+            }
+        }
+
+        [Fact]
         public void RestoreCommand_MissingPackagesConfigFile()
         {
             var randomTestFolder = TestFilesystemUtility.CreateRandomTestFolder();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -202,5 +202,39 @@ namespace NuGet.CommandLine.Test
                 }
             }
         }
+
+        [Fact]
+        public void TestVerbosityQuiet_DoesNotShowInfoMessages()
+        {
+            using (var preserver = new DefaultConfigurationFilePreserver())
+            {
+                // Arrange
+                var nugetexe = Util.GetNuGetExePath();
+                string[] args = new string[] {
+                    "sources",
+                    "Add",
+                    "-Name",
+                    "test_source",
+                    "-Source",
+                    "http://test_source",
+                    "-Verbosity",
+                    "Quiet"
+                };
+
+                // Act
+                // Set the working directory to C:\, otherwise,
+                // the test will change the nuget.config at the code repo's root directory
+                // And, will fail since global nuget.config is updated
+                var result = CommandRunner.Run(nugetexe, @"c:\", string.Join(" ", args), true);
+
+                // Assert
+                Util.VerifyResultSuccess(result);
+                // Ensure that no messages are shown with Verbosity as Quiet
+                Assert.Equal(string.Empty, result.Item2);
+                var settings = Configuration.Settings.LoadDefaultSettings(null, null, null);
+                var source = settings.GetValue("packageSources", "test_source");
+                Assert.Equal("http://test_source", source);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1648
Should not use a null TextWriter when Verbosity is Quiet.

By default, all the info messages are shown along with errors and warnings. Because, default Verbosity is normal. However, when '-Verbosity Quiet' is used, no messages are shown. This is the bug.

Sample snapshot is shared below based on the 'init' command. 

![image](https://cloud.githubusercontent.com/assets/2380340/11352940/5727c008-91f4-11e5-9f89-415c16cca243.png)

After a fix, it will look like the following. Note that warning messages are shown with Verbosity as Quiet.

![image](https://cloud.githubusercontent.com/assets/2380340/11353139/5dfdfc16-91f5-11e5-8ceb-8ddb3de0c70c.png)

@yishaigalatzer @emgarten @zhili1208 @feiling 
