### PR TITLE
Exclude disabled sources in xplat

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandLineSourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandLineSourceRepositoryProvider.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.CommandLine.XPlat
+{
+    /// <summary>
+    /// A singleton caching source repository provider.
+    /// </summary>
+    public class CommandLineSourceRepositoryProvider : ISourceRepositoryProvider
+    {
+        private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
+        private readonly List<Lazy<INuGetResourceProvider>> _resourceProviders;
+        private readonly List<SourceRepository> _repositories = new List<SourceRepository>();
+
+        // There should only be one instance of the source repository for each package source.
+        private static readonly ConcurrentDictionary<Configuration.PackageSource, SourceRepository> _sources
+            = new ConcurrentDictionary<Configuration.PackageSource, SourceRepository>();
+
+        public CommandLineSourceRepositoryProvider(Configuration.IPackageSourceProvider packageSourceProvider)
+        {
+            _packageSourceProvider = packageSourceProvider;
+
+            _resourceProviders = new List<Lazy<INuGetResourceProvider>>();
+            _resourceProviders.AddRange(Protocol.Core.v3.FactoryExtensionsV2.GetCoreV3(Repository.Provider));
+
+            // Create repositories
+            foreach (var source in _packageSourceProvider.LoadPackageSources())
+            {
+                if (source.IsEnabled)
+                {
+                    // Create and cache the repo.
+                    var sourceRepo = CreateRepository(source);
+                    _repositories.Add(sourceRepo);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Retrieve repositories. This does not include cached repos.
+        /// </summary>
+        public IEnumerable<SourceRepository> GetRepositories()
+        {
+            return _repositories;
+        }
+
+        /// <summary>
+        /// Create a repository and add it to the cache.
+        /// </summary>
+        public SourceRepository CreateRepository(Configuration.PackageSource source)
+        {
+            return _sources.GetOrAdd(source, new SourceRepository(source, _resourceProviders));
+        }
+
+        public Configuration.IPackageSourceProvider PackageSourceProvider
+        {
+            get { return _packageSourceProvider; }
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for filtering out disabled sources from nuget.config. It also adds caching for source repositories in the same way nuget.exe stores single instances of each source to avoid extra calls for index.json between project restores.

CommandLineSourceRepositoryProvider has been copied from nuget.exe and has v2 support (non-xplat) removed.

https://github.com/NuGet/Home/issues/1952

//cc @anurse @yishaigalatzer @zhili1208 @alpaix @davidfowl 
