### PR TITLE
Remove x86 default runtime for non-windows

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
@@ -45,7 +45,9 @@ namespace NuGet.Commands
             }
             else
             {
-                yield return runtimeOsName + "-x86"; // We do support x86 on Linux/Darwin via Mono
+                // Core CLR only supports x64 on non-windows OSes.
+                // Mono supports x86, for those scenarios the runtimes
+                // will need to be passed in or added to project.json.
                 yield return runtimeOsName + "-x64";
             }
         }


### PR DESCRIPTION
Removes the [os]-x86 default runtime for non-windows OSes.

https://github.com/NuGet/Home/issues/1941

//cc @anurse @davidfowl @yishaigalatzer @joelverhagen @zhili1208 
