### PR TITLE
link the runtime graph in the lock file

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -30,7 +30,11 @@ namespace NuGet.CommandLine.XPlat
             if (args.Contains("--debug"))
             {
                 args = args.Skip(1).ToArray();
-                Debugger.Launch();
+                while (!Debugger.IsAttached)
+                {
+
+                }
+                Debugger.Break();
             }
 #endif
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -766,7 +766,9 @@ namespace NuGet.Commands
                         targetGraph,
                         resolver,
                         correctedPackageName: library.Name,
-                        dependencyType: includeFlags);
+                        dependencyType: includeFlags,
+                        targetFrameworkOverride: null,
+                        dependencies: graphItem.Data.Dependencies);
 
                     target.Libraries.Add(targetLibrary);
 
@@ -782,7 +784,8 @@ namespace NuGet.Commands
                             resolver,
                             correctedPackageName: library.Name,
                             targetFrameworkOverride: nonFallbackFramework,
-                            dependencyType: includeFlags);
+                            dependencyType: includeFlags,
+                            dependencies: graphItem.Data.Dependencies);
 
                         if (!targetLibrary.Equals(targetLibraryWithoutFallback))
                         {


### PR DESCRIPTION
I need to add a test for this

https://github.com/NuGet/Home/issues/1890

/cc @ericstj @emgarten 

e.g.:

``` JSON
"System.Runtime.Extensions/4.0.11-beta-23516": {
    "type": "package",
    "dependencies": {
      "System.Runtime": "4.0.20",
      "runtime.win7.System.Runtime.Extensions": "4.0.11-beta-23516"
    },
    "compile": {
      "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
    }
},
```
