### PR TITLE
fix for solution level update that uses -Id option

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -256,16 +256,21 @@ namespace NuGet.CommandLine
             {
                 foreach (var packageId in Id)
                 {
-                    var actions = await packageManager.PreviewUpdatePackagesAsync(
-                       packageId,
-                       nugetProject,
-                       resolutionContext,
-                       project.NuGetProjectContext,
-                       sourceRepositories,
-                       Enumerable.Empty<SourceRepository>(),
-                       CancellationToken.None);
+                    var installed = await nugetProject.GetInstalledPackagesAsync(CancellationToken.None);
 
-                    projectActions.AddRange(actions);
+                    if (installed.Where(pr => pr.PackageIdentity.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase)).Any())
+                    {
+                        var actions = await packageManager.PreviewUpdatePackagesAsync(
+                           packageId,
+                           nugetProject,
+                           resolutionContext,
+                           project.NuGetProjectContext,
+                           sourceRepositories,
+                           Enumerable.Empty<SourceRepository>(),
+                           CancellationToken.None);
+
+                        projectActions.AddRange(actions);
+                    }
                 }
             }
             else

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -104,15 +104,20 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public async Task UpdateCommand_Success_References_MultipleProjects()
         {
-            var packagesSourceDirectory = TestFilesystemUtility.CreateRandomTestFolder();
-            var solutionDirectory = TestFilesystemUtility.CreateRandomTestFolder();
-            var projectDirectory1 = Path.Combine(solutionDirectory, "proj1");
-            var projectDirectory2 = Path.Combine(solutionDirectory, "proj2");
-            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
-            var workingPath = TestFilesystemUtility.CreateRandomTestFolder();
+            string packagesSourceDirectory = null;
+            string solutionDirectory = null;
+            string workingPath = null;
 
             try
             {
+                packagesSourceDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+                solutionDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+                workingPath = TestFilesystemUtility.CreateRandomTestFolder();
+
+                var projectDirectory1 = Path.Combine(solutionDirectory, "proj1");
+                var projectDirectory2 = Path.Combine(solutionDirectory, "proj2");
+                var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
                 var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -102,6 +102,139 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task UpdateCommand_Success_References_MultipleProjects()
+        {
+            var packagesSourceDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            var solutionDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectDirectory1 = Path.Combine(solutionDirectory, "proj1");
+            var projectDirectory2 = Path.Combine(solutionDirectory, "proj2");
+            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+            var workingPath = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
+                var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
+
+                var b1 = new PackageIdentity("B", new NuGetVersion("1.0.0"));
+                var b2 = new PackageIdentity("B", new NuGetVersion("2.0.0"));
+
+                var a1Package = Util.CreateTestPackage(
+                    a1.Id,
+                    a1.Version.ToString(),
+                    packagesSourceDirectory,
+                    new List<NuGetFramework>() { NuGetFramework.Parse("net45") },
+                    new List<PackageDependencyGroup>() { });
+
+                var a2Package = Util.CreateTestPackage(
+                    a2.Id,
+                    a2.Version.ToString(),
+                    packagesSourceDirectory,
+                    new List<NuGetFramework>() { NuGetFramework.Parse("net45") },
+                    new List<PackageDependencyGroup>() { });
+
+                var b1Package = Util.CreateTestPackage(
+                    b1.Id,
+                    b1.Version.ToString(),
+                    packagesSourceDirectory,
+                    new List<NuGetFramework>() { NuGetFramework.Parse("net45") },
+                    new List<PackageDependencyGroup>() { });
+
+                var b2Package = Util.CreateTestPackage(
+                    b2.Id,
+                    b2.Version.ToString(),
+                    packagesSourceDirectory,
+                    new List<NuGetFramework>() { NuGetFramework.Parse("net45") },
+                    new List<PackageDependencyGroup>() { });
+
+                Directory.CreateDirectory(projectDirectory1);
+
+                Util.CreateFile(
+                    projectDirectory1,
+                    "proj1.csproj",
+                    Util.CreateProjFileContent());
+
+                Directory.CreateDirectory(projectDirectory2);
+
+                Util.CreateFile(
+                    projectDirectory2,
+                    "proj2.csproj",
+                    Util.CreateProjFileContent());
+
+                Util.CreateFile(solutionDirectory, "a.sln",
+                    Util.CreateSolutionFileContent());
+
+                var projectFile1 = Path.Combine(projectDirectory1, "proj1.csproj");
+                var projectFile2 = Path.Combine(projectDirectory2, "proj2.csproj");
+                var solutionFile = Path.Combine(solutionDirectory, "a.sln");
+
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msbuildDirectory = MsBuildUtility.GetMsbuildDirectory("14.0", null);
+                var projectSystem1 = new MSBuildProjectSystem(msbuildDirectory, projectFile1, testNuGetProjectContext);
+                var projectSystem2 = new MSBuildProjectSystem(msbuildDirectory, projectFile2, testNuGetProjectContext);
+                var msBuildProject1 = new MSBuildNuGetProject(projectSystem1, packagesDirectory, projectDirectory1);
+                var msBuildProject2 = new MSBuildNuGetProject(projectSystem2, packagesDirectory, projectDirectory2);
+
+                using (var stream = File.OpenRead(a1Package))
+                {
+                    var downloadResult = new DownloadResourceResult(stream);
+                    await msBuildProject1.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
+               }
+
+                using (var stream = File.OpenRead(b1Package))
+                {
+                    var downloadResult = new DownloadResourceResult(stream);
+                    await msBuildProject2.InstallPackageAsync(
+                        b1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
+                }
+
+                projectSystem1.Save();
+                projectSystem2.Save();
+
+                var args = new[]
+                {
+                    "update",
+                    solutionFile,
+                    "-Source",
+                    packagesSourceDirectory,
+                    "-Id",
+                    "A"
+                };
+
+                var r = CommandRunner.Run(
+                    Util.GetNuGetExePath(),
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+
+                var content1 = File.ReadAllText(projectFile1);
+                Assert.False(content1.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
+
+                var content2 = File.ReadAllText(projectFile2);
+                Assert.True(content2.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(solutionDirectory, workingPath, packagesSourceDirectory);
+            }
+        }
+
+        [Fact]
         public async Task UpdateCommand_Success_NOPrerelease()
         {
             var packagesSourceDirectory = TestFilesystemUtility.CreateRandomTestFolder();


### PR DESCRIPTION
Fix is to check whether the project actually contains the package before we ask package manager to update that package. Because asking packageManager to update a package is tantamount to asking it to add the package.

Added a unit test to verify the scenario: multiple projects under a solution and a solution level targeted  update of a specific package.
