### PR TITLE
NuGet pack append prerelease suffix to version

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -60,6 +60,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "PackageCommandVersionDescription")]
         public string Version { get; set; }
 
+        [Option(typeof(NuGetCommand), "PackageCommandSuffixDescription")]
+        public string Suffix { get; set; }
+
         [Option(typeof(NuGetCommand), "PackageCommandExcludeDescription")]
         public ICollection<string> Exclude
         {
@@ -150,6 +153,11 @@ namespace NuGet.CommandLine
             if (!String.IsNullOrEmpty(Version))
             {
                 builder.Version = new SemanticVersion(Version);
+            }
+
+            if (!string.IsNullOrEmpty(Suffix))
+            {
+                builder.Version = new SemanticVersion(builder.Version.Version, Suffix);
             }
 
             if (_minClientVersionValue != null)

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -7724,6 +7724,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Adds a suffix to the generated version.
+        /// </summary>
+        internal static string PackageCommandSuffixDescription {
+            get {
+                return ResourceManager.GetString("PackageCommandSuffixDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Determines if a package containing sources and symbols should be created. When specified with a nuspec, creates a regular NuGet package file and the corresponding symbols package..
         /// </summary>
         internal static string PackageCommandSymbolsDescription {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -7724,7 +7724,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adds a suffix to the generated version.
+        ///   Looks up a localized string similar to Appends a pre-release suffix to the internally generated version number..
         /// </summary>
         internal static string PackageCommandSuffixDescription {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5303,6 +5303,6 @@ nuget locals global-packages -list</value>
     <value>List the selected local resources or cache location(s).</value>
   </data>
   <data name="PackageCommandSuffixDescription" xml:space="preserve">
-    <value>Adds a suffix to the generated version</value>
+    <value>Appends a pre-release suffix to the internally generated version number.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5302,4 +5302,7 @@ nuget locals global-packages -list</value>
   <data name="LocalsCommandListDescription" xml:space="preserve">
     <value>List the selected local resources or cache location(s).</value>
   </data>
+  <data name="PackageCommandSuffixDescription" xml:space="preserve">
+    <value>Adds a suffix to the generated version</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -1858,7 +1859,7 @@ namespace Proj2
         public void PackCommand_VersionSuffixIsAssigned()
         {
             var nugetexe = Util.GetNuGetExePath();
-            var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder();
 
             try
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1854,6 +1854,37 @@ namespace Proj2
             }
         }
 
+        [Fact]
+        public void PackCommand_VersionSuffixIsAssigned()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            try
+            {
+                // Arrange
+                Util.CreateDirectory(workingDirectory);
+
+                CreateTestProject(workingDirectory, "proj1", null);
+
+                // Act
+                var proj1Directory = Path.Combine(workingDirectory, "proj1");
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    proj1Directory,
+                    "pack proj1.csproj -Build -Suffix alpha",
+                    waitForExit: true);
+
+                // Assert
+                var package = new OptimizedZipPackage(Path.Combine(proj1Directory, "proj1.0.0.0.0-alpha.nupkg"));
+                Assert.Equal(package.Version.ToString(), "0.0.0.0-alpha");
+            }
+            finally
+            {
+                Directory.Delete(workingDirectory, true);
+            }
+        }
+
         /// <summary>
         /// Creates a simple project.
         /// </summary>


### PR DESCRIPTION
Added a -Suffix option to the NuGet pack command.
- Example: nuget pack proj1.csproj -Suffix alpha
#694
