### PR TITLE
Fixes the regression with 'nuget sources enable <packageSource>'

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -533,10 +533,13 @@ namespace NuGet.Configuration
             // add entries to the disablePackageSource for disabled package sources that are not in loaded 'sources'
             foreach (var setting in existingDisabledSources)
             {
-                if (!sourcesToDisable.Any(
-                    s => s.Key == setting.Key
-                    && s.Priority == setting.Priority
-                    && s.IsMachineWide == setting.IsMachineWide))
+                // The following code ensures that we do not miss to mark an existing disabled source as disabled.
+                // However, ONLY mark an existing disable source setting as disabled, if,
+                // 1) it is not in the list of loaded package sources, or,
+                // 2) it is not already in the list of sources to disable.
+                if (!sources.Any(s => string.Equals(s.Name, setting.Key, StringComparison.OrdinalIgnoreCase)) &&
+                    !sourcesToDisable.Any(s => string.Equals(s.Key, setting.Key, StringComparison.OrdinalIgnoreCase)
+                                            && s.Priority == setting.Priority))
                 {
                     sourcesToDisable.Add(setting);
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetSourcesCommandTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Test.Utility;
 using Xunit;
 using Xunit.Extensions;
 
@@ -200,6 +201,164 @@ namespace NuGet.CommandLine.Test
                 {
                     File.Delete(configFilePath);
                 }
+            }
+        }
+
+        [Fact]
+        public void SourcesCommandTest_EnableSource()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            var configFileDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            try
+            {
+                var configFileName = "nuget.config";
+                var configFilePath = Path.Combine(configFileDirectory, configFileName);
+
+                Util.CreateFile(configFileDirectory, configFileName,
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""test_source"" value=""http://test_source"" />
+  </packageSources>
+  <disabledPackageSources>
+    <add key=""test_source"" value=""true"" />
+    <add key=""Microsoft and .NET"" value=""true"" />
+  </disabledPackageSources>
+</configuration>");
+
+                string[] args = new string[] {
+                    "sources",
+                    "Enable",
+                    "-Name",
+                    "test_source",
+                    "-ConfigFile",
+                    configFilePath
+                };
+
+                // Act
+                var settings = Configuration.Settings.LoadDefaultSettings(
+                    configFileDirectory,
+                    configFileName,
+                    null);
+                var packageSourceProvider = new Configuration.PackageSourceProvider(settings);
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                Assert.Single(sources);
+
+                var source = sources.Single();
+                Assert.Equal("test_source", source.Name);
+                Assert.Equal("http://test_source", source.Source);
+                Assert.False(source.IsEnabled);
+
+                // Main Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    true);
+
+                // Assert
+                Util.VerifyResultSuccess(result);
+
+                settings = Configuration.Settings.LoadDefaultSettings(
+                    configFileDirectory,
+                    configFileName,
+                    null);
+
+                var disabledSources = settings.GetSettingValues("disabledPackageSources").ToList();
+                Assert.Single(disabledSources);
+                var disabledSource = disabledSources.Single();
+                Assert.Equal("Microsoft and .NET", disabledSource.Key);
+
+                packageSourceProvider = new Configuration.PackageSourceProvider(settings);
+                sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                var testSources = sources.Where(s => s.Name == "test_source");
+                Assert.Single(testSources);
+                source = testSources.Single();
+
+                Assert.Equal("test_source", source.Name);
+                Assert.Equal("http://test_source", source.Source);
+                Assert.True(source.IsEnabled, "Source is not enabled");
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(configFileDirectory);
+            }
+        }
+
+        [Fact]
+        public void SourcesCommandTest_DisableSource()
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+            var configFileDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            try
+            {
+                var configFileName = "nuget.config";
+                var configFilePath = Path.Combine(configFileDirectory, configFileName);
+
+                Util.CreateFile(configFileDirectory, configFileName,
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""test_source"" value=""http://test_source"" />
+  </packageSources>
+</configuration>");
+
+                string[] args = new string[] {
+                    "sources",
+                    "Disable",
+                    "-Name",
+                    "test_source",
+                    "-ConfigFile",
+                    configFilePath
+                };
+
+                // Act
+                var settings = Configuration.Settings.LoadDefaultSettings(
+                    configFileDirectory,
+                    configFileName,
+                    null);
+
+                var packageSourceProvider = new Configuration.PackageSourceProvider(settings);
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                Assert.Single(sources);
+
+                var source = sources.Single();
+                Assert.Equal("test_source", source.Name);
+                Assert.Equal("http://test_source", source.Source);
+                Assert.True(source.IsEnabled);
+
+                // Main Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    true);
+
+                // Assert
+                Util.VerifyResultSuccess(result);
+
+                settings = Configuration.Settings.LoadDefaultSettings(
+                    configFileDirectory,
+                    configFileName,
+                    null);
+
+                packageSourceProvider = new Configuration.PackageSourceProvider(settings);
+                sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                var testSources = sources.Where(s => s.Name == "test_source");
+                Assert.Single(testSources);
+                source = testSources.Single();
+
+                Assert.Equal("test_source", source.Name);
+                Assert.Equal("http://test_source", source.Source);
+                Assert.False(source.IsEnabled, "Source is not disabled");
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(configFileDirectory);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1766.

A disable package source is considered to be missed and needs to be done
explicitly ONLY if

```
1) it is not in the list of loaded package sources, or,
2) it is not already in the list of sources to disable.
```
1. Added a test each for 'nuget.exe sources enable' and 'nuget.exe sources disable'
2. Verified that all the existing tests are passing. (Running them again)
3. Verified the following manually
   1. 'nuget.exe sources enable' and 'nuget.exe sources disable' works
   2. Verified manually that enabling and disabling of sources from the UI settings dialog does not create duplicate entries on nuget.config
   3. Verified that running nuget.exe sources add when 'Microsoft and .NET' feed is disabled does not enable it by mistake

@yishaigalatzer @emgarten @zhili1208 
