### PR TITLE
fixed PackageSourceProviderTests.AddPackageSourcesWithConfigFile and …

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -29,5 +29,43 @@ namespace NuGet.Common
         {
             get { return _isMono.Value; }
         }
+
+        public static bool IsMacOSX
+        {
+            get
+            {
+#if DNXCORE50
+                // This API does work on full framework but it requires a newer nuget client (RID aware)
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                {
+                    return true;
+                }
+
+                return false;
+#else
+                var platform = (int)Environment.OSVersion.Platform;
+                return platform == 6;
+#endif
+            }
+        }
+
+        public static bool IsLinux
+        {
+            get
+            {
+#if DNXCORE50
+                // This API does work on full framework but it requires a newer nuget client (RID aware)
+                if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+                {
+                    return true;
+                }
+
+                return false;
+#else
+                var platform = (int)Environment.OSVersion.Platform;
+                return platform == 4;
+#endif
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -29,7 +29,7 @@ namespace NuGet.Configuration
         /// NuGet config names with casing ordered by precedence.
         /// </summary>
         public static readonly string[] OrderedSettingsFileNames =
-            !RuntimeEnvironmentHelper.IsLinux ?
+            (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsWindows) ?
             new[] { DefaultSettingsFileName } :
             new[]
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -29,7 +29,7 @@ namespace NuGet.Configuration
         /// NuGet config names with casing ordered by precedence.
         /// </summary>
         public static readonly string[] OrderedSettingsFileNames =
-            RuntimeEnvironmentHelper.IsWindows ?
+            !RuntimeEnvironmentHelper.IsLinux ?
             new[] { DefaultSettingsFileName } :
             new[]
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -29,7 +29,7 @@ namespace NuGet.Configuration
         /// NuGet config names with casing ordered by precedence.
         /// </summary>
         public static readonly string[] OrderedSettingsFileNames =
-            (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsWindows) ?
+            (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX) ?
             new[] { DefaultSettingsFileName } :
             new[]
             {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2015,7 +2015,7 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                    configFileName: "NuGet.config",
                    machineWideSettings: null,
-                   loadAppDataSettings: true);
+                   loadAppDataSettings: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act


### PR DESCRIPTION
fixed PackageSourceProviderTests.AddPackageSourcesWithConfigFile and SettingsTests.SettingsValuesProvideOriginData

Since Mac HFS+ is case insensitive file system, use default NuGet.Config for Mac
@emgarten @yishaigalatzer 
