### PR TITLE
fixes https://github.com/NuGet/Home/issues/1787

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Constants.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Constants.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Core.v3
         public static readonly string SearchGalleryQueryService = "SearchGalleryQueryService" + Version300beta;
         public static readonly string MetricsService = "MetricsService" + Version300beta;
         public static readonly string RegistrationsBaseUrl = "RegistrationsBaseUrl" + Version300beta;
-        public static readonly string ReportAbuse = "ReportAbuseUriTemplate" + Version300beta;
+        public static readonly string ReportAbuse = "ReportAbuseUriTemplate" + Version300;
         public static readonly string Stats = "Stats" + Version300beta;
         public static readonly string LegacyGallery = "LegacyGallery" + Version200;
         public static readonly string PackagePublish = "PackagePublish" + Version200;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3.cs
@@ -10,19 +10,26 @@ namespace NuGet.Protocol.Core.v3
 {
     public class ReportAbuseResourceV3 : INuGetResource
     {
+        private readonly string _uriTemplate;
+        private const string _fallbackUriTemplate = "https://www.nuget.org/packages/{id}/{version}/ReportAbuse";
+
         public ReportAbuseResourceV3()
+            : this(_fallbackUriTemplate)
         {
         }
 
-        //public ReportAbuseResourceV3(IEnumerable<Uri> reportAbuseTemplates)
-        //{
-        //    if (reportAbuseTemplates == null || !reportAbuseTemplates.Any())
-        //    {
-        //        throw new ArgumentNullException("reportAbuseTemplates");
-        //    }
-
-        //    _reportAbuseTemplates = reportAbuseTemplates;
-        //}
+        public ReportAbuseResourceV3(string uriTemplate)
+        {
+            if (string.IsNullOrEmpty(uriTemplate))
+            {
+                // fallback to default nuget.org ReportAbuseUriTemplate
+                _uriTemplate = _fallbackUriTemplate;
+            }
+            else
+            {
+                _uriTemplate = uriTemplate;
+            }
+        }
 
         /// <summary>
         /// Gets a URL for reporting package abuse. The URL will not be verified to exist.
@@ -32,50 +39,10 @@ namespace NuGet.Protocol.Core.v3
         /// <returns>The first URL from the resource, with the URI template applied.</returns>
         public Uri GetReportAbuseUrl(string id, NuGetVersion version)
         {
-            //return Utility.ApplyPackageIdVersionToUriTemplate(_reportAbuseTemplates.First(), id, version);
-            return new Uri(String.Format(CultureInfo.InvariantCulture, "https://www.nuget.org/packages/{0}/{1}/ReportAbuse", id, version.ToNormalizedString()));
+            var url = string.Format(CultureInfo.InvariantCulture, _uriTemplate, id, version.ToNormalizedString());
+            var uriBuilder = new UriBuilder(url);
+
+            return uriBuilder.Uri;
         }
-
-        /// <summary>
-        /// Gets a URL for reporting package abuse. The URL will be tested for success with a HEAD request.
-        /// </summary>
-        /// <param name="id">The package id (natural casing)</param>
-        /// <param name="version">The package version</param>
-        /// <param name="cancellationToken">The cancellation token to terminate HTTP requests</param>
-        /// <returns>The first URL available from the resource, with the URI template applied.</returns>
-        //public async Task<Uri> GetReportAbuseUrl(string id, NuGetVersion version, CancellationToken cancellationToken)
-        //{
-        //    // REVIEW: maballia - doesn't this logic hit the first resource every time, not balancing to secondary resources unless the first is broken?
-        //    foreach (Uri uri in Utility.ApplyPackageIdVersionToUriTemplate(_reportAbuseTemplates, id, version))
-        //    {
-        //        if (!cancellationToken.IsCancellationRequested)
-        //        {
-        //            // Get a new HttpClient each time because some BadRequest
-        //            // responses were corrupting the HttpClient instance and
-        //            // subsequent requests on it would hang unexpectedly
-        //            // REVIEW: maballia - would this support proxy / auth scenarios? I guess we need a client that does support those, right?
-        //            using (HttpClient http = new HttpClient())
-        //            {
-        //                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Head, uri);
-
-        //                try
-        //                {
-        //                    HttpResponseMessage response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-
-        //                    if (response.IsSuccessStatusCode)
-        //                    {
-        //                        return uri;
-        //                    }
-        //                }
-        //                catch
-        //                {
-        //                    // Any exception means we couldn't connect to the resource
-        //                }
-        //            }
-        //        }
-        //    }
-
-        //    return null;
-        //}
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3.cs
@@ -33,20 +33,11 @@ namespace NuGet.Protocol.Core.v3
         /// <returns>The first URL from the resource, with the URI template applied.</returns>
         public Uri GetReportAbuseUrl(string id, NuGetVersion version)
         {
-            try
-            {
-                var uriString = _uriTemplate
-                   .Replace("{id}", id)
-                   .Replace("{version}", version.ToNormalizedString());
+            var uriString = _uriTemplate
+               .Replace("{id}", id)
+               .Replace("{version}", version.ToNormalizedString());
 
-                return new Uri(uriString);
-            }
-            catch (UriFormatException)
-            {
-                // fallback to default nuget.org ReportAbuse Uri
-                return new Uri(string.Format(CultureInfo.InvariantCulture,
-                    $"https://www.nuget.org/packages/{id}/{version.ToNormalizedString()}/ReportAbuse"));
-            }
+            return new Uri(uriString);
         }
 
         private static bool IsValidUriTemplate(string uriTemplate)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/ReportAbuseResourceV3Provider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
@@ -23,13 +24,10 @@ namespace NuGet.Protocol.Core.v3
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
-                resource = new ReportAbuseResourceV3();
+                var uriTemplate = serviceIndex[ServiceTypes.ReportAbuse].FirstOrDefault()?.AbsoluteUri;
 
-                //IEnumerable<Uri> templateUrls = serviceIndex[ServiceTypes.ReportAbuse];
-                //if (templateUrls != null && templateUrls.Any())
-                //{
-                //    resource = new ReportAbuseResourceV3(templateUrls);
-                //}
+                // construct a new resource
+                resource = new ReportAbuseResourceV3(uriTemplate);
             }
 
             return new Tuple<bool, INuGetResource>(resource != null, resource);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ReportAbuseResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ReportAbuseResourceV3Tests.cs
@@ -1,0 +1,25 @@
+﻿using NuGet.Protocol.Core.v3;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class ReportAbuseResourceV3Tests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("https://test.nuget.org/ReportAbuse/{id}")]
+        [InlineData("https://test.nuget.org/ReportAbuse/{version}")]
+        [InlineData("https://test.nuget.org/ReportAbuse/{0}/{1}")]
+        [InlineData(null)]
+        public void GetReportAbuseUrlFallsBackToDefaultForInvalidUriTemplate(string uriTemplate)
+        {
+            const string expectedDefault = "https://www.nuget.org/packages/TestPackage/1.0.0/ReportAbuse";
+            var resource = new ReportAbuseResourceV3(uriTemplate);
+
+            var actual = resource.GetReportAbuseUrl("TestPackage", NuGetVersion.Parse("1.0.0"));
+
+            Assert.Equal(expectedDefault, actual.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1787
The report abuse URI template is currently not read from v3/index.json.
This PR queries the index.json for service type `ReportAbuseUriTemplate/3.0.0` and uses that template when present.
If not present, it falls back to the hardcoded nuget.org template.

cc @emgarten 
