### PR TITLE
Fixed https://github.com/NuGet/Home/issues/1815

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -111,7 +111,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         /// <param name="envDTEProject">The project.</param>
         /// <returns>The full path of the project directory.</returns>
-        internal static string GetFullPath(EnvDTEProject envDTEProject)
+        public static string GetFullPath(EnvDTEProject envDTEProject)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -820,7 +820,7 @@ namespace NuGetVSExtension
             return 0;
         }
 
-        private IEnumerable<projectInfo> GetProjectFolderPath()
+        private IEnumerable<ProjectInfo> GetProjectFolderPath()
         {
             var projects = _dte.Solution.Projects;
             foreach (var item in projects)
@@ -829,7 +829,7 @@ namespace NuGetVSExtension
 
                 if (project != null)
                 {
-                    yield return new projectInfo(EnvDTEProjectUtility.GetFullPath(project), project.Name);
+                    yield return new ProjectInfo(EnvDTEProjectUtility.GetFullPath(project), project.Name);
                 }
             }
         }
@@ -847,13 +847,13 @@ namespace NuGetVSExtension
             }
         }
 
-        private class projectInfo
+        private class ProjectInfo
         {
             public string ProjectPath { get; }
 
             public string ProjectName { get; }
 
-            public projectInfo(string projectPath, string projectName)
+            public ProjectInfo(string projectPath, string projectName)
             {
                 ProjectPath = projectPath;
                 ProjectName = projectName;

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -157,11 +157,6 @@ namespace NuGetVSExtension
         {
             try
             {
-                // check packages.config or project.json file exist, if not, skip restore
-                if (!GetProjectFolderPath().Where(p => CheckPackagesConfig(p.ProjectPath, p.ProjectName)).Any())
-                {
-                    return;
-                }
                 if (Action == vsBuildAction.vsBuildActionClean)
                 {
                     // Clear the project.json restore cache on clean to ensure that the next build restores again
@@ -623,7 +618,8 @@ namespace NuGetVSExtension
 
                 if (!packages.Any())
                 {
-                    if (!isSolutionAvailable)
+                    if (!isSolutionAvailable 
+                        && GetProjectFolderPath().Any(p => CheckPackagesConfig(p.ProjectPath, p.ProjectName)))
                     {
                         MessageHelper.ShowError(_errorListProvider,
                             TaskErrorCategory.Error,
@@ -847,9 +843,7 @@ namespace NuGetVSExtension
             else
             {
                 return File.Exists(Path.Combine(folderPath, "packages.config"))
-                    || File.Exists(Path.Combine(folderPath, "project.json"))
-                    || File.Exists(Path.Combine(folderPath, "packages." + projectName + ".config"))
-                    || File.Exists(Path.Combine(folderPath, projectName + ".project.json"));
+                    || File.Exists(Path.Combine(folderPath, "packages." + projectName + ".config"));
             }
         }
 

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -158,7 +158,7 @@ namespace NuGetVSExtension
             try
             {
                 // check packages.config or project.json file exist, if not, skip restore
-                if (!GetProjectFolderPath().Where(p => CheckPackagesConfig(p.Item1, p.Item2)).Any())
+                if (!GetProjectFolderPath().Where(p => CheckPackagesConfig(p.ProjectPath, p.ProjectName)).Any())
                 {
                     return;
                 }
@@ -824,7 +824,7 @@ namespace NuGetVSExtension
             return 0;
         }
 
-        private IEnumerable<Tuple<string, string>> GetProjectFolderPath()
+        private IEnumerable<projectInfo> GetProjectFolderPath()
         {
             var projects = _dte.Solution.Projects;
             foreach (var item in projects)
@@ -833,7 +833,7 @@ namespace NuGetVSExtension
 
                 if (project != null)
                 {
-                    yield return new Tuple<string, string>(EnvDTEProjectUtility.GetFullPath(project), project.Name);
+                    yield return new projectInfo(EnvDTEProjectUtility.GetFullPath(project), project.Name);
                 }
             }
         }
@@ -848,8 +848,21 @@ namespace NuGetVSExtension
             {
                 return File.Exists(Path.Combine(folderPath, "packages.config"))
                     || File.Exists(Path.Combine(folderPath, "project.json"))
-                    || File.Exists(Path.Combine(folderPath, "packages." + projectName + ".config"));
+                    || File.Exists(Path.Combine(folderPath, "packages." + projectName + ".config"))
+                    || File.Exists(Path.Combine(folderPath, projectName + ".project.json"));
+            }
+        }
 
+        private class projectInfo
+        {
+            public string ProjectPath { get; }
+
+            public string ProjectName { get; }
+
+            public projectInfo(string projectPath, string projectName)
+            {
+                ProjectPath = projectPath;
+                ProjectName = projectName;
             }
         }
 


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1815

the bug is for some project, there is no solution, but we restore packages for the project during build, then will get error.

the fix is before restore, check packages.config or project.json exist, if no, skip restore during build 
