### PR TITLE
Get-Package -Updates generating correct query

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
@@ -201,7 +201,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                var task = Task.Run<IPackageSearchMetadata>(async () =>
                {
-                   var results = await GetPackagesFromRemoteSourceAsync(installedPackage.PackageIdentity.Id, frameworks, IncludePrerelease.IsPresent, Skip, First);
+                   var searchTerm = string.Format("packageid:{0}", installedPackage.PackageIdentity.Id);
+                   var results = await GetPackagesFromRemoteSourceAsync(searchTerm, frameworks, IncludePrerelease.IsPresent, Skip, First);
                    var metadata = results.Where(p => string.Equals(p.Identity.Id, installedPackage.PackageIdentity.Id, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
 
                    if (metadata != null)


### PR DESCRIPTION
note this is a functionality issue not a performance bug.

I was leaving the linq based post query in the command code because it is harmless in the case of nuget.org which understands the packageid: syntax but might help keep other sources behaving reasonably
