### PR TITLE
Eval env variables in config values

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -359,7 +359,17 @@ namespace NuGet.Configuration
                 curr = curr._next;
             }
 
-            return ret;
+            return ApplyEnvironmentTransform(ret);
+        }
+
+        private string ApplyEnvironmentTransform(string configValue)
+        {
+            if (string.IsNullOrEmpty(configValue))
+            { 
+                return configValue;
+            }
+
+            return Environment.ExpandEnvironmentVariables(configValue);
         }
 
         public IList<SettingValue> GetSettingValues(string section, bool isPath = false)
@@ -376,6 +386,8 @@ namespace NuGet.Configuration
                 curr.PopulateValues(section, settingValues, isPath);
                 curr = curr._next;
             }
+
+            settingValues.ForEach(settingValue => settingValue.Value = ApplyEnvironmentTransform(settingValue.Value));
 
             return settingValues.AsReadOnly();
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
@@ -1,0 +1,66 @@
+﻿using NuGet.Test.Utility;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Configuration.Test
+{
+    public class EnvironmentSupportTests
+    {
+        private readonly string DefaultNuGetConfigurationWithEnvironmentVariable = @"
+<configuration>
+    <config>
+        <add key='repositoryPath' value='%RP_ENV_VAR%\two' />
+    </config>
+</configuration>";
+
+        [Fact]
+        public void GetValueEvaluatesEnvironmentVariable()
+        {
+            //Arrange
+            var expectedRepositoryPath = @"ONE\two";
+
+            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nugetConfigFile = "NuGet.config";
+                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
+
+                File.WriteAllText(nugetConfigFilePath, DefaultNuGetConfigurationWithEnvironmentVariable);
+
+                Environment.SetEnvironmentVariable("RP_ENV_VAR", "ONE");
+
+                //Act
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
+
+                //Assert
+                Assert.Equal(settings.GetValue("config", "repositoryPath"), expectedRepositoryPath);
+            }
+        }
+
+        [Fact]
+        public void GetSettingValuesEvaluatesEnvironmentVariable()
+        {
+            //Arrange
+            var expectedRepositoryPath = @"ONE\two";
+
+            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nugetConfigFile = "NuGet.config";
+                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
+
+                File.WriteAllText(nugetConfigFilePath, DefaultNuGetConfigurationWithEnvironmentVariable);
+
+                Environment.SetEnvironmentVariable("RP_ENV_VAR", "ONE");
+
+                //Act
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
+
+                //Assert
+                var settingsForConfig = settings.GetSettingValues("config");
+                Assert.Single(settingsForConfig);
+                Assert.Equal(settingsForConfig.Single().Value, expectedRepositoryPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Applies to NuGet/Home#1852

Takes environment variable references in config values, and evaluates those references to what's in the environment. Uses `Environment.ExpandEnvironmentVariables`, so it should be cross platform already. 
## Execution
- [x] `Settings.GetValue()`
- [x] `Settings.GetSettingValues()`
- [x] Documentation NuGet/NuGetDocs#431
## Tested
- [x] Windows
- [x] Mac OS X
- [x] Linux
- [x] Unit tests
- [x] Functional tests
## Considerations
- `Environment.ExpandEnvironmentVariables` looks for `%ENV_NAME%` and *nix-based systems use the format `$ENV_NAME`. Both could be supported, but looking at a couple other projects, it seems the Windows-style naming is consistent on .NET-based cross platform projects. 
- Are there other channels this misses? `ConfigurationDefaults`, for example, uses both `GetValue` and `GetSettingValues`. I didn't obviously see another location that taps into this different.
