### PR TITLE
Frameworks within the portable profile are not allowed to have profiles themselves

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -413,7 +413,15 @@ namespace NuGet.Frameworks
             var result = new List<NuGetFramework>();
             foreach (var name in shortNames)
             {
-                result.Add(NuGetFramework.Parse(name, this));
+                var framework = NuGetFramework.Parse(name, this);
+                if (framework.HasProfile)
+                {
+                    // Frameworks within the portable profile are not allowed
+                    // to have profiles themselves #1869
+                    throw new FrameworkException(Strings.InvalidPortableFrameworks);
+                }
+
+                result.Add(framework);
             }
 
             frameworks = result;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -115,6 +115,15 @@ namespace NuGet.Frameworks
                     profile = profilePart.Split('=')[1];
                 }
 
+                if (StringComparer.OrdinalIgnoreCase.Equals(FrameworkConstants.FrameworkIdentifiers.Portable, platform)
+                    && !string.IsNullOrEmpty(profile)
+                    && profile.Contains("-"))
+                {
+                    // Frameworks within the portable profile are not allowed
+                    // to have profiles themselves #1869
+                    throw new FrameworkException(Strings.InvalidPortableFrameworks);
+                }
+
                 result = new NuGetFramework(platform, version, profile);
             }
 

--- a/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
@@ -434,6 +434,33 @@ namespace NuGet.Test.Utility
             return file;
         }
 
+        public static TempFile GetLegacyTestPackageWithInvalidPortableFrameworkFolderName()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/test.dll", ZeroContent);
+                zip.AddEntry("lib/net45/test45.dll", ZeroContent);
+                zip.AddEntry("lib/portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS/test.dll", ZeroContent);
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata>
+                                <id>packageA</id>
+                                <version>2.0.3</version>
+                                <authors>Author1, author2</authors>
+                                <description>Sample description</description>
+                                <language>en-US</language>
+                                <projectUrl>http://www.nuget.org/</projectUrl>
+                                <licenseUrl>http://www.nuget.org/license</licenseUrl>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
         public static TempFile GetLegacyContentPackage()
         {
             var file = new TempFile();

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -277,5 +277,16 @@ namespace NuGet.Test
         {
             Assert.Equal("Profile259", NuGetFramework.Parse(framework).Profile);
         }
+
+        [Theory]
+        [InlineData(".NETPortable,Version=v0.0,Profile=win+net-cf")]
+        [InlineData("portable-win+net-cf")]
+        [InlineData(".NETPortable,Version=v0.0,Profile=net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
+        [InlineData("portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
+        public void NuGetFramework_PortableWithInnerPortableProfileFails(string framework)
+        {
+            Assert.Throws<FrameworkException>(
+                () => NuGetFramework.Parse(framework));
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -497,5 +497,20 @@ namespace NuGet.Packaging.Test
                 }
             }
         }
+
+        [Fact]
+        public void PackageReader_SupportedFrameworksForInvalidPortableFrameworkThrows()
+        {
+            using (var packageFile = TestPackages.GetLegacyTestPackageWithInvalidPortableFrameworkFolderName())
+            {
+                var zip = TestPackages.GetZip(packageFile);
+
+                using (PackageReader reader = new PackageReader(zip))
+                {
+                    Assert.Throws<FrameworkException>(
+                        () => reader.GetSupportedFrameworks());
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1869

Note that current 3.3 does not throw when such invalid framework is encountered. Instead, it parses the framework into: `.NETPortable,Version=v0.0,Profile=net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS`

This PR changes the behaviour and will throw `FrameworkException` in these cases.
