### PR TITLE
Fix of issue NuGet/Home#1896: spacebar does not select/deselect items.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -301,6 +301,7 @@
     </Border>
     <ListBox
       x:Name="_list"
+      PreviewKeyUp="List_PreviewKeyUp"
       Grid.Row="1"
       Background="{DynamicResource {x:Static resx:Brushes.ListPaneBackground}}"
       Foreground="{DynamicResource {x:Static resx:Brushes.UIText}}"

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -421,5 +421,16 @@ namespace NuGet.PackageManagement.UI
                 UpdateButtonClicked(this, EventArgs.Empty);
             }
         }
+
+        private void List_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            // toggle the selection state when user presses the space bar
+            var package = _list.SelectedItem as PackageItemListViewModel;
+            if (package != null && e.Key == System.Windows.Input.Key.Space)
+            {
+                package.Selected = !package.Selected;
+                e.Handled = true;
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml
@@ -163,6 +163,7 @@
       x:Name="_projectList"
       Margin="0,8,0,0"
       ScrollViewer.VerticalScrollBarVisibility="Visible"
+      PreviewKeyUp="ProjectList_PreviewKeyUp"
       ItemsSource="{Binding Projects}"
       Background="{DynamicResource {x:Static local:Brushes.ListPaneBackground}}"
       Foreground="{DynamicResource {x:Static local:Brushes.UIText}}" >

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/SolutionView.xaml.cs
@@ -198,5 +198,16 @@ namespace NuGet.PackageManagement.UI
             // this width adjustment is only done once.
             _projectList.SizeChanged -= ListView_SizeChanged;
         }
+
+        private void ProjectList_PreviewKeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            // toggle the selection state when user presses the space bar
+            var packageInstallationInfo = _projectList.SelectedItem as PackageInstallationInfo;
+            if (packageInstallationInfo != null && e.Key == System.Windows.Input.Key.Space)
+            {
+                packageInstallationInfo.IsSelected = !packageInstallationInfo.IsSelected;
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Now the user can toggle the checkboxes in the project list and packages in
the package list by pressing the spacebar.

@yishaigalatzer @emgarten @deepakaravindr 
