### PR TITLE
Lock file dependency version formatting fixes

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -121,6 +121,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Test.Server", "src\Nu
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Common.Test", "test\NuGet.Core.Tests\NuGet.Common.Test\NuGet.Common.Test.xproj", "{7FACD9D7-F70D-41C4-BE61-2753E018057D}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.LibraryModel.Tests", "test\NuGet.Core.Tests\NuGet.LibraryModel.Tests\NuGet.LibraryModel.Tests.xproj", "{D8E35E61-07AE-41D2-BB40-F3BDD8770A92}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -343,6 +345,10 @@ Global
 		{7FACD9D7-F70D-41C4-BE61-2753E018057D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7FACD9D7-F70D-41C4-BE61-2753E018057D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7FACD9D7-F70D-41C4-BE61-2753E018057D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8E35E61-07AE-41D2-BB40-F3BDD8770A92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8E35E61-07AE-41D2-BB40-F3BDD8770A92}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8E35E61-07AE-41D2-BB40-F3BDD8770A92}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8E35E61-07AE-41D2-BB40-F3BDD8770A92}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -401,5 +407,6 @@ Global
 		{95CCAF1D-B922-4DDF-A0B2-8570F5FA9BA8} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{DF85929B-6BB1-49F4-82B4-E29A0290C13E} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{7FACD9D7-F70D-41C4-BE61-2753E018057D} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{D8E35E61-07AE-41D2-BB40-F3BDD8770A92} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -52,31 +52,42 @@ namespace NuGet.LibraryModel
         {
             var sb = new StringBuilder();
             sb.Append(Name);
-            sb.Append(" ");
 
-            if (VersionRange == null)
+            if (VersionRange != null)
             {
-                return sb.ToString();
-            }
+                if (VersionRange.HasLowerBound || VersionRange.HasUpperBound)
+                {
+                    if (VersionRange.HasLowerBound)
+                    {
+                        sb.Append(" ");
 
-            var minVersion = VersionRange.MinVersion;
-            var maxVersion = VersionRange.MaxVersion;
+                        if (VersionRange.IsMinInclusive)
+                        {
+                            sb.Append(">= ");
+                        }
+                        else
+                        {
+                            sb.Append("> ");
+                        }
 
-            sb.Append(">= ");
+                        if (VersionRange.IsFloating)
+                        {
+                            sb.Append(VersionRange.Float.ToString());
+                        }
+                        else
+                        {
+                            sb.Append(VersionRange.MinVersion.ToNormalizedString());
+                        }
+                    }
 
-            if (VersionRange.IsFloating)
-            {
-                sb.Append(VersionRange.Float.ToString());
-            }
-            else
-            {
-                sb.Append(minVersion.ToString());
-            }
+                    if (VersionRange.HasUpperBound)
+                    {
+                        sb.Append(" ");
 
-            if (maxVersion != null)
-            {
-                sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
-                sb.Append(maxVersion.Version.ToString());
+                        sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
+                        sb.Append(VersionRange.MaxVersion.ToNormalizedString());
+                    }
+                }
             }
 
             return sb.ToString();

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
@@ -1,0 +1,31 @@
+﻿using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class LibraryRangeTests
+    {
+
+        [Theory]
+        [InlineData("1.0.0", "packageA >= 1.0.0")]
+        [InlineData("1.0.0-*", "packageA >= 1.0.0-*")]
+        [InlineData("[ , ]", "packageA")]
+        [InlineData("[ , 1.0.0 ]", "packageA <= 1.0.0")]
+        [InlineData("[ , 1.0.0 )", "packageA < 1.0.0")]
+        [InlineData("[1.0.0 , 2.0.0]", "packageA >= 1.0.0 <= 2.0.0")]
+        [InlineData("(1.0.0 , 2.0.0)", "packageA > 1.0.0 < 2.0.0")]
+        public void LibraryRange_ToLockFileDependencyGroupString(string versionRange, string expected)
+        {
+            // Arrange
+            LibraryRange range = new LibraryRange()
+            {
+                Name = "packageA",
+                VersionRange = VersionRange.Parse(versionRange),
+                TypeConstraint = LibraryDependencyTarget.Project
+            };
+
+            // Act and Assert
+            Assert.Equal(expected, range.ToLockFileDependencyGroupString());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.xproj
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/NuGet.LibraryModel.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d8e35e61-07ae-41d2-bb40-f3bdd8770a92</ProjectGuid>
+    <RootNamespace>NuGet.LibraryModel.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.LibraryModel.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NuGet.LibraryModel.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d8e35e61-07ae-41d2-bb40-f3bdd8770a92")]

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -1,0 +1,17 @@
+﻿{
+  "version": "3.4.0-*",
+  "dependencies": {
+    "NuGet.ProjectModel": "3.4.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
+  },
+  "commands": {
+    "test": "xunit.runner.dnx"
+  },
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {
+      "imports": [ "portable-net45+win8" ]
+    }
+  }
+}


### PR DESCRIPTION
Fixes around formatting version ranges into the pretty print format used in the lock file.

//cc @joelverhagen @deepakaravindr @zhili1208 
