### PR TITLE
fixed Mac test 

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -1042,7 +1042,7 @@ namespace NuGet.Configuration
             {
                 return false;
             }
-            else if (RuntimeEnvironmentHelper.IsWindows)
+            else if (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX)
             {
                 return path1.Equals(path2, StringComparison.OrdinalIgnoreCase);
             }

--- a/src/NuGet.Core/SynchronizationTestApp/Program.cs
+++ b/src/NuGet.Core/SynchronizationTestApp/Program.cs
@@ -78,6 +78,7 @@ namespace SynchronizationTestApp
                 await writer.WriteLineAsync("Locked");
                 await writer.FlushAsync();
 
+                // ReadLine is blocked on Mac, skip it here
                 if (!RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     await reader.ReadLineAsync();

--- a/src/NuGet.Core/SynchronizationTestApp/Program.cs
+++ b/src/NuGet.Core/SynchronizationTestApp/Program.cs
@@ -78,8 +78,10 @@ namespace SynchronizationTestApp
                 await writer.WriteLineAsync("Locked");
                 await writer.FlushAsync();
 
-                await reader.ReadLineAsync();
-
+                if (!RuntimeEnvironmentHelper.IsMacOSX)
+                {
+                    await reader.ReadLineAsync();
+                }
                 if (_abandonLock)
                 {
                     // Kill the process so if the locking mechanism doesn't deal with abandoned locks

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
@@ -286,7 +286,7 @@ namespace NuGet.Commands.Test
         {
             var data = await result.Reader.ReadLineAsync();
 
-            if (data.Trim() != "Locked")
+            if (data!=null && data.Trim() != "Locked")
             {
                 throw new InvalidOperationException($"Unexpected output from process: {data}");
             }

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
@@ -286,7 +286,8 @@ namespace NuGet.Commands.Test
         {
             var data = await result.Reader.ReadLineAsync();
 
-            if (data!=null && data.Trim() != "Locked")
+            // data will be null on Mac, skip the check on Mac
+            if (!RuntimeEnvironmentHelper.IsMacOSX && data.Trim() != "Locked")
             {
                 throw new InvalidOperationException($"Unexpected output from process: {data}");
             }


### PR DESCRIPTION
https://github.com/dotnet/corefx/issues/5436 TcpClient bug blocked Synchronization test, skip ReadLine part in test here.
another bug is on mac, since mac is case insensitive, setting hierarchy will pick specified config file, then load same config twice. ignore case on mac here 
