### PR TITLE
fixed https://github.com/NuGet/Home/issues/1977

### DIFF
--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -78,11 +78,11 @@ namespace NuGet.Common
                         }
                         else if (RuntimeEnvironmentHelper.IsMacOSX)
                         {
-                            return Path.Combine(@"/","Library", "Application Support");
+                            return @"/Library/Application Support";
                         }
                         else
                         {
-                            return Path.Combine(@"/","etc","opt");
+                            return @"/etc/opt";
                         }
 
                     case SpecialFolder.ApplicationData:

--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -14,16 +14,7 @@ namespace NuGet.Common
             {
                 case NuGetFolderPath.MachineWideSettingsBaseDirectory:
                     var appData = string.Empty;
-                    if (RuntimeEnvironmentHelper.IsWindows)
-                    {
-                        appData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-                    }
-                    else
-                    {
-                        // Only super users have write access to common app data folder on *nix,
-                        // so we use roaming local app data folder instead
-                        appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-                    }
+                    appData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
                     return Path.Combine(appData, "NuGet");
                 case NuGetFolderPath.MachineWideConfigDirectory:
                     return Path.Combine(GetFolderPath(NuGetFolderPath.MachineWideSettingsBaseDirectory),
@@ -85,22 +76,23 @@ namespace NuGet.Common
                                 () => GetEnvironmentVariable("PROGRAMDATA"),
                                 () => GetEnvironmentVariable("ALLUSERSPROFILE"));
                         }
+                        else if (RuntimeEnvironmentHelper.IsMacOSX)
+                        {
+                            return Path.Combine(@"/","Library", "Application Support");
+                        }
                         else
                         {
-                            return "/usr/share";
+                            return Path.Combine(@"/","etc","opt");
                         }
+
                     case SpecialFolder.ApplicationData:
                         if (RuntimeEnvironmentHelper.IsWindows)
                         {
                             return GetEnvironmentVariable("APPDATA");
                         }
-                        else if (RuntimeEnvironmentHelper.IsMacOSX)
-                        {
-                            return Path.Combine("Library", "Application Support","NuGet");
-                        }
                         else
                         {
-                            return Path.Combine("etc", "opt");
+                            return Path.Combine(GetHome(), ".nuget");
                         }
                     case SpecialFolder.LocalApplicationData:
                         if (RuntimeEnvironmentHelper.IsWindows)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Xml;
 using Microsoft.Extensions.PlatformAbstractions;
 using Moq;
+using NuGet.Common;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -32,6 +33,75 @@ namespace NuGet.Configuration.Test
                 // Assert
                 Assert.Equal(tuple.Item1, expectedFileName);
                 Assert.Equal(tuple.Item2, expectedRoot);
+            }
+        }
+
+        [Fact] 
+        public void TestNuGetEnviromentPath()
+        {
+            if (PlatformServices.Default.Runtime.OperatingSystem.Equals("windows", StringComparison.OrdinalIgnoreCase))
+            {
+                // Act
+                var machineWidePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.MachineWideSettingsBaseDirectory), "NuGet.Config");
+                var globalConfigPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory), "NuGet.Config");
+                var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
+                var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
+
+#if DNXCORE50
+                var commonApplicationData = Environment.GetEnvironmentVariable("PROGRAMDATA") ??
+                    Environment.GetEnvironmentVariable("ALLUSERSPROFILE") ?? null;
+                var userSetting = Environment.GetEnvironmentVariable("APPDATA");
+#else
+                var commonApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+#endif
+                // Assert 
+                Assert.Equal(Path.Combine(commonApplicationData, "NuGet"), machineWidePathTuple.Item2);
+                Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
+                Assert.Equal(Path.Combine(userSetting, "NuGet"), globalConfigTuple.Item2);
+                Assert.Equal("NuGet.Config", globalConfigTuple.Item1);
+            }
+            else if(PlatformServices.Default.Runtime.OperatingSystem.Equals("linux", StringComparison.OrdinalIgnoreCase))
+            {
+                // Act
+                var machineWidePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.MachineWideSettingsBaseDirectory), "NuGet.Config");
+                var globalConfigPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory), "NuGet.Config");
+                var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
+                var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
+
+#if DNXCORE50
+                var commonApplicationData = @"/etc/opt";
+                var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
+#else
+                var commonApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+#endif
+                // Assert 
+                Assert.Equal(Path.Combine(commonApplicationData, "NuGet"), machineWidePathTuple.Item2);
+                Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
+                Assert.Equal(Path.Combine(userSetting, "NuGet"), globalConfigTuple.Item2);
+                Assert.Equal("NuGet.Config", globalConfigTuple.Item1);
+            }
+            else if (PlatformServices.Default.Runtime.OperatingSystem.Equals("mac", StringComparison.OrdinalIgnoreCase))
+            {
+                // Act
+                var machineWidePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.MachineWideSettingsBaseDirectory), "NuGet.Config");
+                var globalConfigPath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory), "NuGet.Config");
+                var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
+                var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
+
+#if DNXCORE50
+                var commonApplicationData = @"/Library/Application Support";
+                var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
+#else
+                var commonApplicationData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+                var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+#endif
+                // Assert 
+                Assert.Equal(Path.Combine(commonApplicationData, "NuGet"), machineWidePathTuple.Item2);
+                Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
+                Assert.Equal(Path.Combine(userSetting, "NuGet"), globalConfigTuple.Item2);
+                Assert.Equal("NuGet.Config", globalConfigTuple.Item1);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -3,7 +3,8 @@
         "NuGet.Configuration": "3.4.0-*",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-rc1-build204",
-        "NuGet.Test.Utility": "3.4.0-*"
+        "NuGet.Test.Utility": "3.4.0-*",
+        "NuGet.Common": "3.4.0-*"
     },
     "commands": {
         "test": "xunit.runner.dnx"


### PR DESCRIPTION
in this pr, I fixed applicationData and CommonApplicationData path. 

machine wide location is 

Windows :  programdata
Linux : /etc/opt for coreClr, /usr/share for mono
OSX: /Library/Application support, /usr/share for mono

Global NuGet.Config Location
Windows: AppData
Linux: $Home/.nuget
Mac: $Home/.nuget

@yishaigalatzer @emgarten @anurse @glennc
