### PR TITLE
And name resolution failure test and improve nuget.exe messages

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -70,7 +70,7 @@ namespace NuGet.CommandLine
             var console = new Common.Console();
             var fileSystem = new PhysicalFileSystem(workingDirectory);
 
-            Func<Exception, string> getErrorMessage = e => e.Message;
+            Func<Exception, string> getErrorMessage = ExceptionUtilities.DisplayMessage;
 
             try
             {
@@ -120,34 +120,20 @@ namespace NuGet.CommandLine
             }
             catch (AggregateException exception)
             {
-                string message;
                 Exception unwrappedEx = ExceptionUtility.Unwrap(exception);
-                if (unwrappedEx == exception)
-                {
-                    // If the AggregateException contains more than one InnerException, it cannot be unwrapped. In which case, simply print out individual error messages
-                    message = String.Join(Environment.NewLine, exception.InnerExceptions.Select(getErrorMessage)
-                                                                        .Distinct(StringComparer.CurrentCulture));
-                }
-                else if (unwrappedEx is TargetInvocationException)
-                {
-                    message = getErrorMessage(unwrappedEx.InnerException);
-                }
-                else if (unwrappedEx is ExitCodeException)
+                if (unwrappedEx is ExitCodeException)
                 {
                     // Return the exit code without writing out the exception type
                     var exitCodeEx = unwrappedEx as ExitCodeException;
                     return exitCodeEx.ExitCode;
                 }
-                else
-                {
-                    message = getErrorMessage(unwrappedEx);
-                }
-                console.WriteError(message);
+                
+                console.WriteError(getErrorMessage(exception));
                 return 1;
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                console.WriteError(getErrorMessage(ExceptionUtility.Unwrap(e)));
+                console.WriteError(getErrorMessage(exception));
                 return 1;
             }
             finally

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -316,7 +316,7 @@ namespace NuGet.DependencyResolver
             }
         }
 
-        public Task<GraphItem<RemoteResolveResult>> FindLibraryCached(
+        private Task<GraphItem<RemoteResolveResult>> FindLibraryCached(
             ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>> cache,
             LibraryRange libraryRange,
             NuGetFramework framework,
@@ -512,7 +512,7 @@ namespace NuGet.DependencyResolver
             }
         }
 
-        public Task<RemoteMatch> FindProjectMatch(
+        private Task<RemoteMatch> FindProjectMatch(
             LibraryRange libraryRange,
             NuGetFramework framework,
             GraphEdge<RemoteResolveResult> outerEdge,

--- a/src/NuGet.Core/NuGet.Test.Server/ITestServer.cs
+++ b/src/NuGet.Core/NuGet.Test.Server/ITestServer.cs
@@ -6,7 +6,8 @@ namespace NuGet.Test.Server
     public enum TestServerMode
     {
         ConnectFailure,
-        ServerProtocolViolation
+        ServerProtocolViolation,
+        NameResolutionFailure
     }
 
     public interface ITestServer

--- a/src/NuGet.Core/NuGet.Test.Server/UnknownDnsServer.cs
+++ b/src/NuGet.Core/NuGet.Test.Server/UnknownDnsServer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Test.Server
+{
+    public class UnknownDnsServer : ITestServer
+    {
+        public async Task<T> ExecuteAsync<T>(Func<string, Task<T>> action)
+        {
+            if (Mode != TestServerMode.NameResolutionFailure)
+            {
+                throw new InvalidOperationException($"The mode {Mode} is not supported by this server.");
+            }
+
+            var address = $"http://{Guid.NewGuid()}.org/index.json";
+            return await action(address);
+        }
+
+        public TestServerMode Mode { get; set; }
+    }
+}


### PR DESCRIPTION
1. Add test to make sure `HttpRetryHandler` is throwing the right exception on DNS failure.
2. Use `ExceptionUtilities.DisplayMessage` to handle an exception that has bubbled all the way out in nuget.exe (this now mimics Xplat).
3. Makes some method private that are only used by the class itself (unrelated minor cleanup to simplify public API surface area).

Related to https://github.com/NuGet/Home/issues/2057 and https://github.com/NuGet/Home/issues/1949.

@emgarten @johnataylor @zhili1208 @deepakaravindr 
