### PR TITLE
Fix broken NumberToString tests on computers with ',' decimal separator

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.UI
 
         // Convert numbers into strings like "1.2K", "33.4M" etc.
         // Precondition: number > 0.
-        public static string NumberToString(long number)
+        public static string NumberToString(long number, IFormatProvider culture = null)
         {
             double v = (double)number;
             int exp = 0;
@@ -69,9 +69,12 @@ namespace NuGet.PackageManagement.UI
                 v /= 1000;
                 ++exp;
             }
+            
+            if (culture == null)
+                culture = CultureInfo.CurrentCulture;
 
             var s = string.Format(
-                CultureInfo.CurrentCulture,
+                culture,
                 "{0:G3}{1}",
                 v,
                 _scalingFactor[exp]);

--- a/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Utility/UIUtility.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.UI
 
         // Convert numbers into strings like "1.2K", "33.4M" etc.
         // Precondition: number > 0.
-        public static string NumberToString(long number, IFormatProvider culture = null)
+        public static string NumberToString(long number, IFormatProvider culture)
         {
             double v = (double)number;
             int exp = 0;
@@ -70,9 +70,6 @@ namespace NuGet.PackageManagement.UI
                 ++exp;
             }
             
-            if (culture == null)
-                culture = CultureInfo.CurrentCulture;
-
             var s = string.Format(
                 culture,
                 "{0:G3}{1}",

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/AuthorAndDownloadCount.xaml.cs
@@ -119,7 +119,7 @@ namespace NuGet.PackageManagement.UI
 
                 _textBlockDownloadCount.Inlines.Add(new Run(begin)); 
                 _textBlockDownloadCount.Inlines.Add(
-                    new Run(UIUtility.NumberToString(DownloadCount.Value))
+                    new Run(UIUtility.NumberToString(DownloadCount.Value, CultureInfo.CurrentCulture))
                     {
                         FontWeight = FontWeights.Bold
                     });

--- a/test/NuGet.Clients.Tests/PackageManagement.UI.Test/ConverterTests.cs
+++ b/test/NuGet.Clients.Tests/PackageManagement.UI.Test/ConverterTests.cs
@@ -32,7 +32,7 @@ namespace PackageManagement.UI.Test
         [InlineData(1234000000, "1.23G")]
         public void DownloadCountToStringTest(int num, string expected)
         {
-            var s = UIUtility.NumberToString(num);
+            var s = UIUtility.NumberToString(num, CultureInfo.InvariantCulture); // force '.' decimal separator
             Assert.Equal(expected, s);
         }
     }

--- a/test/NuGet.Clients.Tests/PackageManagement.UI.Test/ConverterTests.cs
+++ b/test/NuGet.Clients.Tests/PackageManagement.UI.Test/ConverterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;


### PR DESCRIPTION
Add optional "culture" argument to NumberToString to enable different decimal separators.

Fixes broken unit tests on computers with ',' as decimal separator (https://github.com/NuGet/Home/issues/1998).
