### PR TITLE
Nuget exe update1803

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -11,6 +11,7 @@ using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
+using NuGet.Packaging.Core;
 
 namespace NuGet.CommandLine
 {
@@ -260,8 +261,9 @@ namespace NuGet.CommandLine
                 var installed = await nugetProject.GetInstalledPackagesAsync(CancellationToken.None);
 
                 var targetIdentities = installed
-                    .Select(pr => pr.PackageIdentity)
-                    .Where(pi => targetIds.Contains(pi.Id))
+                    .Select(pr => pr.PackageIdentity.Id)
+                    .Where(id => targetIds.Contains(id))
+                    .Select(id => new PackageIdentity(id, null))
                     .ToList();
 
                 if (targetIdentities.Any())

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -595,7 +595,20 @@ namespace NuGet.PackageManagement
                 // If we have been given explicit PackageIdentities to install then we will naturally prefer that
                 foreach (var packageIdentity in packageIdentities)
                 {
-                    preferredVersions[packageIdentity.Id] = packageIdentity;
+                    // Just a check to make sure the preferredVersions created from the existing package list actually contains the target
+                    if (preferredVersions.ContainsKey(packageIdentity.Id))
+                    {
+                        // If there was a version specified we will prefer that version
+                        if (packageIdentity.HasVersion)
+                        {
+                            preferredVersions[packageIdentity.Id] = packageIdentity;
+                        }
+                        // Otherwise we just have the Id and so we wil explicitly not prefer the one currently installed
+                        else
+                        {
+                            preferredVersions.Remove(packageIdentity.Id);
+                        }
+                    }
                 }
             }
             // We have just been given the package id, in which case we will look for the highest version and attempt to move to that
@@ -702,7 +715,7 @@ namespace NuGet.PackageManagement
                     prunedAvailablePackages = PrunePackageTree.PrunePrereleaseExceptAllowed(
                         prunedAvailablePackages,
                         oldListOfInstalledPackages,
-                        isUpdateAll: (packageId == null && packageIdentities.Count == 0));
+                        isUpdateAll);
                 }
 
                 // Remove packages that do not meet the constraints specified in the UpdateConstrainst

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -589,7 +589,7 @@ namespace NuGet.PackageManagement
             // We have been given the exact PackageIdentities (id and version) to update to e.g. from PMC update-package -Id <id> -Version <version>
             if (packageIdentities.Count > 0)
             {
-                primaryTargets = packageIdentities;
+                primaryTargets = new List<PackageIdentity>();
                 primaryTargetIds = packageIdentities.Select(p => p.Id);
 
                 // If we have been given explicit PackageIdentities to install then we will naturally prefer that
@@ -602,6 +602,7 @@ namespace NuGet.PackageManagement
                         if (packageIdentity.HasVersion)
                         {
                             preferredVersions[packageIdentity.Id] = packageIdentity;
+                            ((List<PackageIdentity>)primaryTargets).Add(packageIdentity);
                         }
                         // Otherwise we just have the Id and so we wil explicitly not prefer the one currently installed
                         else


### PR DESCRIPTION
this fixes the regression from 2.8.
- basically this allows PackageManagement to take a list of Ids and then it does its best to resolve from that.
- now we get the same results from the nuget.exe -Id <x> -Id <y> -Id <z> as we do in 2.8
