### PR TITLE
Floating versions should not force an on build restore

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -427,7 +427,7 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredWithFloatingVersion()
+        public async Task BuildIntegratedRestoreUtility_IsRestoreNotRequiredWithFloatingVersion()
         {
             // Arrange
             var projectName = "testproj";
@@ -479,7 +479,7 @@ namespace NuGet.Test
                 var b = await BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver, context);
 
                 // Assert
-                Assert.True(b);
+                Assert.False(b);
             }
         }
 


### PR DESCRIPTION
Floating versions will no longer force a restore when building. Users can update floating versions by using the restore menu item or by running a rebuild. When this feature was first added the restore menu item did not exist. 

https://github.com/NuGet/Home/issues/2098

//cc @deepakaravindr @zhili1208 @joelverhagen @yishaigalatzer 
