### PR TITLE
Clean up --verbosity minimal logging

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -160,7 +160,7 @@ namespace NuGet.CommandLine
                 }
             }
 
-            RestoreSummary.Log(Console, restoreSummaries);
+            RestoreSummary.Log(Console, restoreSummaries, Verbosity != Verbosity.Quiet);
 
             if (restoreSummaries.Any(x => !x.Success))
             {
@@ -518,7 +518,7 @@ namespace NuGet.CommandLine
                 else if (File.Exists(Constants.PackageReferenceFile)) // look for packages.config file
                 {
                     var packagesConfigFileFullPath = Path.GetFullPath(Constants.PackageReferenceFile);
-                    if (Verbosity == NuGet.Verbosity.Detailed)
+                    if (Verbosity == Verbosity.Detailed)
                     {
                         Console.WriteLine(
                             LocalizedResourceManager.GetString(

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/CommandOutputLogger.cs
@@ -13,21 +13,11 @@ namespace NuGet.CommandLine.XPlat
     internal class CommandOutputLogger : ILogger
     {
         private static readonly bool _useConsoleColor = true;
-        private Lazy<LogLevel> _verbosity;
+        private readonly LogLevel _logLevel;
 
-        private LogLevel Verbosity { get { return _verbosity.Value; } }
-
-        internal CommandOutputLogger(CommandOption verbosity)
+        internal CommandOutputLogger(LogLevel logLevel)
         {
-            _verbosity = new Lazy<LogLevel>(() =>
-            {
-                LogLevel level;
-                if (!Enum.TryParse(value: verbosity.Value(), ignoreCase: true, result: out level))
-                {
-                    level = LogLevel.Information;
-                }
-                return level;
-            });
+            _logLevel = logLevel;
         }
 
         public void LogDebug(string data)
@@ -67,7 +57,7 @@ namespace NuGet.CommandLine.XPlat
 
         private void LogInternal(LogLevel logLevel, string message)
         {
-            if (logLevel < Verbosity)
+            if (logLevel < _logLevel)
             {
                 return;
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -222,7 +222,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Warning, Error..
+        ///    Looks up a localized string similar to The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, Error..
         /// </summary>
         internal static string Switch_Verbosity {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -172,7 +172,7 @@
     <value>Specifies a NuGet package source to use during the restore.</value>
   </data>
   <data name="Switch_Verbosity" xml:space="preserve">
-    <value>The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Warning, Error.</value>
+    <value>The verbosity of logging to use. Allowed values: Debug, Verbose, Information, Minimal, Warning, Error.</value>
     <comment>The allowed values should not be localized as they are Enum variants</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreSummary.cs
@@ -72,7 +72,7 @@ namespace NuGet.Commands
             Errors = errors.ToArray();
         }
 
-        public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries)
+        public static void Log(ILogger logger, IEnumerable<RestoreSummary> restoreSummaries, bool showInformation)
         {
             if (!restoreSummaries.Any())
             {
@@ -98,47 +98,50 @@ namespace NuGet.Commands
                 }
             }
 
-            // Display the information summary
-            var configFiles = restoreSummaries
-                .SelectMany(summary => summary.ConfigFiles)
-                .Distinct();
-
-            if (configFiles.Any())
+            if (showInformation)
             {
-                logger.LogSummary(string.Empty);
-                logger.LogSummary(Strings.Log_ConfigFileSummary);
-                foreach (var configFile in configFiles)
+                // Display the information summary
+                var configFiles = restoreSummaries
+                    .SelectMany(summary => summary.ConfigFiles)
+                    .Distinct();
+
+                if (configFiles.Any())
                 {
-                    logger.LogSummary($"    {configFile}");
+                    logger.LogSummary(string.Empty);
+                    logger.LogSummary(Strings.Log_ConfigFileSummary);
+                    foreach (var configFile in configFiles)
+                    {
+                        logger.LogSummary($"    {configFile}");
+                    }
                 }
-            }
 
-            var feedsUsed = restoreSummaries
-                .SelectMany(summary => summary.FeedsUsed)
-                .Distinct();
+                var feedsUsed = restoreSummaries
+                    .SelectMany(summary => summary.FeedsUsed)
+                    .Distinct();
 
-            if (feedsUsed.Any())
-            {
-                logger.LogSummary(string.Empty);
-                logger.LogSummary(Strings.Log_FeedsUsedSummary);
-                foreach (var feedUsed in feedsUsed)
+                if (feedsUsed.Any())
                 {
-                    logger.LogSummary($"    {feedUsed}");
+                    logger.LogSummary(string.Empty);
+                    logger.LogSummary(Strings.Log_FeedsUsedSummary);
+                    foreach (var feedUsed in feedsUsed)
+                    {
+                        logger.LogSummary($"    {feedUsed}");
+                    }
                 }
-            }
 
-            var installed = restoreSummaries
-                .GroupBy(summary => summary.InputPath, summary => summary.InstallCount)
-                .Select(group => new KeyValuePair<string, int>(group.Key, group.Sum()))
-                .Where(pair => pair.Value > 0);
+                var installed = restoreSummaries
+                    .GroupBy(summary => summary.InputPath, summary => summary.InstallCount)
+                    .Select(group => new KeyValuePair<string, int>(group.Key, group.Sum()))
+                    .Where(pair => pair.Value > 0);
 
-            if (installed.Any())
-            {
-                logger.LogSummary(string.Empty);
-                logger.LogSummary(Strings.Log_InstalledSummary);
-                foreach (var pair in installed)
+                if (installed.Any())
                 {
-                    logger.LogSummary("    " + Strings.FormatLog_InstalledSummaryCount(pair.Value, pair.Key));
+                    logger.LogSummary(string.Empty);
+                    logger.LogSummary(Strings.Log_InstalledSummary);
+                    foreach (var pair in installed)
+                    {
+                        logger.LogSummary("    " + Strings.FormatLog_InstalledSummaryCount(pair.Value, pair.Key));
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. Move the `Committing restore...` to Information level (not Minimal).
2. Do not show information summary at `Minimal` level (that is, config files used, feeds used, and install counts).
3. Add `Minimal` to the `--verbosity` help text.

This is responding to https://github.com/NuGet/Home/issues/2069.

@emgarten @zhili1208 @deepakaravindr 
