### PR TITLE
Fix timeout option ignored bug for nuget push.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -55,7 +55,7 @@ namespace NuGet.CommandLine
             }
 
             var timeout = TimeSpan.FromSeconds(Math.Abs(Timeout));
-            if (timeout.TotalSeconds <= 0)
+            if (timeout.TotalSeconds == 0)
             {
                 timeout = TimeSpan.FromMinutes(5); // Default to 5 minutes
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -55,7 +55,7 @@ namespace NuGet.CommandLine
             }
 
             var timeout = TimeSpan.FromSeconds(Math.Abs(Timeout));
-            if (timeout.Seconds <= 0)
+            if (timeout.TotalSeconds <= 0)
             {
                 timeout = TimeSpan.FromMinutes(5); // Default to 5 minutes
             }


### PR DESCRIPTION
Timeout values dividable by 60 will be ignored, and replaced by the default 5 minute value. The reason for this is that `TimeSpan.Seconds` only return the "seconds" part of the time in the 0-59 range (https://msdn.microsoft.com/en-us/library/system.timespan.seconds.aspx), whereas minutes and hours are ignored. Switching to `TotalSeconds` should fix this problem.

This issue have previously been reported on https://nuget.codeplex.com/workitem/3917 . There, the issue is flagged as "resolved" and scheduled to be released with NuGet 3.0. Clearly, this is not the case.
