### PR TITLE
Apply SuppressParent: all to Type: build dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -226,6 +226,14 @@ namespace NuGet.ProjectModel
                         if (TryGetStringEnumerable(dependencyValue["type"], out strings))
                         {
                             dependencyTypeValue = LibraryDependencyType.Parse(strings);
+
+                            // Types are used at pack time, they should be translated to suppressParent to 
+                            // provide a matching effect for project to project references.
+                            // This should be set before suppressParent is checked.
+                            if (!dependencyTypeValue.Contains(LibraryDependencyTypeFlag.BecomesNupkgDependency))
+                            {
+                                suppressParentFlagsValue = LibraryIncludeFlags.All;
+                            }
                         }
 
                         if (TryGetStringEnumerable(dependencyValue["include"], out strings))
@@ -240,6 +248,7 @@ namespace NuGet.ProjectModel
 
                         if (TryGetStringEnumerable(dependencyValue["suppressParent"], out strings))
                         {
+                            // This overrides any settings that came from the type property.
                             suppressParentFlagsValue = LibraryIncludeFlagUtils.GetFlags(strings);
                         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -940,6 +940,52 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task IncludeType_ProjectToProjectReferenceWithBuildTypeDependencyApplied()
+        {
+            // Restore Project1
+            // Project2 has only build dependencies
+            // Project1 -> Project2 -(suppress: all)-> packageX -> packageY -> packageB
+
+            // Arrange
+            var logger = new TestLogger();
+            var framework = "net46";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configJson2 = @"{
+                    ""dependencies"": {
+                        ""packageX"": {
+                            ""version"": ""1.0.0"",
+                            ""type"": ""build""
+                        }
+                    },
+                    ""frameworks"": {
+                    ""net46"": {}
+                    }
+                }";
+
+                var configJson1 = @"{
+                    ""dependencies"": {
+                    },
+                    ""frameworks"": {
+                    ""net46"": {}
+                    }
+                }";
+
+                var result = await ProjectToProjectSetup(workingDir, logger, configJson1, configJson2);
+
+                var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
+
+                // Assert
+                Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
+                Assert.Equal(0, logger.Errors);
+                Assert.Equal(0, logger.Warnings);
+                Assert.Equal(0, target.Libraries.Where(lib => lib.Type == LibraryTypes.Package).Count());
+                Assert.Equal(0, result.LockFile.Libraries.Where(lib => lib.Type == LibraryTypes.Package).Count());
+            }
+        }
+
+        [Fact]
         public async Task IncludeType_ProjectIncludesOnlyCompile()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
@@ -7,6 +7,78 @@ namespace NuGet.ProjectModel.Test
     public class IncludeFlagTests
     {
         [Fact]
+        public void IncludeFlag_ConvertFromTypeOverride()
+        {
+            // Arrange
+            var json = @"{
+                          ""dependencies"": {
+                                ""packageA"": {
+                                    ""version"": ""1.0.0"",
+                                    ""type"": ""build"",
+                                    ""suppressParent"": ""none""
+                                }
+                            },
+                            ""frameworks"": {
+                                ""net46"": {}
+                            }
+                        }";
+
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var dependency = spec.Dependencies.Single();
+
+            // Assert
+            Assert.Equal(LibraryIncludeFlags.None, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void IncludeFlag_ConvertFromTypeDefault()
+        {
+            // Arrange
+            var json = @"{
+                          ""dependencies"": {
+                                ""packageA"": {
+                                    ""version"": ""1.0.0""
+                                }
+                            },
+                            ""frameworks"": {
+                                ""net46"": {}
+                            }
+                        }";
+
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var dependency = spec.Dependencies.Single();
+
+            // Assert
+            Assert.Equal(LibraryIncludeFlagUtils.DefaultSuppressParent, dependency.SuppressParent);
+        }
+
+        [Fact]
+        public void IncludeFlag_ConvertFromTypeBuild()
+        {
+            // Arrange
+            var json = @"{
+                          ""dependencies"": {
+                                ""packageA"": {
+                                    ""version"": ""1.0.0"",
+                                    ""type"": ""build""
+                                }
+                            },
+                            ""frameworks"": {
+                                ""net46"": {}
+                            }
+                        }";
+
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var dependency = spec.Dependencies.Single();
+
+            // Assert
+            Assert.Equal(LibraryIncludeFlags.All, dependency.SuppressParent);
+        }
+
+        [Fact]
         public void IncludeFlag_UnknownFlagsParse()
         {
             // Arrange


### PR DESCRIPTION
This change applies suppressParent: all to dependencies with type: build. Type is a pack time flag used by DNX. For P2Ps in NuGet the suppressParent property handles this, and it should be set to match the existing DNX type behavior.

https://github.com/NuGet/Home/issues/1961

//cc @zhili1208 @joelverhagen @yishaigalatzer @davidfowl 
