### PR TITLE
build.sh exit code fix and protocol.v3 test fixes

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,9 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="BuildFeed" value="Nupkgs" />
     <add key="NuGetVolatile" value="https://www.myget.org/F/nuget-volatile/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="BuildFeed" value="Nupkgs" />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
      <clear />

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -251,10 +251,12 @@ Function Restore-XProject {
         if (-not $V2) {
             $opts += '-s', 'https://www.myget.org/F/nuget-volatile/api/v3/index.json'
             $opts += '-s', 'https://api.nuget.org/v3/index.json'
+            $opts += '-s', 'https://www.myget.org/F/aspnetvnext/api/v3/index.json'
         }
         else {
             $opts += '-s', 'https://www.myget.org/F/nuget-volatile/api/v2/'
             $opts += '-s', 'https://www.nuget.org/api/v2/'
+            $opts += '-s', 'https://www.myget.org/F/aspnetvnext/api/v2/'
         }
         if (-not $VerbosePreference) {
             $opts += '--quiet'

--- a/src/NuGet.Core/NuGet.Config
+++ b/src/NuGet.Core/NuGet.Config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="NuGetVolatile" value="https://www.myget.org/F/nuget-volatile/api/v3/index.json" />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/test/NuGet.Core.Tests/NuGet.Config
+++ b/test/NuGet.Core.Tests/NuGet.Config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="NuGetVolatile" value="https://www.myget.org/F/nuget-volatile/api/v3/index.json" />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ServiceIndexResourceV3ProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ServiceIndexResourceV3ProviderTests.cs
@@ -3,13 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Moq;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using Test.Utility;
@@ -90,10 +87,10 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
                 new INuGetResourceProvider[] { handlerProvider, provider });
 
             // Act and assert
-            await Assert.ThrowsAsync<JsonReaderException> (async () =>
-            {
-                var result = await provider.TryCreate(sourceRepository, default(CancellationToken));
-            });
+            await Assert.ThrowsAsync<JsonReaderException>(async () =>
+           {
+               var result = await provider.TryCreate(sourceRepository, default(CancellationToken));
+           });
         }
 
         [Theory]
@@ -159,101 +156,6 @@ xmlns=""http://www.w3.org/2007/app"" xmlns:atom=""http://www.w3.org/2005/Atom"">
             Assert.True(result.Item1);
             var resource = Assert.IsType<ServiceIndexResourceV3>(result.Item2);
             Assert.NotNull(resource.Index);
-        }
-
-        // [Fact]
-        // Need a new test for this scenario
-        public async Task TryCreate_CachesResultsForFortyMinutes()
-        {
-            // Arrange
-            var source = "http://some-site/index.json";
-            var content = @"{ version: '3.1.0-beta' }";
-            var handler = new Mock<TestMessageHandler>(new Dictionary<string, string> { { source, content } })
-            {
-                CallBase = true
-            };
-            var sequence = new MockSequence();
-            handler
-                .InSequence(sequence)
-                .Setup(h => h.SendAsyncPublic(It.IsAny<HttpRequestMessage>()))
-                .Returns(() =>
-                {
-                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
-                });
-
-            handler
-                .InSequence(sequence)
-                .Setup(h => h.SendAsyncPublic(It.IsAny<HttpRequestMessage>()))
-                .Returns(() =>
-                {
-                    var response = new HttpResponseMessage();
-                    response.Content = new StringContent(content);
-                    return Task.FromResult(response);
-                });
-
-            var provider = new TestableSerivceIndexResourceProvider();
-            var sourceRepository = new SourceRepository(new PackageSource(source),
-                new INuGetResourceProvider[] { new TestHttpHandlerProvider(handler.Object), provider });
-            var startTime = DateTime.UtcNow;
-
-            // Act - 1
-            var result = await provider.TryCreate(sourceRepository, default(CancellationToken));
-
-            // Assert - 1
-            Assert.False(result.Item1);
-            Assert.Null(result.Item2);
-
-            // Act - 2
-            var minutesago45 = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(45));
-
-            var index = new ServiceIndexResourceV3(new JObject(), minutesago45);
-
-            provider.ReplaceCache(source, minutesago45, index);
-
-            result = await provider.TryCreate(sourceRepository, default(CancellationToken));
-            var result2 = await provider.TryCreate(sourceRepository, default(CancellationToken));
-
-            // Assert - 2
-            Assert.True(result.Item1);
-            Assert.True(index != result.Item2);         // Previous entry was expired
-            Assert.True(result.Item2 == result2.Item2); // Same as last request
-
-            // Act - 3
-            var minutesago20 = DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(20));
-
-            index = new ServiceIndexResourceV3(new JObject(), minutesago20);
-
-            provider.ReplaceCache(source, minutesago20, index);
-
-            result = await provider.TryCreate(sourceRepository, default(CancellationToken));
-            result2 = await provider.TryCreate(sourceRepository, default(CancellationToken));
-
-            // Assert - 3
-            Assert.True(result.Item1);
-            Assert.True(result2.Item1);
-            Assert.True(index == result.Item2);   // Same
-            Assert.True(index == result2.Item2);  // Same
-        }
-
-        private class TestableSerivceIndexResourceProvider : ServiceIndexResourceV3Provider
-        {
-            public void SetDuration(TimeSpan span)
-            {
-                MaxCacheDuration = span;
-            }
-
-            public void ReplaceCache(string url, DateTime date, ServiceIndexResourceV3 index)
-            {
-                _cache.Clear();
-
-                var entry = new ServiceIndexCacheInfo()
-                {
-                    CachedTime = date,
-                    Index = index
-                };
-
-                _cache.TryAdd(url, entry);
-            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "Moq": "4.2.1408.0717",
     "NuGet.Protocol.Core.v3": "3.4.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
@@ -10,6 +9,11 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {}
+    "dnx451": { },
+    "dnxcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.10-beta-23109"
+      }
+    }
   }
 }


### PR DESCRIPTION
This change fixes the current build issues
- AspnetVNext has been added as a feed to get the runtime packages for xplat, since we have all dnxcore versions locked down this should not affect other projects
- Added a non-zero exit code to build.sh when dnx test fails to build or run
- Enabled protocol v3 tests for dnxcore50
- Removed an already disabled test and logged a tracking issue: https://github.com/NuGet/Home/issues/1930  This was the only test using moq, and likely the reason why protocol v3 wasn't running under dnxcore
- Removed the extra nuget.config files, these were put in as a workaround for a dnx beta7 issue

//cc @alpaix @zhili1208 @yishaigalatzer @joelverhagen @deepakaravindr @xavierdecoster 
