### PR TITLE
do recursive deletion in code to be able to report granular error messages

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 
 namespace NuGet.CommandLine.Commands
@@ -219,7 +218,7 @@ namespace NuGet.CommandLine.Commands
         {
             // In order to get detailed error messages, we need to do recursion ourselves.
             var failedDeletes = new List<string>();
-            DeleteDirectoryTree(folderPath, failedDeletes);
+            LocalResourceUtils.DeleteDirectoryTree(folderPath, failedDeletes);
 
             if (failedDeletes.Any())
             {
@@ -238,101 +237,6 @@ namespace NuGet.CommandLine.Commands
             else
             {
                 return true;
-            }
-        }
-
-        private static void DeleteDirectoryTree(string folderPath, List<string> failedDeletes)
-        {
-            if (!Directory.Exists(folderPath))
-            {
-                // Non-issue.
-                return;
-            }
-
-            DeleteFilesInDirectoryTree(folderPath, failedDeletes);
-
-            try
-            {
-                SafeDeleteDirectoryTree(folderPath);
-            }
-            catch (PathTooLongException)
-            {
-                failedDeletes.Add(folderPath);
-            }
-            catch (UnauthorizedAccessException)
-            {
-                failedDeletes.Add(folderPath);
-            }
-        }
-
-        private static void SafeDeleteDirectoryTree(string folderPath)
-        {
-            try
-            {
-                // Deletes the specified directory and any subdirectories and files in the directory.
-                // When deleting a directory that contains a reparse point, such as a symbolic link or a mount point:
-                // * If the reparse point is a directory, such as a mount point,
-                //   it is unmounted and the mount point is deleted.
-                //   This method does not recurse through the reparse point.
-                // * If the reparse point is a symbolic link to a file,
-                //   the reparse point is deleted and not the target of the symbolic link.
-                Directory.Delete(folderPath, recursive: true);
-            }
-            catch (DirectoryNotFoundException)
-            {
-                // Should not happen, but it is a non-issue.
-            }
-            catch (IOException)
-            {
-                // Try once more.
-                // The directory may be in use by another process and cause an IOException.
-                Thread.Sleep(500);
-                Directory.Delete(folderPath, recursive: true);
-            }
-        }
-
-        private static void DeleteFilesInDirectoryTree(string folderPath, List<string> failedDeletes)
-        {
-            // Using the default SearchOption.TopDirectoryOnly, as SearchOption.AllDirectories would also
-            // include reparse points such as mounted drives and symbolic links in the search.
-            foreach (var subFolderPath in Directory.EnumerateDirectories(folderPath))
-            {
-                var directoryInfo = new DirectoryInfo(subFolderPath);
-                if (!directoryInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
-                {
-                    DeleteFilesInDirectoryTree(subFolderPath, failedDeletes);
-                }
-            }
-
-            foreach (var file in Directory.EnumerateFiles(folderPath))
-            {
-                var filePath = Path.Combine(folderPath, Path.GetFileName(file));
-                try
-                {
-                    // When files or folders are readonly, the File.Delete method may not be able to delete it.
-                    var attributes = File.GetAttributes(filePath);
-                    if (attributes.HasFlag(FileAttributes.ReadOnly))
-                    {
-                        // Remove the readonly flag when set.
-                        attributes &= ~FileAttributes.ReadOnly;
-                        File.SetAttributes(filePath, attributes);
-                    }
-
-                    File.Delete(filePath);
-                }
-                catch (PathTooLongException)
-                {
-                    failedDeletes.Add(filePath);
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    failedDeletes.Add(filePath);
-                }
-                catch (IOException)
-                {
-                    // The file is being used by another process.
-                    failedDeletes.Add(filePath);
-                }
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/LocalResourceUtils.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/LocalResourceUtils.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace NuGet.Common
+{
+    public class LocalResourceUtils
+    {
+        public static void DeleteDirectoryTree(string folderPath, List<string> failedDeletes)
+        {
+            if (!Directory.Exists(folderPath))
+            {
+                // Non-issue.
+                return;
+            }
+
+            DeleteFilesInDirectoryTree(folderPath, failedDeletes);
+
+            try
+            {
+                SafeDeleteDirectoryTree(folderPath);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Should not happen, but it is a non-issue.
+            }
+            catch (PathTooLongException)
+            {
+                failedDeletes.Add(folderPath);
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                System.Diagnostics.Debug.Assert(e != null);
+                failedDeletes.Add(folderPath);
+            }
+        }
+
+        private static void SafeDeleteDirectoryTree(string folderPath)
+        {
+            try
+            {
+                // Deletes the specified directory and any subdirectories and files in the directory.
+                // When deleting a directory that contains a reparse point, such as a symbolic link or a mount point:
+                // * If the reparse point is a directory, such as a mount point,
+                //   it is unmounted and the mount point is deleted.
+                //   This method does not recurse through the reparse point.
+                // * If the reparse point is a symbolic link to a file,
+                //   the reparse point is deleted and not the target of the symbolic link.
+                Directory.Delete(folderPath, recursive: true);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Should not happen, but it is a non-issue.
+            }
+            catch (IOException)
+            {
+                // Try once more.
+                // The directory may be in use by another process and cause an IOException.
+                Thread.Sleep(500);
+                Directory.Delete(folderPath, recursive: true);
+            }
+        }
+
+        private static void DeleteFilesInDirectoryTree(string folderPath, List<string> failedDeletes)
+        {
+            // Using the default SearchOption.TopDirectoryOnly, as SearchOption.AllDirectories would also
+            // include reparse points such as mounted drives and symbolic links in the search.
+            foreach (var subFolderPath in Directory.EnumerateDirectories(folderPath))
+            {
+                var directoryInfo = new DirectoryInfo(subFolderPath);
+                if (!directoryInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                {
+                    DeleteFilesInDirectoryTree(subFolderPath, failedDeletes);
+                }
+            }
+
+            foreach (var file in Directory.EnumerateFiles(folderPath))
+            {
+                var filePath = Path.Combine(folderPath, Path.GetFileName(file));
+                try
+                {
+                    // When files or folders are readonly, the File.Delete method may not be able to delete it.
+                    var attributes = File.GetAttributes(filePath);
+                    if (attributes.HasFlag(FileAttributes.ReadOnly))
+                    {
+                        // Remove the readonly flag when set.
+                        attributes &= ~FileAttributes.ReadOnly;
+                        File.SetAttributes(filePath, attributes);
+                    }
+
+                    File.Delete(filePath);
+                }
+                catch (PathTooLongException)
+                {
+                    failedDeletes.Add(filePath);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    failedDeletes.Add(filePath);
+                }
+                catch (IOException)
+                {
+                    // The file is being used by another process.
+                    failedDeletes.Add(filePath);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Common\IConsole.cs" />
     <Compile Include="Common\IMSBuildProjectSystem.cs" />
     <Compile Include="Common\LocalizedResourceManager.cs" />
+    <Compile Include="Common\LocalResourceUtils.cs" />
     <Compile Include="Common\MSBuildProjectSystem.cs" />
     <Compile Include="Common\MSBuildUser.cs" />
     <Compile Include="Common\PackageExtractor.cs" />

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -5848,6 +5848,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to delete {0}.
+        /// </summary>
+        public static string LocalsCommand_FailedToDeletePath {
+            get {
+                return ResourceManager.GetString("LocalsCommand_FailedToDeletePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An invalid local resource name was provided. Please provide one of the following values: http-cache, packages-cache, global-packages, all..
         /// </summary>
         public static string LocalsCommand_InvalidLocalResourceName {
@@ -5862,6 +5871,15 @@ namespace NuGet.CommandLine {
         public static string LocalsCommand_LocalResourcePathNotSet {
             get {
                 return ResourceManager.GetString("LocalsCommand_LocalResourcePathNotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Local resources partially cleared..
+        /// </summary>
+        public static string LocalsCommand_LocalsPartiallyCleared {
+            get {
+                return ResourceManager.GetString("LocalsCommand_LocalsPartiallyCleared", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -5848,7 +5848,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to delete {0}.
+        ///   Looks up a localized string similar to Failed to delete &apos;{0}&apos;..
         /// </summary>
         public static string LocalsCommand_FailedToDeletePath {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6137,7 +6137,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>Failed to create a temporary file while trying to get project to project references.</value>
   </data>
   <data name="LocalsCommand_FailedToDeletePath" xml:space="preserve">
-    <value>Failed to delete {0}</value>
+    <value>Failed to delete '{0}'.</value>
   </data>
   <data name="LocalsCommand_LocalsPartiallyCleared" xml:space="preserve">
     <value>Local resources partially cleared.</value>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6136,4 +6136,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_FailedToCreateRandomFileForP2P" xml:space="preserve">
     <value>Failed to create a temporary file while trying to get project to project references.</value>
   </data>
+  <data name="LocalsCommand_FailedToDeletePath" xml:space="preserve">
+    <value>Failed to delete {0}</value>
+  </data>
+  <data name="LocalsCommand_LocalsPartiallyCleared" xml:space="preserve">
+    <value>Local resources partially cleared.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/LocalResourceUtilsTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class LocalResourceUtilsTest
+    {
+        [WindowsNTFact]
+        public void DeleteDirectoryTreeDeletesReparsePointsButNotReparsePointTargets()
+        {
+            // This test creates a cached package and a subdirectory in the working directory.
+            // The subdirectory is a reparse point linked to the target directory.
+
+            // Deleting the directory tree should delete the reparse point, but not the target of the reparse point.
+            // The cached package in the working directory should also be deleted.
+
+            // The also creates a dummy file in the linked target directory, and verifies
+            // this file is left as-is after deletion of the directory tree including the reparse point.
+
+            // Finally, test clean-up is verified.
+
+            var failedDeletes = new List<string>();
+
+            string targetDirectoryPath;
+            string fileInTargetDirectory;
+            using (var targetDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                targetDirectoryPath = targetDirectory.Path;
+                var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder();
+                var subDirectoryPath = Path.Combine(workingDirectory.Path, "SubDirectory");
+                var subDirectory = Directory.CreateDirectory(subDirectoryPath);
+
+                Util.CreatePackage(workingDirectory.Path, Guid.NewGuid().ToString("N"), "1.0.0");
+                fileInTargetDirectory = Path.Combine(targetDirectoryPath, "test.txt");
+                File.WriteAllText(fileInTargetDirectory, string.Empty);
+
+                Util.CreateJunctionPoint(subDirectory.FullName, targetDirectoryPath, overwrite: true);
+
+                // Act
+                LocalResourceUtils.DeleteDirectoryTree(workingDirectory.Path, failedDeletes);
+
+                // Assert
+                Assert.Empty(failedDeletes);
+                Assert.False(Directory.Exists(workingDirectory.Path));
+                Assert.True(Directory.Exists(targetDirectoryPath));
+                Assert.True(File.Exists(fileInTargetDirectory));
+            }
+
+            // Verify clean-up
+            Assert.False(Directory.Exists(targetDirectoryPath));
+            Assert.False(File.Exists(fileInTargetDirectory));
+        }
+    }
+
+    /// <summary>
+    /// This attribute ensures the Fact is only run on Windows.
+    /// </summary>
+    public class WindowsNTFactAttribute
+        : FactAttribute
+    {
+        public WindowsNTFactAttribute()
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Skip = "Test only runs on Windows NT or later.";
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NativeMethods.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NativeMethods.cs
@@ -1,0 +1,223 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+
+namespace NuGet.CommandLine.Test
+{
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool DeviceIoControl(
+            IntPtr hDevice, uint dwIoControlCode,
+            IntPtr inBuffer, int nInBufferSize,
+            IntPtr outBuffer, int nOutBufferSize,
+            out int pBytesReturned, IntPtr lpOverlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr CreateFile(
+            string lpFileName,
+            EFileAccess dwDesiredAccess,
+            EFileShare dwShareMode,
+            IntPtr lpSecurityAttributes,
+            ECreationDisposition dwCreationDisposition,
+            EFileAttributes dwFlagsAndAttributes,
+            IntPtr hTemplateFile);
+
+        /// <summary>
+        /// This prefix indicates to NTFS that the path is to be treated as a non-interpreted
+        /// path in the virtual file system.
+        /// </summary>
+        private const string _nonInterpretedPathPrefix = @"\??\";
+
+        /// <summary>
+        /// Reparse point tag used to identify mount points and junction points.
+        /// </summary>
+        private const uint _reparseTagMountPoint = 0xA0000003;
+
+        /// <summary>
+        /// Command to set the reparse point data block.
+        /// </summary>
+        private const int _setReparsePointCommand = 0x000900A4;
+
+        internal static void CreateReparsePoint(string junctionPoint, string targetDirectoryPath)
+        {
+            using (var handle = OpenReparsePoint(junctionPoint, EFileAccess.GenericWrite))
+            {
+                var targetDirBytes = Encoding.Unicode.GetBytes(_nonInterpretedPathPrefix + Path.GetFullPath(targetDirectoryPath));
+
+                var reparseDataBuffer = new ReparseDataBuffer();
+                reparseDataBuffer.ReparseTag = _reparseTagMountPoint;
+                reparseDataBuffer.ReparseDataLength = (ushort)(targetDirBytes.Length + 12);
+                reparseDataBuffer.SubstituteNameOffset = 0;
+                reparseDataBuffer.SubstituteNameLength = (ushort)targetDirBytes.Length;
+                reparseDataBuffer.PrintNameOffset = (ushort)(targetDirBytes.Length + 2);
+                reparseDataBuffer.PrintNameLength = 0;
+                reparseDataBuffer.PathBuffer = new byte[0x3ff0];
+
+                Array.Copy(targetDirBytes, reparseDataBuffer.PathBuffer, targetDirBytes.Length);
+
+                var inBufferSize = Marshal.SizeOf(reparseDataBuffer);
+                var inBuffer = Marshal.AllocHGlobal(inBufferSize);
+
+                try
+                {
+                    Marshal.StructureToPtr(reparseDataBuffer, inBuffer, false);
+
+                    int bytesReturned;
+                    var result = DeviceIoControl(
+                        handle.DangerousGetHandle(),
+                        _setReparsePointCommand,
+                        inBuffer,
+                        targetDirBytes.Length + 20,
+                        IntPtr.Zero,
+                        0,
+                        out bytesReturned,
+                        IntPtr.Zero);
+
+                    if (!result)
+                    {
+                        ThrowLastWin32Error("Unable to create junction point.");
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(inBuffer);
+                }
+            }
+        }
+
+        private static SafeFileHandle OpenReparsePoint(string reparsePoint, EFileAccess accessMode)
+        {
+            var preexistingHandle = CreateFile(reparsePoint,
+                accessMode,
+                EFileShare.Read | EFileShare.Write | EFileShare.Delete,
+                IntPtr.Zero,
+                ECreationDisposition.OpenExisting,
+                EFileAttributes.BackupSemantics | EFileAttributes.OpenReparsePoint,
+                IntPtr.Zero);
+
+            var reparsePointHandle = new SafeFileHandle(preexistingHandle, true);
+
+            if (Marshal.GetLastWin32Error() != 0)
+            {
+                ThrowLastWin32Error("Unable to open reparse point.");
+            }
+
+            return reparsePointHandle;
+        }
+
+        private static void ThrowLastWin32Error(string message)
+        {
+            throw new IOException(message, Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error()));
+        }
+
+        [Flags]
+        private enum EFileShare : uint
+        {
+            None = 0x00000000,
+            Read = 0x00000001,
+            Write = 0x00000002,
+            Delete = 0x00000004,
+        }
+
+        [Flags]
+        private enum EFileAccess : uint
+        {
+            GenericRead = 0x80000000,
+            GenericWrite = 0x40000000,
+            GenericExecute = 0x20000000,
+            GenericAll = 0x10000000,
+        }
+
+        [Flags]
+        private enum EFileAttributes : uint
+        {
+            Readonly = 0x00000001,
+            Hidden = 0x00000002,
+            System = 0x00000004,
+            Directory = 0x00000010,
+            Archive = 0x00000020,
+            Device = 0x00000040,
+            Normal = 0x00000080,
+            Temporary = 0x00000100,
+            SparseFile = 0x00000200,
+            ReparsePoint = 0x00000400,
+            Compressed = 0x00000800,
+            Offline = 0x00001000,
+            NotContentIndexed = 0x00002000,
+            Encrypted = 0x00004000,
+            WriteThrough = 0x80000000,
+            Overlapped = 0x40000000,
+            NoBuffering = 0x20000000,
+            RandomAccess = 0x10000000,
+            SequentialScan = 0x08000000,
+            DeleteOnClose = 0x04000000,
+            BackupSemantics = 0x02000000,
+            PosixSemantics = 0x01000000,
+            OpenReparsePoint = 0x00200000,
+            OpenNoRecall = 0x00100000,
+            FirstPipeInstance = 0x00080000
+        }
+
+        private enum ECreationDisposition : uint
+        {
+            New = 1,
+            CreateAlways = 2,
+            OpenExisting = 3,
+            OpenAlways = 4,
+            TruncateExisting = 5,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ReparseDataBuffer
+        {
+            /// <summary>
+            /// Reparse point tag. Must be a Microsoft reparse point tag.
+            /// </summary>
+            public uint ReparseTag;
+
+            /// <summary>
+            /// Size, in bytes, of the data after the Reserved member. This can be calculated by:
+            /// (4 * sizeof(ushort)) + SubstituteNameLength + PrintNameLength +
+            /// (namesAreNullTerminated ? 2 * sizeof(char) : 0);
+            /// </summary>
+            public ushort ReparseDataLength;
+
+            /// <summary>
+            /// Reserved; do not use.
+            /// </summary>
+            public ushort Reserved;
+
+            /// <summary>
+            /// Offset, in bytes, of the substitute name string in the PathBuffer array.
+            /// </summary>
+            public ushort SubstituteNameOffset;
+
+            /// <summary>
+            /// Length, in bytes, of the substitute name string. If this string is null-terminated,
+            /// SubstituteNameLength does not include space for the null character.
+            /// </summary>
+            public ushort SubstituteNameLength;
+
+            /// <summary>
+            /// Offset, in bytes, of the print name string in the PathBuffer array.
+            /// </summary>
+            public ushort PrintNameOffset;
+
+            /// <summary>
+            /// Length, in bytes, of the print name string. If this string is null-terminated,
+            /// PrintNameLength does not include space for the null character.
+            /// </summary>
+            public ushort PrintNameLength;
+
+            /// <summary>
+            /// A buffer containing the unicode-encoded path string. The path string contains
+            /// the substitute name string and print name string.
+            /// </summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 0x3FF0)]
+            public byte[] PathBuffer;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DefaultConfigurationFilePreserver.cs" />
+    <Compile Include="LocalResourceUtilsTest.cs" />
     <Compile Include="MockServer.cs" />
     <Compile Include="MockServerResource.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -66,6 +67,7 @@
     </Compile>
     <Compile Include="MSBuildProjectSystemTests.cs" />
     <Compile Include="MSBuildUtilityTest.cs" />
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="NetworkCallCountTest.cs" />
     <Compile Include="NuGetAddCommandTests.cs" />
     <Compile Include="NuGetConfigCommandTest.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetLocalsCommandTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using NuGet.Test.Utility;
 using Xunit;
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -692,6 +693,41 @@ EndProject";
         public static string GetNupkgFileName(string normalizedId, string normalizedVersion)
         {
             return string.Format(NupkgFileFormat, normalizedId, normalizedVersion);
+        }
+
+        /// <summary>
+        /// Creates a junction point from the specified directory to the specified target directory.
+        /// </summary>
+        /// <remarks>Only works on NTFS.</remarks>
+        /// <param name="junctionPoint">The junction point path</param>
+        /// <param name="targetDirectoryPath">The target directory</param>
+        /// <param name="overwrite">If true overwrites an existing reparse point or empty directory</param>
+        /// <exception cref="IOException">
+        /// Thrown when the junction point could not be created or when
+        /// an existing directory was found and <paramref name="overwrite" /> if false
+        /// </exception>
+        public static void CreateJunctionPoint(string junctionPoint, string targetDirectoryPath, bool overwrite)
+        {
+            targetDirectoryPath = Path.GetFullPath(targetDirectoryPath);
+
+            if (!Directory.Exists(targetDirectoryPath))
+            {
+                throw new IOException("Target path does not exist or is not a directory.");
+            }
+
+            if (Directory.Exists(junctionPoint))
+            {
+                if (!overwrite)
+                {
+                    throw new IOException("Directory already exists and overwrite parameter is false.");
+                }
+            }
+            else
+            {
+                Directory.CreateDirectory(junctionPoint);
+            }
+
+            NativeMethods.CreateReparsePoint(junctionPoint, targetDirectoryPath);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1722

Screenshot of behavior when file handle was locked (which doesn't block file from being deleted, but blocks parent folder from being deleted):

![image](https://cloud.githubusercontent.com/assets/880728/11926356/6069179e-a7c4-11e5-925a-b4a27bbeb613.png)

cc @yishaigalatzer @deepakaravindr @emgarten 
