### PR TITLE
Exclude runtime.json from rejected packages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -1092,6 +1092,12 @@ namespace NuGet.Commands
                     return;
                 }
 
+                // Ignore runtime.json from rejected nodes
+                if (node.Disposition == Disposition.Rejected)
+                {
+                    return;
+                }
+
                 // Locate the package in the local repository
                 var package = localRepository.FindPackagesById(match.Library.Name)
                     .FirstOrDefault(p => p.Version == match.Library.Version);

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
@@ -15,6 +15,11 @@ namespace NuGet.Test.Utility
         public string Include { get; set; } = string.Empty;
         public string Exclude { get; set; } = string.Empty;
 
+        /// <summary>
+        /// runtime.json
+        /// </summary>
+        public string RuntimeJson { get; set; }
+
         public PackageIdentity Identity
         {
             get


### PR DESCRIPTION
This is a simple fix to exclude runtime.json from rejected packages which are not part of the final dependency graph.

https://github.com/NuGet/Home/issues/1418

//cc @zhili1208 @joelverhagen @yishaigalatzer @anurse @ericstj 
