### PR TITLE
OnBuild performance improvements and project.json discovery fixes

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -73,29 +73,34 @@ namespace NuGet.PackageManagement.VisualStudio
             // DTE calls need to be done from the main thread
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            var results = new HashSet<ExternalProjectReference>();
+            var results = new SortedSet<ExternalProjectReference>();
 
-            // projects to walk
-            var toProcess = new Queue<EnvDTEProject>();
-
-            // start with the current project
-            toProcess.Enqueue(EnvDTEProject);
+            // projects to walk - DFS
+            var toProcess = new Stack<DTEReference>();
 
             // keep track of found projects to avoid duplicates
-            var uniqueProjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var rootProjectPath = EnvDTEProjectUtility.GetFullProjectPath(EnvDTEProject);
 
-            uniqueProjects.Add(rootProjectPath);
+            // start with the current project
+            toProcess.Push(new DTEReference(EnvDTEProject, rootProjectPath));
 
             var itemsFactory = ServiceLocator.GetInstance<IVsEnumHierarchyItemsFactory>();
+            var uniqueNames = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // continue walking all project references until we run out
             while (toProcess.Count > 0)
             {
-                var project = toProcess.Dequeue();
+                var dteReference = toProcess.Pop();
 
                 // Find the path of the current project
-                var projectFileFullPath = EnvDTEProjectUtility.GetFullProjectPath(project);
+                var projectFileFullPath = dteReference.Path;
+                var project = dteReference.Project;
+
+                if (!uniqueNames.Add(projectFileFullPath))
+                {
+                    // This has already been processed
+                    continue;
+                }
 
                 IReadOnlyList<ExternalProjectReference> cacheReferences;
                 if (cache.TryGetValue(projectFileFullPath, out cacheReferences))
@@ -106,215 +111,210 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 else
                 {
-                    // Find projectName.project.json first
-                    var projectName = Path.GetFileNameWithoutExtension(projectFileFullPath);
-
-                    var fileWithProjectName =
-                        BuildIntegratedProjectUtility.GetProjectConfigWithProjectName(projectName);
-
-                    string jsonConfigItem = null;
-
-                    // Loop through all root project items. Sub folders will not be part of this.
-                    jsonConfigItem = GetJsonConfigFromProject(project, fileWithProjectName);
-
-                    // Verify ReferenceOutputAssembly
-                    var excludedProjects = GetExcludedReferences(project, itemsFactory);
-
-                    var childReferences = new List<string>();
-                    var hasMissingReferences = false;
-
-                    // find all references in the project
-                    foreach (var childReference in GetProjectReferences(project))
-                    {
-                        try
-                        {
-                            var reference3 = childReference as Reference3;
-
-                            if (reference3 != null && !reference3.Resolved)
-                            {
-                                // Skip missing references and show a warning
-                                hasMissingReferences = true;
-                                continue;
-                            }
-
-                            // Skip missing references
-                            if (childReference.SourceProject != null)
-                            {
-                                if (EnvDTEProjectUtility.HasUnsupportedProjectCapability(childReference.SourceProject))
-                                {
-                                    // Skip this shared project
-                                    continue;
-                                }
-
-                                var childName = EnvDTEProjectUtility.GetFullProjectPath(childReference.SourceProject);
-
-                                // Skip projects which have ReferenceOutputAssembly=false
-                                if (!excludedProjects.Contains(childName, StringComparer.OrdinalIgnoreCase))
-                                {
-                                    childReferences.Add(childName);
-
-                                    // avoid looping by checking if we already have this project
-                                    if (!uniqueProjects.Contains(childName))
-                                    {
-                                        toProcess.Enqueue(childReference.SourceProject);
-                                        uniqueProjects.Add(childName);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                // SDK references do not have a SourceProject or child references, 
-                                // but they can contain project.json files, and should be part of the closure
-                                // SDKs are not projects, only the project.json name is checked here
-
-                                var possibleSdkPath = childReference.Path;
-
-                                if (!string.IsNullOrEmpty(possibleSdkPath) && Directory.Exists(possibleSdkPath))
-                                {
-                                    var possibleProjectJson = Path.Combine(
-                                                                possibleSdkPath,
-                                                                BuildIntegratedProjectUtility.ProjectConfigFileName);
-
-                                    if (File.Exists(possibleProjectJson))
-                                    {
-                                        childReferences.Add(possibleProjectJson);
-
-                                        var projectSpec = context.GetOrCreateSpec(
-                                            childReference.Name,
-                                            possibleProjectJson);
-
-                                        // add the sdk to the results here
-                                        results.Add(new ExternalProjectReference(
-                                            possibleProjectJson,
-                                            projectSpec,
-                                            msbuildProjectPath: null,
-                                            projectReferences: Enumerable.Empty<string>()));
-                                    }
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            // Exceptions are expected in some scenarios for native projects,
-                            // ignore them and show a warning
-                            hasMissingReferences = true;
-
-                            Debug.Fail("Unable to find project closure: " + ex.ToString());
-                        }
-                    }
-
-                    if (hasMissingReferences)
-                    {
-                        // Log a warning message once per project
-                        // This warning contains only the names of the root project and the project with the
-                        // broken reference. Attempting to display more details on the actual reference 
-                        // that has the problem may lead to another exception being thrown.
-                        var warning = string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.Warning_ErrorDuringProjectClosureWalk,
-                            projectName,
-                            rootProjectPath);
-
-                        logger.LogWarning(warning);
-                    }
-
-                    // Add the current project (include the root) to the results
-                    PackageSpec packageSpec = null;
-                    if (File.Exists(jsonConfigItem))
-                    {
-                        // Not all projects have a project.json, only read it if it exists
-                        packageSpec = context.GetOrCreateSpec(projectName, jsonConfigItem);
-                    }
-
-                    // For the xproj -> xproj -> csproj scenario find all xproj-> xproj references.
-                    if (projectFileFullPath.EndsWith(XProjUtility.XProjExtension, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // All xproj paths, these are already checked for project.json
-                        var xprojFiles = XProjUtility.GetProjectReferences(projectFileFullPath);
-
-                        if (xprojFiles.Count > 0)
-                        {
-                            var pathToProject = GetPathToDTEProjectLookup(project);
-
-                            foreach (var xProjPath in xprojFiles)
-                            {
-                                // Only add projects that we can find in the solution, otherwise they will
-                                // end up causing failures. If this is an actual failure the resolver will
-                                // fail when resolving the dependency from project.json
-                                Project xProjDTE;
-                                if (pathToProject.TryGetValue(xProjPath, out xProjDTE))
-                                {
-                                    var xProjFullPath = EnvDTEProjectUtility.GetFullProjectPath(xProjDTE);
-                                    childReferences.Add(xProjFullPath);
-
-                                    // Continue walking this project if it has not been walked already
-                                    if (!uniqueProjects.Contains(xProjFullPath))
-                                    {
-                                        toProcess.Enqueue(xProjDTE);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    results.Add(new ExternalProjectReference(
+                    // Get direct references
+                    var projectResult = GetDirectProjectReferences(
+                        dteReference.Project,
                         projectFileFullPath,
-                        packageSpec,
-                        projectFileFullPath,
-                        childReferences));
+                        context,
+                        itemsFactory,
+                        rootProjectPath);
+
+                    // Add results to the closure
+                    results.UnionWith(projectResult.Processed);
+
+                    // Continue processing
+                    foreach (var item in projectResult.ToProcess)
+                    {
+                        toProcess.Push(item);
+                    }
                 }
             }
 
-            // Cache the results
-            if (!cache.ContainsKey(rootProjectPath))
+            // Cache the results for this project and every child project which has not been cached
+            foreach (var project in results)
             {
-                // Create a new copy of the list so that callers cannot modify it
-                cache.Add(rootProjectPath, new List<ExternalProjectReference>(results));
+                if (!context.Cache.ContainsKey(project.UniqueName))
+                {
+                    var closure = BuildIntegratedRestoreUtility.GetExternalClosure(project.UniqueName, results);
+
+                    context.Cache.Add(project.UniqueName, closure.ToList());
+                }
             }
 
-            return results.ToList();
+            return cache[rootProjectPath];
         }
 
         /// <summary>
-        /// Find project.json or projectName.project.json
+        /// Get only the direct dependencies from a project
         /// </summary>
-        private static string GetJsonConfigFromProject(EnvDTEProject project, string fileWithProjectName)
+        private DirectReferences GetDirectProjectReferences(
+            EnvDTEProject project,
+            string projectFileFullPath,
+            ExternalProjectReferenceContext context,
+            IVsEnumHierarchyItemsFactory itemsFactory,
+            string rootProjectPath)
         {
-            string jsonConfigItem = null;
+            var logger = context.Logger;
+            var cache = context.Cache;
 
-            foreach (var filePath in project.ProjectItems.OfType<ProjectItem>()
-                                    .Select(p => p.FileNames[1]))
+            var result = new DirectReferences();
+
+            // Find a project.json in the project
+            // This checks for files on disk to match how BuildIntegratedProjectSystem checks at creation time.
+            // NuGet.exe also uses disk paths and not the project file.
+            var projectName = Path.GetFileNameWithoutExtension(projectFileFullPath);
+
+            var projectDirectory = Path.GetDirectoryName(projectFileFullPath);
+
+            // Check for projectName.project.json and project.json
+            string jsonConfigItem =
+                BuildIntegratedProjectUtility.GetProjectConfigPath(
+                    directoryPath: projectDirectory,
+                    projectName: projectName);
+
+            var hasProjectJson = true;
+
+            // Verify the file exists, otherwise clear it
+            if (jsonConfigItem != null && !File.Exists(jsonConfigItem))
             {
-                if (!BuildIntegratedProjectUtility.IsProjectConfig(filePath))
+                jsonConfigItem = null;
+                hasProjectJson = false;
+            }
+
+            // Verify ReferenceOutputAssembly
+            var excludedProjects = GetExcludedReferences(project, itemsFactory);
+
+            var childReferences = new SortedSet<string>(StringComparer.Ordinal);
+            var hasMissingReferences = false;
+
+            // find all references in the project
+            foreach (var childReference in GetProjectReferences(project))
+            {
+                try
                 {
-                    continue;
+                    var reference3 = childReference as Reference3;
+
+                    if (reference3 != null && !reference3.Resolved)
+                    {
+                        // Skip missing references and show a warning
+                        hasMissingReferences = true;
+                        continue;
+                    }
+
+                    // Skip missing references
+                    if (childReference.SourceProject != null)
+                    {
+                        if (EnvDTEProjectUtility.HasUnsupportedProjectCapability(childReference.SourceProject))
+                        {
+                            // Skip this shared project
+                            continue;
+                        }
+
+                        var childName = EnvDTEProjectUtility.GetFullProjectPath(childReference.SourceProject);
+
+                        // Skip projects which have ReferenceOutputAssembly=false
+                        if (!excludedProjects.Contains(childName, StringComparer.OrdinalIgnoreCase))
+                        {
+                            childReferences.Add(childName);
+
+                            result.ToProcess.Add(new DTEReference(childReference.SourceProject, childName));
+                        }
+                    }
+                    else if (hasProjectJson)
+                    {
+                        // SDK references do not have a SourceProject or child references, 
+                        // but they can contain project.json files, and should be part of the closure
+                        // SDKs are not projects, only the project.json name is checked here
+                        var possibleSdkPath = childReference.Path;
+
+                        if (!string.IsNullOrEmpty(possibleSdkPath)
+                            && !possibleSdkPath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                            && Directory.Exists(possibleSdkPath))
+                        {
+                            var possibleProjectJson = Path.Combine(
+                                                        possibleSdkPath,
+                                                        BuildIntegratedProjectUtility.ProjectConfigFileName);
+
+                            if (File.Exists(possibleProjectJson))
+                            {
+                                childReferences.Add(possibleProjectJson);
+
+                                // add the sdk to the results here
+                                result.Processed.Add(new ExternalProjectReference(
+                                    possibleProjectJson,
+                                    childReference.Name,
+                                    possibleProjectJson,
+                                    msbuildProjectPath: null,
+                                    projectReferences: Enumerable.Empty<string>()));
+                            }
+                        }
+                    }
                 }
-
-                // The filename is also checked in BuildIntegratedProjectUtility.IsProjectConfig, if it
-                // is invalid, it will return false above.
-                var fileName = Path.GetFileName(filePath);
-
-                // Check for projName.project.json
-                if (string.Equals(
-                        fileWithProjectName,
-                        fileName,
-                        StringComparison.OrdinalIgnoreCase))
+                catch (Exception ex)
                 {
-                    jsonConfigItem = filePath;
-                    break;
-                }
+                    // Exceptions are expected in some scenarios for native projects,
+                    // ignore them and show a warning
+                    hasMissingReferences = true;
 
-                // Fallback to project.json if projName.project.json does not exist
-                if (string.Equals(
-                        BuildIntegratedProjectUtility.ProjectConfigFileName,
-                        fileName,
-                        StringComparison.OrdinalIgnoreCase))
-                {
-                    jsonConfigItem = filePath;
+                    Debug.Fail("Unable to find project closure: " + ex.ToString());
                 }
             }
 
-            return jsonConfigItem;
+            if (hasMissingReferences)
+            {
+                // Log a warning message once per project
+                // This warning contains only the names of the root project and the project with the
+                // broken reference. Attempting to display more details on the actual reference 
+                // that has the problem may lead to another exception being thrown.
+                var warning = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Warning_ErrorDuringProjectClosureWalk,
+                    projectName,
+                    rootProjectPath);
+
+                logger.LogWarning(warning);
+            }
+
+            // For the xproj -> xproj -> csproj scenario find all xproj-> xproj references.
+            if (projectFileFullPath.EndsWith(XProjUtility.XProjExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                // All xproj paths, these are already checked for project.json
+                var xprojFiles = XProjUtility.GetProjectReferences(projectFileFullPath);
+
+                if (xprojFiles.Count > 0)
+                {
+                    var pathToProject = GetPathToDTEProjectLookup(project);
+
+                    foreach (var xProjPath in xprojFiles)
+                    {
+                        // Only add projects that we can find in the solution, otherwise they will
+                        // end up causing failures. If this is an actual failure the resolver will
+                        // fail when resolving the dependency from project.json
+                        Project xProjDTE;
+                        if (pathToProject.TryGetValue(xProjPath, out xProjDTE))
+                        {
+                            var xProjFullPath = EnvDTEProjectUtility.GetFullProjectPath(xProjDTE);
+                            childReferences.Add(xProjFullPath);
+
+                            // Continue walking this project if it has not been walked already
+                            result.ToProcess.Add(new DTEReference(xProjDTE, xProjFullPath));
+                        }
+                    }
+                }
+            }
+
+            // Only set a package spec project name if a package spec exists
+            var packageSpecProjectName = jsonConfigItem == null ? null : projectName;
+
+            // Add the parent project to the results
+            result.Processed.Add(new ExternalProjectReference(
+                projectFileFullPath,
+                packageSpecProjectName,
+                jsonConfigItem,
+                projectFileFullPath,
+                childReferences));
+
+            return result;
         }
 
         private static Dictionary<string, EnvDTEProject> GetPathToDTEProjectLookup(EnvDTEProject project)
@@ -468,6 +468,52 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return excludedReferences;
+        }
+
+        /// <summary>
+        /// Top level references
+        /// </summary>
+        private class DirectReferences
+        {
+            public SortedSet<DTEReference> ToProcess { get; } = new SortedSet<DTEReference>();
+
+            public SortedSet<ExternalProjectReference> Processed { get; } = new SortedSet<ExternalProjectReference>();
+        }
+
+        /// <summary>
+        /// Holds the full path to a project and the DTE object for the project.
+        /// </summary>
+        private class DTEReference : IEquatable<DTEReference>, IComparable<DTEReference>
+        {
+            public DTEReference(EnvDTEProject project, string path)
+            {
+                Project = project;
+                Path = path;
+            }
+
+            public EnvDTEProject Project { get; }
+
+            public string Path { get; }
+
+            public bool Equals(DTEReference other)
+            {
+                return StringComparer.Ordinal.Equals(Path, other.Path);
+            }
+
+            public int CompareTo(DTEReference other)
+            {
+                return StringComparer.Ordinal.Compare(Path, other.Path);
+            }
+
+            public override int GetHashCode()
+            {
+                return StringComparer.Ordinal.GetHashCode(Path);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals(obj as DTEReference);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -189,7 +189,10 @@ namespace NuGet.Commands
             {
                 // There should be at most one match in the external projects.
                 var rootProjectMatches = _request.ExternalProjects.Where(proj =>
-                     string.Equals(_request.Project.Name, proj.PackageSpec?.Name, StringComparison.OrdinalIgnoreCase))
+                     string.Equals(
+                         _request.Project.Name,
+                         proj.PackageSpecProjectName,
+                         StringComparison.OrdinalIgnoreCase))
                      .ToList();
 
                 if (rootProjectMatches.Count > 1)

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectCacheEntry.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectCacheEntry.cs
@@ -13,8 +13,8 @@ namespace NuGet.PackageManagement
     {
         public BuildIntegratedProjectCacheEntry(
             string projectConfigPath,
-            IEnumerable<string> referenceClosure,
-            IEnumerable<string> supportsProfiles)
+            ISet<string> referenceClosure,
+            DateTimeOffset projectConfigLastModified)
         {
             if (projectConfigPath == null)
             {
@@ -26,14 +26,14 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(referenceClosure));
             }
 
-            if (supportsProfiles == null)
+            if (projectConfigLastModified == null)
             {
-                throw new ArgumentNullException(nameof(supportsProfiles));
+                throw new ArgumentNullException(nameof(projectConfigLastModified));
             }
 
             ProjectConfigPath = projectConfigPath;
-            ReferenceClosure = new HashSet<string>(referenceClosure);
-            SupportsProfiles = supportsProfiles;
+            ReferenceClosure = referenceClosure;
+            ProjectConfigLastModified = projectConfigLastModified;
         }
 
         /// <summary>
@@ -44,8 +44,11 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// All project.json files and msbuild references in the closure.
         /// </summary>
-        public HashSet<string> ReferenceClosure { get; }
+        public ISet<string> ReferenceClosure { get; }
 
-        public IEnumerable<string> SupportsProfiles { get; }
+        /// <summary>
+        /// Timestamp from the last time project.json was modified.
+        /// </summary>
+        public DateTimeOffset ProjectConfigLastModified { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -181,7 +181,16 @@ namespace NuGet.PackageManagement
                 // Get all project.json file paths in the closure
                 var closure = await project.GetProjectReferenceClosureAsync(context);
 
-                var files = new List<string>();
+                var files = new SortedSet<string>(StringComparer.Ordinal);
+
+                // Store the last modified date of the project.json file
+                // If there are any changes a restore is needed
+                var lastModified = DateTimeOffset.MinValue;
+
+                if (File.Exists(project.JsonConfigPath))
+                {
+                    lastModified = File.GetLastWriteTimeUtc(project.JsonConfigPath);
+                }
 
                 foreach (var reference in closure)
                 {
@@ -190,26 +199,16 @@ namespace NuGet.PackageManagement
                         files.Add(reference.MSBuildProjectPath);
                     }
 
-                    if (reference.PackageSpec != null)
+                    if (reference.PackageSpecPath != null)
                     {
-                        Debug.Assert(reference.PackageSpec.FilePath != null, "Empty project.json path");
-                        files.Add(reference.PackageSpec.FilePath);
+                        files.Add(reference.PackageSpecPath);
                     }
-                }
-
-                var supportsProfiles = Enumerable.Empty<string>();
-
-                if (project.PackageSpec != null)
-                {
-                    supportsProfiles = project.PackageSpec.RuntimeGraph.Supports.Keys
-                        .OrderBy(p => p, StringComparer.Ordinal)
-                        .ToArray();
                 }
 
                 var projectInfo = new BuildIntegratedProjectCacheEntry(
                     project.JsonConfigPath,
                     files,
-                    supportsProfiles);
+                    lastModified);
 
                 var uniqueName = project.GetMetadata<string>(NuGetProjectMetadataKeys.UniqueName);
 
@@ -244,16 +243,15 @@ namespace NuGet.PackageManagement
                     return true;
                 }
 
-                if (!item.Value.ReferenceClosure.OrderBy(s => s, StringComparer.Ordinal)
-                    .SequenceEqual(projectInfo.ReferenceClosure.OrderBy(s => s, StringComparer.Ordinal)))
+                if (!item.Value.ProjectConfigLastModified.Equals(projectInfo.ProjectConfigLastModified))
                 {
-                    // The project closure has changed
+                    // project.json has been modified
                     return true;
                 }
 
-                if (!Enumerable.SequenceEqual(item.Value.SupportsProfiles, projectInfo.SupportsProfiles))
+                if (!item.Value.ReferenceClosure.SetEquals(projectInfo.ReferenceClosure))
                 {
-                    // Supports nodes have changes. Compatibility checks need to be done during the restore.
+                    // The project closure has changed
                     return true;
                 }
             }
@@ -395,9 +393,9 @@ namespace NuGet.PackageManagement
 
                     // find all projects which have a child reference matching the same project.json path as the target
                     if (closure.Any(reference =>
-                        reference.PackageSpec != null &&
+                        reference.PackageSpecPath != null &&
                         string.Equals(targetProjectJson,
-                            Path.GetFullPath(reference.PackageSpec.FilePath),
+                            Path.GetFullPath(reference.PackageSpecPath),
                             StringComparison.OrdinalIgnoreCase)))
                     {
                         parents.Add(project);
@@ -467,6 +465,49 @@ namespace NuGet.PackageManagement
             }
 
             return version;
+        }
+
+        /// <summary>
+        /// Find the project closure from a larger set of references.
+        /// </summary>
+        public static ISet<ExternalProjectReference> GetExternalClosure(
+            string rootUniqueName,
+            ISet<ExternalProjectReference> references)
+        {
+            var closure = new SortedSet<ExternalProjectReference>();
+
+            // Start with the parent node
+            var parent = references.FirstOrDefault(project =>
+                    rootUniqueName.Equals(project.UniqueName, StringComparison.Ordinal));
+
+            if (parent != null)
+            {
+                closure.Add(parent);
+            }
+
+            // Loop adding child projects each time
+            var notDone = true;
+            while (notDone)
+            {
+                notDone = false;
+
+                foreach (var childName in closure
+                    .Where(project => project.ExternalProjectReferences != null)
+                    .SelectMany(project => project.ExternalProjectReferences)
+                    .ToArray())
+                {
+                    var child = references.FirstOrDefault(project =>
+                        childName.Equals(project.UniqueName, StringComparison.Ordinal));
+
+                    // Continue until nothing new is added
+                    if (child != null)
+                    {
+                        notDone |= closure.Add(child);
+                    }
+                }
+            }
+
+            return closure;
         }
     }
 }


### PR DESCRIPTION
This change improves on build restore performance and makes the p2p walk from DTE consistent with nuget.exe and how projects are read from the solution at the start in VS: by checking for project.json on disk.

Caching was previously imperfect and would cache based only on finding the full project closure. This change allows all child projects to also add their closures to the cache to avoid re-walking them. In large solutions such as Roslyn this would cause Visual Studio to hang for a few seconds before the restore wait dialog appeared.

Package specs can now be loaded lazily to avoid reading all of them before the wait dialog appears when an a restore is needed.

Instead of reading all project.json files to cache the supports section the timestamp is now used. This will also cover changes to the runtimes and anything else in the file.

https://github.com/NuGet/Home/issues/2059
https://github.com/NuGet/Home/issues/1680

//cc @deepakaravindr @joelverhagen @zhili1208 @yishaigalatzer 
