### PR TITLE
Dev reference output assembly

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.targets
+++ b/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.targets
@@ -18,7 +18,8 @@
 
         <!-- Filter out project references that specify ReferenceOutputAssembly=false -->
         <ItemGroup>
-          <ValidProjectInputForNuGet Include="@(ProjectReference)" Condition=" %(ProjectReference.ReferenceOutputAssembly) != 'false' " />
+          <ValidProjectInputForNuGet Include="@(ProjectReference)" 
+              Condition=" %(ProjectReference.ReferenceOutputAssembly) != 'false' AND %(ProjectReference.ReferenceOutputAssembly) != 'off' AND %(ProjectReference.ReferenceOutputAssembly) != '0'" />
         </ItemGroup>
 
         <MSBuild

--- a/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.targets
+++ b/src/NuGet.Clients/NuGet.CommandLine/GetProjectsReferencingProjectJsonFiles.targets
@@ -16,8 +16,13 @@
                 Condition=" '$(MSBuildProjectFullPath)' != '$(EntryPointProject)' " />
         </ItemGroup>
 
+        <!-- Filter out project references that specify ReferenceOutputAssembly=false -->
+        <ItemGroup>
+          <ValidProjectInputForNuGet Include="@(ProjectReference)" Condition=" %(ProjectReference.ReferenceOutputAssembly) != 'false' " />
+        </ItemGroup>
+
         <MSBuild
-          Projects="@(ProjectReference)"
+          Projects="@(ValidProjectInputForNuGet)"
           Targets="_NuGet_GetProjectsReferencingProjectJsonInternal"
           BuildInParallel="$(BuildInParallel)"
           Properties="

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -121,7 +121,7 @@ namespace NuGet.CommandLine.Test
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
 
                 var format = new LockFileFormat();
-                var lockFile1 = format.Read(test2Lock.FullName);
+                var lockFile1 = format.Read(test1Lock.FullName);
                 var lockFile2 = format.Read(test2Lock.FullName);
 
                 var a1 = lockFile1.Libraries

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -10,6 +10,143 @@ namespace NuGet.CommandLine.Test
     public class RestoreProjectJsonTest
     {
         [Fact]
+        public void RestoreProjectJson_RestoreFromSlnWithReferenceOutputAssemblyFalse()
+        {
+            // Arrange
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var projectDir1 = Path.Combine(workingPath, "test1");
+                var projectDir2 = Path.Combine(workingPath, "test2");
+                var nugetexe = Util.GetNuGetExePath();
+
+                Directory.CreateDirectory(projectDir1);
+                Directory.CreateDirectory(projectDir2);
+                Directory.CreateDirectory(repositoryPath);
+                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+
+                Util.CreateFile(projectDir1, "project.json",
+                                                @"{
+                                                    'dependencies': {
+                                                    },
+                                                    'frameworks': {
+                                                                'uap10.0': { }
+                                                            }
+                                                    }");
+
+                Util.CreateFile(projectDir1, "test1.csproj",
+                        @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <Project ToolsVersion=""14.0"" DefaultTargets=""Build""
+                                        xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                            <Target Name=""_NuGet_GetProjectsReferencingProjectJsonInternal""></Target>
+                            <ItemGroup Label=""Project References"">
+                            <ProjectReference Include=""" + projectDir2 + @"\\test2.csproj"">
+                              <Project>{BB6279C1-B5EE-4C6B-9FA3-A794CE195136}</Project>
+                              <Name>Test2</Name>
+                              <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+                            </ProjectReference>
+                            </ItemGroup>
+                        </Project>");
+
+                Util.CreateFile(projectDir2, "project.json",
+                                    @"{
+                                        'version': '1.0.0-*',
+                                        'dependencies': {
+                                            ""packageA"": ""1.0.0""
+                                        },
+                                        'frameworks': {
+                                                    'uap10.0': { }
+                                                }
+                                        }");
+
+                Util.CreateFile(projectDir2, "test2.csproj",
+                        @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <Project ToolsVersion=""14.0"" DefaultTargets=""Build""
+                                        xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+                            <Target Name=""_NuGet_GetProjectsReferencingProjectJsonInternal""></Target>
+                        </Project>");
+
+                var slnPath = Path.Combine(workingPath, "xyz.sln");
+
+                Util.CreateFile(workingPath, "xyz.sln",
+                           @"
+                        Microsoft Visual Studio Solution File, Format Version 12.00
+                        # Visual Studio 14
+                        VisualStudioVersion = 14.0.23107.0
+                        MinimumVisualStudioVersion = 10.0.40219.1
+                        Project(""{AAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""test1"", ""test1\test1.csproj"", ""{AA6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Project(""{BBE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""test2"", ""test2\test2.csproj"", ""{BB6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Global
+                            GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                                Debug|Any CPU = Debug|Any CPU
+                                Release|Any CPU = Release|Any CPU
+                            EndGlobalSection
+                            GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                                {AA6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                                {AA6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                                {BB6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                                {BB6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                            EndGlobalSection
+                            GlobalSection(SolutionProperties) = preSolution
+                                HideSolutionNode = FALSE
+                            EndGlobalSection
+                        EndGlobal
+                        ");
+
+                var packageA = Util.CreateTestPackageBuilder("packageA", "1.0.0");
+                var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
+                packageA.Files.Add(libA);
+                Util.CreateTestPackage(packageA, repositoryPath);
+
+                string[] args = new string[] {
+                    "restore",
+                    "-Source",
+                    repositoryPath,
+                    "-solutionDir",
+                    workingPath,
+                    slnPath
+                };
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                var test1Lock = new FileInfo(Path.Combine(projectDir1, "project.lock.json"));
+                var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
+
+                var format = new LockFileFormat();
+                var lockFile1 = format.Read(test2Lock.FullName);
+                var lockFile2 = format.Read(test2Lock.FullName);
+
+                var a1 = lockFile1.Libraries
+                    .Where(lib => lib.Name.Equals("packageA", StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+
+                var a2 = lockFile2.Libraries
+                    .Where(lib => lib.Name.Equals("packageA", StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+
+                // Assert
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+
+                Assert.True(test1Lock.Exists);
+                Assert.True(test2Lock.Exists);
+
+                // Verify the package does exist in 2
+                Assert.NotNull(a2);
+
+                // Verify the package does not flow to 1
+                Assert.Null(a1);
+            }
+        }
+
+        [Fact]
         public void RestoreProjectJson_RestoreProjectFileNotFound()
         {
             // Arrange


### PR DESCRIPTION
This change adds support for skipping projects with ReferenceOutputAssembly=false in both nuget.exe and the VSIX.

Valid ReferenceOutputAssembly values: `false`, `off`, `0`   Is there an official list somewhere?

https://github.com/NuGet/Home/issues/1629

//cc @yishaigalatzer @alpaix 
