### PR TITLE
Correct all Specifiy text to Specify globally

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -17705,7 +17705,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifiy the version of dependency and rebuild your package..
+        ///   Looks up a localized string similar to Specify the version of dependency and rebuild your package..
         /// </summary>
         public static string Warning_UnspecifiedDependencyVersionSolution {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -5703,7 +5703,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The version of dependency '{0}' is not specified.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionSolution" xml:space="preserve">
-    <value>Specifiy the version of dependency and rebuild your package.</value>
+    <value>Specify the version of dependency and rebuild your package.</value>
   </data>
   <data name="Warning_UnspecifiedDependencyVersionTitle" xml:space="preserve">
     <value>Specify version of dependencies.</value>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1509,7 +1509,7 @@ namespace Proj1
                 // Assert
                 Assert.Contains("Issue: Specify version of dependencies.", r.Item2);
                 Assert.Contains("Description: The version of dependency 'json' is not specified.", r.Item2);
-                Assert.Contains("Solution: Specifiy the version of dependency and rebuild your package.", r.Item2);
+                Assert.Contains("Solution: Specify the version of dependency and rebuild your package.", r.Item2);
             }
         }
 


### PR DESCRIPTION
Spelling fix.

FWIW this is also in mono/nuget: https://github.com/mono/nuget/blob/d129831d6fa1c7e3c83b520b877a273c636e120e/test/Test.Integration/NuGetCommandLine/NuGetPackCommandTest.cs#L1172
## 

I submitted a similar PR to another repo: https://github.com/NuGet/NuGet2/pull/31
