### PR TITLE
Avoid conflicts with reference type dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/LockFileUtils.cs
@@ -148,11 +148,8 @@ namespace NuGet.Commands
                 referenceFilter = new HashSet<string>(referenceSet.Items, StringComparer.OrdinalIgnoreCase);
             }
 
-            // TODO: Remove this when we do #596
-            // ASP.NET Core isn't compatible with generic PCL profiles
-            if (!string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.AspNetCore, StringComparison.OrdinalIgnoreCase)
-                &&
-                !string.Equals(framework.Framework, FrameworkConstants.FrameworkIdentifiers.DnxCore, StringComparison.OrdinalIgnoreCase))
+            // Exclude framework references for package based frameworks.
+            if (!framework.IsPackageBased)
             {
                 var frameworkAssemblies = nuspec.GetFrameworkReferenceGroups().GetNearest(framework);
                 if (frameworkAssemblies != null)

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -71,6 +71,7 @@ namespace NuGet.Test.Utility
                 zip.AddEntry("contentFiles/any/any/config.xml", new byte[] { 0 });
                 zip.AddEntry("contentFiles/cs/net45/code.cs", new byte[] { 0 });
                 zip.AddEntry("lib/net45/a.dll", new byte[] { 0 });
+                zip.AddEntry("lib/netstandard1.0/a.dll", new byte[] { 0 });
                 zip.AddEntry($"build/net45/{id}.targets", @"<targets />", Encoding.UTF8);
                 zip.AddEntry("native/net45/a.dll", new byte[] { 0 });
                 zip.AddEntry("tools/a.exe", new byte[] { 0 });

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -20,6 +20,70 @@ namespace NuGet.Commands.Test
     public class RestoreCommandTests
     {
         [Fact]
+        public async Task RestoreCommand_PackageAndReferenceWithSameNameAndVersion()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // Both TxMs reference packageA, but they are different types.
+            // Verify that the reference does not show up under libraries.
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net45"": {
+                    ""frameworkAssemblies"": {
+                         ""packageA"": ""4.0.0""
+                    }
+                },
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""packageA"": ""4.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "packageA", "4.0.0");
+
+                // Act
+                var logger = new TestLogger();
+                var command = new RestoreCommand(logger, request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, lockFile.Libraries.Count);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_RestoreProjectWithNoDependencies()
         {
             // Arrange


### PR DESCRIPTION
References types from the graph can cause collisions when creating a dictionary of libraries by id/version. 

This fix filters out reference type libraries for both the full library list, and for target graphs:

 `else if (library.Type == LibraryTypes.Package)`

This is a small change, github shows it as larger due to the spacing change.

https://github.com/NuGet/Home/issues/1959

//cc @joelverhagen @zhili1208 @yishaigalatzer @anurse 
