### PR TITLE
Parallel project restores for xplat

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -250,6 +250,8 @@ namespace NuGet.CommandLine
                     packagesDirectory: null))
                 {
                     request.PackagesDirectory = localCache.RepositoryRoot;
+                    request.SharedLocalCache = localCache;
+
                     var packageSaveMode = EffectivePackageSaveMode;
                     if (packageSaveMode != Packaging.PackageSaveMode.None)
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -168,6 +168,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Disables restoring multiple projects in parallel..
+        /// </summary>
+        internal static string Restore_Switch_DisableParallel_Description {
+            get {
+                return ResourceManager.GetString("Restore_Switch_DisableParallel_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to A list of packages sources to use as a fallback..
         /// </summary>
         internal static string Restore_Switch_Fallback_Description {
@@ -182,15 +191,6 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Restore_Switch_Packages_Description {
             get {
                 return ResourceManager.GetString("Restore_Switch_Packages_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to The number of concurrent tasks to use when restoring. Defaults to {0}; pass &apos;none&apos; to run without concurrency..
-        /// </summary>
-        internal static string Restore_Switch_Parallel_Description {
-            get {
-                return ResourceManager.GetString("Restore_Switch_Parallel_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -153,14 +153,14 @@
   <data name="Restore_Description" xml:space="preserve">
     <value>Restores packages for a project and writes a lock file.</value>
   </data>
+  <data name="Restore_Switch_DisableParallel_Description" xml:space="preserve">
+    <value>Disables restoring multiple projects in parallel.</value>
+  </data>
   <data name="Restore_Switch_Fallback_Description" xml:space="preserve">
     <value>A list of packages sources to use as a fallback.</value>
   </data>
   <data name="Restore_Switch_Packages_Description" xml:space="preserve">
     <value>Directory to install packages in.</value>
-  </data>
-  <data name="Restore_Switch_Parallel_Description" xml:space="preserve">
-    <value>The number of concurrent tasks to use when restoring. Defaults to {0}; pass 'none' to run without concurrency.</value>
   </data>
   <data name="Restore_Switch_Runtime_Description" xml:space="preserve">
     <value>List of runtime identifiers to restore for.</value>

--- a/src/NuGet.Core/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/LockFileUtils.cs
@@ -94,27 +94,8 @@ namespace NuGet.Commands
 
             contentItems.Load(files);
 
-            NuspecReader nuspec = null;
-
-            var nuspecPath = defaultPackagePathResolver.GetManifestFilePath(package.Id, package.Version);
-
-            if (File.Exists(nuspecPath))
-            {
-                using (var stream = File.OpenRead(nuspecPath))
-                {
-                    nuspec = new NuspecReader(stream);
-                }
-            }
-            else
-            {
-                var dir = defaultPackagePathResolver.GetPackageDirectory(package.Id, package.Version);
-                var folderReader = new PackageFolderReader(dir);
-
-                using (var stream = folderReader.GetNuspec())
-                {
-                    nuspec = new NuspecReader(stream);
-                }
-            }
+            // This will throw an appropriate error if the nuspec is missing
+            var nuspec = package.Nuspec;
 
             if (dependencies == null)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -67,7 +67,9 @@ namespace NuGet.Commands
 
         public async Task<RestoreResult> ExecuteAsync(CancellationToken token)
         {
-            var localRepository = new NuGetv3LocalRepository(_request.PackagesDirectory, checkPackageIdCase: false);
+            // Use the shared cache if one was provided, otherwise create a new one.
+            var localRepository = _request.SharedLocalCache ?? new NuGetv3LocalRepository(_request.PackagesDirectory);
+
             var projectLockFilePath = string.IsNullOrEmpty(_request.LockFilePath) ?
                 Path.Combine(_request.Project.BaseDirectory, LockFileFormat.LockFileName) :
                 _request.LockFilePath;

--- a/src/NuGet.Core/NuGet.Commands/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreRequest.cs
@@ -11,6 +11,7 @@ using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v3;
+using NuGet.Repositories;
 
 namespace NuGet.Commands
 {
@@ -126,6 +127,14 @@ namespace NuGet.Commands
         public ISet<string> FallbackRuntimes { get; } = new SortedSet<string>(StringComparer.Ordinal);
 
         public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; } = PackageExtractionBehavior.XmlDocFileSaveMode;
+
+        /// <summary>
+        /// A <see cref="NuGetv3LocalRepository"/> repository may be passed in as part of the request.
+        /// This allows multiple restores to share the same cache for the global packages folder
+        /// and reduce disk hits.
+        /// </summary>
+        /// <remarks>This is optional and may be null.</remarks>
+        public NuGetv3LocalRepository SharedLocalCache { get; set; }
 
         public void Dispose()
         {

--- a/src/NuGet.Core/NuGet.DependencyResolver/NuGetDependencyResolver.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver/NuGetDependencyResolver.cs
@@ -37,11 +37,7 @@ namespace NuGet.DependencyResolver
 
             if (package != null)
             {
-                NuspecReader nuspecReader = null;
-                using (var stream = File.OpenRead(package.ManifestPath))
-                {
-                    nuspecReader = new NuspecReader(stream);
-                }
+                var nuspecReader = package.Nuspec;
 
                 var description = new Library
                 {

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuspecCoreReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuspecCoreReaderBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using NuGet.Versioning;
 
@@ -28,11 +29,38 @@ namespace NuGet.Packaging.Core
         protected const string PackageTypeVersion = "version";
 
         /// <summary>
+        /// Read a nuspec from a path.
+        /// </summary>
+        public NuspecCoreReaderBase(string path)
+            : this(File.OpenRead(path))
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            _xml = LoadXml(File.OpenRead(path), leaveStreamOpen: false);
+        }
+
+        /// <summary>
         /// Read a nuspec from a stream.
         /// </summary>
         public NuspecCoreReaderBase(Stream stream)
-            : this(XDocument.Load(stream))
+            : this(stream, leaveStreamOpen: false)
         {
+        }
+
+        /// <summary>
+        /// Read a nuspec from a stream.
+        /// </summary>
+        public NuspecCoreReaderBase(Stream stream, bool leaveStreamOpen)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            _xml = LoadXml(stream, leaveStreamOpen);
         }
 
         /// <summary>
@@ -42,7 +70,7 @@ namespace NuGet.Packaging.Core
         {
             if (xml == null)
             {
-                throw new ArgumentNullException("xml");
+                throw new ArgumentNullException(nameof(xml));
             }
 
             _xml = xml;
@@ -143,6 +171,19 @@ namespace NuGet.Packaging.Core
         public PackageIdentity GetIdentity()
         {
             return new PackageIdentity(GetId(), GetVersion());
+        }
+
+        private static XDocument LoadXml(Stream stream, bool leaveStreamOpen)
+        {
+            var xmlReader = XmlReader.Create(stream, new XmlReaderSettings()
+            {
+                CloseInput = !leaveStreamOpen,
+                IgnoreWhitespace = true,
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true
+            });
+
+            return XDocument.Load(xmlReader, LoadOptions.None);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -42,11 +42,29 @@ namespace NuGet.Packaging
         private readonly IFrameworkNameProvider _frameworkProvider;
 
         /// <summary>
+        /// Nuspec file reader.
+        /// </summary>
+        public NuspecReader(string path)
+            : this(path, DefaultFrameworkNameProvider.Instance)
+        {
+        }
+
+        /// <summary>
+        /// Nuspec file reader.
+        /// </summary>
+        public NuspecReader(string path, IFrameworkNameProvider frameworkProvider)
+            : base(path)
+        {
+            _frameworkProvider = frameworkProvider;
+        }
+
+
+        /// <summary>
         /// Nuspec file reader
         /// </summary>
         /// <param name="stream">Nuspec file stream.</param>
         public NuspecReader(Stream stream)
-            : this(stream, DefaultFrameworkNameProvider.Instance)
+            : this(stream, DefaultFrameworkNameProvider.Instance, leaveStreamOpen: false)
         {
 
         }
@@ -66,8 +84,8 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="stream">Nuspec file stream.</param>
         /// <param name="frameworkProvider">Framework mapping provider for NuGetFramework parsing.</param>
-        public NuspecReader(Stream stream, IFrameworkNameProvider frameworkProvider)
-            : base(stream)
+        public NuspecReader(Stream stream, IFrameworkNameProvider frameworkProvider, bool leaveStreamOpen)
+            : base(stream, leaveStreamOpen)
         {
             _frameworkProvider = frameworkProvider;
         }

--- a/src/NuGet.Core/NuGet.Repositories/LocalPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Repositories/LocalPackageInfo.cs
@@ -8,13 +8,18 @@ namespace NuGet.Repositories
 {
     public class LocalPackageInfo
     {
-        public LocalPackageInfo(string packageId, NuGetVersion version, string path)
+        public LocalPackageInfo(
+            string packageId,
+            NuGetVersion version,
+            string path,
+            string manifestPath,
+            string zipPath)
         {
             Id = packageId;
             Version = version;
             ExpandedPath = path;
-            ManifestPath = Path.Combine(path, string.Format("{0}.nuspec", Id));
-            ZipPath = Path.Combine(path, string.Format("{0}.{1}.nupkg", Id, Version.ToNormalizedString()));
+            ManifestPath = manifestPath;
+            ZipPath = zipPath;
         }
 
         public string Id { get; }

--- a/src/NuGet.Core/NuGet.Repositories/LocalPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Repositories/LocalPackageInfo.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
+using NuGet.Packaging;
 using NuGet.Versioning;
 
 namespace NuGet.Repositories
 {
     public class LocalPackageInfo
     {
+        private NuspecReader _nuspec;
+
         public LocalPackageInfo(
             string packageId,
             NuGetVersion version,
@@ -31,6 +34,35 @@ namespace NuGet.Repositories
         public string ManifestPath { get; }
 
         public string ZipPath { get; }
+
+        /// <summary>
+        /// Caches the nuspec reader.
+        /// If the nuspec does not exist this will throw a friendly exception.
+        /// </summary>
+        public NuspecReader Nuspec
+        {
+            get
+            {
+                if (_nuspec == null)
+                {
+                    // Verify that the nuspec has the correct name before opening it
+                    if (File.Exists(ManifestPath))
+                    {
+                        _nuspec = new NuspecReader(File.OpenRead(ManifestPath));
+                    }
+                    else
+                    {
+                        // Scan the folder for the nuspec
+                        var folderReader = new PackageFolderReader(ExpandedPath);
+
+                        // This will throw if the nuspec is not found
+                        _nuspec = new NuspecReader(folderReader.GetNuspec());
+                    }
+                }
+
+                return _nuspec;
+            }
+        }
 
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Repositories/NuGetv3LocalRepository.cs
+++ b/src/NuGet.Core/NuGet.Repositories/NuGetv3LocalRepository.cs
@@ -2,22 +2,37 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NuGet.Packaging;
 using NuGet.Versioning;
 
 namespace NuGet.Repositories
 {
+    /// <summary>
+    /// Caches package info from the global packages folder in memory.
+    /// Packages not yet in the cache will be retrieved from disk.
+    /// </summary>
     public class NuGetv3LocalRepository
     {
-        private readonly Dictionary<string, IEnumerable<LocalPackageInfo>> _cache = new Dictionary<string, IEnumerable<LocalPackageInfo>>(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, IEnumerable<LocalPackageInfo>> _cache
+            = new ConcurrentDictionary<string, IEnumerable<LocalPackageInfo>>(StringComparer.OrdinalIgnoreCase);
         private readonly bool _checkPackageIdCase;
+        private readonly VersionFolderPathResolver _pathResolver;
+
+        public NuGetv3LocalRepository(string path)
+            : this(path, checkPackageIdCase: false)
+        {
+        }
 
         public NuGetv3LocalRepository(string path, bool checkPackageIdCase)
         {
             RepositoryRoot = path;
             _checkPackageIdCase = checkPackageIdCase;
+
+            _pathResolver = new VersionFolderPathResolver(path);
         }
 
         public string RepositoryRoot { get; }
@@ -26,11 +41,11 @@ namespace NuGet.Repositories
         {
             if (string.IsNullOrEmpty(packageId))
             {
-                throw new ArgumentNullException("packageId");
+                throw new ArgumentNullException(nameof(packageId));
             }
 
             // packages\{packageId}\{version}\{packageId}.nuspec
-            return GetOrAdd(packageId, id =>
+            return _cache.GetOrAdd(packageId, id =>
                 {
                     var packages = new List<LocalPackageInfo>();
 
@@ -69,7 +84,17 @@ namespace NuGet.Repositories
                             id = Path.GetFileNameWithoutExtension(manifestFileName);
                         }
 
-                        packages.Add(new LocalPackageInfo(id, version, fullVersionDir));
+                        var sha512Path = _pathResolver.GetHashPath(id, version);
+
+                        // The hash file is written last. If this file does not exist then the package is
+                        // incomplete and should not be used.
+                        if (File.Exists(sha512Path))
+                        {
+                            var manifestPath = _pathResolver.GetManifestFilePath(id, version);
+                            var zipPath = _pathResolver.GetPackageFilePath(id, version);
+
+                            packages.Add(new LocalPackageInfo(id, version, fullVersionDir, manifestPath, zipPath));
+                        }
                     }
 
                     return packages;
@@ -82,27 +107,10 @@ namespace NuGet.Repositories
         /// </summary>
         public void ClearCacheForIds(IEnumerable<string> packageIds)
         {
-            lock (_cache)
+            foreach (var packageId in packageIds)
             {
-                foreach (var packageId in packageIds)
-                {
-                    _cache.Remove(packageId);
-                }
-            }
-        }
-
-        private IEnumerable<LocalPackageInfo> GetOrAdd(string packageId, Func<string, List<LocalPackageInfo>> factory)
-        {
-            lock (_cache)
-            {
-                IEnumerable<LocalPackageInfo> results;
-                if (!_cache.TryGetValue(packageId, out results))
-                {
-                    results = factory(packageId);
-                    _cache[packageId] = results;
-                }
-
-                return results;
+                IEnumerable<LocalPackageInfo> packages;
+                _cache.TryRemove(packageId, out packages);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
       "version": "3.4.0-*"
@@ -15,7 +15,8 @@
     "dnxcore50": {
       "dependencies": {
         "System.IO.FileSystem": "4.0.0-beta-23109",
-        "System.Threading": "4.0.10-beta-23109"
+        "System.Threading": "4.0.10-beta-23109",
+        "System.Collections.Concurrent": "4.0.10-beta-23109"
       }
     }
   }


### PR DESCRIPTION
This change adds support for restoring multiple projects in parallel in the same way nuget.exe does today. It also adds the --disable-parallel flag to turn it off. 
- --disable-parallel turns off both concurrent project restore as well as multiple threads within a single restore, this matches the nuget.exe flag.
- nuspecs are cached in the local repository, this should help reduce the number of open files between restores
- the local repository is now shared between restores to reduce the number of disk hits
- nuspec reader will now close streams by default
- when searching the global packages folder for already installed packages the local repo will now check if the sha512 file exists to verify that the package is fully there and valid
- added a ctor that take a path to the nuspec reader as part of the clean up
- Misc clean up in NuGetv3LocalRepository to use the path resolver instead of constructing the package paths

Roslyn restore time goes from 25s to 21s with these optimizations.

//cc @joelverhagen @zhili1208 @yishaigalatzer @alpaix 
