### PR TITLE
Re-enabled PackageDownloaderTests.TestDownloadPackage_InV2

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -75,7 +75,7 @@ namespace NuGet.PackageManagement
             Assert.NotNull(exception);
         }
 
-        [Fact(Skip = "Skipped since it is flaky. Tracked by issue https://github.com/NuGet/Home/issues/1525")]
+        [Fact]
         public async Task TestDownloadPackage_InV2()
         {
             // Arrange


### PR DESCRIPTION
Re-enabling the test which validates downloading of a package from an v2 http source.

@yishaigalatzer @emgarten @zhili1208 
