### PR TITLE
Improve concurrency controls for project.json restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/CommandOutputLogger.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/CommandOutputLogger.cs
@@ -24,7 +24,6 @@ namespace NuGet.CommandLine
 
         private LogLevel Verbosity { get { return _verbosity.Value; } }
 
-
         internal CommandOutputLogger()
         {
             _verbosity = new Lazy<LogLevel>(() => LogLevel.Verbose);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
@@ -26,6 +26,12 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
         private readonly Func<Task<HttpHandlerResource>> _messageHandlerFactory;
         private readonly Uri _baseUri;
 
+        private const int ConcurrencyLimit = 128;
+
+        // Limiting concurrent requests to limit the amount of files open at a time on Mac OSX
+        // the default is 256 which is easy to hit if we don't limit concurrency
+        private readonly static SemaphoreSlim _throttle = new SemaphoreSlim(ConcurrencyLimit);
+
         public HttpSource(string sourceUrl, Func<Task<HttpHandlerResource>> messageHandlerFactory)
         {
             _baseUri = new Uri(sourceUrl);
@@ -51,83 +57,94 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                 return result;
             }
 
-            Logger.LogVerbose(string.Format(CultureInfo.InvariantCulture, "  {0} {1}.", "GET", uri));
-
-            ICredentials credentials = CredentialStore.Instance.GetCredentials(_baseUri);
-
-            var retry = true;
-            while (retry)
+            try
             {
-                var handlerResource = await _messageHandlerFactory();
+                await _throttle.WaitAsync();
 
-                using (var client = new DataClient(handlerResource))
+                Logger.LogVerbose($"Current http requests queued: {_throttle.CurrentCount + 1}");
+
+                Logger.LogVerbose(string.Format(CultureInfo.InvariantCulture, "  {0} {1}.", "GET", uri));
+
+                ICredentials credentials = CredentialStore.Instance.GetCredentials(_baseUri);
+
+                var retry = true;
+                while (retry)
                 {
-                    if (credentials != null)
-                    {
-                        handlerResource.ClientHandler.Credentials = credentials;
-                    }
-                    else
-                    {
-                        handlerResource.ClientHandler.UseDefaultCredentials = true;
-                    }
+                    var handlerResource = await _messageHandlerFactory();
 
-                    var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                    STSAuthHelper.PrepareSTSRequest(_baseUri, CredentialStore.Instance, request);
-
-                    // Read the response headers before reading the entire stream to avoid timeouts from large packages.
-                    using (var response = await client.SendAsync(
-                        request,
-                        HttpCompletionOption.ResponseHeadersRead,
-                        cancellationToken))
+                    using (var client = new DataClient(handlerResource))
                     {
-                        if (ignoreNotFounds && response.StatusCode == HttpStatusCode.NotFound)
+                        if (credentials != null)
                         {
-                            Logger.LogInformation(string.Format(CultureInfo.InvariantCulture,
+                            handlerResource.ClientHandler.Credentials = credentials;
+                        }
+                        else
+                        {
+                            handlerResource.ClientHandler.UseDefaultCredentials = true;
+                        }
+
+                        var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                        STSAuthHelper.PrepareSTSRequest(_baseUri, CredentialStore.Instance, request);
+
+                        // Read the response headers before reading the entire stream to avoid timeouts from large packages.
+                        using (var response = await client.SendAsync(
+                            request,
+                            HttpCompletionOption.ResponseHeadersRead,
+                            cancellationToken))
+                        {
+                            if (ignoreNotFounds && response.StatusCode == HttpStatusCode.NotFound)
+                            {
+                                Logger.LogInformation(string.Format(CultureInfo.InvariantCulture,
+                                    "  {1} {0} {2}ms", uri, response.StatusCode.ToString(), sw.ElapsedMilliseconds.ToString()));
+                                return new HttpSourceResult();
+                            }
+
+                            if (response.StatusCode == HttpStatusCode.Unauthorized)
+                            {
+                                if (STSAuthHelper.TryRetrieveSTSToken(_baseUri, CredentialStore.Instance, response))
+                                {
+                                    continue;
+                                }
+
+                                if (HttpHandlerResourceV3.PromptForCredentials != null)
+                                {
+                                    credentials = await HttpHandlerResourceV3.PromptForCredentials(_baseUri, cancellationToken).ConfigureAwait(false);
+                                }
+
+                                if (credentials == null)
+                                {
+                                    response.EnsureSuccessStatusCode();
+                                }
+                                else
+                                {
+                                    continue;
+                                }
+                            }
+
+                            retry = false;
+                            response.EnsureSuccessStatusCode();
+
+                            if (HttpHandlerResourceV3.CredentialsSuccessfullyUsed != null && credentials != null)
+                            {
+                                HttpHandlerResourceV3.CredentialsSuccessfullyUsed(_baseUri, credentials);
+                            }
+
+                            await CreateCacheFile(result, response, cacheAgeLimit, cancellationToken);
+
+                            Logger.LogVerbose(string.Format(CultureInfo.InvariantCulture,
                                 "  {1} {0} {2}ms", uri, response.StatusCode.ToString(), sw.ElapsedMilliseconds.ToString()));
-                            return new HttpSourceResult();
+
+                            return result;
                         }
-
-                        if (response.StatusCode == HttpStatusCode.Unauthorized)
-                        {
-                            if (STSAuthHelper.TryRetrieveSTSToken(_baseUri, CredentialStore.Instance, response))
-                            {
-                                continue;
-                            }
-
-                            if (HttpHandlerResourceV3.PromptForCredentials != null)
-                            {
-                                credentials = await HttpHandlerResourceV3.PromptForCredentials(_baseUri, cancellationToken).ConfigureAwait(false);
-                            }
-
-                            if (credentials == null)
-                            {
-                                response.EnsureSuccessStatusCode();
-                            }
-                            else
-                            {
-                                continue;
-                            }
-                        }
-
-                        retry = false;
-                        response.EnsureSuccessStatusCode();
-
-                        if (HttpHandlerResourceV3.CredentialsSuccessfullyUsed != null && credentials != null)
-                        {
-                            HttpHandlerResourceV3.CredentialsSuccessfullyUsed(_baseUri, credentials);
-                        }
-
-                        await CreateCacheFile(result, response, cacheAgeLimit, cancellationToken);
-
-                        Logger.LogVerbose(string.Format(CultureInfo.InvariantCulture,
-                            "  {1} {0} {2}ms", uri, response.StatusCode.ToString(), sw.ElapsedMilliseconds.ToString()));
-
-                        return result;
                     }
                 }
-            }
 
-            return result;
+                return result;
+            }
+            finally
+            {
+                _throttle.Release();
+            }
         }
 
         private static Task CreateCacheFile(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -138,9 +138,9 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         // (2) cache for pages is valid for only 30 min.
                         // So we decide to leave current logic and observe.
                         using (var data = await _httpSource.GetAsync(
-                            uri, 
+                            uri,
                             $"list_{id}_page{page}",
-                            retry == 0 ? CacheContext.ListMaxAgeTimeSpan : TimeSpan.Zero, 
+                            retry == 0 ? CacheContext.ListMaxAgeTimeSpan : TimeSpan.Zero,
                             cancellationToken))
                         {
                             try
@@ -263,10 +263,16 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         cancellationToken))
                     {
                         return new NupkgEntry
-                            {
-                                TempFileName = data.CacheFileName
-                            };
+                        {
+                            TempFileName = data.CacheFileName
+                        };
                     }
+                }
+                catch (TaskCanceledException ex) when (retry == 0)
+                {
+                    // First request can get cancelled if we got the data from elsewhere, no reason to warn.
+                    // Theoretically we can still get
+                    Logger.LogInformation(string.Format("Warning: DownloadPackageAsync: {1}\r\n  {0}", ex.Message, package.ContentUri));
                 }
                 catch (Exception ex)
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -403,7 +403,7 @@ namespace NuGet.CommandLine.Test
 
                 foreach (var package in expectedPackages)
                 {
-                    Assert.True(allPackages.Any(p => p.Id == package.Id 
+                    Assert.True(allPackages.Any(p => p.Id == package.Id
                         && p.Version.ToNormalizedString() == package.Version.ToNormalizedString()));
                 }
 
@@ -1312,11 +1312,12 @@ namespace NuGet.CommandLine.Test
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.Equal(1, hitsByUrl["/index.json"]);
 
-                // PackageE is hit twice, once from packages.config and the other from project.json. 
+                // PackageE is hit twice, once from packages.config and the other from project.json.
                 // The rest should only be hit once.
                 foreach (var url in hitsByUrl.Keys.Where(s => s != "/reg/packagee/index.json"))
                 {
-                    Assert.True(1 == hitsByUrl[url], url);
+                    var hits = hitsByUrl[url];
+                    Assert.True(1 == hits, url + $" was hit {hitsByUrl[url]} times instead of 1");
                 }
             }
         }
@@ -1562,7 +1563,7 @@ namespace NuGet.CommandLine.Test
         {
             return ServerHandler(request,
                 hitsByUrl,
-                server, 
+                server,
                 indexJson,
                 localRepo,
                 new ManualResetEventSlim(true),


### PR DESCRIPTION
This adds concurrency controls to UWP restore, the test was verified by the roslyn team (so they don't see any more timeouts/taskcancelled exceptions)
