### PR TITLE
Reverted async file io operations

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -14,7 +14,7 @@ namespace NuGet.Common
 {
     public static class ConcurrencyUtilities
     {
-        public async static Task<T> ExecuteWithFileLocked<T>(string filePath,
+        public async static Task<T> ExecuteWithFileLockedAsync<T>(string filePath,
             Func<CancellationToken, Task<T>> action,
             CancellationToken token)
         {
@@ -47,7 +47,7 @@ namespace NuGet.Common
 
                 try
                 {
-                    await fs.WriteAsync(bytes, 0, bytes.Length, token);
+                    fs.Write(bytes, 0, bytes.Length);
                 }
                 catch
                 {

--- a/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
@@ -55,6 +55,6 @@ namespace NuGet.Packaging.Core
         /// </summary>
         Stream GetNuspec();
 
-        Task<IEnumerable<string>> CopyFilesAsync(string destination, IEnumerable<string> packageFiles, CancellationToken token);
+        IEnumerable<string> CopyFiles(string destination, IEnumerable<string> packageFiles, CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -133,7 +133,7 @@ namespace NuGet.Packaging
             }
         }
 
-        public override async Task<IEnumerable<string>> CopyFilesAsync(string destination, IEnumerable<string> packageFiles, CancellationToken token)
+        public override IEnumerable<string> CopyFiles(string destination, IEnumerable<string> packageFiles, CancellationToken token)
         {
             var filesCopied = new List<string>();
 
@@ -161,17 +161,17 @@ namespace NuGet.Packaging
                     continue;
                 }
 
-                var copiedFile = await entry.SaveAsFileAsync(targetFilePath, token);
+                var copiedFile = entry.SaveAsFile(targetFilePath);
                 filesCopied.Add(copiedFile);
             }
 
             return filesCopied;
         }
 
-        public async Task<string> ExtractFileAsync(string packageFile, string targetFilePath, CancellationToken token)
+        public string ExtractFile(string packageFile, string targetFilePath)
         {
             var entry = GetEntry(packageFile);
-            var copiedFile = await entry.SaveAsFileAsync(targetFilePath, token);
+            var copiedFile = entry.SaveAsFile(targetFilePath);
             return copiedFile;
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/StreamExtensions.cs
@@ -1,12 +1,10 @@
 ﻿using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace NuGet.Packaging
 {
     public static class StreamExtensions
     {
-        public static async Task<string> CopyToFileAsync(this Stream inputStream, string fileFullPath, CancellationToken token)
+        public static string CopyToFile(this Stream inputStream, string fileFullPath)
         {
             if (Path.GetFileName(fileFullPath).Length == 0)
             {
@@ -26,10 +24,9 @@ namespace NuGet.Packaging
                 return fileFullPath;
             }
 
-            const int DefaultBufferSize = 4096;
-            using (var outputStream = File.Create(fileFullPath, DefaultBufferSize, FileOptions.Asynchronous))
+            using (var outputStream = File.Create(fileFullPath))
             {
-                await inputStream.CopyToAsync(outputStream, DefaultBufferSize, token);
+                inputStream.CopyTo(outputStream);
             }
 
             return fileFullPath;

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -49,11 +49,11 @@ namespace NuGet.Packaging
             return entry.Open();
         }
 
-        public static async Task<string> SaveAsFileAsync(this ZipArchiveEntry entry, string fileFullPath, CancellationToken token)
+        public static string SaveAsFile(this ZipArchiveEntry entry, string fileFullPath)
         {
             using (var inputStream = entry.Open())
             {
-                await inputStream.CopyToFileAsync(fileFullPath, token);
+                inputStream.CopyToFile(fileFullPath);
             }
 
             var attr = File.GetAttributes(fileFullPath);

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -155,7 +155,7 @@ namespace NuGet.Packaging
             return String.Join("/", parts);
         }
 
-        public override Task<IEnumerable<string>> CopyFilesAsync(string destination, IEnumerable<string> packageFiles, CancellationToken token)
+        public override IEnumerable<string> CopyFiles(string destination, IEnumerable<string> packageFiles, CancellationToken token)
         {
             var filesCopied = new List<string>();
 
@@ -174,7 +174,7 @@ namespace NuGet.Packaging
                 filesCopied.Add(targetPath);
             }
 
-            return Task.FromResult< IEnumerable<string>>(filesCopied);
+            return filesCopied;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -63,7 +63,7 @@ namespace NuGet.Packaging
 
         public abstract IEnumerable<string> GetFiles(string folder);
 
-        public abstract Task<IEnumerable<string>> CopyFilesAsync(string destination, IEnumerable<string> packageFiles, CancellationToken token);
+        public abstract IEnumerable<string> CopyFiles(string destination, IEnumerable<string> packageFiles, CancellationToken token);
 
         public virtual PackageIdentity GetIdentity()
         {

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -49,7 +49,7 @@ namespace NuGet.ProjectManagement
             return Task.FromResult(Enumerable.Empty<PackageReference>());
         }
 
-        public override async Task<bool> InstallPackageAsync(
+        public override Task<bool> InstallPackageAsync(
             PackageIdentity packageIdentity,
             DownloadResourceResult downloadResourceResult,
             INuGetProjectContext nuGetProjectContext,
@@ -79,7 +79,7 @@ namespace NuGet.ProjectManagement
             if (PackageExists(packageIdentity))
             {
                 nuGetProjectContext.Log(MessageLevel.Info, Strings.PackageAlreadyExistsInFolder, packageIdentity, Root);
-                return false;
+                return Task.FromResult(false);
             }
 
             nuGetProjectContext.Log(MessageLevel.Info, Strings.AddingPackageToFolder, packageIdentity, Path.GetFullPath(Root));
@@ -90,7 +90,7 @@ namespace NuGet.ProjectManagement
             if (downloadResourceResult.PackageReader != null)
             {
                 addedPackageFilesList.AddRange(
-                    await PackageExtractor.ExtractPackageAsync(
+                    PackageExtractor.ExtractPackage(
                         downloadResourceResult.PackageReader,
                         downloadResourceResult.PackageStream,
                         PackagePathResolver,
@@ -100,7 +100,7 @@ namespace NuGet.ProjectManagement
             else
             {
                 addedPackageFilesList.AddRange(
-                    await PackageExtractor.ExtractPackageAsync(
+                    PackageExtractor.ExtractPackage(
                         downloadResourceResult.PackageStream,
                         PackagePathResolver,
                         nuGetProjectContext.PackageExtractionContext ?? new PackageExtractionContext(),
@@ -121,7 +121,7 @@ namespace NuGet.ProjectManagement
             FileSystemUtility.PendAddFiles(addedPackageFilesList, Root, nuGetProjectContext);
 
             nuGetProjectContext.Log(MessageLevel.Info, Strings.AddedPackageToFolder, packageIdentity, Path.GetFullPath(Root));
-            return true;
+            return Task.FromResult(true);
         }
 
         public override Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)
@@ -138,11 +138,11 @@ namespace NuGet.ProjectManagement
             return !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
         }
 
-        public async Task<bool> CopySatelliteFilesAsync(PackageIdentity packageIdentity,
+        public Task<bool> CopySatelliteFilesAsync(PackageIdentity packageIdentity,
             INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
-            var copiedSatelliteFiles = await PackageExtractor.CopySatelliteFilesAsync(
+            var copiedSatelliteFiles = PackageExtractor.CopySatelliteFiles(
                 packageIdentity,
                 PackagePathResolver,
                 GetPackageSaveMode(nuGetProjectContext),
@@ -150,7 +150,7 @@ namespace NuGet.ProjectManagement
 
             FileSystemUtility.PendAddFiles(copiedSatelliteFiles, Root, nuGetProjectContext);
 
-            return copiedSatelliteFiles.Any();
+            return Task.FromResult(copiedSatelliteFiles.Any());
         }
 
         public string GetInstalledPackageFilePath(PackageIdentity packageIdentity)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -235,7 +235,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName,
+            return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(result.TempFileName,
                 action: token =>
                 {
                     return Task.FromResult(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpSource.cs
@@ -176,7 +176,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
             // The update of a cached file is divided into two steps:
             // 1) Delete the old file. 2) Create a new file with the same name.
             // To prevent race condition among multiple processes, here we use a lock to make the update atomic.
-            return ConcurrencyUtilities.ExecuteWithFileLocked(result.CacheFileName,
+            return ConcurrencyUtilities.ExecuteWithFileLockedAsync(result.CacheFileName,
                 action: async token =>
                 {
                     using (var stream = new FileStream(
@@ -246,7 +246,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(cacheFile,
+            return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(cacheFile,
                 action: cancellationToken =>
                 {
                     if (File.Exists(cacheFile))

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -240,7 +240,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName,
+            return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(result.TempFileName,
                 action: token =>
                 {
                     return Task.FromResult(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -149,7 +149,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
             // Acquire the lock on a file before we open it to prevent this process
             // from opening a file deleted by the logic in HttpSource.GetAsync() in another process
-            return await ConcurrencyUtilities.ExecuteWithFileLocked(result.TempFileName,
+            return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(result.TempFileName,
                 action: token =>
                 {
                     return Task.FromResult(

--- a/src/NuGet.Core/SynchronizationTestApp/Program.cs
+++ b/src/NuGet.Core/SynchronizationTestApp/Program.cs
@@ -47,7 +47,7 @@ namespace SynchronizationTestApp
 
             _client = new TcpClient();
 
-            var lockedTask = ConcurrencyUtilities.ExecuteWithFileLocked(filename, WaitInALock, CancellationToken.None);
+            var lockedTask = ConcurrencyUtilities.ExecuteWithFileLockedAsync(filename, WaitInALock, CancellationToken.None);
 
             try
             {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -20,6 +20,7 @@ using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
+using Moq;
 
 namespace NuGet.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging.Test
                 var packagePath = Path.Combine(root, "packageA.2.0.3");
 
                 // Act
-                var files = await PackageExtractor.ExtractPackageAsync(packageReader,
+                var files = PackageExtractor.ExtractPackage(packageReader,
                                                                  packageStream,
                                                                  new PackagePathResolver(root),
                                                                  new PackageExtractionContext(),
@@ -51,7 +51,7 @@ namespace NuGet.Packaging.Test
                     using (var folderReader = new PackageFolderReader(packageFolder))
                     {
                         // Act
-                        var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                        var files = PackageExtractor.ExtractPackage(folderReader,
                                                                          stream,
                                                                          new PackagePathResolver(root),
                                                                          new PackageExtractionContext(),
@@ -82,7 +82,7 @@ namespace NuGet.Packaging.Test
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nupkg;
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                    var files = PackageExtractor.ExtractPackage(folderReader,
                                                                          packageStream,
                                                                          new PackagePathResolver(root),
                                                                          packageExtractionContext,
@@ -113,7 +113,7 @@ namespace NuGet.Packaging.Test
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nuspec;
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                    var files = PackageExtractor.ExtractPackage(folderReader,
                                                                          packageStream,
                                                                          new PackagePathResolver(root),
                                                                          packageExtractionContext,
@@ -144,7 +144,7 @@ namespace NuGet.Packaging.Test
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nuspec | PackageSaveMode.Nupkg;
 
                     // Act
-                    var files = await PackageExtractor.ExtractPackageAsync(folderReader,
+                    var files = PackageExtractor.ExtractPackage(folderReader,
                                                                          packageStream,
                                                                          new PackagePathResolver(root),
                                                                          packageExtractionContext,
@@ -172,12 +172,12 @@ namespace NuGet.Packaging.Test
                     var packageExtractionContext = new PackageExtractionContext();
 
                     // Act
-                    var packageFiles = await PackageExtractor.ExtractPackageAsync(packageStream,
+                    var packageFiles = PackageExtractor.ExtractPackage(packageStream,
                                                                      new PackagePathResolver(root),
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
 
-                    var satellitePackageFiles = await PackageExtractor.ExtractPackageAsync(satellitePackageStream,
+                    var satellitePackageFiles = PackageExtractor.ExtractPackage(satellitePackageStream,
                                                                      new PackagePathResolver(root),
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverUtilityTests.cs
@@ -351,10 +351,10 @@ namespace NuGet.Resolver.Test
             var available = solution.ToList();
 
             // Act
-            var message = ResolverUtility.GetDiagnosticMessage(solution, available, Enumerable.Empty<PackageReference>(), new string[] { "a" }, Enumerable.Empty<PackageSource>());
+            var message = ResolverUtility.GetDiagnosticMessage(solution, available, Enumerable.Empty<PackageReference>(), new[] { "a" }, Enumerable.Empty<PackageSource>());
 
             // Assert
-            Assert.Equal("Unable to find a version of 'b' that is compatible with 'a 1.0.0 constraint: b (\u2265 1.0.0)'.", message);
+            Assert.Equal("Unable to find a version of 'b' that is compatible with 'a 1.0.0 constraint: b (>= 1.0.0)'.", message);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
@@ -32,18 +32,18 @@ namespace NuGet.Commands.Test
             var tasks = new Task<int>[4];
 
             // Act
-            tasks[0] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForever1, cts.Token);
+            tasks[0] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForever1, cts.Token);
 
             await _waitForEverStarted.WaitAsync();
 
             // We should now be blocked, so the value returned from here should not be returned until the token is cancelled.
-            tasks[1] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+            tasks[1] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
             Assert.False(tasks[0].IsCompleted, $"task status: {tasks[0].Status}");
 
             _value1 = 1;
 
-            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
             Assert.False(cts.Token.IsCancellationRequested);
             cts.Cancel();
@@ -53,7 +53,7 @@ namespace NuGet.Commands.Test
 
             _value1 = 2;
 
-            tasks[3] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+            tasks[3] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
             await tasks[3];
 
@@ -86,11 +86,11 @@ namespace NuGet.Commands.Test
                 _value1 = 0;
 
                 // We should now be blocked, so the value returned from here should not be returned until the process has terminated.
-                tasks[0] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+                tasks[0] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
                 _value1 = 1;
 
-                tasks[1] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+                tasks[1] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
                 Assert.False(result.Process.HasExited);
 
@@ -114,7 +114,7 @@ namespace NuGet.Commands.Test
 
             _value1 = 2;
 
-            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt1, timeout.Token);
+            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt1, timeout.Token);
 
             await Task.WhenAll(tasks);
 
@@ -140,19 +140,19 @@ namespace NuGet.Commands.Test
             var tasks = new Task<int>[4];
 
             // Act
-            tasks[0] = ConcurrencyUtilities.ExecuteWithFileLocked("x" + fileId, WaitForever, cts.Token);
+            tasks[0] = ConcurrencyUtilities.ExecuteWithFileLockedAsync("x" + fileId, WaitForever, cts.Token);
 
             _value2 = 0;
 
             // We should now be blocked, so the value returned from here should not be
             // returned until the token is cancelled.
-            tasks[1] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt2, timeout.Token);
+            tasks[1] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt2, timeout.Token);
 
             await tasks[1];
 
             _value2 = 1;
 
-            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt2, timeout.Token);
+            tasks[2] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt2, timeout.Token);
 
             await tasks[2]; // let the first tasks pass we get a deadlock if there is a lock applied by the first task
 
@@ -161,7 +161,7 @@ namespace NuGet.Commands.Test
 
             _value2 = 2;
 
-            tasks[3] = ConcurrencyUtilities.ExecuteWithFileLocked(fileId, WaitForInt2, timeout.Token);
+            tasks[3] = ConcurrencyUtilities.ExecuteWithFileLockedAsync(fileId, WaitForInt2, timeout.Token);
 
             await tasks[3];
 


### PR DESCRIPTION
Changed async file io writes to be sync to avoid performance issues.
Test fix.
Renamed methods to reflect the changes (removed async suffix where
applicable).
