### PR TITLE
Change NumberToString to always use '.' as decimal separator.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
@@ -71,7 +71,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             var s = string.Format(
-                CultureInfo.CurrentCulture,
+                CultureInfo.InvariantCulture, // force '.' as decimal separator
                 "{0:G3}{1}",
                 v,
                 _scalingFactor[exp]);


### PR DESCRIPTION
Fixes broken unit tests on computers with ',' as decimal separator (https://github.com/NuGet/Home/issues/1998).
