### PR TITLE
Adding automatic gzip compression for http calls

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DataClient/DataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DataClient/DataClient.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,7 +19,6 @@ namespace NuGet.Protocol.Core.v3.Data
     public sealed class DataClient : HttpClient
     {
         private bool _disposed;
-        private readonly INuGetMessageHandlerProvider[] _modifiers;
 
         /// <summary>
         /// Use a HttpHandlerResource containing a message handler.
@@ -48,74 +45,14 @@ namespace NuGet.Protocol.Core.v3.Data
         }
 
         /// <summary>
-        /// DataClient with the default options and caching support
-        /// </summary>
-        public DataClient()
-            : this(DefaultHandler)
-        {
-        }
-
-        /// <summary>
-        /// Internal constructor for building the final handler
-        /// </summary>
-        internal DataClient(HttpClientHandler handler, IEnumerable<INuGetMessageHandlerProvider> modifiers)
-            : this(AssembleHandlers(handler, modifiers))
-        {
-            _modifiers = modifiers.ToArray();
-        }
-
-        /// <summary>
-        /// Default caching handler used by the data client
-        /// </summary>
-        public static HttpHandlerResourceV3 DefaultHandler
-        {
-            get
-            {
-                // Client handler at the end of the pipeline
-                var clientHandler = CachingHandler;
-
-                return CreateHandler(clientHandler);
-            }
-        }
-
-        /// <summary>
         /// Default caching handler used by the data client
         /// </summary>
         public static HttpHandlerResourceV3 CreateHandler(HttpClientHandler clientHandler)
         {
             // Retry handler wrapping the client
-            var messageHandler = new RetryHandler(clientHandler, 5);
+            var messageHandler = new RetryHandler(clientHandler, maxTries: 5);
 
             return new HttpHandlerResourceV3(clientHandler, messageHandler);
-        }
-
-        /// <summary>
-        /// Chain the handlers together
-        /// </summary>
-        private static HttpClientHandler AssembleHandlers(
-            HttpClientHandler handler, 
-            IEnumerable<INuGetMessageHandlerProvider> modifiers)
-        {
-            return handler;
-        }
-
-        /// <summary>
-        /// Retrieve a json file
-        /// </summary>
-        public JObject GetJObject(Uri address)
-        {
-            var task = GetJObjectAsync(address, CancellationToken.None);
-            task.Wait();
-
-            return task.Result;
-        }
-
-        /// <summary>
-        /// Retrieve a json file
-        /// </summary>
-        public async Task<JObject> GetJObjectAsync(Uri address)
-        {
-            return await GetJObjectAsync(address, CancellationToken.None);
         }
 
         /// <summary>
@@ -132,36 +69,6 @@ namespace NuGet.Protocol.Core.v3.Data
                 {
                     return JObject.Parse(json);
                 });
-        }
-
-        private static HttpClientHandler CachingHandler
-        {
-            get
-            {
-#if !DNXCORE50
-                return new WebRequestHandler()
-                    {
-                        CachePolicy = new RequestCachePolicy(RequestCacheLevel.Default)
-                    };
-#else
-                return new HttpClientHandler();
-#endif
-            }
-        }
-
-        private static HttpMessageHandler NoCacheHandler
-        {
-            get
-            {
-#if !DNXCORE50
-                return new WebRequestHandler()
-                    {
-                        CachePolicy = new RequestCachePolicy(RequestCacheLevel.BypassCache)
-                    };
-#else
-                return new HttpClientHandler();
-#endif
-            }
         }
 
         protected override void Dispose(bool disposing)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpHandlerResourceV3Provider.cs
@@ -27,15 +27,8 @@ namespace NuGet.Protocol.Core.v3
 
             var clientHandler = TryGetCredentialAndProxy(source.PackageSource);
 
-            if (clientHandler == null)
-            {
-                curResource = DataClient.DefaultHandler;
-            }
-            else
-            {
-                // replace the handler with the proxy aware handler
-                curResource = DataClient.CreateHandler(clientHandler);
-            }
+            // replace the handler with the proxy aware handler
+            curResource = DataClient.CreateHandler(clientHandler);
 
             return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));
         }
@@ -44,7 +37,9 @@ namespace NuGet.Protocol.Core.v3
 
         private HttpClientHandler TryGetCredentialAndProxy(PackageSource packageSource)
         {
-            return new HttpClientHandler();
+            var handler = new HttpClientHandler();
+            handler.AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate);
+            return handler;
         }
 #else
 
@@ -79,7 +74,8 @@ namespace NuGet.Protocol.Core.v3
             return new CredentialPromptWebRequestHandler()
             {
                 Proxy = proxy,
-                Credentials = credential
+                Credentials = credential,
+                AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)
             };
         }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/SearchLatestResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/SearchLatestResourceV3Provider.cs
@@ -11,19 +11,11 @@ namespace NuGet.Protocol.Core.v3
 {
     public class SearchLatestResourceV3Provider : ResourceProvider
     {
-        private readonly DataClient _client;
-
         public SearchLatestResourceV3Provider()
-            : this(new DataClient())
-        {
-        }
-
-        public SearchLatestResourceV3Provider(DataClient client)
             : base(typeof(SearchLatestResource),
                   nameof(SearchLatestResourceV3Provider),
                   "SearchLatestResourceV2Provider")
         {
-            _client = client;
         }
 
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/PSAutoCompleteResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/PSAutoCompleteResourceV3Provider.cs
@@ -12,17 +12,9 @@ namespace NuGet.Protocol.VisualStudio
 {
     public class PSAutoCompleteResourceV3Provider : ResourceProvider
     {
-        private readonly DataClient _client;
-
         public PSAutoCompleteResourceV3Provider()
-            : this(new DataClient())
-        {
-        }
-
-        public PSAutoCompleteResourceV3Provider(DataClient client)
             : base(typeof(PSAutoCompleteResource), "PSAutoCompleteResourceV3Provider", "V2PSAutoCompleteResourceProvider")
         {
-            _client = client;
         }
 
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
@@ -34,9 +26,11 @@ namespace NuGet.Protocol.VisualStudio
             if (serviceIndex != null)
             {
                 var regResource = await source.GetResourceAsync<RegistrationResourceV3>(token);
+                var handlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
+                var client = new DataClient(handlerResource.MessageHandler);
 
                 // construct a new resource
-                curResource = new PSAutoCompleteResourceV3(_client, serviceIndex, regResource);
+                curResource = new PSAutoCompleteResourceV3(client, serviceIndex, regResource);
             }
 
             return new Tuple<bool, INuGetResource>(curResource != null, curResource);

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/UIMetadataResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/UIMetadataResourceV3Provider.cs
@@ -12,17 +12,9 @@ namespace NuGet.Protocol.VisualStudio
 {
     public class UIMetadataResourceV3Provider : ResourceProvider
     {
-        private readonly DataClient _client;
-
         public UIMetadataResourceV3Provider()
-            : this(new DataClient())
-        {
-        }
-
-        public UIMetadataResourceV3Provider(DataClient client)
             : base(typeof(UIMetadataResource), "UIMetadataResourceV3Provider", "UIMetadataResourceV2Provider")
         {
-            _client = client;
         }
 
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
@@ -34,8 +26,11 @@ namespace NuGet.Protocol.VisualStudio
                 var regResource = await source.GetResourceAsync<RegistrationResourceV3>();
                 var reportAbuseResource = await source.GetResourceAsync<ReportAbuseResourceV3>();
 
+                var handlerResource = await source.GetResourceAsync<HttpHandlerResource>(token);
+                var client = new DataClient(handlerResource.MessageHandler);
+
                 // construct a new resource
-                curResource = new UIMetadataResourceV3(_client, regResource, reportAbuseResource);
+                curResource = new UIMetadataResourceV3(client, regResource, reportAbuseResource);
             }
 
             return new Tuple<bool, INuGetResource>(curResource != null, curResource);

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/UISearchResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/UISearchResourceV3Provider.cs
@@ -12,17 +12,9 @@ namespace NuGet.Protocol.VisualStudio
 {
     public class UISearchResourceV3Provider : ResourceProvider
     {
-        private readonly DataClient _client;
-
         public UISearchResourceV3Provider()
-            : this(new DataClient())
-        {
-        }
-
-        public UISearchResourceV3Provider(DataClient client)
             : base(typeof(UISearchResource), nameof(UISearchResourceV3Provider), "UISearchResourceV2Provider")
         {
-            _client = client;
         }
 
         public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)


### PR DESCRIPTION
This adds `AutomaticDecompression = (DecompressionMethods.GZip | DecompressionMethods.Deflate)`

I've also done some clean up around the DataClient and removed places where other handlers were getting in. It appears that the UI metadata resource and PS auto complete may not have been using a handler with auth and proxy support, it's unclear how those were working.

https://github.com/NuGet/Home/issues/2016

//cc @johnataylor @yishaigalatzer @joyhui @joelverhagen 
