### PR TITLE
XPlat exception logging

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -113,6 +113,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "SynchronizationTestApp", "s
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Shared", "src\NuGet.Core\NuGet.Shared\NuGet.Shared.xproj", "{CA92BD12-5500-4809-B998-F6ECDD9DD79B}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.CommandLine.XPlat.Test", "test\NuGet.Core.Tests\NuGet.CommandLine.XPlat.Test\NuGet.CommandLine.XPlat.Test.xproj", "{82FF10C5-8724-4187-953E-5096AD90184F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -319,6 +321,10 @@ Global
 		{CA92BD12-5500-4809-B998-F6ECDD9DD79B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA92BD12-5500-4809-B998-F6ECDD9DD79B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA92BD12-5500-4809-B998-F6ECDD9DD79B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82FF10C5-8724-4187-953E-5096AD90184F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82FF10C5-8724-4187-953E-5096AD90184F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82FF10C5-8724-4187-953E-5096AD90184F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82FF10C5-8724-4187-953E-5096AD90184F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -373,5 +379,6 @@ Global
 		{9CF4E081-EEB2-4E83-9762-7BC79B55FF4D} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{77DC049B-16EA-4FE6-9287-E8E514F4700F} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{CA92BD12-5500-4809-B998-F6ECDD9DD79B} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
+		{82FF10C5-8724-4187-953E-5096AD90184F} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
@@ -31,7 +31,7 @@ namespace NuGet.CommandLine.XPlat
             _verbosity = new Lazy<LogLevel>(() =>
             {
                 LogLevel level;
-                if (!Enum.TryParse(verbosity.Value(), out level))
+                if (!Enum.TryParse(value: verbosity.Value(), ignoreCase: true, result: out level))
                 {
                     level = LogLevel.Information;
                 }
@@ -66,7 +66,7 @@ namespace NuGet.CommandLine.XPlat
 
         private void LogInternal(LogLevel logLevel, string message)
         {
-            if(logLevel < Verbosity)
+            if (logLevel < Verbosity)
             {
                 return;
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -24,7 +24,10 @@ namespace NuGet.CommandLine.XPlat
 {
     public class Program
     {
-        private static ILogger _log;
+        private const string HelpOption = "-h|--help";
+        private const string VerbosityOption = "-v|--verbosity <verbosity>";
+
+        public static ILogger Log { get; set; }
 
         public static int Main(string[] args)
         {
@@ -43,14 +46,155 @@ namespace NuGet.CommandLine.XPlat
             var app = new CommandLineApplication();
             app.Name = "nuget3";
             app.FullName = Strings.App_FullName;
-            app.HelpOption("-h|--help");
+            app.HelpOption(HelpOption);
             app.VersionOption("--version", typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString());
 
             var verbosity = app.Option("-v|--verbosity <verbosity>", Strings.Switch_Verbosity, CommandOptionType.SingleValue);
 
-            // Set up logging
-            _log = new CommandOutputLogger(verbosity);
+            SetConnectionLimit();
 
+            app.Command("restore", restore =>
+            {
+                restore.Description = Strings.Restore_Description;
+                restore.HelpOption(HelpOption);
+
+                var sources = restore.Option(
+                    "-s|--source <source>",
+                    Strings.Restore_Switch_Source_Description,
+                    CommandOptionType.MultipleValue);
+                var packagesDirectory = restore.Option(
+                    "--packages <packagesDirectory>",
+                    Strings.Restore_Switch_Packages_Description,
+                    CommandOptionType.SingleValue);
+                var parallel = restore.Option(
+                    "-p|--parallel <noneOrNumberOfParallelTasks>",
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.Restore_Switch_Parallel_Description,
+                        RestoreRequest.DefaultDegreeOfConcurrency),
+                    CommandOptionType.SingleValue);
+                var fallBack = restore.Option(
+                    "-f|--fallbacksource <FEED>",
+                    Strings.Restore_Switch_Fallback_Description,
+                    CommandOptionType.MultipleValue);
+                var runtime = restore.Option(
+                    "--runtime <RID>",
+                    Strings.Restore_Switch_Runtime_Description,
+                    CommandOptionType.MultipleValue);
+                verbosity = restore.Option(VerbosityOption,
+                    Strings.Switch_Verbosity,
+                    CommandOptionType.SingleValue);
+
+                EnsureLog(verbosity);
+
+                var argRoot = restore.Argument(
+                    "[root]",
+                    Strings.Restore_Arg_ProjectName_Description,
+                    multipleValues: true);
+
+                restore.OnExecute(async () =>
+                {
+                    // Ignore casing on windows
+                    var comparer = RuntimeEnvironmentHelper.IsWindows ?
+                        StringComparer.OrdinalIgnoreCase
+                        : StringComparer.Ordinal;
+
+                    var inputValues = new HashSet<string>(comparer);
+
+                    if (argRoot.Values.Count < 1)
+                    {
+                        // Use the current directory if no path was given
+                        var workingDir = Path.GetFullPath(".");
+
+                        inputValues.UnionWith(GetProjectJsonFilesInDirectory(workingDir));
+                    }
+                    else
+                    {
+                        foreach (var inputPath in argRoot.Values)
+                        {
+                            var fullPath = Path.GetFullPath(inputPath);
+
+                            // For directories find all children
+                            if (Directory.Exists(inputPath))
+                            {
+                                inputValues.UnionWith(GetProjectJsonFilesInDirectory(fullPath));
+                            }
+                            else
+                            {
+                                // Add the input directly
+                                inputValues.Add(fullPath);
+                            }
+                        }
+                    }
+
+                    var restoreExitCode = 0;
+
+                    foreach (var inputPath in inputValues)
+                    {
+                        var currentExitCode = await ExecuteRestore(
+                            sources,
+                            packagesDirectory,
+                            parallel,
+                            fallBack,
+                            runtime,
+                            inputPath);
+
+                        if (currentExitCode != 0)
+                        {
+                            restoreExitCode = currentExitCode;
+                        }
+                    }
+
+                    return restoreExitCode;
+                });
+            });
+
+            app.OnExecute(() =>
+            {
+                app.ShowHelp();
+                return 0;
+            });
+
+            var exitCode = 0;
+
+            try
+            {
+                exitCode = app.Execute(args);
+            }
+            catch (Exception e)
+            {
+                EnsureLog(verbosity);
+
+                // Log the error
+                Log.LogError(ExceptionUtilities.DisplayMessage(e));
+
+                // Log the stack trace as verbose output.
+                Log.LogVerbose(e.ToString());
+
+                exitCode = 1;
+            }
+
+            // Limit the exit code range to 0-255 to support POSIX
+            if (exitCode < 0 || exitCode > 255)
+            {
+                exitCode = 1;
+            }
+
+            return exitCode;
+        }
+
+        private static void EnsureLog(CommandOption verbosity)
+        {
+            // Set up logging.
+            // For tests this will already be set.
+            if (Log == null)
+            {
+                Log = new CommandOutputLogger(verbosity);
+            }
+        }
+
+        private static void SetConnectionLimit()
+        {
 #if !DNXCORE50
             // Increase the maximum number of connections per server.
             if (!RuntimeEnvironmentHelper.IsMono)
@@ -63,103 +207,6 @@ namespace NuGet.CommandLine.XPlat
                 ServicePointManager.DefaultConnectionLimit = 1;
             }
 #endif
-
-            app.Command("restore", restore =>
-                {
-                    restore.Description = Strings.Restore_Description;
-
-                    var sources = restore.Option(
-                        "-s|--source <source>",
-                        Strings.Restore_Switch_Source_Description,
-                        CommandOptionType.MultipleValue);
-                    var packagesDirectory = restore.Option(
-                        "--packages <packagesDirectory>",
-                        Strings.Restore_Switch_Packages_Description,
-                        CommandOptionType.SingleValue);
-                    var parallel = restore.Option(
-                        "-p|--parallel <noneOrNumberOfParallelTasks>",
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Restore_Switch_Parallel_Description,
-                            RestoreRequest.DefaultDegreeOfConcurrency),
-                        CommandOptionType.SingleValue);
-                    var fallBack = restore.Option(
-                        "-f|--fallbacksource <FEED>",
-                        Strings.Restore_Switch_Fallback_Description,
-                        CommandOptionType.MultipleValue);
-                    var runtime = restore.Option(
-                        "--runtime <RID>",
-                        Strings.Restore_Switch_Runtime_Description,
-                        CommandOptionType.MultipleValue);
-                    var argRoot = restore.Argument(
-                        "[root]",
-                        Strings.Restore_Arg_ProjectName_Description,
-                        multipleValues: true);
-
-                    restore.OnExecute(async () =>
-                    {
-                        // Ignore casing on windows
-                        var comparer = RuntimeEnvironmentHelper.IsWindows ?
-                            StringComparer.OrdinalIgnoreCase
-                            : StringComparer.Ordinal;
-
-                        var inputValues = new HashSet<string>(comparer);
-
-                        if (argRoot.Values.Count < 1)
-                        {
-                            // Use the current directory if no path was given
-                            var workingDir = Path.GetFullPath(".");
-
-                            inputValues.UnionWith(GetProjectJsonFilesInDirectory(workingDir));
-                        }
-                        else
-                        {
-                            foreach (var inputPath in argRoot.Values)
-                            {
-                                var fullPath = Path.GetFullPath(inputPath);
-
-                                // For directories find all children
-                                if (Directory.Exists(inputPath))
-                                {
-                                    inputValues.UnionWith(GetProjectJsonFilesInDirectory(fullPath));
-                                }
-                                else
-                                {
-                                    // Add the input directly
-                                    inputValues.Add(fullPath);
-                                }
-                            }
-                        }
-
-                        var exitCode = 0;
-
-                        foreach (var inputPath in inputValues)
-                        {
-                            var currentExitCode = await ExecuteRestore(
-                                sources,
-                                packagesDirectory,
-                                parallel,
-                                fallBack,
-                                runtime,
-                                inputPath);
-
-                            if (currentExitCode != 0)
-                            {
-                                exitCode = currentExitCode;
-                            }
-                        }
-
-                        return exitCode;
-                    });
-                });
-
-            app.OnExecute(() =>
-                {
-                    app.ShowHelp();
-                    return 0;
-                });
-
-            return app.Execute(args);
         }
 
         private static IEnumerable<string> GetProjectJsonFilesInDirectory(string path)
@@ -182,7 +229,7 @@ namespace NuGet.CommandLine.XPlat
             var projectPath = Path.GetFullPath(inputPath);
             if (string.Equals(PackageSpec.PackageSpecFileName, Path.GetFileName(projectPath), StringComparison.OrdinalIgnoreCase))
             {
-                _log.LogVerbose(string.Format(
+                Log.LogVerbose(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Log_ReadingProject,
                     inputPath));
@@ -201,7 +248,7 @@ namespace NuGet.CommandLine.XPlat
                 var projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
                 var packageSpecFile = Path.Combine(projectDirectory, PackageSpec.PackageSpecFileName);
                 project = JsonPackageSpecReader.GetPackageSpec(File.ReadAllText(packageSpecFile), projectPath, inputPath);
-                _log.LogVerbose(string.Format(
+                Log.LogVerbose(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Log_ReadingProject, inputPath));
 #endif
@@ -210,21 +257,21 @@ namespace NuGet.CommandLine.XPlat
             {
                 var file = Path.Combine(projectPath, PackageSpec.PackageSpecFileName);
 
-                _log.LogVerbose(string.Format(
+                Log.LogVerbose(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Log_ReadingProject,
                     file));
 
                 project = JsonPackageSpecReader.GetPackageSpec(File.ReadAllText(file), Path.GetFileName(projectPath), file);
             }
-            _log.LogVerbose(string.Format(
+            Log.LogVerbose(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Log_LoadedProject,
                     project.Name, project.FilePath));
 
             // Resolve the root directory
             var rootDirectory = PackageSpecResolver.ResolveRootDirectory(projectPath);
-            _log.LogVerbose(string.Format(
+            Log.LogVerbose(string.Format(
                 CultureInfo.CurrentCulture,
                 Strings.Log_FoundProjectRoot,
                 rootDirectory));
@@ -252,7 +299,7 @@ namespace NuGet.CommandLine.XPlat
                 }
 
                 // Resolve the packages directory
-                _log.LogVerbose(string.Format(
+                Log.LogVerbose(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.Log_UsingPackagesDirectory,
                     request.PackagesDirectory));
@@ -299,28 +346,28 @@ namespace NuGet.CommandLine.XPlat
                 }
                 if (request.MaxDegreeOfConcurrency <= 1)
                 {
-                    _log.LogInformation(Strings.Log_RunningNonParallelRestore);
+                    Log.LogInformation(Strings.Log_RunningNonParallelRestore);
                 }
                 else
                 {
-                    _log.LogInformation(string.Format(
+                    Log.LogInformation(string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.Log_RunningParallelRestore,
                         request.MaxDegreeOfConcurrency));
                 }
-                var command = new RestoreCommand(_log, request);
+                var command = new RestoreCommand(Log, request);
                 var sw = Stopwatch.StartNew();
                 var result = await command.ExecuteAsync();
 
                 // Commit the result
-                _log.LogInformation(Strings.Log_Committing);
-                result.Commit(_log);
+                Log.LogInformation(Strings.Log_Committing);
+                result.Commit(Log);
 
                 sw.Stop();
 
                 if (result.Success)
                 {
-                    _log.LogInformation(string.Format(
+                    Log.LogInformation(string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.Log_RestoreComplete,
                         sw.ElapsedMilliseconds));
@@ -328,7 +375,7 @@ namespace NuGet.CommandLine.XPlat
                 }
                 else
                 {
-                    _log.LogInformation(string.Format(
+                    Log.LogInformation(string.Format(
                         CultureInfo.CurrentCulture,
                         Strings.Log_RestoreFailed,
                         sw.ElapsedMilliseconds));

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
-namespace NuGet.Commands.Test
+namespace NuGet.Test.Utility
 {
-    public class TestLogger : NuGet.Logging.ILogger
+    public class TestLogger : Logging.ILogger
     {
         /// <summary>
         /// Logged messages

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
@@ -1,0 +1,96 @@
+﻿using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.XPlat.Test
+{
+    public class BasicLoggingTests
+    {
+        [Fact]
+        public void BasicLogging_VerifyExceptionLogged()
+        {
+            // Arrange
+            var log = new TestLogger();
+            Program.Log = log;
+
+            var args = new string[]
+            {
+                "--unknown",
+            };
+
+            // Act
+            var exitCode = Program.Main(args);
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Equal(2, log.Messages.Count);
+            Assert.Equal(1, log.Errors);
+            Assert.Equal(0, log.Warnings);
+            Assert.Contains("--unknown", log.Messages.ToArray()[0]);  // error
+            Assert.Contains("Program.cs", log.Messages.ToArray()[1]); // verbose stack trace
+        }
+
+        [Fact]
+        public void BasicLogging_NoParams_ExitCode()
+        {
+            // Arrange
+            var log = new TestLogger();
+            Program.Log = log;
+
+            var args = new string[]
+            {
+                //empty
+            };
+
+            // Act
+            var exitCode = Program.Main(args);
+
+            // Assert
+            Assert.Equal(0, exitCode);
+        }
+
+        [Fact]
+        public void BasicLogging_RestoreHelp_ExitCode()
+        {
+            // Arrange
+            var log = new TestLogger();
+            Program.Log = log;
+
+            var args = new string[]
+            {
+                "restore",
+                "--help",
+            };
+
+            // Act
+            var exitCode = Program.Main(args);
+
+            // Assert
+            Assert.Equal(0, exitCode);
+        }
+
+        [Fact]
+        public void BasicLogging_RestoreUnknownOption_ExitCode()
+        {
+            // Arrange
+            var log = new TestLogger();
+            Program.Log = log;
+
+            var args = new string[]
+            {
+                "restore",
+                "--unknown",
+            };
+
+            // Act
+            var exitCode = Program.Main(args);
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Equal(2, log.Messages.Count);
+            Assert.Equal(1, log.Errors);
+            Assert.Equal(0, log.Warnings);
+            Assert.Contains("--unknown", log.Messages.ToArray()[0]);  // error
+            Assert.Contains("Program.cs", log.Messages.ToArray()[1]); // verbose stack trace
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/NuGet.CommandLine.XPlat.Test.xproj
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/NuGet.CommandLine.XPlat.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>82ff10c5-8724-4187-953e-5096ad90184f</ProjectGuid>
+    <RootNamespace>NuGet.CommandLine.XPlat.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.CommandLine.XPlat.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NuGet.CommandLine.XPlat.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("82ff10c5-8724-4187-953e-5096ad90184f")]

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "version": "3.4.0-*",
+  "dependencies": {
+    "NuGet.CommandLine.XPlat": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
+  },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+  "frameworks": {
+    "dnx451": { },
+    "dnxcore50": { }
+  }
+}


### PR DESCRIPTION
Misc xplat fixes around exit codes and exceptions.
- Hides stack traces for xplat failures unless verbosity is set to verbose
- Added support for "restore --help"
- Added support for "restore --verbosity"
- exit code clean up
- --verbosity is now case insensitive

//cc @yishaigalatzer @zhili1208 @joelverhagen @anurse 
