### PR TITLE
Add APIs to discover .NETStandard TFMs

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsFrameworkCompatibility.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Runtime.Versioning;
+using NuGet.Frameworks;
+using NuGet.VisualStudio.Implementation.Resources;
+
+namespace NuGet.VisualStudio
+{
+    [Export(typeof(IVsFrameworkCompatibility))]
+    public class VsFrameworkCompatibility : IVsFrameworkCompatibility
+    {
+        public IEnumerable<FrameworkName> GetNetStandardFrameworks()
+        {
+            return DefaultFrameworkNameProvider
+                .Instance
+                .GetNetStandardVersions()
+                .Select(GetFrameworkName);
+        }
+
+        public IEnumerable<FrameworkName> GetFrameworksSupportingNetStandard(FrameworkName frameworkName)
+        {
+            if (frameworkName == null)
+            {
+                throw new ArgumentNullException(nameof(frameworkName));
+            }
+
+            var nuGetFramework = GetNuGetFramework(frameworkName);
+
+            if (!StringComparer.OrdinalIgnoreCase.Equals(
+                nuGetFramework.Framework,
+                FrameworkConstants.FrameworkIdentifiers.NetStandard))
+            {
+                throw new ArgumentException(string.Format(
+                    VsResources.InvalidNetStandardFramework,
+                    frameworkName));
+            }
+
+            return CompatibilityListProvider
+                .Default
+                .GetFrameworksSupporting(nuGetFramework)
+                .Select(GetFrameworkName);
+        }
+
+        private NuGetFramework GetNuGetFramework(FrameworkName frameworkName)
+        {
+            return NuGetFramework.ParseFrameworkName(frameworkName.ToString(), DefaultFrameworkNameProvider.Instance);
+        }
+
+        private FrameworkName GetFrameworkName(NuGetFramework nuGetFramework)
+        {
+            return new FrameworkName(nuGetFramework.DotNetFrameworkName);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonResources.cs" />
+    <Compile Include="Extensibility\VsFrameworkCompatibility.cs" />
     <Compile Include="Extensibility\VsPackageInstaller.cs" />
     <Compile Include="Extensibility\VsPackageInstallerEvents.cs" />
     <Compile Include="Extensibility\VsPackageInstallerServices.cs" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
@@ -61,6 +61,15 @@ namespace NuGet.VisualStudio.Implementation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified framework name &apos;{0}&apos; must be .NETStandard..
+        /// </summary>
+        internal static string InvalidNetStandardFramework {
+            get {
+                return ResourceManager.GetString("InvalidNetStandardFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Package list contains invalid or duplicate entries..
         /// </summary>
         internal static string InvalidPackageList {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
@@ -168,4 +168,7 @@
   <data name="InvalidSource" xml:space="preserve">
     <value>The specified source '{0}' is invalid. Please provide a valid source.</value>
   </data>
+  <data name="InvalidNetStandardFramework" xml:space="preserve">
+    <value>The specified framework name '{0}' must be .NETStandard.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// Contains methods to discover frameworks and compatibility between frameworks.
+    /// </summary>
+    [ComImport]
+    [Guid("3B742C14-3DCB-463D-9198-F0C004BF65DD")]
+    public interface IVsFrameworkCompatibility
+    {
+        /// <summary>
+        /// Gets all .NETStandard frameworks currently supported, in ascending order by version.
+        /// </summary>
+        IEnumerable<FrameworkName> GetNetStandardFrameworks();
+
+        /// <summary>
+        /// Gets frameworks that support packages of the provided .NETStandard version.
+        /// </summary>
+        /// <remarks>
+        /// The result list is not exhaustive as it is meant to human-readable. For example,
+        /// equivalent frameworks are not returned. Additionally, a framework name with version X
+        /// in the result implies that framework names with versions greater than or equal to X
+        /// but having the same <see cref="FrameworkName.Identifier"/> are also supported.
+        /// </remarks>
+        /// <param name="frameworkName">The .NETStandard version to get supporting frameworks for.</param>
+        IEnumerable<FrameworkName> GetFrameworksSupportingNetStandard(FrameworkName frameworkName);
+    }
+}

--- a/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
+++ b/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
@@ -101,6 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensibility\IVsGlobalPackagesInitScriptExecutor.cs" />
+    <Compile Include="Extensibility\IVsFrameworkCompatibility.cs" />
     <Compile Include="Extensibility\IVsPackageSourceProvider.cs" />
     <Compile Include="Extensibility\IVsPackageInstaller.cs" />
     <Compile Include="Extensibility\IVsPackageInstallerEvents.cs" />

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Frameworks
+{
+    public sealed class CompatibilityListProvider : IFrameworkCompatibilityListProvider
+    {
+        private readonly IFrameworkNameProvider _nameProvider;
+        private readonly IFrameworkCompatibilityProvider _compatibilityProvider;
+        private readonly FrameworkReducer _reducer;
+
+        public CompatibilityListProvider(IFrameworkNameProvider nameProvider, IFrameworkCompatibilityProvider compatibilityProvider)
+        {
+            _nameProvider = nameProvider;
+            _compatibilityProvider = compatibilityProvider;
+            _reducer = new FrameworkReducer(_nameProvider, _compatibilityProvider);
+        }
+
+        public IEnumerable<NuGetFramework> GetFrameworksSupporting(NuGetFramework target)
+        {
+            var remaining = _nameProvider
+                .GetCompatibleCandidates()
+                .Where(candidate => _compatibilityProvider.IsCompatible(candidate, target));
+
+            remaining = _reducer.ReduceEquivalent(remaining);
+
+            remaining = ReduceDownwards(remaining);
+
+            return remaining
+                .OrderBy(f => f, new NuGetFrameworkSorter());
+        }
+
+        private IEnumerable<NuGetFramework> ReduceDownwards(IEnumerable<NuGetFramework> frameworks)
+        {
+            // This is a simplified reduce downwards that does not reduce frameworks with
+            // different names or PCL frameworks.
+            var lookup = frameworks.ToLookup(f => f.IsPCL);
+            return lookup[false]
+                .GroupBy(f => f.Framework, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.Aggregate((a, b) => a.Version < b.Version ? a : b))
+                .Concat(lookup[true]);
+        }
+
+        private static IFrameworkCompatibilityListProvider _default;
+
+        public static IFrameworkCompatibilityListProvider Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    _default = new CompatibilityListProvider(DefaultFrameworkNameProvider.Instance, DefaultCompatibilityProvider.Instance);
+                }
+
+                return _default;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -548,6 +548,35 @@ namespace NuGet.Frameworks
             }
         }
 
+        private static string[] _equivalentFrameworkPrecedence;
+
+        public IEnumerable<string> EquivalentFrameworkPrecedence
+        {
+            get
+            {
+                if (_equivalentFrameworkPrecedence == null)
+                {
+                    _equivalentFrameworkPrecedence = new[]
+                    {
+                        FrameworkConstants.FrameworkIdentifiers.Windows,
+                        FrameworkConstants.FrameworkIdentifiers.NetCore,
+                        FrameworkConstants.FrameworkIdentifiers.WinRT,
+
+                        FrameworkConstants.FrameworkIdentifiers.WindowsPhone,
+                        FrameworkConstants.FrameworkIdentifiers.Silverlight,
+
+                        FrameworkConstants.FrameworkIdentifiers.DnxCore,
+                        FrameworkConstants.FrameworkIdentifiers.AspNetCore,
+
+                        FrameworkConstants.FrameworkIdentifiers.Dnx,
+                        FrameworkConstants.FrameworkIdentifiers.AspNet
+                    };
+                }
+
+                return _equivalentFrameworkPrecedence;
+            }
+        }
+
         private static KeyValuePair<NuGetFramework, NuGetFramework>[] _shortNameReplacements;
 
         public IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
@@ -68,8 +68,6 @@ namespace NuGet.Frameworks
                     }
                 }
             }
-
-            yield break;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace NuGet.Frameworks
@@ -47,9 +48,16 @@ namespace NuGet.Frameworks
         // framework ordering (for package based frameworks)
         private readonly Dictionary<string, int> _packageBasedFrameworkPrecedence;
 
+        // framework ordering (when choosing between equivalent frameworks)
+        private readonly Dictionary<string, int> _equivalentFrameworkPrecedence;
+
         // Rewrite mappings
         private readonly Dictionary<NuGetFramework, NuGetFramework> _shortNameRewrites;
         private readonly Dictionary<NuGetFramework, NuGetFramework> _fullNameRewrites;
+
+        // NetStandard information
+        private readonly List<NuGetFramework> _netStandardVersions;
+        private readonly List<NuGetFramework> _compatibleCandidates;
 
         public FrameworkNameProvider(IEnumerable<IFrameworkMappings> mappings, IEnumerable<IPortableFrameworkMappings> portableMappings)
         {
@@ -65,14 +73,19 @@ namespace NuGet.Frameworks
             _subSetFrameworks = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
             _nonPackageBasedFrameworkPrecedence = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             _packageBasedFrameworkPrecedence = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            _equivalentFrameworkPrecedence = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             _compatibilityMappings = new Dictionary<string, HashSet<OneWayCompatibilityMappingEntry>>(StringComparer.OrdinalIgnoreCase);
             _portableCompatibilityMappings = new Dictionary<int, HashSet<FrameworkRange>>();
             _shortNameRewrites = new Dictionary<NuGetFramework, NuGetFramework>(NuGetFramework.Comparer);
             _fullNameRewrites = new Dictionary<NuGetFramework, NuGetFramework>(NuGetFramework.Comparer);
+            _netStandardVersions = new List<NuGetFramework>();
+            _compatibleCandidates = new List<NuGetFramework>();
 
             InitMappings(mappings);
 
             InitPortableMappings(portableMappings);
+
+            InitNetStandard();
         }
 
         /// <summary>
@@ -581,6 +594,7 @@ namespace NuGet.Frameworks
                     // add framework ordering rules
                     AddFrameworkPrecedenceMappings(_nonPackageBasedFrameworkPrecedence, mapping.NonPackageBasedFrameworkPrecedence);
                     AddFrameworkPrecedenceMappings(_packageBasedFrameworkPrecedence, mapping.PackageBasedFrameworkPrecedence);
+                    AddFrameworkPrecedenceMappings(_equivalentFrameworkPrecedence, mapping.EquivalentFrameworkPrecedence);
 
                     // add rewrite rules
                     AddShortNameRewriteMappings(mapping.ShortNameReplacements);
@@ -605,6 +619,15 @@ namespace NuGet.Frameworks
                     AddPortableCompatibilityMappings(portableMapping.CompatibilityMappings);
                 }
             }
+        }
+
+        private void InitNetStandard()
+        {
+            // populate the list of frameworks that could be compatible with NetStandard
+            AddCompatibleCandidates();
+
+            // populate the list of NetStandard versions
+            AddNetStandardVersions();
         }
 
         private void AddShortNameRewriteMappings(IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> mappings)
@@ -724,25 +747,48 @@ namespace NuGet.Frameworks
             {
                 foreach (var pair in mappings)
                 {
-                    // first direction
-                    HashSet<NuGetFramework> eqFrameworks = null;
+                    var remaining = new Stack<NuGetFramework>();
+                    remaining.Push(pair.Key);
+                    remaining.Push(pair.Value);
 
-                    if (!_equivalentFrameworks.TryGetValue(pair.Key, out eqFrameworks))
+                    var seen = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+                    while (remaining.Any())
                     {
-                        eqFrameworks = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
-                        _equivalentFrameworks.Add(pair.Key, eqFrameworks);
+                        var next = remaining.Pop();
+                        if (!seen.Add(next))
+                        {
+                            continue;
+                        }
+
+                        HashSet<NuGetFramework> eqFrameworks;
+                        if (!_equivalentFrameworks.TryGetValue(next, out eqFrameworks))
+                        {
+                            // initialize set
+                            eqFrameworks = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+                            _equivalentFrameworks.Add(next, eqFrameworks);
+                        }
+                        else
+                        {
+                            // explore all equivalent
+                            foreach (var framework in eqFrameworks)
+                            {
+                                remaining.Push(framework);
+                            }   
+                        }
                     }
 
-                    eqFrameworks.Add(pair.Value);
-
-                    // reverse direction
-                    if (!_equivalentFrameworks.TryGetValue(pair.Value, out eqFrameworks))
+                    // add this equivalency rule, enforcing transitivity
+                    foreach (var framework in seen)
                     {
-                        eqFrameworks = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
-                        _equivalentFrameworks.Add(pair.Value, eqFrameworks);
+                        foreach (var other in seen)
+                        {
+                            if (!NuGetFramework.Comparer.Equals(framework, other))
+                            {
+                                _equivalentFrameworks[framework].Add(other);
+                            }
+                        }
                     }
 
-                    eqFrameworks.Add(pair.Key);
                 }
             }
         }
@@ -899,25 +945,8 @@ namespace NuGet.Frameworks
             return false;
         }
 
-        /// <summary>
-        /// The ascending order of frameworks should be based on the the following ordered groups:
-        /// 
-        /// 1. Non-package-based frameworks in <see cref="IFrameworkMappings.NonPackageBasedFrameworkPrecedence"/>.
-        /// 2. Other non-package-based frameworks.
-        /// 3. Package-based frameworks in <see cref="IFrameworkMappings.PackageBasedFrameworkPrecedence"/>.
-        /// 4. Other package-based frameworks.
-        /// 
-        /// For group #1 and #3, the order within the group is based on the order of the respective precedence list.
-        /// For group #2 and #4, the order is the original order in the incoming list. This should later be made
-        /// consistent between different input orderings by using the <see cref="NuGetFrameworkSorter"/>.
-        /// </summary>
         public int CompareFrameworks(NuGetFramework x, NuGetFramework y)
         {
-            if (StringComparer.OrdinalIgnoreCase.Equals(x.Framework, y.Framework))
-            {
-                return 0;
-            }
-
             if (x.IsPackageBased != y.IsPackageBased)
             {
                 // non-package based always come before package based
@@ -925,6 +954,21 @@ namespace NuGet.Frameworks
             }
 
             var precedence = x.IsPackageBased ? _packageBasedFrameworkPrecedence : _nonPackageBasedFrameworkPrecedence;
+
+            return CompareUsingPrecedence(x, y, precedence);
+        }
+
+        public int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y)
+        {
+            return CompareUsingPrecedence(x, y, _equivalentFrameworkPrecedence);
+        }
+
+        private static int CompareUsingPrecedence(NuGetFramework x, NuGetFramework y, Dictionary<string, int> precedence)
+        {
+            if (StringComparer.OrdinalIgnoreCase.Equals(x.Framework, y.Framework))
+            {
+                return 0;
+            }
 
             int xIndex;
             if (!precedence.TryGetValue(x.Framework, out xIndex))
@@ -940,6 +984,7 @@ namespace NuGet.Frameworks
 
             return xIndex.CompareTo(yIndex);
         }
+
 
         public NuGetFramework GetShortNameReplacement(NuGetFramework framework)
         {
@@ -965,6 +1010,100 @@ namespace NuGet.Frameworks
             }
 
             return result;
+        }
+
+        public IEnumerable<NuGetFramework> GetNetStandardVersions()
+        {
+            return _netStandardVersions.AsReadOnly();
+        }
+
+        public IEnumerable<NuGetFramework> GetCompatibleCandidates()
+        {
+            return _compatibleCandidates.AsReadOnly();
+        }
+
+        private void AddNetStandardVersions()
+        {
+            foreach (var framework in _compatibleCandidates)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard))
+                {
+                    _netStandardVersions.Add(framework);
+                }
+            }
+
+            _netStandardVersions.Sort(new NuGetFrameworkSorter());
+        }
+
+        private void AddCompatibleCandidates()
+        {
+            var set = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+
+            // equivalent
+            foreach (var framework in _equivalentFrameworks.Values.SelectMany(x => x))
+            {
+                set.Add(framework);
+            }
+
+            // compatible
+            foreach (var mapping in _compatibilityMappings.SelectMany(p => p.Value))
+            {
+                set.Add(mapping.TargetFrameworkRange.Min);
+                set.Add(mapping.TargetFrameworkRange.Max);
+                set.Add(mapping.SupportedFrameworkRange.Min);
+                set.Add(mapping.SupportedFrameworkRange.Max);
+            }
+
+            // portable compatible
+            foreach (var pair in _portableCompatibilityMappings)
+            {
+                var portable = new NuGetFramework(
+                    FrameworkConstants.FrameworkIdentifiers.Portable,
+                    FrameworkConstants.EmptyVersion,
+                    string.Format(NumberFormatInfo.InvariantInfo, "Profile{0}", pair.Key));
+
+                set.Add(portable);
+                foreach (var range in pair.Value)
+                {
+                    set.Add(range.Min);
+                    set.Add(range.Max);
+                }
+            }
+
+            // subset and superset
+            var superSetFrameworks = _subSetFrameworks
+                .SelectMany(p => p.Value.Select(subset => new { Superset = p.Key, Subset = subset }))
+                .GroupBy(p => p.Subset, p => p.Superset, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => new HashSet<string>(g, StringComparer.OrdinalIgnoreCase));
+
+            foreach (var framework in set.ToArray())
+            {
+                if (framework.HasProfile)
+                {
+                    continue;
+                }
+
+                HashSet<string> subset;
+                if (_subSetFrameworks.TryGetValue(framework.Framework, out subset))
+                {
+                    foreach (var subFramework in subset)
+                    {
+                        set.Add(new NuGetFramework(subFramework, framework.Version, framework.Profile));
+                    }
+                }
+
+                HashSet<string> superset;
+                if (superSetFrameworks.TryGetValue(framework.Framework, out superset))
+                {
+                    foreach (var superFramework in superset)
+                    {
+                        set.Add(new NuGetFramework(superFramework, framework.Version, framework.Profile));
+                    }
+                }
+            }
+
+            _compatibleCandidates.AddRange(set);
+            _compatibleCandidates.Sort(new NuGetFrameworkSorter());
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
@@ -175,7 +175,7 @@ namespace NuGet.Frameworks
                 {
                     // Sort by precedence rules, then by name in the case of a tie
                     nearest = reduced
-                        .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings))
+                        .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings, false))
                         .ThenByDescending(f => f, new NuGetFrameworkSorter())
                         .ThenBy(f => f.GetHashCode())
                         .First();
@@ -188,35 +188,35 @@ namespace NuGet.Frameworks
         /// <summary>
         /// Remove duplicates found in the equivalence mappings.
         /// </summary>
-        public IEnumerable<NuGetFramework> Reduce(IEnumerable<NuGetFramework> frameworks)
+        public IEnumerable<NuGetFramework> ReduceEquivalent(IEnumerable<NuGetFramework> frameworks)
         {
             // order first so we get consistent results for equivalent frameworks
-            var input = frameworks.OrderBy(f => f.DotNetFrameworkName, StringComparer.OrdinalIgnoreCase).ToArray();
+            var input = frameworks
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(_mappings, true))
+                .ThenByDescending(f => f, new NuGetFrameworkSorter())
+                .ToArray();
 
-            var comparer = new NuGetFrameworkFullComparer();
-
-            for (var i = 0; i < input.Length; i++)
+            var duplicates = new HashSet<NuGetFramework>(NuGetFramework.Comparer);
+            foreach (var framework in input)
             {
-                var dupe = false;
-
-                IEnumerable<NuGetFramework> eqFrameworks = null;
-                if (!_mappings.TryGetEquivalentFrameworks(input[i], out eqFrameworks))
+                if (duplicates.Contains(framework))
                 {
-                    eqFrameworks = new List<NuGetFramework>() { input[i] };
+                    continue;
                 }
 
-                for (var j = i + 1; !dupe && j < input.Length; j++)
-                {
-                    dupe = eqFrameworks.Contains(input[j], comparer);
-                }
+                yield return framework;
 
-                if (!dupe)
+                duplicates.Add(framework);
+
+                IEnumerable<NuGetFramework> eqFrameworks;
+                if (_mappings.TryGetEquivalentFrameworks(framework, out eqFrameworks))
                 {
-                    yield return input[i];
+                    foreach (var eqFramework in eqFrameworks)
+                    {
+                        duplicates.Add(eqFramework);
+                    }
                 }
             }
-
-            yield break;
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace NuGet.Frameworks
             if (frameworks.Any(e => e == NuGetFramework.AnyFramework))
             {
                 // Any is always the lowest
-                return new NuGetFramework[] { NuGetFramework.AnyFramework };
+                return new[] { NuGetFramework.AnyFramework };
             }
 
             return ReduceCore(frameworks, (x, y) => _compat.IsCompatible(x, y)).ToArray();
@@ -331,7 +331,7 @@ namespace NuGet.Frameworks
 
             // reduce the sub frameworks - this would only have an effect if the PCL is 
             // poorly formed and contains duplicates such as portable-win8+win81
-            subFrameworks = Reduce(subFrameworks);
+            subFrameworks = ReduceEquivalent(subFrameworks);
 
             // Find all frameworks in all PCLs
             var pclToFrameworks = ExplodePortableFrameworks(reduced);

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
@@ -11,16 +11,17 @@ namespace NuGet.Frameworks
     public class FrameworkPrecedenceSorter : IComparer<NuGetFramework>
     {
         private readonly IFrameworkNameProvider _mappings;
+        private readonly bool _allEquivalent;
 
-        public FrameworkPrecedenceSorter(IFrameworkNameProvider mappings)
+        public FrameworkPrecedenceSorter(IFrameworkNameProvider mappings, bool allEquivalent)
         {
             _mappings = mappings;
+            _allEquivalent = allEquivalent;
         }
 
         public int Compare(NuGetFramework x, NuGetFramework y)
         {
-            // This is a simple wrapper for the compare method on the name provider.
-            return _mappings.CompareFrameworks(x, y);
+            return _allEquivalent ? _mappings.CompareEquivalentFrameworks(x, y) : _mappings.CompareFrameworks(x, y);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityListProvider.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Frameworks
+{
+    public interface IFrameworkCompatibilityListProvider
+    {
+        /// <summary>
+        /// Get a list of frameworks supporting the provided framework. This list
+        /// is not meant to be exhaustive but is instead meant to be human-readable.
+        /// Ex: netstandard1.5 -> netstandardapp1.5, net462, dnxcore50, ...
+        /// </summary>
+        IEnumerable<NuGetFramework> GetFrameworksSupporting(NuGetFramework target);
+    }
+}

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
@@ -70,6 +70,12 @@ namespace NuGet.Frameworks
         IEnumerable<string> PackageBasedFrameworkPrecedence { get; }
 
         /// <summary>
+        /// Only used to choose between frameworks that are equivalent. This favors more human-readable target
+        /// frameworks identifiers.
+        /// </summary>
+        IEnumerable<string> EquivalentFrameworkPrecedence { get; }
+
+        /// <summary>
         /// Rewrite folder short names to the given value.
         /// Ex: dotnet50 -> dotnet
         /// </summary>

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -102,10 +102,26 @@ namespace NuGet.Frameworks
         bool TryGetSubSetFrameworks(string frameworkIdentifier, out IEnumerable<string> subSetFrameworkIdentifiers);
 
         /// <summary>
-        /// Attempts order and prefer one framework over the other based on framework preference rules.
+        /// The ascending order of frameworks should be based on the following ordered groups:
+        /// 
+        /// 1. Non-package-based frameworks in <see cref="IFrameworkMappings.NonPackageBasedFrameworkPrecedence"/>.
+        /// 2. Other non-package-based frameworks.
+        /// 3. Package-based frameworks in <see cref="IFrameworkMappings.PackageBasedFrameworkPrecedence"/>.
+        /// 4. Other package-based frameworks.
+        /// 
+        /// For group #1 and #3, the order within the group is based on the order of the respective precedence list.
+        /// For group #2 and #4, the order is the original order in the incoming list. This should later be made
+        /// consistent between different input orderings by using the <see cref="NuGetFrameworkSorter"/>.
         /// </summary>
-        /// <returns>0 if no order can be determined, -1 if the first framework is preferred.</returns>
         int CompareFrameworks(NuGetFramework x, NuGetFramework y);
+
+        /// <summary>
+        /// Used to pick between two equivalent frameworks. This is meant to favor the more human-readable
+        /// framework. Note that this comparison does not validate that the provided frameworks are indeed
+        /// equivalent (e.g. with
+        /// <see cref="TryGetEquivalentFrameworks(NuGetFramework, out IEnumerable{NuGetFramework})"/>).
+        /// </summary>
+        int CompareEquivalentFrameworks(NuGetFramework x, NuGetFramework y);
 
         /// <summary>
         /// Returns folder short names rewrites.
@@ -118,5 +134,15 @@ namespace NuGet.Frameworks
         /// Ex: .NETPlatform,Version=v0.0 -> .NETPlatform,Version=v5.0
         /// </summary>
         NuGetFramework GetFullNameReplacement(NuGetFramework framework);
+
+        /// <summary>
+        /// Returns all versions of .NETStandard in ascending order.
+        /// </summary>
+        IEnumerable<NuGetFramework> GetNetStandardVersions();
+
+        /// <summary>
+        /// Returns a list of frameworks that could be compatible with .NETStandard.
+        /// </summary>
+        IEnumerable<NuGetFramework> GetCompatibleCandidates();
     }
 }

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -365,6 +365,39 @@ function Test-GetSourceAPI
     Assert-NotNull $sources
 }
 
+function Test-GetNetStandardVersions 
+{
+    # Arrange
+    $cm = Get-VsComponentModel
+    $service = $cm.GetService([NuGet.VisualStudio.IVsFrameworkCompatibility])
+
+    # Act
+    $actual = $service.GetNetStandardFrameworks()
+
+    # Assert
+    Assert-AreEqual ".NETStandard,Version=v1.0" ($actual | Select-Object -Index 0)
+    Assert-AreEqual ".NETStandard,Version=v1.1" ($actual | Select-Object -Index 1)
+    Assert-AreEqual ".NETStandard,Version=v1.2" ($actual | Select-Object -Index 2)
+    Assert-AreEqual ".NETStandard,Version=v1.3" ($actual | Select-Object -Index 3)
+    Assert-AreEqual ".NETStandard,Version=v1.4" ($actual | Select-Object -Index 4)
+    Assert-AreEqual ".NETStandard,Version=v1.5" ($actual | Select-Object -Index 5)
+}
+
+function Test-GetFrameworksSupportingNetStandard
+{
+    # Arrange
+    $cm = Get-VsComponentModel
+    $service = $cm.GetService([NuGet.VisualStudio.IVsFrameworkCompatibility])
+
+    # Act
+    $actual = $service.GetFrameworksSupportingNetStandard(".NETStandard,Version=v1.2")
+
+    # Assert
+    Assert-AreEqual ".NETCore,Version=v5.0" ($actual | Select-Object -Index 0)
+    Assert-AreEqual ".NETFramework,Version=v4.5.1" ($actual | Select-Object -Index 1)
+    Assert-AreEqual ".NETPortable,Version=v0.0,Profile=Profile151" ($actual | Select-Object -Index 2)
+}
+
 function Test-RestorePackageAPI
 {
     param($context)

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Frameworks.Test
+{
+    public class CompatibilityListProviderTests
+    {
+        [Fact]
+        public void CompatibilityListProvider_NetStandard12Supporting()
+        {
+            // Arrange
+            var provider = CompatibilityListProvider.Default;
+
+            // Act
+            var actual = provider
+                .GetFrameworksSupporting(FrameworkConstants.CommonFrameworks.NetStandard12)
+                .Select(f => f.ToString())
+                .ToArray();
+
+            // Assert
+            // positive
+            Assert.Contains(".NETCore,Version=v5.0", actual);
+            Assert.Contains(".NETFramework,Version=v4.5.1", actual);
+            Assert.Contains(".NETPortable,Version=v0.0,Profile=Profile151", actual); // PCL frameworks are not reduced
+            Assert.Contains(".NETPortable,Version=v0.0,Profile=Profile32", actual);
+            Assert.Contains(".NETPortable,Version=v0.0,Profile=Profile44", actual);
+            Assert.Contains(".NETStandard,Version=v1.2", actual); // the framework itself
+            Assert.Contains(".NETStandardApp,Version=v1.2", actual); // superset frameworks
+            Assert.Contains("DNX,Version=v4.5.1", actual);
+            Assert.Contains("DNXCore,Version=v5.0", actual);
+            Assert.Contains("MonoAndroid,Version=v0.0", actual);
+            Assert.Contains("MonoMac,Version=v0.0", actual);
+            Assert.Contains("MonoTouch,Version=v0.0", actual);
+            Assert.Contains("UAP,Version=v10.0", actual);
+            Assert.Contains("Windows,Version=v8.1", actual); // the preferred equivalent name is returned
+            Assert.Contains("WindowsPhoneApp,Version=v8.1", actual);
+            Assert.Contains("Xamarin.iOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.Mac,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStation3,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStation4,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStationVita,Version=v0.0", actual);
+            Assert.Contains("Xamarin.TVOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
+            Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+
+            // negative
+            Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // only the minimum support version is returned
+            Assert.DoesNotContain(".NETFramework,Version=v4.5", actual); // versions that are too small are not returned
+            Assert.DoesNotContain(".NETPlatform,Version=v5.3", actual); // frameworks with no relationship are not returned
+        }
+
+        [Fact]
+        public void CompatibilityListProvider_NetStandard15Supporting()
+        {
+            // Arrange
+            var provider = CompatibilityListProvider.Default;
+
+            // Act
+            var actual = provider
+                .GetFrameworksSupporting(FrameworkConstants.CommonFrameworks.NetStandard15)
+                .Select(f => f.ToString())
+                .ToArray();
+
+            // Assert
+            // positive
+            Assert.Contains(".NETCore,Version=v5.0", actual);
+            Assert.Contains(".NETFramework,Version=v4.6.2", actual);
+            Assert.Contains(".NETStandard,Version=v1.5", actual);
+            Assert.Contains(".NETStandardApp,Version=v1.5", actual);
+            Assert.Contains("DNX,Version=v4.6.2", actual);
+            Assert.Contains("DNXCore,Version=v5.0", actual);
+            Assert.Contains("MonoAndroid,Version=v0.0", actual);
+            Assert.Contains("MonoMac,Version=v0.0", actual);
+            Assert.Contains("MonoTouch,Version=v0.0", actual);
+            Assert.Contains("UAP,Version=v10.0", actual);
+            Assert.Contains("Xamarin.iOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.Mac,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStation3,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStation4,Version=v0.0", actual);
+            Assert.Contains("Xamarin.PlayStationVita,Version=v0.0", actual);
+            Assert.Contains("Xamarin.TVOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
+            Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
+            Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+
+            // negative
+            Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
+            Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // versions that are too small are not returned
+            Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using NuGet.Frameworks;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkComparerTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.Test
 
             // Act
             list = list
-                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
                 .ThenByDescending(f => f, new NuGetFrameworkSorter())
                 .ToList();
 
@@ -93,7 +93,7 @@ namespace NuGet.Test
 
             // Act
             list = list
-                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
                 .ThenByDescending(f => f, new NuGetFrameworkSorter())
                 .ToList();
 
@@ -135,7 +135,7 @@ namespace NuGet.Test
 
             // Act
             list = list
-                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance))
+                .OrderBy(f => f, new FrameworkPrecedenceSorter(DefaultFrameworkNameProvider.Instance, false))
                 .ThenByDescending(f => f, new NuGetFrameworkSorter())
                 .ToList();
 

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -764,7 +764,7 @@ namespace NuGet.Test
 
             var all = new NuGetFramework[] { framework1, framework2 };
 
-            var result = reducer.Reduce(all);
+            var result = reducer.ReduceEquivalent(all);
 
             Assert.Equal(framework1, result.Single());
         }
@@ -780,10 +780,32 @@ namespace NuGet.Test
 
             var all = new NuGetFramework[] { sl3wp, wp7, win81 };
 
-            var result = reducer.Reduce(all);
+            var result = reducer.ReduceEquivalent(all);
 
+            Assert.Equal(2, result.Count());
             Assert.Equal(win81, result.First());
-            Assert.Equal(wp7, result.Skip(1).First());
+            Assert.Equal(wp7, result.ElementAt(1));
+        }
+
+        [Fact]
+        public void FrameworkReducer_ReducePrecedence()
+        {
+            FrameworkReducer reducer = new FrameworkReducer();
+
+            var win = NuGetFramework.Parse("win");
+            var win8 = NuGetFramework.Parse("win8");
+            var netcore45 = NuGetFramework.Parse("netcore45");
+            var winrt45 = NuGetFramework.Parse("winrt45");
+            var winrt = NuGetFramework.Parse("netcore");
+            var net45 = NuGetFramework.Parse("net45");
+
+            var all = new NuGetFramework[] { win, win8, netcore45, winrt45, winrt, net45 };
+
+            var result = reducer.ReduceEquivalent(all);
+
+            Assert.Equal(2, result.Count());
+            Assert.Equal(win8, result.First());
+            Assert.Equal(net45, result.ElementAt(1));
         }
 
         [Fact]
@@ -796,7 +818,7 @@ namespace NuGet.Test
 
             var all = new NuGetFramework[] { sl3wp, wp7 };
 
-            var result = reducer.Reduce(all);
+            var result = reducer.ReduceEquivalent(all);
 
             Assert.Equal(wp7, result.Single());
         }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1826
1. Add `IFrameworkNameProvider.GetNetStandardVersions()`
2. Add `IFrameworkCompatibilityListProvider.GetFrameworksSupporting(NuGetFramework)`
3. Add VS APIs to expose this data.

The intent is that we do not need to maintain (much) additional configuration to evaluate these methods. This can be done by exploring the existing TxM graph configured in `IFrameworkMappings`.

One additional construct needed in `IFrameworkMappings` is a precedence for equivalent TxMs. For example, `win8` and `winrt45` are equivalent (by transitivity) but the user only wants to see `win8`. Previously, equivalency reduction favored TxMs that come first when ordered lexically. 

@emgarten @yishaigalatzer @zhili1208 
