### PR TITLE
Add "netstandard" moniker

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.Frameworks
 {
     public sealed class DefaultFrameworkMappings : IFrameworkMappings
     {
-        public DefaultFrameworkMappings()
-        {
-        }
-
         private static KeyValuePair<string, string>[] _identifierSynonyms;
 
         public IEnumerable<KeyValuePair<string, string>> IdentifierSynonyms
@@ -59,6 +56,7 @@ namespace NuGet.Frameworks
                 {
                     _identifierShortNames = new KeyValuePair<string, string>[]
                         {
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetStandard, "netstandard"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetPlatform, "dotnet"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Net, "net"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetMicro, "netmf"),
@@ -128,8 +126,8 @@ namespace NuGet.Frameworks
                         {
                             // UAP 0.0 <-> UAP 10.0
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
-                                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
-                                                    FrameworkConstants.CommonFrameworks.UAP10),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
+                                FrameworkConstants.CommonFrameworks.UAP10),
 
                             // win <-> win8
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
@@ -266,10 +264,14 @@ namespace NuGet.Frameworks
                     _subSetFrameworks = new KeyValuePair<string, string>[]
                         {
                             // .NET is a subset of DNX
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.FrameworkIdentifiers.Dnx),
+                            new KeyValuePair<string, string>(
+                                FrameworkConstants.FrameworkIdentifiers.Net,
+                                FrameworkConstants.FrameworkIdentifiers.Dnx),
 
-                            // DotNet is a subset of DNXCore
-                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetPlatform, FrameworkConstants.FrameworkIdentifiers.DnxCore),
+                            // NetPlatform is a subset of DNXCore
+                            new KeyValuePair<string, string>(
+                                FrameworkConstants.FrameworkIdentifiers.NetPlatform,
+                                FrameworkConstants.FrameworkIdentifiers.DnxCore)
                         };
                 }
 
@@ -285,203 +287,292 @@ namespace NuGet.Frameworks
             {
                 if (_compatibilityMappings == null)
                 {
-                    _compatibilityMappings = new OneWayCompatibilityMappingEntry[]
-                        {
-                            // UAP supports Win81
-                            new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
-                                new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.EmptyVersion),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, new Version(8, 1, 0, 0)))),
-
-                            // UAP supports WPA81
-                            new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
-                                new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp, FrameworkConstants.EmptyVersion),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp, new Version(8, 1, 0, 0)))),
-
-                            // UAP supports NetCore50
-                            new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
-                                new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5))),
-
-                            // Win projects support WinRT
-                            new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                    _compatibilityMappings = new[]
+                    {
+                        // UAP supports Win81
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.EmptyVersion),
-                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.MaxVersion)),
-                                new FrameworkRange(
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, FrameworkConstants.EmptyVersion),
-                                    new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, new Version(4, 5, 0, 0)))),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, new Version(8, 1, 0, 0)))),
 
-                           // the below frameworks support dotnet
+                        // UAP supports WPA81
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp, new Version(8, 1, 0, 0)))),
 
-                           // dnxcore50 -> dotnet5.6
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.DnxCore,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                        // UAP supports NetCore50
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.EmptyVersion),
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCore, FrameworkConstants.Version5))),
 
-                           // uap -> dotnet5.6
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.UAP,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                        // Win projects support WinRT
+                        new OneWayCompatibilityMappingEntry(new FrameworkRange(
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.EmptyVersion),
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, FrameworkConstants.MaxVersion)),
+                            new FrameworkRange(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, FrameworkConstants.EmptyVersion),
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, new Version(4, 5, 0, 0)))),
 
-                           // netcore50 -> dotnet5.6
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.NetCore50,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                        // netstandard supports dotnet, but not the reverse
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard10,
+                            FrameworkConstants.CommonFrameworks.DotNet51),
 
-                           // wpa81 -> dotnet5.3
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.WPA81,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet53),
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard11,
+                            FrameworkConstants.CommonFrameworks.DotNet52),
 
-                           // wp8, wp81 -> dotnet5.1
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.WP8,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet51),
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard12,
+                            FrameworkConstants.CommonFrameworks.DotNet53),
 
-                           // net45 -> dotnet5.2
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.Net45,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet52),
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard13,
+                            FrameworkConstants.CommonFrameworks.DotNet54),
 
-                           // net451 -> dotnet5.3
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.Net451,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet53),
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard14,
+                            FrameworkConstants.CommonFrameworks.DotNet55),
 
-                           // net46 -> dotnet5.4
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.Net46,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet54),
+                        CreateGenerationMapping(
+                            FrameworkConstants.CommonFrameworks.NetStandard15,
+                            FrameworkConstants.CommonFrameworks.DotNet56)
+                    }
+                        .Concat(new[]
+                        {
+                            // dnxcore50 -> dotnet5.6, netstandard1.5
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.DnxCore,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           // net461 -> dotnet5.5
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.Net461,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet55),
+                            // uap -> dotnet5.6, netstandard1.5
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.UAP,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           // net462 -> dotnet5.6
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.Net462,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // netcore50 -> dotnet5.6, netstandard1.5
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.NetCore50,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           // netcore45 -> dotnet5.2
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.NetCore45,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet52),
+                            // wpa81 -> dotnet5.3, netstandard1.2
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.WPA81,
+                                FrameworkConstants.CommonFrameworks.DotNet53,
+                                FrameworkConstants.CommonFrameworks.NetStandard12),
 
-                           // netcore451 -> dotnet5.3
-                           CreateDotNetGenerationMapping(
-                               FrameworkConstants.CommonFrameworks.NetCore451,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet53),
+                            // wp8, wp81 -> dotnet5.1, netstandard1.0
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.WP8,
+                                FrameworkConstants.CommonFrameworks.DotNet51,
+                                FrameworkConstants.CommonFrameworks.NetStandard10),
 
-                           // xamarin frameworks
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.MonoAndroid,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // net45 -> dotnet5.2, netstandard1.1
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.Net45,
+                                FrameworkConstants.CommonFrameworks.DotNet52,
+                                FrameworkConstants.CommonFrameworks.NetStandard11),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.MonoMac,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // net451 -> dotnet5.3, netstandard1.2
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.Net451,
+                                FrameworkConstants.CommonFrameworks.DotNet53,
+                                FrameworkConstants.CommonFrameworks.NetStandard12),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.MonoTouch,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // net46 -> dotnet5.4, netstandard1.3
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.Net46,
+                                FrameworkConstants.CommonFrameworks.DotNet54,
+                                FrameworkConstants.CommonFrameworks.NetStandard13),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // net461 -> dotnet5.5, netstandard1.4
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.Net461,
+                                FrameworkConstants.CommonFrameworks.DotNet55,
+                                FrameworkConstants.CommonFrameworks.NetStandard14),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // net462 -> dotnet5.6, netstandard1.5
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.Net462,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // netcore45 -> dotnet5.2, netstandard1.1
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.NetCore45,
+                                FrameworkConstants.CommonFrameworks.DotNet52,
+                                FrameworkConstants.CommonFrameworks.NetStandard11),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinMac,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // netcore451 -> dotnet5.3, netstandard1.2
+                            CreateGenerationAndStandardMapping(
+                                FrameworkConstants.CommonFrameworks.NetCore451,
+                                FrameworkConstants.CommonFrameworks.DotNet53,
+                                FrameworkConstants.CommonFrameworks.NetStandard12),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            // xamarin frameworks
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.MonoAndroid,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation4,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.MonoMac,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinPlayStationVita,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.MonoTouch,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinXbox360,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinTVOS,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56),
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
 
-                           CreateDotNetGenerationMappingForAllVersions(
-                               FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS,
-                               FrameworkConstants.DotNetGenerationRanges.DotNet56)
-                        };
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinMac,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation3,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinPlayStation4,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinPlayStationVita,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinXbox360,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinXboxOne,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinTVOS,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15),
+
+                            CreateGenerationAndStandardMappingForAllVersions(
+                                FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS,
+                                FrameworkConstants.CommonFrameworks.DotNet56,
+                                FrameworkConstants.CommonFrameworks.NetStandard15)
+                        }.SelectMany(mappings => mappings))
+                        .ToArray();
                 }
 
                 return _compatibilityMappings;
             }
         }
 
-        // Map the given framework to dotnet generation
-        private static OneWayCompatibilityMappingEntry CreateDotNetGenerationMapping(
+        private static OneWayCompatibilityMappingEntry CreateGenerationMapping(
             NuGetFramework framework,
-            FrameworkRange dotnetGeneration)
+            NuGetFramework netPlatform)
         {
-            return new OneWayCompatibilityMappingEntry(new FrameworkRange(
-                        framework,
-                        new NuGetFramework(framework.Framework, FrameworkConstants.MaxVersion)),
-                        dotnetGeneration);
+            return new OneWayCompatibilityMappingEntry(
+                new FrameworkRange(
+                    framework,
+                    new NuGetFramework(framework.Framework, FrameworkConstants.MaxVersion)),
+                new FrameworkRange(
+                    FrameworkConstants.CommonFrameworks.DotNet,
+                    netPlatform));
         }
 
-        private static OneWayCompatibilityMappingEntry CreateDotNetGenerationMappingForAllVersions(
+        private static IEnumerable<OneWayCompatibilityMappingEntry> CreateGenerationAndStandardMapping(
+            NuGetFramework framework,
+            NuGetFramework netPlatform,
+            NuGetFramework netStandard)
+        {
+            yield return CreateGenerationMapping(framework, netPlatform);
+
+            yield return new OneWayCompatibilityMappingEntry(
+                new FrameworkRange(
+                    framework,
+                    new NuGetFramework(framework.Framework, FrameworkConstants.MaxVersion)),
+                new FrameworkRange(
+                    FrameworkConstants.CommonFrameworks.NetStandard10,
+                    netStandard));
+        }
+
+        private static IEnumerable<OneWayCompatibilityMappingEntry> CreateGenerationAndStandardMappingForAllVersions(
             string framework,
-            FrameworkRange dotnetGeneration)
+            NuGetFramework netPlatform,
+            NuGetFramework netStandard)
         {
             var lowestFramework = new NuGetFramework(framework, FrameworkConstants.EmptyVersion);
-
-            return CreateDotNetGenerationMapping(lowestFramework, dotnetGeneration);
+            return CreateGenerationAndStandardMapping(lowestFramework, netPlatform, netStandard);
         }
 
-        private static string[] _frameworkPrecedence;
+        private static string[] _nonPackageBasedFrameworkPrecedence;
 
-        public IEnumerable<string> FrameworkPrecedence
+        public IEnumerable<string> NonPackageBasedFrameworkPrecedence
         {
             get
             {
-                if (_frameworkPrecedence == null)
+                if (_nonPackageBasedFrameworkPrecedence == null)
                 {
-                    _frameworkPrecedence = new string[]
+                    _nonPackageBasedFrameworkPrecedence = new[]
                     {
                         FrameworkConstants.FrameworkIdentifiers.Net,
                         FrameworkConstants.FrameworkIdentifiers.NetCore,
                         FrameworkConstants.FrameworkIdentifiers.Windows,
-                        FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp,
+                        FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp
                     };
                 }
 
-                return _frameworkPrecedence;
+                return _nonPackageBasedFrameworkPrecedence;
+            }
+        }
+
+        private static string[] _packageBasedFrameworkPrecedence;
+
+        public IEnumerable<string> PackageBasedFrameworkPrecedence
+        {
+            get
+            {
+                if (_packageBasedFrameworkPrecedence == null)
+                {
+                    _packageBasedFrameworkPrecedence = new[]
+                    {
+                        FrameworkConstants.FrameworkIdentifiers.NetStandard,
+                        FrameworkConstants.FrameworkIdentifiers.NetPlatform
+                    };
+                }
+
+                return _packageBasedFrameworkPrecedence;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -32,6 +32,7 @@ namespace NuGet.Frameworks
 
         public static class FrameworkIdentifiers
         {
+            public const string NetStandard = ".NETStandard";
             public const string NetPlatform = ".NETPlatform";
             public const string DotNet = "dotnet";
             public const string Net = ".NETFramework";
@@ -112,13 +113,13 @@ namespace NuGet.Frameworks
 
             public static readonly NuGetFramework DotNet
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, EmptyVersion);
-            public static readonly NuGetFramework DotNet50 
+            public static readonly NuGetFramework DotNet50
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, Version5);
             public static readonly NuGetFramework DotNet51
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, new Version(5, 1, 0, 0));
-            public static readonly NuGetFramework DotNet52 
+            public static readonly NuGetFramework DotNet52
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, new Version(5, 2, 0, 0));
-            public static readonly NuGetFramework DotNet53 
+            public static readonly NuGetFramework DotNet53
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, new Version(5, 3, 0, 0));
             public static readonly NuGetFramework DotNet54
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, new Version(5, 4, 0, 0));
@@ -127,34 +128,23 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework DotNet56
                 = new NuGetFramework(FrameworkIdentifiers.NetPlatform, new Version(5, 6, 0, 0));
 
-            public static readonly NuGetFramework UAP10 = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, Version10);
-        }
+            public static readonly NuGetFramework NetStandard
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, EmptyVersion);
+            public static readonly NuGetFramework NetStandard10
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 0, 0, 0));
+            public static readonly NuGetFramework NetStandard11
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 1, 0, 0));
+            public static readonly NuGetFramework NetStandard12
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 2, 0, 0));
+            public static readonly NuGetFramework NetStandard13
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 3, 0, 0));
+            public static readonly NuGetFramework NetStandard14
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 4, 0, 0));
+            public static readonly NuGetFramework NetStandard15
+                = new NuGetFramework(FrameworkIdentifiers.NetStandard, new Version(1, 5, 0, 0));
 
-        /// <summary>
-        /// Ranges of dotnet frameworks
-        /// </summary>
-        public static class DotNetGenerationRanges
-        {
-            public static readonly FrameworkRange DotNet50 
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet50);
-
-            public static readonly FrameworkRange DotNet51
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet51);
-
-            public static readonly FrameworkRange DotNet52
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet52);
-
-            public static readonly FrameworkRange DotNet53
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet53);
-
-            public static readonly FrameworkRange DotNet54
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet54);
-
-            public static readonly FrameworkRange DotNet55
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet55);
-
-            public static readonly FrameworkRange DotNet56
-                = new FrameworkRange(CommonFrameworks.DotNet, CommonFrameworks.DotNet56);
+            public static readonly NuGetFramework UAP10
+                = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, Version10);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
@@ -118,7 +118,7 @@ namespace NuGet.Frameworks
                     }
                 }
 
-                // Packages based framework reduce 
+                // Packages based framework reduce
                 if (reduced.Count() > 1
                     && reduced.Any(f => f.IsPackageBased)
                     && reduced.Any(f => !f.IsPackageBased))
@@ -167,7 +167,8 @@ namespace NuGet.Frameworks
                 if (nearest == null && reduced.Any())
                 {
                     // Sort by precedence rules, then by name in the case of a tie
-                    nearest = reduced.OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings))
+                    nearest = reduced
+                        .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings))
                         .ThenByDescending(f => f, new NuGetFrameworkSorter())
                         .ThenBy(f => f.GetHashCode())
                         .First();

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -270,6 +270,8 @@ namespace NuGet.Frameworks
             {
                 return FrameworkConstants.FrameworkIdentifiers.NetPlatform
                     .Equals(Framework, StringComparison.OrdinalIgnoreCase)
+                    || FrameworkConstants.FrameworkIdentifiers.NetStandard
+                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
                     || FrameworkConstants.FrameworkIdentifiers.DnxCore
                     .Equals(Framework, StringComparison.OrdinalIgnoreCase);
             }

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
@@ -61,7 +61,13 @@ namespace NuGet.Frameworks
         /// equivalently compatible to a new framework.
         /// Example: UAP10.0 -> win81, wpa81
         /// </summary>
-        IEnumerable<string> FrameworkPrecedence { get; }
+        IEnumerable<string> NonPackageBasedFrameworkPrecedence { get; }
+
+        /// <summary>
+        /// Same as <see cref="NonPackageBasedFrameworkPrecedence"/> but is only referred to if all of the packages
+        /// in consideration are package based (determined by <see cref="NuGetFramework.IsPackageBased"/>).
+        /// </summary>
+        IEnumerable<string> PackageBasedFrameworkPrecedence { get; }
 
         /// <summary>
         /// Rewrite folder short names to the given value.

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -14,7 +14,13 @@ namespace NuGet.Test
         [InlineData("dotnet", "dotnet", true)]
         [InlineData("dotnet5.1", "dotnet", true)]
 
-        // dnxcore50 -> dotnet
+        // dnxcore50 -> dotnet, netstandard
+        [InlineData("dnxcore50", "netstandard1.5", true)]
+        [InlineData("dnxcore50", "netstandard1.4", true)]
+        [InlineData("dnxcore50", "netstandard1.3", true)]
+        [InlineData("dnxcore50", "netstandard1.2", true)]
+        [InlineData("dnxcore50", "netstandard1.1", true)]
+        [InlineData("dnxcore50", "netstandard1.0", true)]
         [InlineData("dnxcore50", "dotnet5.6", true)]
         [InlineData("dnxcore50", "dotnet5.5", true)]
         [InlineData("dnxcore50", "dotnet5.4", true)]
@@ -22,7 +28,13 @@ namespace NuGet.Test
         [InlineData("dnxcore50", "dotnet5.2", true)]
         [InlineData("dnxcore50", "dotnet5.1", true)]
 
-        // net -> dotnet
+        // net -> dotnet, netstandard
+        [InlineData("net462", "netstandard1.5", true)]
+        [InlineData("net462", "netstandard1.4", true)]
+        [InlineData("net462", "netstandard1.3", true)]
+        [InlineData("net462", "netstandard1.2", true)]
+        [InlineData("net462", "netstandard1.1", true)]
+        [InlineData("net462", "netstandard1.0", true)]
         [InlineData("net462", "dotnet5.6", true)]
         [InlineData("net462", "dotnet5.5", true)]
         [InlineData("net462", "dotnet5.4", true)]
@@ -31,6 +43,12 @@ namespace NuGet.Test
         [InlineData("net462", "dotnet5.1", true)]
         [InlineData("net462", "dotnet", true)]
         
+        [InlineData("net461", "netstandard1.5", false)]
+        [InlineData("net461", "netstandard1.4", true)]
+        [InlineData("net461", "netstandard1.3", true)]
+        [InlineData("net461", "netstandard1.2", true)]
+        [InlineData("net461", "netstandard1.1", true)]
+        [InlineData("net461", "netstandard1.0", true)]
         [InlineData("net461", "dotnet5.6", false)]
         [InlineData("net461", "dotnet5.5", true)]
         [InlineData("net461", "dotnet5.4", true)]
@@ -39,6 +57,12 @@ namespace NuGet.Test
         [InlineData("net461", "dotnet5.1", true)]
         [InlineData("net461", "dotnet", true)]
 
+        [InlineData("net46", "netstandard1.5", false)]
+        [InlineData("net46", "netstandard1.4", false)]
+        [InlineData("net46", "netstandard1.3", true)]
+        [InlineData("net46", "netstandard1.2", true)]
+        [InlineData("net46", "netstandard1.1", true)]
+        [InlineData("net46", "netstandard1.0", true)]
         [InlineData("net46", "dotnet5.6", false)]
         [InlineData("net46", "dotnet5.5", false)]
         [InlineData("net46", "dotnet5.4", true)]
@@ -47,6 +71,12 @@ namespace NuGet.Test
         [InlineData("net46", "dotnet5.1", true)]
         [InlineData("net46", "dotnet", true)]
 
+        [InlineData("net452", "netstandard1.5", false)]
+        [InlineData("net452", "netstandard1.4", false)]
+        [InlineData("net452", "netstandard1.3", false)]
+        [InlineData("net452", "netstandard1.2", true)]
+        [InlineData("net452", "netstandard1.1", true)]
+        [InlineData("net452", "netstandard1.0", true)]
         [InlineData("net452", "dotnet5.6", false)]
         [InlineData("net452", "dotnet5.5", false)]
         [InlineData("net452", "dotnet5.4", false)]
@@ -55,6 +85,12 @@ namespace NuGet.Test
         [InlineData("net452", "dotnet5.1", true)]
         [InlineData("net452", "dotnet", true)]
 
+        [InlineData("net451", "netstandard1.5", false)]
+        [InlineData("net451", "netstandard1.4", false)]
+        [InlineData("net451", "netstandard1.3", false)]
+        [InlineData("net451", "netstandard1.2", true)]
+        [InlineData("net451", "netstandard1.1", true)]
+        [InlineData("net451", "netstandard1.0", true)]
         [InlineData("net451", "dotnet5.6", false)]
         [InlineData("net451", "dotnet5.5", false)]
         [InlineData("net451", "dotnet5.4", false)]
@@ -63,6 +99,12 @@ namespace NuGet.Test
         [InlineData("net451", "dotnet5.1", true)]
         [InlineData("net451", "dotnet", true)]
 
+        [InlineData("net45", "netstandard1.5", false)]
+        [InlineData("net45", "netstandard1.4", false)]
+        [InlineData("net45", "netstandard1.3", false)]
+        [InlineData("net45", "netstandard1.2", false)]
+        [InlineData("net45", "netstandard1.1", true)]
+        [InlineData("net45", "netstandard1.0", true)]
         [InlineData("net45", "dotnet5.6", false)]
         [InlineData("net45", "dotnet5.5", false)]
         [InlineData("net45", "dotnet5.4", false)]
@@ -71,7 +113,13 @@ namespace NuGet.Test
         [InlineData("net45", "dotnet5.1", true)]
         [InlineData("net45", "dotnet", true)]
 
-        // dnx -> dotnet
+        // dnx -> dotnet, netstandard
+        [InlineData("dnx462", "netstandard1.5", true)]
+        [InlineData("dnx462", "netstandard1.4", true)]
+        [InlineData("dnx462", "netstandard1.3", true)]
+        [InlineData("dnx462", "netstandard1.2", true)]
+        [InlineData("dnx462", "netstandard1.1", true)]
+        [InlineData("dnx462", "netstandard1.0", true)]
         [InlineData("dnx462", "dotnet5.6", true)]
         [InlineData("dnx462", "dotnet5.5", true)]
         [InlineData("dnx462", "dotnet5.4", true)]
@@ -80,6 +128,12 @@ namespace NuGet.Test
         [InlineData("dnx462", "dotnet5.1", true)]
         [InlineData("dnx462", "dotnet", true)]
         
+        [InlineData("dnx461", "netstandard1.5", false)]
+        [InlineData("dnx461", "netstandard1.4", true)]
+        [InlineData("dnx461", "netstandard1.3", true)]
+        [InlineData("dnx461", "netstandard1.2", true)]
+        [InlineData("dnx461", "netstandard1.1", true)]
+        [InlineData("dnx461", "netstandard1.0", true)]
         [InlineData("dnx461", "dotnet5.6", false)]
         [InlineData("dnx461", "dotnet5.5", true)]
         [InlineData("dnx461", "dotnet5.4", true)]
@@ -88,6 +142,12 @@ namespace NuGet.Test
         [InlineData("dnx461", "dotnet5.1", true)]
         [InlineData("dnx461", "dotnet", true)]
 
+        [InlineData("dnx46", "netstandard1.5", false)]
+        [InlineData("dnx46", "netstandard1.4", false)]
+        [InlineData("dnx46", "netstandard1.3", true)]
+        [InlineData("dnx46", "netstandard1.2", true)]
+        [InlineData("dnx46", "netstandard1.1", true)]
+        [InlineData("dnx46", "netstandard1.0", true)]
         [InlineData("dnx46", "dotnet5.6", false)]
         [InlineData("dnx46", "dotnet5.5", false)]
         [InlineData("dnx46", "dotnet5.4", true)]
@@ -96,6 +156,12 @@ namespace NuGet.Test
         [InlineData("dnx46", "dotnet5.1", true)]
         [InlineData("dnx46", "dotnet", true)]
 
+        [InlineData("dnx452", "netstandard1.5", false)]
+        [InlineData("dnx452", "netstandard1.4", false)]
+        [InlineData("dnx452", "netstandard1.3", false)]
+        [InlineData("dnx452", "netstandard1.2", true)]
+        [InlineData("dnx452", "netstandard1.1", true)]
+        [InlineData("dnx452", "netstandard1.0", true)]
         [InlineData("dnx452", "dotnet5.6", false)]
         [InlineData("dnx452", "dotnet5.5", false)]
         [InlineData("dnx452", "dotnet5.4", false)]
@@ -104,6 +170,12 @@ namespace NuGet.Test
         [InlineData("dnx452", "dotnet5.1", true)]
         [InlineData("dnx452", "dotnet", true)]
 
+        [InlineData("dnx451", "netstandard1.5", false)]
+        [InlineData("dnx451", "netstandard1.4", false)]
+        [InlineData("dnx451", "netstandard1.3", false)]
+        [InlineData("dnx451", "netstandard1.2", true)]
+        [InlineData("dnx451", "netstandard1.1", true)]
+        [InlineData("dnx451", "netstandard1.0", true)]
         [InlineData("dnx451", "dotnet5.6", false)]
         [InlineData("dnx451", "dotnet5.5", false)]
         [InlineData("dnx451", "dotnet5.4", false)]
@@ -113,6 +185,12 @@ namespace NuGet.Test
         [InlineData("dnx451", "dotnet", true)]
 
         // dnx45 doesn't really work, but it's here for completeness :)
+        [InlineData("dnx45", "netstandard1.5", false)]
+        [InlineData("dnx45", "netstandard1.4", false)]
+        [InlineData("dnx45", "netstandard1.3", false)]
+        [InlineData("dnx45", "netstandard1.2", false)]
+        [InlineData("dnx45", "netstandard1.1", true)]
+        [InlineData("dnx45", "netstandard1.0", true)]
         [InlineData("dnx45", "dotnet5.6", false)]
         [InlineData("dnx45", "dotnet5.5", false)]
         [InlineData("dnx45", "dotnet5.4", false)]
@@ -121,10 +199,16 @@ namespace NuGet.Test
         [InlineData("dnx45", "dotnet5.1", true)]
         [InlineData("dnx45", "dotnet", true)]
 
-        // uap10 -> netcore50 -> win81 -> wpa81 -> dotnet
+        // uap10 -> netcore50 -> win81 -> wpa81 -> dotnet, netstandard
         [InlineData("uap10.0", "netcore50", true)]
         [InlineData("uap10.0", "win81", true)]
         [InlineData("uap10.0", "wpa81", true)]
+        [InlineData("uap10.0", "netstandard1.5", true)]
+        [InlineData("uap10.0", "netstandard1.4", true)]
+        [InlineData("uap10.0", "netstandard1.3", true)]
+        [InlineData("uap10.0", "netstandard1.2", true)]
+        [InlineData("uap10.0", "netstandard1.1", true)]
+        [InlineData("uap10.0", "netstandard1.0", true)]
         [InlineData("uap10.0", "dotnet5.6", true)]
         [InlineData("uap10.0", "dotnet5.5", true)]
         [InlineData("uap10.0", "dotnet5.4", true)]
@@ -133,6 +217,12 @@ namespace NuGet.Test
         [InlineData("uap10.0", "dotnet5.1", true)]
         [InlineData("netcore50", "win81", true)]
         [InlineData("netcore50", "wpa81", false)]
+        [InlineData("netcore50", "netstandard1.5", true)]
+        [InlineData("netcore50", "netstandard1.4", true)]
+        [InlineData("netcore50", "netstandard1.3", true)]
+        [InlineData("netcore50", "netstandard1.2", true)]
+        [InlineData("netcore50", "netstandard1.1", true)]
+        [InlineData("netcore50", "netstandard1.0", true)]
         [InlineData("netcore50", "dotnet5.6", true)]
         [InlineData("netcore50", "dotnet5.5", true)]
         [InlineData("netcore50", "dotnet5.4", true)]
@@ -140,7 +230,18 @@ namespace NuGet.Test
         [InlineData("netcore50", "dotnet5.2", true)]
         [InlineData("netcore50", "dotnet5.1", true)]
 
-        // wpa81/win81 -> dotnet
+        // wpa81/win81 -> dotnet, netstandard
+        [InlineData("wpa81", "netstandard1.5", false)]
+        [InlineData("wpa81", "netstandard1.4", false)]
+        [InlineData("wpa81", "netstandard1.3", false)]
+        [InlineData("wpa81", "netstandard1.2", true)]
+        [InlineData("wpa81", "netstandard1.1", true)]
+        [InlineData("wpa81", "netstandard1.0", true)]
+        [InlineData("win81", "netstandard1.4", false)]
+        [InlineData("win81", "netstandard1.3", false)]
+        [InlineData("win81", "netstandard1.2", true)]
+        [InlineData("win81", "netstandard1.1", true)]
+        [InlineData("win81", "netstandard1.0", true)]
         [InlineData("wpa81", "dotnet5.6", false)]
         [InlineData("wpa81", "dotnet5.5", false)]
         [InlineData("wpa81", "dotnet5.4", false)]
@@ -153,7 +254,31 @@ namespace NuGet.Test
         [InlineData("win81", "dotnet5.2", true)]
         [InlineData("win81", "dotnet5.1", true)]
 
-        // wp8/wp81 -> dotnet
+        // wp8/wp81 -> dotnet, netstandard
+        [InlineData("wp81", "netstandard1.5", false)]
+        [InlineData("wp81", "netstandard1.4", false)]
+        [InlineData("wp81", "netstandard1.3", false)]
+        [InlineData("wp81", "netstandard1.2", false)]
+        [InlineData("wp81", "netstandard1.1", false)]
+        [InlineData("wp81", "netstandard1.0", true)]
+        [InlineData("wp8", "netstandard1.5", false)]
+        [InlineData("wp8", "netstandard1.4", false)]
+        [InlineData("wp8", "netstandard1.3", false)]
+        [InlineData("wp8", "netstandard1.2", false)]
+        [InlineData("wp8", "netstandard1.1", false)]
+        [InlineData("wp8", "netstandard1.0", true)]
+        [InlineData("sl8-windowsphone", "netstandard1.5", false)]
+        [InlineData("sl8-windowsphone", "netstandard1.4", false)]
+        [InlineData("sl8-windowsphone", "netstandard1.3", false)]
+        [InlineData("sl8-windowsphone", "netstandard1.2", false)]
+        [InlineData("sl8-windowsphone", "netstandard1.1", false)]
+        [InlineData("sl8-windowsphone", "netstandard1.0", true)]
+        [InlineData("sl7-windowsphone", "netstandard1.5", false)]
+        [InlineData("sl7-windowsphone", "netstandard1.4", false)]
+        [InlineData("sl7-windowsphone", "netstandard1.3", false)]
+        [InlineData("sl7-windowsphone", "netstandard1.2", false)]
+        [InlineData("sl7-windowsphone", "netstandard1.1", false)]
+        [InlineData("sl7-windowsphone", "netstandard1.0", false)]
         [InlineData("wp81", "dotnet5.6", false)]
         [InlineData("wp81", "dotnet5.5", false)]
         [InlineData("wp81", "dotnet5.4", false)]
@@ -179,7 +304,13 @@ namespace NuGet.Test
         [InlineData("sl7-windowsphone", "dotnet5.2", false)]
         [InlineData("sl7-windowsphone", "dotnet5.1", false)]
 
-        // win8 -> dotnet
+        // win8 -> netstandard
+        [InlineData("win8", "netstandard1.5", false)]
+        [InlineData("win8", "netstandard1.4", false)]
+        [InlineData("win8", "netstandard1.3", false)]
+        [InlineData("win8", "netstandard1.2", false)]
+        [InlineData("win8", "netstandard1.1", true)]
+        [InlineData("win8", "netstandard1.0", true)]
         [InlineData("win8", "dotnet5.6", false)]
         [InlineData("win8", "dotnet5.5", false)]
         [InlineData("win8", "dotnet5.4", false)]
@@ -187,7 +318,14 @@ namespace NuGet.Test
         [InlineData("win8", "dotnet5.2", true)]
         [InlineData("win8", "dotnet5.1", true)]
 
-        // Older things don't support dotnet at all
+        // Older things don't support netstandard or dotnet at all
+        [InlineData("sl4", "netstandard", false)]
+        [InlineData("sl3", "netstandard", false)]
+        [InlineData("sl2", "netstandard", false)]
+        [InlineData("net40", "netstandard", false)]
+        [InlineData("net35", "netstandard", false)]
+        [InlineData("net20", "netstandard", false)]
+        [InlineData("net20", "netstandard", false)]
         [InlineData("sl4", "dotnet", false)]
         [InlineData("sl3", "dotnet", false)]
         [InlineData("sl2", "dotnet", false)]
@@ -196,7 +334,22 @@ namespace NuGet.Test
         [InlineData("net20", "dotnet", false)]
         [InlineData("net20", "dotnet", false)]
 
-        // dotnet doesn't support the things that support it
+        // dotnet and netstandard doesn't support the things that support it
+        [InlineData("netstandard1.0", "net45", false)]
+        [InlineData("netstandard1.1", "net45", false)]
+        [InlineData("netstandard1.1", "net451", false)]
+        [InlineData("netstandard1.1", "net452", false)]
+        [InlineData("netstandard1.0", "net46", false)]
+        [InlineData("netstandard1.1", "net46", false)]
+        [InlineData("netstandard1.2", "net46", false)]
+        [InlineData("netstandard1.0", "net461", false)]
+        [InlineData("netstandard1.1", "net461", false)]
+        [InlineData("netstandard1.2", "net461", false)]
+        [InlineData("netstandard1.3", "net461", false)]
+        [InlineData("netstandard1.0", "dnxcore50", false)]
+        [InlineData("netstandard1.1", "dnxcore50", false)]
+        [InlineData("netstandard1.2", "dnxcore50", false)]
+        [InlineData("netstandard1.3", "dnxcore50", false)]
         [InlineData("dotnet5.1", "net45", false)]
         [InlineData("dotnet5.2", "net45", false)]
         [InlineData("dotnet5.2", "net451", false)]
@@ -213,7 +366,14 @@ namespace NuGet.Test
         [InlineData("dotnet5.3", "dnxcore50", false)]
         [InlineData("dotnet5.4", "dnxcore50", false)]
 
-        // Old-world Portable doesn't support dotnet and vice-versa
+        // Old-world Portable doesn't support netstandard or dotnet and vice-versa
+        [InlineData("netstandard", "portable-net40+sl5+win8", false)]
+        [InlineData("portable-net40+sl5+win8", "netstandard", false)]
+        [InlineData("portable-net45+win8", "netstandard", false)]
+        [InlineData("portable-net451+win81", "netstandard", false)]
+        [InlineData("portable-net451+win8+core50", "netstandard", false)]
+        [InlineData("portable-net451+win8+dnxcore50", "netstandard", false)]
+        [InlineData("portable-net451+win8+aspnetcore50", "netstandard", false)]
         [InlineData("dotnet", "portable-net40+sl5+win8", false)]
         [InlineData("portable-net40+sl5+win8", "dotnet", false)]
         [InlineData("portable-net45+win8", "dotnet", false)]
@@ -224,13 +384,33 @@ namespace NuGet.Test
         public void Compatibility_FrameworksAreCompatible(string project, string package, bool compatible)
         {
             // Arrange
-            var framework1 = NuGetFramework.Parse(project);
-            var framework2 = NuGetFramework.Parse(package);
+            var projectFramework = NuGetFramework.Parse(project);
+            var packageFramework = NuGetFramework.Parse(package);
 
             var compat = DefaultCompatibilityProvider.Instance;
 
             // Act & Assert
-            Assert.Equal(compatible, compat.IsCompatible(framework1, framework2));
+            Assert.Equal(compatible, compat.IsCompatible(projectFramework, packageFramework));
+        }
+
+        [Theory]
+        [InlineData("netstandard1.0", "dotnet5.1")]
+        [InlineData("netstandard1.1", "dotnet5.2")]
+        [InlineData("netstandard1.2", "dotnet5.3")]
+        [InlineData("netstandard1.3", "dotnet5.4")]
+        [InlineData("netstandard1.4", "dotnet5.5")]
+        [InlineData("netstandard1.5", "dotnet5.6")]
+        public void Compatibility_NetStandardSupportsNetPlatform(string netStandard, string netPlatform)
+        {
+            var project = NuGetFramework.Parse(netStandard);
+            var package = NuGetFramework.Parse(netPlatform);
+
+            var compat = DefaultCompatibilityProvider.Instance;
+
+            Assert.True(compat.IsCompatible(project, package));
+
+            // verify the relationship is unidirectional
+            Assert.False(compat.IsCompatible(package, project));
         }
 
         [Fact]
@@ -293,7 +473,7 @@ namespace NuGet.Test
             Assert.True(compat.IsCompatible(framework1, framework2));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
         [Theory]
@@ -330,9 +510,10 @@ namespace NuGet.Test
             Assert.True(compat.IsCompatible(framework1, framework2));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
+        [Theory]
         [InlineData("netcore451", "win81")]
         [InlineData("netcore45", "win8")]
         [InlineData("netcore", "win")]
@@ -341,6 +522,7 @@ namespace NuGet.Test
         [InlineData("win8", "netcore45")]
         [InlineData("wpa", "wpa81")]
         [InlineData("uap", "uap10.0")]
+        [InlineData("dotnet", "dotnet5.0")]
         public void Compatibility_SimpleTwoWay(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);
@@ -450,15 +632,17 @@ namespace NuGet.Test
         [InlineData("netmf")]
         [InlineData("wp7")]
         [InlineData("net40")]
-        public void Compatibility_ProjectCannotInstallDotNetLibraries(string framework)
+        public void Compatibility_ProjectCannotInstallGenerationLibraries(string framework)
         {
             // Arrange
-            var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("dotnet");
+            var library = NuGetFramework.Parse(framework);
+            var netStandard = NuGetFramework.Parse("netstandard");
+            var netPlatform = NuGetFramework.Parse("dotnet");
             var compat = DefaultCompatibilityProvider.Instance;
 
             // Act & Assert
-            Assert.False(compat.IsCompatible(framework1, framework2));
+            Assert.False(compat.IsCompatible(library, netStandard));
+            Assert.False(compat.IsCompatible(library, netPlatform));
         }
 
         [Theory]
@@ -495,21 +679,24 @@ namespace NuGet.Test
         [InlineData("xamarinxboxthreesixty")]
         [InlineData("xamarinwatchos")]
         [InlineData("xamarinxboxone")]
-        public void Compatibility_ProjectCanInstallDotNetLibraries(string framework)
+        public void Compatibility_ProjectCanInstallGenerationLibraries(string framework)
         {
             // Arrange
-            var framework1 = NuGetFramework.Parse(framework);
-            var framework2 = NuGetFramework.Parse("dotnet");
+            var project = NuGetFramework.Parse(framework);
+            var netStandard = NuGetFramework.Parse("netstandard");
+            var netPlatform = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
             // Act & Assert
 
             // verify that compatibility is inferred across all the mappings
-            Assert.True(compat.IsCompatible(framework1, framework2));
+            Assert.True(compat.IsCompatible(project, netStandard));
+            Assert.True(compat.IsCompatible(project, netPlatform));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(netStandard, project));
+            Assert.False(compat.IsCompatible(netPlatform, project));
         }
 
         [Theory]
@@ -541,23 +728,25 @@ namespace NuGet.Test
         [InlineData("netcore50")]
         [InlineData("netcore60")]
         [InlineData("sl6")]
-        public void Compatibility_DotNetProjectCompatNeg(string framework)
+        public void Compatibility_GenerationProjectsCannotInstallNonGenerationPackages(string package)
         {
             // Arrange
-            var framework1 = NuGetFramework.Parse(framework);
-            var project = NuGetFramework.Parse("dotnet");
+            var packageFramework = NuGetFramework.Parse(package);
+            var netStandardProject = NuGetFramework.Parse("netstandard");
+            var netPlatformProject = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
 
             // Act & Assert
-            Assert.False(compat.IsCompatible(project, framework1));
+            Assert.False(compat.IsCompatible(netStandardProject, packageFramework));
+            Assert.False(compat.IsCompatible(netPlatformProject, packageFramework));
         }
 
         [Fact]
-        public void Compatibility_InferredDotNet()
+        public void Compatibility_InferredNetPlatform()
         {
-            // dnxcore50 -> coreclr -> native
-            var framework1 = NuGetFramework.Parse("dnxcore50");
+            // uap -> netcore50 -> dotnet
+            var framework1 = NuGetFramework.Parse("uap");
             var framework2 = NuGetFramework.Parse("dotnet");
 
             var compat = DefaultCompatibilityProvider.Instance;
@@ -566,7 +755,23 @@ namespace NuGet.Test
             Assert.True(compat.IsCompatible(framework1, framework2));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(framework2, framework1));
+        }
+
+        [Fact]
+        public void Compatibility_InferredNetStandard()
+        {
+            // uap -> netcore50 -> netstandard
+            var framework1 = NuGetFramework.Parse("uap");
+            var framework2 = NuGetFramework.Parse("netstandard");
+
+            var compat = DefaultCompatibilityProvider.Instance;
+
+            // verify that compatibility is inferred across all the mappings
+            Assert.True(compat.IsCompatible(framework1, framework2));
+
+            // verify that this was a one way mapping
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
         [Fact]
@@ -582,7 +787,7 @@ namespace NuGet.Test
             Assert.True(compat.IsCompatible(framework1, framework2));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
         [Theory]
@@ -619,7 +824,7 @@ namespace NuGet.Test
             Assert.True(compat.IsCompatible(framework1, framework2));
 
             // verify that this was a one way mapping
-            Assert.True(!compat.IsCompatible(framework2, framework1));
+            Assert.False(compat.IsCompatible(framework2, framework1));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
@@ -11,7 +11,56 @@ namespace NuGet.Test
     public class FrameworkComparerTests
     {
         [Fact]
-        public void FrameworkComparer_FrameworkOrderingWithPreferredAndNormalSorting()
+        public void FrameworkComparer_OrderingMixedFrameworksTypes()
+        {
+            // Arrange
+            // non-package-based in the precedence list
+            var fw1 = NuGetFramework.Parse("net45");      
+            var fw2 = NuGetFramework.Parse("netcore451");
+            var fw3 = NuGetFramework.Parse("win81");
+            var fw4 = NuGetFramework.Parse("wpa81");
+            // non-package-based not in the precedence list
+            var fw5 = NuGetFramework.Parse("xamarinios");
+            var fw6 = NuGetFramework.Parse("sl5");
+            // package-based in the precedence list
+            var fw7 = NuGetFramework.Parse("netstandard1.1");
+            var fw8 = NuGetFramework.Parse("dotnet5.2");
+            // package-based not in the precedence list
+            var fw9 = NuGetFramework.Parse("dnxcore50");
+
+            var list = new List<NuGetFramework>
+            {
+                fw3,
+                fw6,
+                fw5,
+                fw9,
+                fw2,
+                fw4,
+                fw1,
+                fw7,
+                fw8,
+            };
+
+            // Act
+            list = list
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ToList();
+
+            // Assert
+            Assert.Equal(fw1, list[0]);
+            Assert.Equal(fw2, list[1]);
+            Assert.Equal(fw3, list[2]);
+            Assert.Equal(fw4, list[3]);
+            Assert.Equal(fw5, list[4]);
+            Assert.Equal(fw6, list[5]);
+            Assert.Equal(fw7, list[6]);
+            Assert.Equal(fw8, list[7]);
+            Assert.Equal(fw9, list[8]);
+        }
+
+        [Fact]
+        public void FrameworkComparer_NonPackageBasedFrameworkPreferredAndNormalOrdering()
         {
             // Arrange
             var fw1 = NuGetFramework.Parse("net45");
@@ -25,24 +74,25 @@ namespace NuGet.Test
             var fw9 = NuGetFramework.Parse("sl4");
             var fw10 = NuGetFramework.Parse("sl3");
 
-            var list = new List<NuGetFramework>()
+            var list = new List<NuGetFramework>
             {
-                fw1,
                 fw3,
                 fw5,
+                fw10,
+                fw9,
                 fw2,
                 fw4,
+                fw1,
                 fw6,
                 fw7,
                 fw8,
-                fw9,
-                fw10,
             };
 
             // Act
-            list = list.OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
-                       .ThenByDescending(f => f, new NuGetFrameworkSorter())
-                       .ToList();
+            list = list
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ToList();
 
             // Assert
             Assert.Equal(fw1, list[0]);
@@ -58,28 +108,29 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public void FrameworkComparer_PreferredFrameworkOrdering()
+        public void FrameworkComparer_PackageBasedFrameworkPreferredAndNormalOrdering()
         {
             // Arrange
-            var fw1 = NuGetFramework.Parse("net45");
-            var fw2 = NuGetFramework.Parse("netcore45");
-            var fw3 = NuGetFramework.Parse("win81");
-            var fw4 = NuGetFramework.Parse("wpa81");
-            var fw5 = NuGetFramework.Parse("sl5");
+            var fw1 = NuGetFramework.Parse("netstandard1.1");
+            var fw2 = NuGetFramework.Parse("netstandard1.0");
+            var fw3 = NuGetFramework.Parse("dotnet5.2");
+            var fw4 = NuGetFramework.Parse("dotnet5.1");
+            var fw5 = NuGetFramework.Parse("dnxcore50");
 
-            var list = new List<NuGetFramework>()
+            var list = new List<NuGetFramework>
             {
-                fw1, 
                 fw3,
                 fw5,
-                fw2, 
+                fw2,
                 fw4,
+                fw1
             };
 
-            var comparer = new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance);
-
             // Act
-            list.Sort(comparer);
+            list = list
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ToList();
 
             // Assert
             Assert.Equal(fw1, list[0]);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkExpanderTests.cs
@@ -64,14 +64,23 @@ namespace NuGet.Test
             NuGetFramework framework = NuGetFramework.Parse("net45");
 
             FrameworkExpander expander = new FrameworkExpander();
-            var expanded = expander.Expand(framework).ToArray();
+            var expanded = expander
+                .Expand(framework)
+                .OrderBy(n => n.ToString())
+                .ThenBy(n => n.Version)
+                .ToArray();
 
-            Assert.Equal(5, expanded.Length);
+            Assert.Equal(8, expanded.Length);
             Assert.Equal(".NETFramework,Version=v4.5,Profile=Client", expanded[0].ToString());
             Assert.Equal(".NETFramework,Version=v4.5,Profile=Full", expanded[1].ToString());
-            Assert.Equal(".NETPlatform,Version=v5.0", expanded[2].ToString()); // dotnet5
-            Assert.Equal(".NETPlatform,Version=v5.2", expanded[3].ToString());
-            Assert.Equal(".NETPlatform,Version=v5.0", expanded[4].ToString());  // dotnet
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[2].ToString()); // dotnet
+            Assert.Equal(new Version(0, 0, 0, 0), expanded[2].Version);
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[3].ToString()); // dotnet5
+            Assert.Equal(new Version(5, 0, 0, 0), expanded[3].Version);
+            Assert.Equal(".NETPlatform,Version=v5.1", expanded[4].ToString());
+            Assert.Equal(".NETPlatform,Version=v5.2", expanded[5].ToString());
+            Assert.Equal(".NETStandard,Version=v1.0", expanded[6].ToString());
+            Assert.Equal(".NETStandard,Version=v1.1", expanded[7].ToString());
         }
 
         [Fact]
@@ -80,9 +89,26 @@ namespace NuGet.Test
             NuGetFramework framework = NuGetFramework.Parse("win");
 
             FrameworkExpander expander = new FrameworkExpander();
-            var expanded = expander.Expand(framework).ToArray();
+            var expanded = expander
+                .Expand(framework)
+                .OrderBy(n => n.ToString())
+                .ThenBy(n => n.Version)
+                .ToArray();
 
-            Assert.Equal<int>(8, expanded.Length);
+            Assert.Equal(11, expanded.Length);
+            Assert.Equal(".NETCore,Version=v0.0", expanded[0].ToString());
+            Assert.Equal(".NETCore,Version=v4.5", expanded[1].ToString());
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[2].ToString()); // dotnet
+            Assert.Equal(new Version(0, 0, 0, 0), expanded[2].Version);
+            Assert.Equal(".NETPlatform,Version=v5.0", expanded[3].ToString()); // dotnet5
+            Assert.Equal(new Version(5, 0, 0, 0), expanded[3].Version);
+            Assert.Equal(".NETPlatform,Version=v5.1", expanded[4].ToString());
+            Assert.Equal(".NETPlatform,Version=v5.2", expanded[5].ToString());
+            Assert.Equal(".NETStandard,Version=v1.0", expanded[6].ToString());
+            Assert.Equal(".NETStandard,Version=v1.1", expanded[7].ToString());
+            Assert.Equal("Windows,Version=v8.0", expanded[8].ToString());
+            Assert.Equal("WinRT,Version=v0.0", expanded[9].ToString());
+            Assert.Equal("WinRT,Version=v4.5", expanded[10].ToString());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -16,14 +16,17 @@ namespace NuGet.Test
         // 1. lib/uap10, 
         // 2. then lib/win81, 
         // 3. then lib/wpa81, 
-        // 4. then lib/dotnet5.3, 
-        // 5. then portable-win81+*, etc
+        // 4. then lib/netstandard1.2, 
+        // 5. then lib/dotnet5.3, 
+        // 6. then portable-win81+*, etc
         [InlineData("uap10.0", "uap10.0,win81,wpa81,dotnet5.4,portable-win81+net45", "uap10.0")]
         [InlineData("uap10.0", "win81,wpa81,dotnet5.4,portable-win81+net45", "win81")]
         [InlineData("uap10.0", "wpa81,dotnet5.4,portable-win81+net45", "wpa81")]
         [InlineData("uap10.0", "dotnet5.4,portable-win81+net45", "dotnet5.4")]
         [InlineData("uap10.0", "portable-win81+net45", "portable-win81+net45")]
         [InlineData("uap10.0", "dotnet5.6,dotnet5.5,dotnet5.4,portable-win81+net45", "dotnet5.6")]
+        [InlineData("uap10.0", "netstandard1.5,dotnet5.6,dotnet5.5,dotnet5.4,portable-win81+net45", "netstandard1.5")]
+        [InlineData("uap10.0", "netstandard1.4,dotnet5.6,dotnet5.5,dotnet5.4,portable-win81+net45", "netstandard1.4")]
         [InlineData("uap10.0", "dotnet5.4,dotnet,portable-win81+net45", "dotnet5.4")]
         [InlineData("uap10.0", "dotnet,portable-win81+net45", "dotnet")]
         [InlineData("uap10.0", "wpa81,dotnet5.3,portable-win81+net45", "wpa81")]
@@ -34,6 +37,9 @@ namespace NuGet.Test
         [InlineData("uap10.0", "dotnet6.0,portable-win81+net45", "portable-win81+net45")]
         [InlineData("uap10.0", "dotnet6.0,portable-win81+net45+sl5,portable-win81+net45", "portable-win81+net45")]
         [InlineData("uap10.0", "dotnet6.0,portable-win81+net45+sl5,portable-uap11.0", "portable-win81+net45+sl5")]
+        [InlineData("uap10.0", "netstandard7.0,dotnet6.0,portable-win81+net45", "portable-win81+net45")]
+        [InlineData("uap10.0", "netstandard7.0,dotnet6.0,portable-win81+net45+sl5,portable-win81+net45", "portable-win81+net45")]
+        [InlineData("uap10.0", "netstandard7.0,dotnet6.0,portable-win81+net45+sl5,portable-uap11.0", "portable-win81+net45+sl5")]
         // Same TFM wins
         [InlineData("net461", "net462,net461,net46,net45,net4,net2,dotnet6.0,dotnet5.5,dotnet5.4,dotnet5.3,dotnet,portable-net45+win8,portable-net45+win8+wpa81", "net461")]
         [InlineData("net461", "net46,net45,net4,net2,dotnet6.0,dotnet5.5,dotnet5.4,dotnet5.3,dotnet,portable-net45+win8,portable-net45+win8+wpa81", "net46")]
@@ -48,6 +54,16 @@ namespace NuGet.Test
         [InlineData("net461", "portable-net45+win8,portable-net45+win8+wpa81", "portable-net45+win8")]
         [InlineData("net461", "portable-net45+win8+wpa81,native", "portable-net45+win8+wpa81")]
         [InlineData("net7", "dotnet6.0,dotnet5.6,dotnet5.5,dotnet5.4,portable-net45+win8", "dotnet5.6")]
+        // netstandard
+        [InlineData("netstandard1.5", "net4,netstandard7.0,netstandard1.4", "netstandard1.4")]
+        [InlineData("netstandard1.5", "net4,netstandard7.0,netstandard1.5", "netstandard1.5")]
+        [InlineData("netstandard1.5", "net4,netstandard7.0,netstandard1.6", null)]
+        [InlineData("netstandard1.5", "net4,netstandard7.0,netstandard0.0", "netstandard")]
+        [InlineData("netstandard1.5", "dotnet5.6,netstandard1.4", "netstandard1.4")]
+        [InlineData("netstandard1.5", "dotnet1.3,netstandard1.4", "netstandard1.4")]
+        [InlineData("netstandard1.5", "dotnet5.6,netstandard0.1", "netstandard0.1")]
+        [InlineData("netstandard1.5", "dotnet5.6,netstandard0.0", "netstandard")]
+        [InlineData("netstandard7.0", "netstandard6.0,netstandard1.0", "netstandard6.0")]
         // Additional tests
         [InlineData("dotnet5.5", "dotnet6.0,dotnet5.4,portable-net45+win8", "dotnet5.4")]
         [InlineData("dotnet7", "dotnet6.0,dotnet5.4,portable-net45+win8", "dotnet6.0")]
@@ -56,8 +72,14 @@ namespace NuGet.Test
         [InlineData("uap10.0", "uap10.1,dotnet5.7,dotnet5.6.0.1,dotnet6.0,dnxcore50,native", null)]
         [InlineData("dotnet", "", null)]
         [InlineData("dotnet5.4", "", null)]
+        [InlineData("netstandard", "", null)]
+        [InlineData("netstandard1.0", "", null)]
+        [InlineData("netstandard1.5", "", null)]
         [InlineData("uap10.0", "", null)]
         [InlineData("net461", "", null)]
+        [InlineData("unsupported", "any", "any")]
+        [InlineData("any", "any", "any")]
+        [InlineData("any", "unsupported", "unsupported")]
         public void FrameworkReducer_GetNearestWithGenerations(
             string projectFramework,
             string packageFrameworks,

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -201,6 +201,16 @@ namespace NuGet.Test
         [InlineData("dotnet5.5", ".NETPlatform,Version=v5.5")]
         [InlineData("dotnet6.0", ".NETPlatform,Version=v6.0")]
         [InlineData("dotnet6.0", ".NETPlatform,Version=v6")]
+        [InlineData("netstandard", ".NETStandard,Version=v0.0")]
+        [InlineData("netstandard1.0", ".NETStandard,Version=v1.0")]
+        [InlineData("netstandard1.0", ".NETStandard,Version=v1.0.0")]
+        [InlineData("netstandard0.9", ".NETStandard,Version=v0.9")]
+        [InlineData("netstandard1.0", ".NETStandard,Version=v1.0")]
+        [InlineData("netstandard1.1", ".NETStandard,Version=v1.1")]
+        [InlineData("netstandard1.2", ".NETStandard,Version=v1.2")]
+        [InlineData("netstandard1.3", ".NETStandard,Version=v1.3")]
+        [InlineData("netstandard1.4", ".NETStandard,Version=v1.4")]
+        [InlineData("netstandard1.5", ".NETStandard,Version=v1.5")]
         public void NuGetFramework_ParseToShortName(string expected, string fullName)
         {
             // Arrange
@@ -233,6 +243,12 @@ namespace NuGet.Test
         [InlineData("dotnet5.3", ".NETPlatform,Version=v5.3")]
         [InlineData("dotnet5.4", ".NETPlatform,Version=v5.4")]
         [InlineData("dotnet5.5", ".NETPlatform,Version=v5.5")]
+        [InlineData("netstandard1.0", ".NETStandard,Version=v1.0")]
+        [InlineData("netstandard1.1", ".NETStandard,Version=v1.1")]
+        [InlineData("netstandard1.2", ".NETStandard,Version=v1.2")]
+        [InlineData("netstandard1.3", ".NETStandard,Version=v1.3")]
+        [InlineData("netstandard1.4", ".NETStandard,Version=v1.4")]
+        [InlineData("netstandard1.5", ".NETStandard,Version=v1.5")]
         public void NuGetFramework_Basic(string folderName, string fullName)
         {
             string output = NuGetFramework.Parse(folderName).DotNetFrameworkName;

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -10,7 +10,15 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {},
-    "dnxcore50": {}
+    "dnx451": {
+      "dependencies": {
+        "Moq": "4.2.1409.1722"
+      }
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "moq.netcore": "4.4.0-beta8"
+      }
+    }
   }
 }


### PR DESCRIPTION
Per NuGet/Home#1691.

Issues I need some guidance on.
- Is the unit testing I have added sufficient? There seems to be a ton of tests around the old `dotnet` moniker. I tried to replicate or retrofit them for `netstandard` as appropriate. However, there does not seem to be a consistent approach in the `CompatibilityTests.cs` suite.
- What sort of manual verification should I perform? All of the unit tests in the solution passed (those run within Visual Studio).
- Should the [design document](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/standard-platform.md) be updated to match the state of the code? I have spoke to @ericstj offline about some things and tried to meet the latest requirements.
