### PR TITLE
don't add RIDs to restore graph for compile only TFMs

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -250,11 +250,14 @@ namespace NuGet.Commands
                 // We care about TFM only and null RID for compilation purposes
                 projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, null));
 
-                var runtimeIds = RequestRuntimeUtility.GetRestoreRuntimes(_request);
-
-                foreach (var runtimeId in runtimeIds)
+                if (!framework.FrameworkName.IsCompileOnly)
                 {
-                    projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, runtimeId));
+                    var runtimeIds = RequestRuntimeUtility.GetRestoreRuntimes(_request);
+
+                    foreach (var runtimeId in runtimeIds)
+                    {
+                        projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, runtimeId));
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -261,6 +261,22 @@ namespace NuGet.Frameworks
         }
 
         /// <summary>
+        /// True if the framework is only used for compilation, not for execution.
+        /// Ex: dotnet, netstandard, portable-*
+        /// </summary>
+        public bool IsCompileOnly
+        {
+            get
+            {
+                return FrameworkConstants.FrameworkIdentifiers.NetPlatform
+                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
+                    || FrameworkConstants.FrameworkIdentifiers.NetStandard
+                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
+                    || IsPCL;
+            } 
+        }
+
+        /// <summary>
         /// True if the framework is packages based.
         /// Ex: dotnet, dnxcore
         /// </summary>


### PR DESCRIPTION
This allows the TFMs `netstandard` and `dotnet` (also `portable-*` but those don't use RIDs so don't technically matter) to successfully pass the ref-lib matching check. Libraries that are compiled for `dotnet`/`netstandard` are not expected to be run (if a project is runnable, it must use `net45` or some other runtime TFM) so many packages do not have runtime implementations for that TFM.

/cc @emgarten @davidfowl @yishaigalatzer 
