### PR TITLE
Moves a file stream in PackageBuilder into the 'using' statement.

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Build/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Build/PackageBuilder.cs
@@ -76,7 +76,10 @@ namespace NuGet.Packaging.Build
                 var entry = package.CreateEntry(file.Path, CompressionLevel.Optimal);
                 using (var stream = entry.Open())
                 {
-                    file.GetStream().CopyTo(stream);
+                    using (var sourceStream = file.GetStream())
+                    {
+                        sourceStream.CopyTo(stream);
+                    }
                 }
 
                 extensions.Add(Path.GetExtension(file.Path).Substring(1));


### PR DESCRIPTION
This caught me when I deleted the files right after packing.
