### PR TITLE
Support --configfile in NuGet CommandLine XPlat.

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -88,6 +88,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.Restore_Switch_Runtime_Description,
                     CommandOptionType.MultipleValue);
 
+                var configFile = restore.Option(
+                    "--configfile <file>",
+                    Strings.Restore_Switch_ConfigFile_Description,
+                    CommandOptionType.SingleValue);
+
                 verbosity = restore.Option(VerbosityOption,
                     Strings.Switch_Verbosity,
                     CommandOptionType.SingleValue);
@@ -166,8 +171,9 @@ namespace NuGet.CommandLine.XPlat
                             // Global folder
                             // Load settings based on the current project path.
                             var projectDir = Path.GetDirectoryName(inputPath);
+                            string configFileName = configFile.HasValue() ? configFile.Value() : null;
                             var settings = Settings.LoadDefaultSettings(projectDir,
-                                configFileName: null,
+                                configFileName,
                                 machineWideSettings: null);
 
                             var globalFolderPath = string.Empty;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -168,6 +168,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The NuGet configuration file to use..
+        /// </summary>
+        internal static string Restore_Switch_ConfigFile_Description {
+            get {
+                return ResourceManager.GetString("Restore_Switch_ConfigFile_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Disables restoring multiple projects in parallel..
         /// </summary>
         internal static string Restore_Switch_DisableParallel_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -153,6 +153,9 @@
   <data name="Restore_Description" xml:space="preserve">
     <value>Restores packages for a project and writes a lock file.</value>
   </data>
+  <data name="Restore_Switch_ConfigFile_Description" xml:space="preserve">
+    <value>The NuGet configuration file to use.</value>
+  </data>
   <data name="Restore_Switch_DisableParallel_Description" xml:space="preserve">
     <value>Disables restoring multiple projects in parallel.</value>
   </data>

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
@@ -69,6 +69,29 @@ namespace NuGet.CommandLine.XPlat.Test
         }
 
         [Fact]
+        public void BasicLogging_RestoreConfigFile_ExitCode()
+        {
+            // Arrange
+            var log = new TestLogger();
+            Program.Log = log;
+
+            var args = new string[]
+            {
+                "restore",
+                "--configfile",
+                "MyNuGet.config",
+            };
+
+            // Act
+            var exitCode = Program.Main(args);
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Equal(1, log.Errors);
+            Assert.Contains("MyNuGet.config", log.Messages.ToArray()[1]); // file does not exist
+        }
+
+        [Fact]
         public void BasicLogging_RestoreUnknownOption_ExitCode()
         {
             // Arrange


### PR DESCRIPTION
Adding a --configfile option to nuget command line in order to support "dotnet restore" taking a config file.

Fix https://github.com/NuGet/Home/issues/2033

@yishaigalatzer, @anurse  Please let me know what you think.
