### PR TITLE
Remove build dependencies from lock file target entries

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand.cs
@@ -750,10 +750,13 @@ namespace NuGet.Commands
 
                             // Find all dependencies which would be in the nuspec
                             // Include dependencies with no constraints, or package/project/external
+                            // Exclude suppressed dependencies, the top level project is not written 
+                            // as a target so the node depth does not matter.
                             Dependencies = graphItem.Data.Dependencies
                                 .Where(
                                     d => (d.LibraryRange.TypeConstraintAllowsAnyOf(
-                                        LibraryDependencyTarget.PackageProjectExternal)))
+                                        LibraryDependencyTarget.PackageProjectExternal))
+                                        && d.SuppressParent != LibraryIncludeFlags.All)
                                 .Select(d => GetDependencyVersionRange(d))
                                 .ToList()
                         };


### PR DESCRIPTION
This change removes dependency entries that have type: build or suppressParent: all from the lock file. Since these dependencies are only valid for the top level project, and the top level project is not written into the target graph all nodes with suppressParent set to All can be safely filtered out.

These dependency entries in the lock file are not used by NuGet or MSBuild, but they are used by the project model and should match the libraries actually resolved so that suppressed dependencies are not considered as unresolved.

//cc @davidfowl @zhili1208 @yishaigalatzer 
