### PR TITLE
Snapshot versions

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -142,7 +142,7 @@ namespace NuGet.DependencyResolver
 
         private static string PrettyPrint<TItem>(this GraphNode<TItem> node)
         {
-            return node.Key.Name + " " + node.Key.VersionRange?.PrettyPrint();
+            return node.Key.Name + " " + node.Key.VersionRange?.ToNonSnapshotRange().PrettyPrint();
         }
 
         private static bool TryResolveConflicts<TItem>(this GraphNode<TItem> root, List<VersionConflictResult<TItem>> versionConflicts)

--- a/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
@@ -182,7 +182,7 @@ namespace NuGet.Resolver
             // The range may not exist, or may inclue all versions. For this reason we trim the string afterwards to remove extra spaces due to empty ranges
             var range = package.FindDependencyRange(dependencyId);
             var dependencyString = String.Format(CultureInfo.InvariantCulture, "{0} {1}", dependencyId,
-                range == null ? string.Empty : range.PrettyPrint()).Trim();
+                range == null ? string.Empty : range.ToNonSnapshotRange().PrettyPrint()).Trim();
 
             // A 1.0.0 dependency: B (= 1.5)
             return $"'{package.Id} {package.Version.ToNormalizedString()} {Strings.DependencyConstraint}: {dependencyString}'";

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -12,8 +12,8 @@ namespace NuGet.Versioning
     /// </summary>
     public class VersionRangeFormatter : IFormatProvider, ICustomFormatter
     {
-        private const string LessThanOrEqualTo = "\u2264";
-        private const string GreaterThanOrEqualTo = "\u2265";
+        private const string LessThanOrEqualTo = "<=";
+        private const string GreaterThanOrEqualTo = ">=";
         private const string ZeroN = "{0:N}";
         private readonly VersionFormatter _versionFormatter;
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -852,7 +852,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
-                Assert.Contains("Dependency specified was Newtonsoft.Json (≥ 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
+                Assert.Contains("Dependency specified was Newtonsoft.Json (>= 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -10,6 +10,29 @@ namespace NuGet.Versioning.Test
     public class VersionRangeTests
     {
         [Theory]
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("1.0.0-beta", "1.0.0-beta")]
+        [InlineData("1.0.0-*", "1.0.0")]
+        [InlineData("2.0.0-*", "2.0.0")]
+        [InlineData("1.0.0-rc1-*", "1.0.0-rc1")]
+        [InlineData("1.0.0-5.1.*", "1.0.0-5.1.0")]
+        [InlineData("1.0.0-5.1.0-*", "1.0.0-5.1.0")]
+        [InlineData("1.0.*", "1.0.0")]
+        [InlineData("1.*", "1.0.0")]
+        [InlineData("*", "(, )")]
+        public void VersionRange_VerifyNonSnapshotVersion(string snapshot, string expected)
+        {
+            // Arrange
+            var range = VersionRange.Parse(snapshot);
+
+            // Act
+            var updated = range.ToNonSnapshotRange();
+
+            // Assert
+            Assert.Equal(expected, updated.ToLegacyShortString());
+        }
+
+        [Theory]
         [InlineData("[1.0.0]")]
         [InlineData("[1.0.0, 2.0.0]")]
         [InlineData("[1.0.0, 2.0.0]")]


### PR DESCRIPTION
This change cleans up floating versions in the same way DNU does. Versions such as 1.0.0-\* are considered snapshot versions which will be displayed as the _intended_ version which is 1.0.0. This is done when displaying the version, the actual compares will stay the same.

Currently NuGet displays these versions as 1.0.0-- which is the technically correct lower bound of the range.

I've also cleaned up a couple other places in the code that had problems with displaying version ranges, and changed the unicode characters to the two char >= and <=. On some consoles the unicode characters could not be displayed and were confusing.

//cc @deepakaravindr @yishaigalatzer @joelverhagen @alpaix 
