### PR TITLE
Add error and information summary

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -390,8 +390,7 @@ namespace NuGet.Common
 
         public void LogSummary(string data)
         {
-            // Treat Summary as Debug
-            LogDebug(data);
+            WriteLine(data);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
@@ -94,6 +94,16 @@ namespace NuGet.PackageManagement.VisualStudio
             get { return SolutionSettings.Root; }
         }
 
+        public string FileName
+        {
+            get { return SolutionSettings.FileName; }
+        }
+
+        public IEnumerable<Configuration.ISettings> Priority
+        {
+            get { return SolutionSettings.Priority; }
+        }
+
         public void SetNestedValues(string section, string subSection, IList<KeyValuePair<string, string>> values)
         {
             SolutionSettings.SetNestedValues(section, subSection, values);

--- a/src/NuGet.Clients/StandaloneUI/DefaultSettings.cs
+++ b/src/NuGet.Clients/StandaloneUI/DefaultSettings.cs
@@ -51,6 +51,16 @@ namespace StandaloneUI
             get { return Instance.Root; }
         }
 
+        public string FileName
+        {
+            get { return Instance.FileName; }
+        }
+
+        public IEnumerable<ISettings> Priority
+        {
+            get { return Instance.Priority; }
+        }
+
         public void SetNestedValues(string section, string subSection, IList<KeyValuePair<string, string>> values)
         {
             Instance.SetNestedValues(section, subSection, values);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -213,26 +213,8 @@ namespace NuGet.CommandLine.XPlat
                         restoreSummaries.Add(restoreSummary);
                     }
 
-                    // Display the errors in the same order that they were produced, but grouped by project
-                    if (restoreSummaries.Any())
-                    {
-                        foreach (var restoreSummary in restoreSummaries)
-                        {
-                            if (!restoreSummary.Errors.Any())
-                            {
-                                continue;
-                            }
+                    RestoreSummary.Log(Log, restoreSummaries);
 
-                            Log.LogSummary(string.Empty);
-                            Log.LogSummary(string.Format(Strings.Log_ErrorSummary, restoreSummary.InputPath));
-                            foreach (var error in restoreSummary.Errors)
-                            {
-                                Log.LogSummary($"    {error}");
-                            }
-                        }
-                    }
-
-                    // Return 0 if all restores were successful
                     return restoreSummaries.All(x => x.Success) ? 0 : 1;
                 });
             });
@@ -270,10 +252,7 @@ namespace NuGet.CommandLine.XPlat
 
             return exitCode;
         }
-
-        /// <summary>
-        /// Removes a task from the list and returns the restore summary.
-        /// </summary>
+		
         private static async Task<RestoreSummary> CompleteTaskAsync(List<Task<RestoreSummary>> restoreTasks)
         {
             var doneTask = await Task.WhenAny(restoreTasks);
@@ -445,10 +424,8 @@ namespace NuGet.CommandLine.XPlat
                         sw.ElapsedMilliseconds));
                 }
 
-                return new RestoreSummary(
-                    inputPath,
-                    result.Success,
-                    collectorLog.Errors);
+                // Build the summary
+                return new RestoreSummary(result, inputPath, settings, packageSources, collectorLog.Errors);
             }
         }
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -78,15 +78,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Errors in {0}.
-        /// </summary>
-        internal static string Log_ErrorSummary {
-            get {
-                return ResourceManager.GetString("Log_ErrorSummary", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///    Looks up a localized string similar to Found project root directory: {0}..
         /// </summary>
         internal static string Log_FoundProjectRoot {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -123,9 +123,6 @@
   <data name="Log_Committing" xml:space="preserve">
     <value>Committing restore...</value>
   </data>
-  <data name="Log_ErrorSummary" xml:space="preserve">
-    <value>Errors in {0}</value>
-  </data>
   <data name="Log_FoundProjectRoot" xml:space="preserve">
     <value>Found project root directory: {0}.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/Properties/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Properties/Strings.Designer.cs
@@ -498,6 +498,62 @@ namespace NuGet.Commands
             return string.Format(CultureInfo.CurrentCulture, GetString("Error_UnknownBuildAction"), p0, p1, p2);
         }
 
+        /// <summary>
+        /// NuGet Config files used:
+        /// </summary>
+        internal static string Log_ConfigFileSummary
+        {
+            get { return GetString("Log_ConfigFileSummary"); }
+        }
+
+        /// <summary>
+        /// NuGet Config files used:
+        /// </summary>
+        internal static string Log_ErrorSummary
+        {
+            get { return GetString("Log_ErrorSummary"); }
+        }
+
+        /// <summary>
+        /// Errors in {0}
+        /// </summary>
+        internal static string FormatLog_ErrorSummary(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_ErrorSummary"), p0);
+        }
+
+        /// <summary>
+        /// Feeds used:
+        /// </summary>
+        internal static string Log_FeedsUsedSummary
+        {
+            get { return GetString("Log_FeedsUsedSummary"); }
+        }
+
+        /// <summary>
+        /// Installed:
+        /// </summary>
+        internal static string Log_InstalledSummary
+        {
+            get { return GetString("Log_InstalledSummary"); }
+        }
+
+        /// <summary>
+        /// NuGet Config files used:
+        /// </summary>
+        internal static string Log_InstalledSummaryCount
+        {
+            get { return GetString("Log_InstalledSummaryCount"); }
+        }
+
+        /// <summary>
+        /// {0} package(s) to {1}
+        /// </summary>
+        internal static string FormatLog_InstalledSummaryCount(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("Log_InstalledSummaryCount"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
@@ -2,26 +2,157 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using NuGet.Configuration;
+using NuGet.Logging;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
     public class RestoreSummary
     {
-        public string InputPath { get; }
-
         public bool Success { get; }
 
-        public IEnumerable<string> Errors { get; }
+        public string InputPath { get; }
+
+        public IList<string> ConfigFiles { get; }
+
+        public IList<string> FeedsUsed { get; }
+
+        public int InstallCount { get; }
+
+        public IList<string> Errors { get; }
+
+        public RestoreSummary(bool success)
+        {
+            Success = success;
+            InputPath = null;
+            ConfigFiles = new List<string>().AsReadOnly();
+            FeedsUsed = new List<string>().AsReadOnly();
+            InstallCount = 0;
+            Errors = new List<string>().AsReadOnly();
+        }
 
         public RestoreSummary(
+            RestoreResult result,
             string inputPath,
-            bool success,
+            ISettings settings,
+            IEnumerable<SourceRepository> sourceRepositories,
             IEnumerable<string> errors)
         {
+            Success = result.Success;
             InputPath = inputPath;
-            Success = success;
+            ConfigFiles = settings
+                .Priority
+                .Select(childSettings => Path.Combine(childSettings.Root, childSettings.FileName))
+                .ToList()
+                .AsReadOnly();
+            FeedsUsed = sourceRepositories
+                .Select(source => source.PackageSource.Source)
+                .ToList()
+                .AsReadOnly();
+            InstallCount = result.GetAllInstalled().Count;
             Errors = errors.ToArray();
+        }
+
+        public RestoreSummary(
+            bool success,
+            string inputPath,
+            IEnumerable<string> configFiles,
+            IEnumerable<string> feedsUsed,
+            int installCount,
+            IEnumerable<string> errors)
+        {
+            Success = success;
+            InputPath = inputPath;
+            ConfigFiles = configFiles.ToList().AsReadOnly();
+            FeedsUsed = feedsUsed.ToList().AsReadOnly();
+            InstallCount = installCount;
+            Errors = errors.ToArray();
+        }
+
+        public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries)
+        {
+            if (!restoreSummaries.Any())
+            {
+                return;
+            }
+
+            // Display the errors summary
+            foreach (var restoreSummary in restoreSummaries)
+            {
+                if (!restoreSummary.Errors.Any())
+                {
+                    continue;
+                }
+
+                logger.LogSummary(string.Empty);
+                logger.LogSummary(Strings.FormatLog_ErrorSummary(restoreSummary.InputPath));
+                foreach (var error in restoreSummary.Errors)
+                {
+                    foreach (var line in IndentLines(error))
+                    {
+                        logger.LogSummary(line);
+                    }
+                }
+            }
+
+            // Display the information summary
+            var configFiles = restoreSummaries
+                .SelectMany(summary => summary.ConfigFiles)
+                .Distinct();
+
+            if (configFiles.Any())
+            {
+                logger.LogSummary(string.Empty);
+                logger.LogSummary(Strings.Log_ConfigFileSummary);
+                foreach (var configFile in configFiles)
+                {
+                    logger.LogSummary($"    {configFile}");
+                }
+            }
+
+            var feedsUsed = restoreSummaries
+                .SelectMany(summary => summary.FeedsUsed)
+                .Distinct();
+
+            if (feedsUsed.Any())
+            {
+                logger.LogSummary(string.Empty);
+                logger.LogSummary(Strings.Log_FeedsUsedSummary);
+                foreach (var feedUsed in feedsUsed)
+                {
+                    logger.LogSummary($"    {feedUsed}");
+                }
+            }
+
+            var installed = restoreSummaries
+                .GroupBy(summary => summary.InputPath, summary => summary.InstallCount)
+                .Select(group => new KeyValuePair<string, int>(group.Key, group.Sum()))
+                .Where(pair => pair.Value > 0);
+
+            if (installed.Any())
+            {
+                logger.LogSummary(string.Empty);
+                logger.LogSummary(Strings.Log_InstalledSummary);
+                foreach (var pair in installed)
+                {
+                    logger.LogSummary("    " + Strings.FormatLog_InstalledSummaryCount(pair.Value, pair.Key));
+                }
+            }
+        }
+
+        private static IEnumerable<string> IndentLines(string input)
+        {
+            using (var reader = new StringReader(input))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    yield return $"    {line.TrimEnd()}";
+                }
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -210,4 +210,19 @@
   <data name="Error_UnknownBuildAction" xml:space="preserve">
     <value>Package '{0}' specifies an invalid build action '{1}' for file '{2}'.</value>
   </data>
+  <data name="Log_ConfigFileSummary" xml:space="preserve">
+    <value>NuGet Config files used:</value>
+  </data>
+  <data name="Log_ErrorSummary" xml:space="preserve">
+    <value>Errors in {0}</value>
+  </data>
+  <data name="Log_FeedsUsedSummary" xml:space="preserve">
+    <value>Feeds used:</value>
+  </data>
+  <data name="Log_InstalledSummary" xml:space="preserve">
+    <value>Installed:</value>
+  </data>
+  <data name="Log_InstalledSummaryCount" xml:space="preserve">
+    <value>{0} package(s) to {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ISettings.cs
@@ -17,6 +17,19 @@ namespace NuGet.Configuration
         string Root { get; }
 
         /// <summary>
+        /// The file name of the config file. Joining <see cref="Root"/> and
+        /// <see cref="FileName"/> results in the full path to the config file.
+        /// </summary>
+        string FileName { get; }
+
+        /// <summary>
+        /// Enumerates the sequence of <see cref="ISettings"/> instances used to fetch settings
+        /// values (e.g. with <see cref="GetValue"/>). This enumeration includes this instance
+        /// itself.
+        /// </summary>
+        IEnumerable<ISettings> Priority { get; }
+
+        /// <summary>
         /// Gets a value for the given key from the given section
         /// If isPath is true, then the value represents a path. If the path value is already rooted, it is simply
         /// returned

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -23,6 +23,16 @@ namespace NuGet.Configuration
             get { return String.Empty; }
         }
 
+        public string FileName
+        {
+            get { return String.Empty; }
+        }
+
+        public IEnumerable<ISettings> Priority
+        {
+            get { return new[] { this }; }
+        }
+
         public string GetValue(string section, string key, bool isPath = false)
         {
             return String.Empty;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1473,10 +1473,14 @@ EndProject";
                 Assert.False(r.Item2.IndexOf("exception", StringComparison.OrdinalIgnoreCase) > -1);
                 Assert.False(r.Item3.IndexOf("exception", StringComparison.OrdinalIgnoreCase) > -1);
 
-                Assert.True(r.Item2.IndexOf("Unable to find version '1.1.0' of package 'packageA'.",
-                    StringComparison.OrdinalIgnoreCase) > -1);
-                Assert.True(r.Item3.IndexOf("Unable to find version '1.1.0' of package 'packageA'.",
-                    StringComparison.OrdinalIgnoreCase) > -1);
+                var firstIndex = r.Item2.IndexOf("Unable to find version '1.1.0' of package 'packageA'.",
+                    StringComparison.OrdinalIgnoreCase);
+                Assert.True(firstIndex > -1);
+                var secondIndex = r.Item2.IndexOf(
+                    "Unable to find version '1.1.0' of package 'packageA'.",
+                    firstIndex + 1,
+                    StringComparison.OrdinalIgnoreCase);
+                Assert.True(secondIndex > -1);
             }
         }
 


### PR DESCRIPTION
1. Add information summarizing install count, config files used, and feeds used. This matches DNU.
2. Add this summary information to nuget.exe so that the summary is consistent with Xplat.

This finishes https://github.com/NuGet/Home/issues/1973 and https://github.com/NuGet/Home/issues/1933.
