### PR TITLE
[WIP] Change ZIP file extraction to preserve time stamps

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/ZipArchiveExtensions.cs
@@ -88,7 +88,7 @@ namespace NuGet.Common
                         Directory.CreateDirectory(targetEntryPath);
                     }
 
-                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/true);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Common/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/ZipArchiveExtensions.cs
@@ -88,13 +88,7 @@ namespace NuGet.Common
                         Directory.CreateDirectory(targetEntryPath);
                     }
 
-                    using (var entryStream = entry.Open())
-                    {
-                        using (var targetStream = new FileStream(targetFile, FileMode.Create, FileAccess.Write, FileShare.None))
-                        {
-                            entryStream.CopyTo(targetStream);
-                        }
-                    }
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
@@ -178,14 +178,7 @@ namespace NuGet.Packaging
             }
 
             // Nuspec found, extract and leave the rest
-            using (var entryStream = nuspecEntry.Open())
-            {
-                using (var targetStream
-                    = new FileStream(targetNuspec, FileMode.Create, FileAccess.Write, FileShare.None))
-                {
-                    entryStream.CopyTo(targetStream);
-                }
-            }
+            ZipFileExtensions.ExtractToFile(nuspecEntry, targetNuspec, /*overwrite*/false);
         }
 
         // DNU REFACTORING TODO: delete this temporary workaround after we have NuSpecFormatter.Read()
@@ -294,14 +287,7 @@ namespace NuGet.Packaging
                         Directory.CreateDirectory(targetEntryPath);
                     }
 
-                    using (var entryStream = entry.Open())
-                    {
-                        using (var targetStream
-                            = new FileStream(targetFile, FileMode.Create, FileAccess.Write, FileShare.None))
-                        {
-                            entryStream.CopyTo(targetStream);
-                        }
-                    }
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/NuGetPackageUtils.cs
@@ -178,7 +178,7 @@ namespace NuGet.Packaging
             }
 
             // Nuspec found, extract and leave the rest
-            ZipFileExtensions.ExtractToFile(nuspecEntry, targetNuspec, /*overwrite*/false);
+            ZipFileExtensions.ExtractToFile(nuspecEntry, targetNuspec, /*overwrite*/true);
         }
 
         // DNU REFACTORING TODO: delete this temporary workaround after we have NuSpecFormatter.Read()
@@ -287,7 +287,7 @@ namespace NuGet.Packaging
                         Directory.CreateDirectory(targetEntryPath);
                     }
 
-                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/true);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Test.Utility/ZipExtensions.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/ZipExtensions.cs
@@ -60,14 +60,8 @@ namespace NuGet.Test.Utility
                     {
                         Directory.CreateDirectory(targetEntryPath);
                     }
-
-                    using (var entryStream = entry.Open())
-                    {
-                        using (var targetStream = new FileStream(targetFile, FileMode.Create, FileAccess.Write, FileShare.None))
-                        {
-                            entryStream.CopyTo(targetStream);
-                        }
-                    }
+                    
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Test.Utility/ZipExtensions.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/ZipExtensions.cs
@@ -61,7 +61,7 @@ namespace NuGet.Test.Utility
                         Directory.CreateDirectory(targetEntryPath);
                     }
                     
-                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/false);
+                    ZipFileExtensions.ExtractToFile(entry, targetFile, /*overwrite*/true);
                 }
             }
         }


### PR DESCRIPTION
Work in progress, seeking feedback. Trying to resolve https://github.com/NuGet/Home/issues/420 .

Build fails due to missing "System.IO.Compression.FileSystem" assembly reference(s). Could someone please tell me how to add these, and if the references should be of type ".NET framework" or "DNX Core"?
