### PR TITLE
Fixed version dependent test in NuGetPackageManagerTests suite.

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -3005,7 +3005,7 @@ namespace NuGet.Test
 
                 Assert.NotNull(exception);
                 Assert.True(exception is InvalidOperationException);
-                Assert.Equal("Package 'Newtonsoft.Json.7.0.1' already exists in project 'TestProjectName'", exception.Message);
+                Assert.Equal("Package 'Newtonsoft.Json.8.0.1' already exists in project 'TestProjectName'", exception.Message);
             }
         }
 


### PR DESCRIPTION
- New release of Newtonsoft.Json 8.0.1 rolled out on 12/29 broke the
  unit-test relying on older version.
