### PR TITLE
Tweaks to functional test scripts

### DIFF
--- a/Scripts/CopyToolsAndSetupMachine.ps1
+++ b/Scripts/CopyToolsAndSetupMachine.ps1
@@ -39,9 +39,4 @@ $NuGetTestPath = Join-Path $FuncTestRoot "EndToEnd"
 CopyNuGetCITools $NuGetCIToolsFolder $NuGetTestPath
 
 # Already checked if the prompt is an admin prompt
-$success = DisableCrashDialog
-if ($success -eq $false)
-{
-    Write-Error 'WARNING: Could not disable crash dialog'
-    exit 1
-}
+DisableCrashDialog

--- a/Scripts/LaunchVS.ps1
+++ b/Scripts/LaunchVS.ps1
@@ -7,9 +7,25 @@ $DTEReadyPollFrequencyInSecs,
 [Parameter(Mandatory=$true)]
 $NumberOfPolls)
 
+trap
+{
+    Write-Host $_.Exception -ForegroundColor Red
+    exit 1
+}
+
 . "$PSScriptRoot\VSUtils.ps1"
 
 KillRunningInstancesOfVS
+
+Write-Host 'Waiting for 5 seconds before cleaning the MEF cache'
+start-sleep 5
+
+Write-Host "Force deleting LOCALAPPDATA\Microsoft\VisualStudio\$VSVersion"
+$localappdata = $env:LOCALAPPDATA
+Remove-Item (Join-Path $localappdata\Microsoft\VisualStudio $VSVersion) -Force -Recurse -ErrorAction SilentlyContinue
+
+Write-Host 'Waiting for 5 seconds after cleaning the MEF cache'
+start-sleep 5
 
 LaunchVS $VSVersion
 

--- a/Scripts/RunFunctionalTests.ps1
+++ b/Scripts/RunFunctionalTests.ps1
@@ -15,6 +15,12 @@ param (
 	[ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
     [string]$VSVersion)
 
+trap
+{
+    Write-Host $_.Exception -ForegroundColor Red
+    exit 1
+}
+
 . "$PSScriptRoot\Utils.ps1"
 . "$PSScriptRoot\VSUtils.ps1"
 . "$PSScriptRoot\NuGetFunctionalTestUtils.ps1"


### PR DESCRIPTION
1) Fixed SetupFunctionalTests.ps1 to work on machines where the registry
keys are not present already.
2) Also, it only expects to be on Admin
prompt if the desired values are not set already.
3) Updated LaunchVS.ps1 to always delete the localappdata for VS
before launching VS. Sometimes, the new VSIX installed does not
get picked up by VS

@yishaigalatzer  @emgarten @alpaix 
