### PR TITLE
Handle --debug when it is not passed as the first arg

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -33,9 +33,9 @@ namespace NuGet.CommandLine
         public static int Main(string[] args)
         {
 #if DEBUG
-            if (args.Contains("--debug"))
+            if (args.Contains("--debug", StringComparer.OrdinalIgnoreCase))
             {
-                args = args.Skip(1).ToArray();
+                args = args.Where(arg => !string.Equals(arg, "--debug", StringComparison.OrdinalIgnoreCase)).ToArray();
                 System.Diagnostics.Debugger.Launch();
             }
 #endif


### PR DESCRIPTION
The current implementation is broken when `--debug` is not passed as the first arg; this PR fixes that.
