### PR TITLE
fixed NuGet.Config issue https://github.com/NuGet/Home/issues/2053

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/PackageSourceBuilder.cs
@@ -7,13 +7,7 @@ namespace NuGet
     {
         internal static Configuration.PackageSourceProvider CreateSourceProvider(Configuration.ISettings settings)
         {
-            var defaultPackageSource = new Configuration.PackageSource(
-                NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-            
-            var packageSourceProvider = new Configuration.PackageSourceProvider(
-                settings,
-                new[] { defaultPackageSource });
-            return packageSourceProvider;
+            return new Configuration.PackageSourceProvider(settings);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -19,5 +19,12 @@ namespace NuGet.Configuration
 
         
         public static readonly string FeedName = "nuget.org";
+
+        public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+  </packageSources>
+</configuration>";
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -155,7 +155,8 @@ namespace NuGet.Configuration
                 root,
                 configFileName,
                 machineWideSettings,
-                loadAppDataSettings: true);
+                loadAppDataSettings: true,
+                useTestingGlobalPath : false);
         }
 
         /// <summary>
@@ -165,7 +166,8 @@ namespace NuGet.Configuration
             string root,
             string configFileName,
             IMachineWideSettings machineWideSettings,
-            bool loadAppDataSettings)
+            bool loadAppDataSettings,
+            bool useTestingGlobalPath)
         {
             {
                 // Walk up the tree to find a config file; also look in .nuget subdirectories
@@ -183,7 +185,7 @@ namespace NuGet.Configuration
 
                 if (loadAppDataSettings)
                 {
-                    LoadUserSpecificSettings(validSettingFiles, root, configFileName, machineWideSettings);
+                    LoadUserSpecificSettings(validSettingFiles, root, configFileName, machineWideSettings, useTestingGlobalPath);
                 }
 
                 if (machineWideSettings != null)
@@ -224,7 +226,8 @@ namespace NuGet.Configuration
             List<Settings> validSettingFiles,
             string root,
             string configFileName,
-            IMachineWideSettings machineWideSettings
+            IMachineWideSettings machineWideSettings,
+            bool useTestingGlobalPath
             )
         {
             if (root == null)
@@ -238,8 +241,16 @@ namespace NuGet.Configuration
             Settings appDataSettings = null;
             if (configFileName == null)
             {
-                var userSettingsDir = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
-                var defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
+                var defaultSettingsFilePath = String.Empty;
+                if (useTestingGlobalPath)
+                {
+                    defaultSettingsFilePath = Path.Combine(root, "TestingGlobalPath");
+                }
+                else
+                {
+                    var userSettingsDir = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+                    defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
+                }
 
                 if (!File.Exists(defaultSettingsFilePath) && machineWideSettings != null)
                 {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -75,7 +75,7 @@ namespace NuGet.Configuration
             Root = root;
             FileName = fileName;
             XDocument config = null;
-            ExecuteSynchronized(() => config = XmlUtility.GetOrCreateDocument("configuration", ConfigFilePath));
+            ExecuteSynchronized(() => config = XmlUtility.GetOrCreateDocument(NuGetConstants.DefaultConfigContent, ConfigFilePath));
             ConfigXDocument = config;
             IsMachineWideSettings = isMachineWideSettings;
         }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
@@ -11,7 +11,7 @@ namespace NuGet.Configuration
 {
     internal static class XmlUtility
     {
-        internal static XDocument GetOrCreateDocument(XName rootName, string fullPath)
+        internal static XDocument GetOrCreateDocument(string content, string fullPath)
         {
             if (File.Exists(fullPath))
             {
@@ -21,15 +21,15 @@ namespace NuGet.Configuration
                 }
                 catch (FileNotFoundException)
                 {
-                    return CreateDocument(rootName, fullPath);
+                    return CreateDocument(content, fullPath);
                 }
             }
-            return CreateDocument(rootName, fullPath);
+            return CreateDocument(content, fullPath);
         }
 
-        private static XDocument CreateDocument(XName rootName, string fullPath)
+        private static XDocument CreateDocument(string content, string fullPath)
         {
-            var document = new XDocument(new XElement(rootName));
+            var document = XDocument.Parse(content);
             // Add it to the file system
             FileSystemUtility.AddFile(fullPath, document.Save);
             return document;

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/Repository.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/Repository.cs
@@ -48,34 +48,6 @@ namespace NuGet.Protocol.Core.Types
         }
 
         /// <summary>
-        /// Create a source provider for the given sources
-        /// </summary>
-        public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders, IEnumerable<string> sources)
-        {
-            return CreateProvider(resourceProviders, sources.Select(s => new PackageSource(s)));
-        }
-
-        /// <summary>
-        /// Create a source provider for the given sources and with the extra providers.
-        /// </summary>
-        public static ISourceRepositoryProvider CreateProvider(IEnumerable<INuGetResourceProvider> resourceProviders, IEnumerable<PackageSource> sources)
-        {
-            if (sources == null)
-            {
-                throw new ArgumentNullException("sources");
-            }
-
-            if (resourceProviders == null)
-            {
-                throw new ArgumentNullException("resourceProviders");
-            }
-
-            var sourceProvider = new PackageSourceProvider(NullSettings.Instance, sources, Enumerable.Empty<PackageSource>());
-
-            return new SourceRepositoryProvider(sourceProvider, CreateLazy(resourceProviders));
-        }
-
-        /// <summary>
         /// Create a SourceRepository
         /// </summary>
         public static SourceRepository CreateSource(IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders, string sourceUrl)

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/VSSourceRepositoryProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/VSSourceRepositoryProvider.cs
@@ -16,24 +16,7 @@ namespace NuGet.Protocol.VisualStudio
     [Export(typeof(ISourceRepositoryProvider))]
     public sealed class ExtensibleSourceRepositoryProvider : ISourceRepositoryProvider
     {
-        private static Configuration.PackageSource[] DefaultPrimarySources = new[]
-            {
-                new Configuration.PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName, isEnabled: true, isOfficial: true)
-                    {
-                        Description = Strings.v3sourceDescription,
-                        ProtocolVersion = 3
-                    }
-            };
-
-        private static Configuration.PackageSource[] DefaultSecondarySources = new[]
-            {
-                new Configuration.PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, isEnabled: true, isOfficial: true)
-                    {
-                        Description = Strings.v2sourceDescription,
-                        ProtocolVersion = 2
-                    }
-            };
-
+     
         // TODO: add support for reloading sources when changes occur
         private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
         private IEnumerable<Lazy<INuGetResourceProvider>> _resourceProviders;
@@ -51,7 +34,7 @@ namespace NuGet.Protocol.VisualStudio
         /// </summary>
         [ImportingConstructor]
         public ExtensibleSourceRepositoryProvider([ImportMany] IEnumerable<Lazy<INuGetResourceProvider>> resourceProviders, [Import] Configuration.ISettings settings)
-            : this(new Configuration.PackageSourceProvider(settings, DefaultPrimarySources, DefaultSecondarySources, migratePackageSources: null), resourceProviders)
+            : this(new Configuration.PackageSourceProvider(settings, migratePackageSources: null), resourceProviders)
         {
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1187,33 +1187,5 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(expectedPath), "nuget.exe installed Newtonsoft.Json.7.0.1");
             }
         }
-
-        [Fact]
-        public void TestInstallOnCleanMachine()
-        {
-            var nugetexe = Util.GetNuGetExePath();
-            using (var randomTestFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                string[] args = new string[]
-                {
-                        "install Newtonsoft.Json",
-                        "-version",
-                        "7.0.1"
-                };
-
-                var result = CommandRunner.Run(
-                    nugetexe,
-                    randomTestFolder,
-                    string.Join(" ", args),
-                    true);
-
-                var expectedPath = Path.Combine(
-                    randomTestFolder,
-                    "Newtonsoft.Json.7.0.1",
-                    "Newtonsoft.Json.7.0.1.nupkg");
-
-                Assert.True(File.Exists(expectedPath), "nuget.exe did not install Newtonsoft.Json.7.0.1");
-            }
-        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1156,6 +1156,7 @@ namespace NuGet.CommandLine.Test
             {
                 // Create an empty config file and pass it as -ConfigFile switch.
                 // This imitates the scenario where there is a machine without a default nuget.config under %APPDATA%
+                // In this case, nuget will not create default nuget.config for user.
                 var config = string.Format(
     @"<?xml version='1.0' encoding='utf - 8'?>
 <configuration/>
@@ -1170,6 +1171,34 @@ namespace NuGet.CommandLine.Test
                         "7.0.1",
                         "-ConfigFile",
                         configFileName
+                };
+
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    randomTestFolder,
+                    string.Join(" ", args),
+                    true);
+
+                var expectedPath = Path.Combine(
+                    randomTestFolder,
+                    "Newtonsoft.Json.7.0.1",
+                    "Newtonsoft.Json.7.0.1.nupkg");
+
+                Assert.False(File.Exists(expectedPath), "nuget.exe installed Newtonsoft.Json.7.0.1");
+            }
+        }
+
+        [Fact]
+        public void TestInstallOnCleanMachine()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            using (var randomTestFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                string[] args = new string[]
+                {
+                        "install Newtonsoft.Json",
+                        "-version",
+                        "7.0.1"
                 };
 
                 var result = CommandRunner.Run(

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1538,47 +1538,6 @@ EndProject";
         }
 
         [Fact]
-        public void RestoreCommand_OnCleanMachine()
-        {
-            var nugetexe = Util.GetNuGetExePath();
-            using (var randomTestFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var packagesConfigFileName = Path.Combine(randomTestFolder, "packages.config");
-                File.WriteAllText(
-                    packagesConfigFileName,
-@"<packages>
-  <package id=""Newtonsoft.Json"" version=""7.0.1"" targetFramework=""net45"" />
-</packages>");
-
-                string[] args
-                    = new string[]
-                    {
-                        "restore",
-                        "-PackagesDirectory",
-                        "."
-                    };
-
-                // Act
-                var path = Environment.GetEnvironmentVariable("PATH");
-                Environment.SetEnvironmentVariable("PATH", null);
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    randomTestFolder,
-                    string.Join(" ", args),
-                    waitForExit: true);
-                Environment.SetEnvironmentVariable("PATH", path);
-
-                // Assert
-                var expectedPath = Path.Combine(
-                    randomTestFolder,
-                    "Newtonsoft.Json.7.0.1",
-                    "Newtonsoft.Json.7.0.1.nupkg");
-
-                Assert.True(File.Exists(expectedPath));
-            }
-        }
-
-        [Fact]
         public void RestoreCommand_LegacySolutionLevelPackages_SolutionDirectory()
         {
             using (var randomRepositoryPath = TestFileSystemUtility.CreateRandomTestFolder())

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -317,7 +317,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -360,7 +361,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -408,7 +410,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -460,7 +463,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -511,7 +515,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -565,7 +570,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var packageSourceList = packageSourceProvider.LoadPackageSources().ToList();
@@ -625,7 +631,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var expectedDisabledSources = settings.GetSettingValues("disabledPackageSources")?.ToList();
 
@@ -638,7 +645,8 @@ namespace NuGet.Configuration.Test
                 var newSettings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var actualDisabledSources = newSettings.GetSettingValues("disabledPackageSources").ToList();
 
@@ -676,7 +684,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var disabledSources = settings.GetSettingValues("disabledPackageSources")?.ToList();
 
@@ -701,7 +710,8 @@ namespace NuGet.Configuration.Test
                 var newSettings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 // Main Assert
                 disabledSources = newSettings.GetSettingValues("disabledPackageSources")?.ToList();
@@ -1549,7 +1559,8 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, @"a\b\c"),
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var provider = CreatePackageSourceProvider(settings);
                 // Act
@@ -1588,7 +1599,8 @@ namespace NuGet.Configuration.Test
                     Path.Combine(mockBaseDirectory, "a", "b", "c"),
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var provider = CreatePackageSourceProvider(settings);
 
@@ -1620,7 +1632,8 @@ namespace NuGet.Configuration.Test
                     mockBaseDirectory,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
 
                 var provider = CreatePackageSourceProvider(settings);
 
@@ -1652,7 +1665,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                    configFileName: "NuGet.config",
                    machineWideSettings: null,
-                   loadAppDataSettings: true);
+                   loadAppDataSettings: true,
+                   useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
@@ -1699,7 +1713,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act - 1
@@ -1761,7 +1776,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act - 1
@@ -1835,7 +1851,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act - 1
@@ -1911,7 +1928,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act - 1
@@ -1985,7 +2003,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
-                    loadAppDataSettings: false);
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act - 1
@@ -2065,7 +2084,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                    configFileName: null,
                    machineWideSettings: m.Object,
-                   loadAppDataSettings: false);
+                   loadAppDataSettings: false,
+                   useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -2115,7 +2135,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                    configFileName: null,
                    machineWideSettings: m.Object,
-                   loadAppDataSettings: false);
+                   loadAppDataSettings: false,
+                   useTestingGlobalPath: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
@@ -2133,7 +2154,7 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact(Skip = "Test currently failing")]
+        [Fact]
         public void DisabledMachineWideSourceByDefault()
         {
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
@@ -2159,9 +2180,10 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                       configFileName: null,
                       machineWideSettings: m.Object,
-                      loadAppDataSettings: true);
+                      loadAppDataSettings: true,
+                      useTestingGlobalPath: true);
                 var packageSourceProvider = new PackageSourceProvider(settings);
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                var sources = packageSourceProvider.LoadPackageSources().Where(p => p.IsMachineWide).ToList();
 
                 // Assert
                 Assert.False(sources[0].IsEnabled);
@@ -2169,7 +2191,7 @@ namespace NuGet.Configuration.Test
             }
         }
 
-        [Fact(Skip = "Test currently failing")]
+        [Fact]
         public void DisabledMachineWideSourceByDefaultWithNull()
         {
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
@@ -2178,14 +2200,15 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
                                   machineWideSettings: null,
-                                  loadAppDataSettings: true);
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Assert
-                Assert.Equal(2, sources.Count);
+                Assert.Equal(1, sources.Count);
             }
         }
 
@@ -2207,7 +2230,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
                                   machineWideSettings: null,
-                                  loadAppDataSettings: false);
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
@@ -2237,7 +2261,8 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
                                   machineWideSettings: null,
-                                  loadAppDataSettings: false);
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2229,7 +2229,7 @@ namespace NuGet.Configuration.Test
 <configuration>
     <packageSources>
       <clear />
-      <add key=""test"" value=""C:\Temp\Nuget"" />
+      <add key=""test"" value=""https://nuget/test"" />
     </packageSources>
 </configuration>
 ";
@@ -2245,7 +2245,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(1, sources.Count);
-                Assert.Equal(@"C:\Temp\Nuget", sources[0].Source);
+                Assert.Equal(@"https://nuget/test", sources[0].Source);
                 Assert.Equal("test", sources[0].Name);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -17,292 +17,6 @@ namespace NuGet.Configuration.Test
     public class PackageSourceProviderTests
     {
         [Fact]
-        public void PrimarySourceIsAddedWhenNotPresent()
-        {
-            // Act
-            NullSettings settings = new NullSettings();
-            List<PackageSource> primary = new List<PackageSource>();
-            PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-            primary.Add(item);
-
-            List<PackageSource> secondary = new List<PackageSource>();
-            PackageSource item2 = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, false);
-            secondary.Add(item2);
-
-            PackageSourceProvider psp = new PackageSourceProvider(settings, primary, secondary);
-
-            // Act
-            var sources = psp.LoadPackageSources();
-
-            // Assert
-            //Primary IsEnabled = true, IsOfficial = true (Added for the first time)
-            var actual = Assert.Single(sources);
-            Assert.Equal(item.Name, actual.Name);
-            Assert.Equal(item.Source, actual.Source);
-            Assert.True(actual.IsEnabled);
-            Assert.True(actual.IsOfficial);
-        }
-
-        [Fact]
-        public void SecondarySourceIsPreferredOverPrimaryIfItHasAHigherProtocolVersion()
-        {
-            // Act
-            var settings = new NullSettings();
-            var primarySource = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-
-            var secondarySource = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName);
-            secondarySource.ProtocolVersion = 3;
-
-            var packageSourceProvider = new PackageSourceProvider(settings, new[] { primarySource }, new[] { secondarySource });
-
-            // Act
-            var sources = packageSourceProvider.LoadPackageSources();
-
-            // Assert
-            //Primary IsEnabled = true, IsOfficial = true (Added for the first time)
-            var actual = Assert.Single(sources);
-            Assert.Equal(secondarySource.Name, actual.Name);
-            Assert.Equal(secondarySource.Source, actual.Source);
-            Assert.True(actual.IsEnabled);
-            Assert.True(actual.IsOfficial);
-        }
-
-        [Fact]
-        public void WhenPrimarySourcesAreRepeatedWithTheSameProtocolVersion_FIrstSourceIsPicked()
-        {
-            // Act
-            var settings = new NullSettings();
-            var primarySource1 = new PackageSource("Source1", "FeedName");
-            var primarySource2 = new PackageSource("Source2", "FeedName");
-            var primarySource3 = new PackageSource("Source3", "FeedName")
-            {
-                ProtocolVersion = 3
-            };
-
-            var primarySource4 = new PackageSource("Source4", "FeedName")
-            {
-                ProtocolVersion = 3
-            };
-            var primarySources = new[]
-            {
-                primarySource1, primarySource2, primarySource3, primarySource4
-            };
-
-            var secondarySource = new PackageSource(NuGetConstants.V2FeedUrl, "FeedName");
-            secondarySource.ProtocolVersion = 3;
-
-            var packageSourceProvider = new PackageSourceProvider(settings, primarySources, new[] { secondarySource });
-
-            // Act
-            var sources = packageSourceProvider.LoadPackageSources();
-
-            // Assert
-            //Primary IsEnabled = true, IsOfficial = true (Added for the first time)
-            var actual = Assert.Single(sources);
-            Assert.Equal(primarySource3.Name, actual.Name);
-            Assert.Equal(primarySource3.Source, actual.Source);
-            Assert.True(actual.IsOfficial);
-        }
-
-        public void PrimaryURLIsForcedWhenPrimaryNameHasAnotherFeed()
-        {
-            // Act
-            //Create nuget.config that has Primary name used for a different feed
-            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.config");
-
-                var randomURL = "https://www.somerandomURL.com/";
-                var enabledReplacement = @"<add key='" + NuGetConstants.FeedName + "' value='" + randomURL + "' />";
-                var disabledReplacement = string.Empty;
-                File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement));
-
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.config");
-                PackageSourceProvider before = new PackageSourceProvider(settings);
-                VerifyPackageSource(before, 1, new string[] { NuGetConstants.FeedName },
-                    new string[] { randomURL },
-                    new bool[] { true }, new bool[] { false });
-
-                List<PackageSource> primary = new List<PackageSource>();
-                PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-                primary.Add(item);
-
-                PackageSourceProvider after = new PackageSourceProvider(settings, primary, null);
-
-                // Assert
-                //Primary Name already exists in nuget.config but with different URL
-                //It gets overwritten by primary package source (which is enabled above while creating it)
-                //IsEnabled = true, IsOfficial = true
-                VerifyPackageSource(after, 1, new string[] { NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V3FeedUrl },
-                    new bool[] { false }, new bool[] { true });
-
-            }
-        }
-
-        public void SecondaryURLIsForcedWhenSecondaryNameHasAnotherFeed()
-        {
-            // Act
-            //Create nuget.config that has Secondary name used for a different feed
-            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.config");
-
-                var randomURL = "https://www.somerandomURL.com/";
-                var enabledReplacement = @"<add key='" + NuGetConstants.FeedName + "' value='" + NuGetConstants.V3FeedUrl + "' />";
-                enabledReplacement = enabledReplacement + @"<add key='" + NuGetConstants.FeedName + "' value='" + randomURL + "' />";
-                var disabledReplacement = string.Empty;
-                File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement));
-
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.config");
-                PackageSourceProvider before = new PackageSourceProvider(settings);
-                VerifyPackageSource(before, 2, new string[] { NuGetConstants.FeedName, NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V3FeedUrl, randomURL },
-                    new bool[] { true, true }, new bool[] { false, false });
-
-                List<PackageSource> primary = new List<PackageSource>();
-                PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-                primary.Add(item);
-
-                List<PackageSource> secondary = new List<PackageSource>();
-                PackageSource item2 = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, false);
-                secondary.Add(item2);
-
-                PackageSourceProvider after = new PackageSourceProvider(settings, primary, secondary);
-                // Assert
-                //Seconday name already exists in nuget.config but with different URL
-                //It gets overwritten by secondary scource which is disabled (while getting created above)
-                //IsOfficial is set to true
-                VerifyPackageSource(after, 2, new string[] { NuGetConstants.FeedName, NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V3FeedUrl, NuGetConstants.V2FeedUrl },
-                    new bool[] { true, false }, new bool[] { true, true });
-
-            }
-        }
-
-        [Fact]
-        public void PrimaryNameNotChangedWhenTheFeedHasAnotherName()
-        {
-            // Act
-            //Create nuget.config that has Primary defined (Feed Name is different) and Secondary defined
-            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.config");
-
-                var enabledReplacement = @"<add key='anotherName' value='" + NuGetConstants.V3FeedUrl + "' />";
-                enabledReplacement = enabledReplacement + @"<add key='" + NuGetConstants.FeedName + "' value='" + NuGetConstants.V2FeedUrl + "' />";
-                var disabledReplacement = string.Empty;
-                File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement));
-
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.config");
-                PackageSourceProvider before = new PackageSourceProvider(settings);
-                VerifyPackageSource(before, 2, new string[] { "anotherName", NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V3FeedUrl, NuGetConstants.V2FeedUrl },
-                    new bool[] { true, true }, new bool[] { false, false });
-
-                List<PackageSource> primary = new List<PackageSource>();
-                PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-                primary.Add(item);
-
-                List<PackageSource> secondary = new List<PackageSource>();
-                PackageSource item2 = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, false);
-                secondary.Add(item2);
-
-                PackageSourceProvider after = new PackageSourceProvider(settings, primary, secondary);
-
-                // Assert
-                //Primary feed is present in nuget.config but with a different name
-                //In this case, we don't set IsOfficial = true
-                //Secondary matches both name and URL so secondary is set to true
-                //Since this is not the first time primary is getting added, we aren't aggressive in demoting secondary from enabled to disabled
-                VerifyPackageSource(after, 2, new string[] { "anotherName", NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V3FeedUrl, NuGetConstants.V2FeedUrl },
-                    new bool[] { true, true }, new bool[] { false, true });
-
-            }
-        }
-
-        [Fact]
-        public void SecondaryNameNotChangedWhenTheFeedHasAnotherName()
-        {
-            // Act
-            //Create nuget.config that has Primary defined and Secondary missing
-            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.config");
-
-                var enabledReplacement = @"<add key='" + NuGetConstants.FeedName + "' value='" + NuGetConstants.V3FeedUrl + "' />";
-                enabledReplacement = enabledReplacement + @"<add key='anotherName' value='" + NuGetConstants.V2FeedUrl + "' />";
-                var disabledReplacement = string.Empty;
-                File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement));
-
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.config");
-                PackageSourceProvider before = new PackageSourceProvider(settings);
-                VerifyPackageSource(before, 2, new string[] { NuGetConstants.FeedName, "anotherName" },
-                    new string[] { NuGetConstants.V3FeedUrl, NuGetConstants.V2FeedUrl },
-                    new bool[] { true, true }, new bool[] { false, false });
-
-                List<PackageSource> primary = new List<PackageSource>();
-                PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-                primary.Add(item);
-
-                List<PackageSource> secondary = new List<PackageSource>();
-                PackageSource item2 = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, false);
-                secondary.Add(item2);
-
-                PackageSourceProvider after = new PackageSourceProvider(settings, primary, secondary);
-
-                // Assert
-                //Secondary feed is present in nuget.config but with a different name
-                //In this case, we don't set IsOfficial = true
-                //Primary matches both name and URL so primary's IsOfficial is set to true
-                //Since this is not the first time primary is getting added, we aren't aggressive in demoting secondary from enabled to disabled
-                VerifyPackageSource(after, 2, new string[] { NuGetConstants.FeedName, "anotherName" },
-                    new string[] { NuGetConstants.V3FeedUrl, NuGetConstants.V2FeedUrl },
-                    new bool[] { true, true }, new bool[] { true, false });
-
-            }
-        }
-
-        public void PrimaryIsEnabledAndSecondaryIsDisabledWhenPrimaryIsAddedForTheFirstTimeAndSecondaryAlreadyExists()
-        {
-            // Act
-            //Create nuget.config that has Secondary defined
-            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, "nuget.Config");
-
-                var enabledReplacement = @"<add key='" + NuGetConstants.FeedName + "' value='" + NuGetConstants.V2FeedUrl + "' />";
-                var disabledReplacement = string.Empty;
-                File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement));
-
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.config");
-                PackageSourceProvider before = new PackageSourceProvider(settings);
-                VerifyPackageSource(before, 1, new string[] { NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V2FeedUrl },
-                    new bool[] { true }, new bool[] { false });
-
-                List<PackageSource> primary = new List<PackageSource>();
-                PackageSource item = new PackageSource(NuGetConstants.V3FeedUrl, NuGetConstants.FeedName);
-                primary.Add(item);
-
-                List<PackageSource> secondary = new List<PackageSource>();
-                PackageSource item2 = new PackageSource(NuGetConstants.V2FeedUrl, NuGetConstants.FeedName, false);
-                secondary.Add(item2);
-
-                PackageSourceProvider after = new PackageSourceProvider(settings, primary, secondary);
-
-                // Assert
-                //First time Primary is getting added so it is set to Enabled
-                //Secondary is demoted to disabled even though it is already enabled through nuget.config
-                VerifyPackageSource(after, 2, new string[] { NuGetConstants.FeedName, NuGetConstants.FeedName },
-                    new string[] { NuGetConstants.V2FeedUrl, NuGetConstants.V3FeedUrl },
-                    new bool[] { false, true }, new bool[] { true, true });
-
-            }
-        }
-
-        [Fact]
         public void ActivePackageSourceCanBeReadAndWrittenInNuGetConfig()
         {
             // Act
@@ -465,86 +179,17 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public void LoadPackageSourcesReturnsEmptySequenceIfDefaultPrimaryPackageSourceIsNull()
+        public void LoadPackageSourcesReturnsEmptySequence()
         {
             // Arrange
             var settings = new Mock<ISettings>();
-            var provider = CreatePackageSourceProvider(settings.Object, providerDefaultPrimarySources: null);
+            var provider = CreatePackageSourceProvider(settings.Object);
 
             // Act
             var values = provider.LoadPackageSources();
 
             // Assert
             Assert.False(values.Any());
-        }
-
-        [Fact]
-        public void LoadPackageSourcesReturnsEmptySequenceIfDefaultPackageSourceIsEmpty()
-        {
-            // Arrange
-            var settings = new Mock<ISettings>();
-            var provider = CreatePackageSourceProvider(settings.Object, providerDefaultPrimarySources: new PackageSource[] { });
-
-            // Act
-            var values = provider.LoadPackageSources();
-
-            // Assert
-            Assert.False(values.Any());
-        }
-
-        [Fact]
-        public void LoadPackageSourcesReturnsDefaultSourcesIfSpecified()
-        {
-            // Arrange
-            var settings = new Mock<ISettings>().Object;
-            var provider = CreatePackageSourceProvider(settings, providerDefaultPrimarySources: new[] { new PackageSource("A"), new PackageSource("B") });
-
-            // Act
-            var values = provider.LoadPackageSources().ToList();
-
-            // Assert
-            Assert.Equal(2, values.Count);
-            Assert.Equal("A", values.First().Source);
-            Assert.Equal("B", values.Last().Source);
-        }
-
-        [Fact]
-        public void LoadPackageSourcesWhereAMigratedSourceIsAlsoADefaultSource()
-        {
-            // Arrange
-            var settings = new Mock<ISettings>();
-            settings.Setup(s => s.GetSettingValues("packageSources", true))
-                .Returns(new[] { new SettingValue("AOld", "urlA", false), new SettingValue("userDefinedSource", "userDefinedSourceUrl", false) });
-            settings.Setup(s => s.GetSettingValues("disabledPackageSources", false)).Returns(new SettingValue[0]);
-            settings.Setup(s => s.GetNestedValues("packageSourceCredentials", It.IsAny<string>())).Returns(new KeyValuePair<string, string>[0]);
-
-            var defaultPackageSourceA = new PackageSource("urlA", "ANew");
-            var defaultPackageSourceB = new PackageSource("urlB", "B");
-
-            var provider = CreatePackageSourceProvider(settings.Object, providerDefaultPrimarySources: new[] { defaultPackageSourceA, defaultPackageSourceB },
-                migratePackageSources: new Dictionary<PackageSource, PackageSource>
-                    {
-                        { new PackageSource("urlA", "AOld"), defaultPackageSourceA },
-                    });
-
-            // Act
-            var values = provider.LoadPackageSources().ToList();
-
-            // Assert
-            // Package Source AOld will be migrated to ANew. B will simply get added
-            // Since default source B got added when there are other package sources it will be disabled
-            // However, package source ANew must stay enabled
-            // PackageSource userDefinedSource is a user package source and is untouched
-            Assert.Equal(3, values.Count);
-            Assert.Equal("urlA", values[0].Source);
-            Assert.Equal("ANew", values[0].Name);
-            Assert.True(values[0].IsEnabled);
-            Assert.Equal("userDefinedSourceUrl", values[1].Source);
-            Assert.Equal("userDefinedSource", values[1].Name);
-            Assert.True(values[1].IsEnabled);
-            Assert.Equal("urlB", values[2].Source);
-            Assert.Equal("B", values[2].Name);
-            Assert.False(values[2].IsEnabled);
         }
 
         [Fact]
@@ -571,8 +216,6 @@ namespace NuGet.Configuration.Test
                 .Verifiable();
 
             var provider = CreatePackageSourceProvider(settings.Object,
-                null,
-                null,
                 new Dictionary<PackageSource, PackageSource>
                     {
                         { new PackageSource("onesource", "one"), new PackageSource("goodsource", "good") },
@@ -1233,8 +876,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetNestedValues("packageSourceCredentials", It.IsAny<string>())).Returns(new KeyValuePair<string, string>[0]);
             settings.Setup(s => s.GetSettingValues("disabledPackageSources", false)).Returns(new SettingValue[0]);
 
-            var provider = CreatePackageSourceProvider(settings.Object, providerDefaultPrimarySources: null,
-                providerDefaultSecondarySources: null,
+            var provider = CreatePackageSourceProvider(settings.Object, 
                 migratePackageSources: new Dictionary<PackageSource, PackageSource>
                     {
                         { new PackageSource("https://nuget.org/api/v2", "NuGet official package source"), new PackageSource("https://www.nuget.org/api/v2", "nuget.org") }
@@ -1285,8 +927,6 @@ namespace NuGet.Configuration.Test
                     });
 
             var provider = CreatePackageSourceProvider(settings.Object,
-                providerDefaultPrimarySources: null,
-                providerDefaultSecondarySources: null,
                 migratePackageSources: null);
 
             // Act
@@ -1388,8 +1028,6 @@ namespace NuGet.Configuration.Test
                 };
 
             var provider = CreatePackageSourceProvider(settings.Object,
-                providerDefaultPrimarySources: null,
-                providerDefaultSecondarySources: null,
                 migratePackageSources: migratePackageSources);
 
             // Act
@@ -1446,8 +1084,7 @@ namespace NuGet.Configuration.Test
                 .Callback((string section, IReadOnlyList<SettingValue> settingValues) => { Assert.Empty(settingValues); })
                 .Verifiable();
 
-            var provider = CreatePackageSourceProvider(settings.Object, providerDefaultPrimarySources: null,
-                providerDefaultSecondarySources: null,
+            var provider = CreatePackageSourceProvider(settings.Object,
                 migratePackageSources: new Dictionary<PackageSource, PackageSource>
                     {
                         { new PackageSource("https://nuget.org/api/v2", "NuGet official package source"), new PackageSource("https://www.nuget.org/api/v2", "nuget.org") }
@@ -2552,6 +2189,67 @@ namespace NuGet.Configuration.Test
             }
         }
 
+        [Fact]
+        public void LoadPackageSourceEmptyConfigFileOnUserMachine()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <clear />
+    </packageSources>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "nuget.config"), configContents);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(0, sources.Count);
+            }
+        }
+
+        [Fact]
+        public void LoadPackageSourceLocalConfigFileOnUserMachine()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <clear />
+      <add key=""test"" value=""C:\Temp\Nuget"" />
+    </packageSources>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "nuget.config"), configContents);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(1, sources.Count);
+                Assert.Equal(@"C:\Temp\Nuget", sources[0].Source);
+                Assert.Equal("test", sources[0].Name);
+            }
+        }
+
         private string CreateNuGetConfigContent(string enabledReplacement = "", string disabledReplacement = "", string activeSourceReplacement = "")
         {
             var nugetConfigBaseString = new StringBuilder();
@@ -2598,13 +2296,11 @@ namespace NuGet.Configuration.Test
 
         private IPackageSourceProvider CreatePackageSourceProvider(
             ISettings settings = null,
-            IEnumerable<PackageSource> providerDefaultPrimarySources = null,
-            IEnumerable<PackageSource> providerDefaultSecondarySources = null,
             IDictionary<PackageSource, PackageSource> migratePackageSources = null
             )
         {
             settings = settings ?? new Mock<ISettings>().Object;
-            return new PackageSourceProvider(settings, providerDefaultPrimarySources, providerDefaultSecondarySources, migratePackageSources);
+            return new PackageSourceProvider(settings, migratePackageSources);
         }
 
         private void AssertPackageSource(PackageSource ps, string name, string source, bool isEnabled, bool isMachineWide = false, bool isOfficial = false)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2207,7 +2207,7 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
                                   machineWideSettings: null,
-                                  loadAppDataSettings: true);
+                                  loadAppDataSettings: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
@@ -2237,7 +2237,7 @@ namespace NuGet.Configuration.Test
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
                                   machineWideSettings: null,
-                                  loadAppDataSettings: true);
+                                  loadAppDataSettings: false);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2153,6 +2153,26 @@ namespace NuGet.Configuration.Test
             Assert.Equal(expectedPath, globalPackagesFolderPath);
         }
 
+        [Fact]
+        public void CreateNewConfigFileIfNoConfig()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Act
+                Settings settings = new Settings(mockBaseDirectory);
+
+                // Assert
+                var text = File.ReadAllText(Path.Combine(mockBaseDirectory, "NuGet.Config")).Replace("\r\n", "\n");
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+  </packageSources>
+</configuration>".Replace("\r\n","\n");
+        Assert.Equal(result, text);
+            }
+        }
+
         private void AssertEqualCollections(IList<SettingValue> actual, string[] expected)
         {
             Assert.Equal(actual.Count, expected.Length / 2);


### PR DESCRIPTION
fixed https://github.com/NuGet/Home/issues/2053
In this fix, removed all primary and secondary source things.

the current behavior will be, if there is no nuget.config in %appdata%, nuget will create one which contains v3 source in %appdata%. otherwise, nuget will just read existing nuget.config, will not add nuget.org source to user's nuget.config file.
