### PR TITLE
Fixes https://github.com/NuGet/Home/issues/2080

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
@@ -52,10 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var guids = VsHierarchyUtility.GetProjectTypeGuids(envDTEProject);
             if (guids.Contains(NuGetVSConstants.CppProjectTypeGuid)) // Got a cpp project
             {
-                if (!EnvDTEProjectUtility.IsClr(envDTEProject))
-                {
-                    return new NativeProjectSystem(envDTEProject, nuGetProjectContext);
-                }
+                return new NativeProjectSystem(envDTEProject, nuGetProjectContext);
             }
 
             // Try to get a factory for the project type guid

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1235,26 +1235,8 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 
-            return envDTEProject != null && NuGetVSConstants.CppProjectTypeGuid.Equals(envDTEProject.Kind, StringComparison.OrdinalIgnoreCase) && !IsClr(envDTEProject);
-        }
-
-        /// <summary>
-        /// Checks if a native project type really is a managed project, by checking the CLRSupport item.
-        /// </summary>
-        internal static bool IsClr(EnvDTEProject envDTEProject)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            bool isClr = false;
-
-            // always return false here until we fix clr support issue
-            // Null properties on the DTE project item are a common source of bugs, make sure everything is non-null before attempting this check.    
-            if (envDTEProject != null
-                && envDTEProject.FullName != null)
-            {
-                new VcxProject(envDTEProject.FullName);
-            }
-            return isClr;
+            return envDTEProject != null
+                && NuGetVSConstants.CppProjectTypeGuid.Equals(envDTEProject.Kind, StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsWebProject(EnvDTEProject envDTEProject)


### PR DESCRIPTION
IsClr method which tries to determine if a C++ project is a managed C++ project
always returns false. Removing the method and its uses.

Actual investigation to handle managed C++ projects differently is tracked by
https://github.com/NuGet/Home/issues/2090

@yishaigalatzer @emgarten
