### PR TITLE
Add summary of errors to the end of Xplat output

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -115,6 +115,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Shared", "src\NuGet.C
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.CommandLine.XPlat.Test", "test\NuGet.Core.Tests\NuGet.CommandLine.XPlat.Test\NuGet.CommandLine.XPlat.Test.xproj", "{82FF10C5-8724-4187-953E-5096AD90184F}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Logging.Test", "test\NuGet.Core.Tests\NuGet.Logging.Test\NuGet.Logging.Test.xproj", "{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -325,6 +327,10 @@ Global
 		{82FF10C5-8724-4187-953E-5096AD90184F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{82FF10C5-8724-4187-953E-5096AD90184F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{82FF10C5-8724-4187-953E-5096AD90184F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -380,5 +386,6 @@ Global
 		{77DC049B-16EA-4FE6-9287-E8E514F4700F} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{CA92BD12-5500-4809-B998-F6ECDD9DD79B} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{82FF10C5-8724-4187-953E-5096AD90184F} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Clients/NuGet.CommandLine/CommandOutputLogger.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/CommandOutputLogger.cs
@@ -40,6 +40,11 @@ namespace NuGet.CommandLine
             LogInternal(LogLevel.Error, data);
         }
 
+        public void LogSummary(string data)
+        {
+            Console.WriteLine(data);
+        }
+
         public void LogInformation(string data)
         {
             LogInternal(LogLevel.Information, data);

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -382,5 +382,11 @@ namespace NuGet.Common
         {
             WriteError(data);
         }
+
+        public void LogSummary(string data)
+        {
+            // Treat Summary as Debug
+            LogDebug(data);
+        }
     }
 }

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -907,6 +907,13 @@ namespace NuGetVSExtension
         {
             LogToVS(VerbosityLevel.Quiet, data);
         }
+
+        public void LogSummary(string data)
+        {
+            // Treat Summary as Debug
+            LogDebug(data);
+        }
+
         #endregion ILogger implementation
 
         private void LogToVS(VerbosityLevel verbosityLevel, string message)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
@@ -12,15 +12,6 @@ namespace NuGet.CommandLine.XPlat
     /// </summary>
     internal class CommandOutputLogger : ILogger
     {
-        private enum LogLevel
-        {
-            Debug = 0,
-            Verbose = 1,
-            Information = 2,
-            Warning = 3,
-            Error = 4
-        }
-
         private static readonly bool _useConsoleColor = true;
         private Lazy<LogLevel> _verbosity;
 
@@ -47,6 +38,11 @@ namespace NuGet.CommandLine.XPlat
         public void LogError(string data)
         {
             LogInternal(LogLevel.Error, data);
+        }
+
+        public void LogSummary(string data)
+        {
+            Console.WriteLine(data);
         }
 
         public void LogInformation(string data)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -78,6 +78,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Errors in {0}.
+        /// </summary>
+        internal static string Log_ErrorSummary {
+            get {
+                return ResourceManager.GetString("Log_ErrorSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Found project root directory: {0}..
         /// </summary>
         internal static string Log_FoundProjectRoot {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -123,6 +123,9 @@
   <data name="Log_Committing" xml:space="preserve">
     <value>Committing restore...</value>
   </data>
+  <data name="Log_ErrorSummary" xml:space="preserve">
+    <value>Errors in {0}</value>
+  </data>
   <data name="Log_FoundProjectRoot" xml:space="preserve">
     <value>Found project root directory: {0}.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Commands
+{
+    public class RestoreSummary
+    {
+        public string InputPath { get; }
+
+        public bool Success { get; }
+
+        public IEnumerable<string> Errors { get; }
+
+        public RestoreSummary(
+            string inputPath,
+            bool success,
+            IEnumerable<string> errors)
+        {
+            InputPath = inputPath;
+            Success = success;
+            Errors = errors.ToArray();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -98,16 +98,16 @@ namespace NuGet.Configuration
 
         /// <summary>
         /// Loads user settings from the NuGet configuration files. The method walks the directory
-        /// tree in <paramref name="fileSystem" /> up to its root, and reads each NuGet.config file
+        /// tree in <paramref name="root" /> up to its root, and reads each NuGet.config file
         /// it finds in the directories. It then reads the user specific settings,
         /// which is file <paramref name="configFileName" />
-        /// in <paramref name="fileSystem" /> if <paramref name="configFileName" /> is not null,
+        /// in <paramref name="root" /> if <paramref name="configFileName" /> is not null,
         /// If <paramref name="configFileName" /> is null, the user specific settings file is
         /// %AppData%\NuGet\NuGet.config.
         /// After that, the machine wide settings files are added.
         /// </summary>
         /// <remarks>
-        /// For example, if <paramref name="fileSystem" /> is c:\dir1\dir2, <paramref name="configFileName" />
+        /// For example, if <paramref name="root" /> is c:\dir1\dir2, <paramref name="configFileName" />
         /// is "userConfig.file", the files loaded are (in the order that they are loaded):
         /// c:\dir1\dir2\nuget.config
         /// c:\dir1\nuget.config
@@ -115,7 +115,7 @@ namespace NuGet.Configuration
         /// c:\dir1\dir2\userConfig.file
         /// machine wide settings (e.g. c:\programdata\NuGet\Config\*.config)
         /// </remarks>
-        /// <param name="fileSystem">
+        /// <param name="root">
         /// The file system to walk to find configuration files.
         /// Can be null.
         /// </param>

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -423,16 +423,6 @@ namespace NuGet.Frameworks
                                 FrameworkConstants.CommonFrameworks.NetStandard15),
 
                             CreateGenerationAndStandardMappingForAllVersions(
-                                FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
-                                FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard15),
-
-                            CreateGenerationAndStandardMappingForAllVersions(
-                                FrameworkConstants.FrameworkIdentifiers.XamarinIOs,
-                                FrameworkConstants.CommonFrameworks.DotNet56,
-                                FrameworkConstants.CommonFrameworks.NetStandard15),
-
-                            CreateGenerationAndStandardMappingForAllVersions(
                                 FrameworkConstants.FrameworkIdentifiers.XamarinMac,
                                 FrameworkConstants.CommonFrameworks.DotNet56,
                                 FrameworkConstants.CommonFrameworks.NetStandard15),

--- a/src/NuGet.Core/NuGet.Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Logging/CollectorLogger.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace NuGet.Logging
+{
+    public class CollectorLogger : ICollectorLogger
+    {
+        private readonly ILogger _innerLogger;
+        private readonly ConcurrentQueue<string> _errors;
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
+        /// delegating all log messages to the <see cref="innerLogger"/>.
+        /// </summary>
+        public CollectorLogger(ILogger innerLogger)
+        {
+            _innerLogger = innerLogger;
+            _errors = new ConcurrentQueue<string>();
+        }
+        
+        public void LogDebug(string data)
+        {
+            _innerLogger.LogDebug(data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            _innerLogger.LogVerbose(data);
+        }
+
+        public void LogInformation(string data)
+        {
+            _innerLogger.LogInformation(data);
+        }
+
+        public void LogWarning(string data)
+        {
+            _innerLogger.LogWarning(data);
+        }
+
+        public void LogError(string data)
+        {
+            _errors.Enqueue(data);
+            _innerLogger.LogError(data);
+        }
+
+        public void LogSummary(string data)
+        {
+            _innerLogger.LogSummary(data);
+        }
+
+        public IEnumerable<string> Errors => _errors.ToArray();
+    }
+}

--- a/src/NuGet.Core/NuGet.Logging/ICollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Logging/ICollectorLogger.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.Logging
+{
+    public interface ICollectorLogger : ILogger
+    {
+        /// <summary>
+        /// Fetch all of the errors logged so far. This method is useful when error log messages
+        /// should be redisplayed after the initial log message is emitted.
+        /// </summary>
+        IEnumerable<string> Errors { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Logging/ILogger.cs
+++ b/src/NuGet.Core/NuGet.Logging/ILogger.cs
@@ -17,5 +17,7 @@ namespace NuGet.Logging
         void LogWarning(string data);
 
         void LogError(string data);
+
+        void LogSummary(string data);
     }
 }

--- a/src/NuGet.Core/NuGet.Logging/LogLevel.cs
+++ b/src/NuGet.Core/NuGet.Logging/LogLevel.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Logging
+{
+    public enum LogLevel
+    {
+        Debug = 0,
+        Verbose = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4
+    }
+}

--- a/src/NuGet.Core/NuGet.Logging/NullLogger.cs
+++ b/src/NuGet.Core/NuGet.Logging/NullLogger.cs
@@ -26,5 +26,7 @@
         public void LogVerbose(string data) { }
 
         public void LogWarning(string data) { }
+
+        public void LogSummary(string data) { }
     }
 }

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -20,7 +20,8 @@
     "net45": {},
     "dnxcore50": {
       "dependencies": {
-        "System.Runtime": "4.0.20-beta-23109"
+        "System.Runtime": "4.0.20-beta-23109",
+        "System.Collections.Concurrent": "4.0.10-beta-23109"
       }
     }
   }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/ProjectContextLogger.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/ProjectContextLogger.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement
         public void LogVerbose(string data)
         {
             // Treat Verbose as Debug
-            _projectContext.Log(ProjectManagement.MessageLevel.Debug, data);
+            LogDebug(data);
         }
 
         public void LogError(string data)
@@ -38,6 +38,12 @@ namespace NuGet.PackageManagement
         public void LogWarning(string data)
         {
             _projectContext.Log(ProjectManagement.MessageLevel.Warning, data);
+        }
+
+        public void LogSummary(string data)
+        {
+            // Treat Summary as Debug
+            LogDebug(data);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -45,6 +45,12 @@ namespace NuGet.Test.Utility
             DumpMessage("WARN ", data);
         }
 
+        public void LogSummary(string data)
+        {
+            Messages.Enqueue(data);
+            DumpMessage("SUMRY", data);
+        }
+
         private void DumpMessage(string level, string data)
         {
             // NOTE(anurse): Uncomment this to help when debugging tests

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/CollectorLoggerTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Moq;
+using Xunit;
+
+namespace NuGet.Logging.Test
+{
+    public class CollectorLoggerTests
+    {
+        [Fact]
+        public void CollectorLogger_PassesToInnerLogger()
+        {
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object);
+
+            // Act
+            collector.LogDebug("Debug");
+            collector.LogVerbose("Verbose");
+            collector.LogInformation("Information");
+            collector.LogWarning("Warning");
+            collector.LogError("Error");
+
+            // Assert
+            innerLogger.Verify(x => x.LogDebug("Debug"), Times.Once);
+            innerLogger.Verify(x => x.LogVerbose("Verbose"), Times.Once);
+            innerLogger.Verify(x => x.LogInformation("Information"), Times.Once);
+            innerLogger.Verify(x => x.LogWarning("Warning"), Times.Once);
+            innerLogger.Verify(x => x.LogError("Error"), Times.Once);
+        }
+
+        [Fact]
+        public void CollectorLogger_CollectsErrors()
+        {
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object);
+
+            // Act
+            var errorsStart = collector.Errors.ToArray();
+            collector.LogError("ErrorA");
+            var errorsA = collector.Errors.ToArray();
+            collector.LogError("ErrorB");
+            collector.LogError("ErrorC");
+            var errorsAbc = collector.Errors.ToArray();
+            var errordEnd = collector.Errors.ToArray();
+
+            // Assert
+            Assert.Empty(errorsStart);
+            Assert.Equal(new[] { "ErrorA" }, errorsA);
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsAbc);
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errordEnd);
+        }
+
+        [Fact]
+        public void CollectorLogger_DoesNotCollectNonError()
+        {
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object);
+
+            // Act
+            collector.LogDebug("Debug");
+            collector.LogVerbose("Verbose");
+            collector.LogInformation("Information");
+            collector.LogWarning("Warning");
+            var errors = collector.Errors.ToArray();
+
+            // Assert
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/NuGet.Logging.Test.xproj
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/NuGet.Logging.Test.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>95ccaf1d-b922-4ddf-a0b2-8570f5fa9ba8</ProjectGuid>
+    <RootNamespace>NuGet.Logging.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.Logging.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NuGet.Logging.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("eb3057d4-3265-4f09-8ce0-5e6440f702e2")]

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
@@ -1,0 +1,24 @@
+﻿{
+  "version": "3.4.0-*",
+  "dependencies": {
+    "NuGet.Logging": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
+  },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+  "frameworks": {
+    "dnx451": {
+      "dependencies": {
+        "Moq": "4.2.1510.2205"
+      }
+    },
+    "dnxcore50": {
+      "dependencies": {
+        "moq.netcore": "4.4.0-beta8"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Collect errors encountered while executing each `RestoreCommand` in Xplat and output at the end of the execution. This is a simple approach that intercepts the existing logger and collects all error level messages.

[Example Output](https://gist.github.com/joelverhagen/82e1aef391efad64a041#file-nugetxplaterrorsummary-txt-L64-L113)

Related to: https://github.com/NuGet/Home/issues/1973, https://github.com/NuGet/Home/issues/1933

@emgarten @yishaigalatzer 
