### PR TITLE
Addresses #1978 by adding the required Xamarin BuildActions

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/ContentFiles/ContentFileUtils.cs
@@ -65,7 +65,10 @@ namespace NuGet.Commands
                         "SplashScreen",
                         "DesignData",
                         "DesignDataWithDesignTimeCreatableTypes",
-                        "CodeAnalysisDictionary"
+                        "CodeAnalysisDictionary",
+                        "AndroidAsset",
+                        "AndroidResource",
+                        "BundleResource"
                     }, StringComparer.Ordinal);
                 }
 


### PR DESCRIPTION
Adds 
`AndroidResource`
`AndroidAsset`
`BundleResource`

To the contentFiles whitelist.
