### PR TITLE
Add "no_proxy" support for proxy exceptions

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -99,6 +99,14 @@ namespace NuGet.Configuration
                 {
                     webProxy.Credentials = new NetworkCredential(userName, password);
                 }
+                
+                var noProxy = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationContants.NoProxy);
+                if (!String.IsNullOrEmpty(noProxy))
+                {
+                    // split comma-separated list of domains
+                    webProxy.BypassList = noProxy.Split(new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
+                }
+                
                 return webProxy;
             }
 
@@ -117,6 +125,14 @@ namespace NuGet.Configuration
                         webProxy.Credentials = new NetworkCredential(userName: credentials[0], password: credentials[1]);
                     }
                 }
+                
+                var noProxy = _environment.GetEnvironmentVariable(ConfigurationContants.NoProxy);
+                if (!String.IsNullOrEmpty(noProxy))
+                {
+                    // split comma-separated list of domains
+                    webProxy.BypassList = noProxy.Split(new char[] {','}, StringSplitOptions.RemoveEmptyEntries);
+                }
+                
                 return webProxy;
             }
             return null;

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -34,6 +34,8 @@ namespace NuGet.Configuration
         internal static string UserKey = "http_proxy.user";
 
         internal static string PasswordKey = "http_proxy.password";
+        
+        internal static string NoProxy     = "no_proxy";
 
         internal static string KeyAttribute = "key";
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTest.cs
@@ -65,6 +65,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetValue("config", "http_proxy", false)).Returns(host);
             settings.Setup(s => s.GetValue("config", "http_proxy.user", false)).Returns(user);
             settings.Setup(s => s.GetValue("config", "http_proxy.password", false)).Returns(_password);
+            settings.Setup(s => s.GetValue("config", "no_proxy", false)).Returns("");
             var environment = Mock.Of<IEnvironmentVariableReader>();
             var proxyCache = new ProxyCache(settings.Object, environment);
 
@@ -84,6 +85,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetValue("config", "http_proxy", false)).Returns(host);
             settings.Setup(s => s.GetValue("config", "http_proxy.user", false)).Returns<string>(null);
             settings.Setup(s => s.GetValue("config", "http_proxy.password", false)).Returns<string>(null);
+            settings.Setup(s => s.GetValue("config", "no_proxy", false)).Returns("");
             var environment = Mock.Of<IEnvironmentVariableReader>();
             var proxyCache = new ProxyCache(settings.Object, environment);
 
@@ -122,6 +124,7 @@ namespace NuGet.Configuration.Test
             var settings = Mock.Of<ISettings>();
             var environment = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
             environment.Setup(s => s.GetEnvironmentVariable("http_proxy")).Returns("http://localhost:8081");
+            environment.Setup(s => s.GetEnvironmentVariable("no_proxy")).Returns("");
 
             var proxyCache = new ProxyCache(settings, environment.Object);
 
@@ -141,6 +144,7 @@ namespace NuGet.Configuration.Test
             var settings = Mock.Of<ISettings>();
             var environment = new Mock<IEnvironmentVariableReader>(MockBehavior.Strict);
             environment.Setup(s => s.GetEnvironmentVariable("http_proxy")).Returns(input);
+            environment.Setup(s => s.GetEnvironmentVariable("no_proxy")).Returns("");
 
             var proxyCache = new ProxyCache(settings, environment.Object);
 


### PR DESCRIPTION
As requested in https://github.com/NuGet/Home/issues/1671. This makes it easier to combine NuGet with Git in corporate settings where some of the NuGet servers are placed behind a proxy server.

no_proxy specification: https://www.w3.org/Daemon/User/Proxies/ProxyClients.html
