### PR TITLE
treat .exe files as valid assemblies

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -34,7 +34,7 @@ namespace NuGet.Client
             parser: o => o); // Identity parser, all strings are valid for any
         private static readonly ContentPropertyDefinition AssemblyProperty = new ContentPropertyDefinition(PropertyNames.ManagedAssembly,
             parser: o => o.Equals(PackagingCoreConstants.EmptyFolder, StringComparison.Ordinal) ? o : null, // Accept "_._" as a pseudo-assembly
-            fileExtensions: new[] { ".dll", ".winmd" });
+            fileExtensions: new[] { ".dll", ".winmd", ".exe" });
         private static readonly ContentPropertyDefinition MSBuildProperty = new ContentPropertyDefinition(PropertyNames.MSBuild, fileExtensions: new[] { ".targets", ".props" });
         private static readonly ContentPropertyDefinition SatelliteAssemblyProperty = new ContentPropertyDefinition(PropertyNames.SatelliteAssembly, fileExtensions: new[] { ".resources.dll" });
 


### PR DESCRIPTION
Right now, `ilc` (the managed-to-native compiler used by `dotnet-compile`) is distributed in a NuGet package under the `runtimes/...` section. It relies on being picked up and put in the `runtime` section of the lock file. In order for that to happen, it needs to be treated as a valid assembly.

Also, `.exe` is a valid extension for a Managed Assembly, so it should always have been there anyway.

/cc @emgarten @yishaigalatzer @davidfowl 
