### PR TITLE
File lock casing

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -95,7 +95,10 @@ namespace NuGet.Common
             // to a unique lock name.
             using (var sha = SHA1.Create())
             {
-                var hash = sha.ComputeHash(Encoding.UTF32.GetBytes(filePath));
+                // To avoid conflicts on package id casing a case-insensitive lock is used.
+                var normalizedPath = Path.GetFullPath(filePath).ToUpperInvariant();
+
+                var hash = sha.ComputeHash(Encoding.UTF32.GetBytes(normalizedPath));
 
                 return ToHex(hash);
             }

--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
@@ -24,38 +23,47 @@ namespace NuGet.Common
             }
 
             var lockPath = FileLockPath(filePath);
-            var bytes = Encoding.UTF8.GetBytes($"{ProcessId}{Environment.NewLine}{filePath}{Environment.NewLine}");
 
             while (true)
             {
                 FileStream fs = null;
-                try
-                {
-                    fs = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
-                }
-                catch (DirectoryNotFoundException)
-                {
-                    throw;
-                }
-                catch (IOException)
-                {
-                    token.ThrowIfCancellationRequested();
-
-                    await Task.Delay(10);
-                    continue;
-                }
 
                 try
                 {
-                    fs.Write(bytes, 0, bytes.Length);
-                }
-                catch
-                {
-                }
+                    try
+                    {
+                        // This file is deleted when the stream is closed.
+                        // Sync operations have shown much better performance than FileOptions.Asynchronous
+                        fs = new FileStream(
+                            lockPath,
+                            FileMode.OpenOrCreate,
+                            FileAccess.ReadWrite,
+                            FileShare.None,
+                            bufferSize: 32,
+                            options: FileOptions.DeleteOnClose);
+                    }
+                    catch (DirectoryNotFoundException)
+                    {
+                        throw;
+                    }
+                    catch (IOException)
+                    {
+                        token.ThrowIfCancellationRequested();
 
-                using (fs)
-                {
+                        await Task.Delay(10);
+                        continue;
+                    }
+
+                    // Run the action within the lock
                     return await action(token);
+                }
+                finally
+                {
+                    if (fs != null)
+                    {
+                        // Dispose of the stream, this will cause a delete
+                        fs.Dispose();
+                    }
                 }
             }
         }
@@ -127,20 +135,6 @@ namespace NuGet.Common
             else
             {
                 return (char)(input + 0x30);
-            }
-        }
-
-        private static int _processId = -1;
-        private static int ProcessId
-        {
-            get
-            {
-                if (_processId < 0)
-                {
-                    _processId = Process.GetCurrentProcess().Id;
-                }
-
-                return _processId;
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class ConcurrencyUtilitiesTests
+    {
+
+        [Fact]
+        public async Task ConcurrencyUtilities_LockAllCasings()
+        {
+            // Arrange
+            var token = CancellationToken.None;
+            var path1 = "/tmp/packageA/1.0.0";
+            var path2 = "/tmp/packagea/1.0.0";
+            var action1HitSem = new ManualResetEventSlim();
+            var action1Sem = new ManualResetEventSlim();
+            var action2Sem = new ManualResetEventSlim();
+
+            Func<CancellationToken, Task<bool>> action1 = (ct) => {
+                action1HitSem.Set();
+                action1Sem.Wait();
+                return Task.FromResult(true);
+            };
+
+            Func<CancellationToken, Task<bool>> action2 = (ct) =>
+            {
+                action2Sem.Set();
+                return Task.FromResult(true);
+            };
+
+            // Act
+            var task1 = Task.Run(async () => await ConcurrencyUtilities.ExecuteWithFileLockedAsync<bool>(
+                path1,
+                action1,
+                token));
+
+            var task2Started = action1HitSem.Wait(60 * 1000 * 5, token);
+            Assert.True(task2Started);
+
+            var task2 = Task.Run(async () => await ConcurrencyUtilities.ExecuteWithFileLockedAsync<bool>(
+                path2,
+                action2,
+                token));
+
+            // Wait 1s to verify that task2 has not started
+            await Task.Delay(1000);
+
+            var task2blocked = !action2Sem.IsSet;
+            action1Sem.Set();
+
+            await task1;
+            var result = await task2;
+
+            // Assert
+            Assert.True(task2blocked);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task ConcurrencyUtilities_NormalizePaths()
+        {
+            // Arrange
+            var token = CancellationToken.None;
+            var path1 = "/tmp/packageA/1.0.0";
+            var path2 = "/tmp/sub/../packageA/1.0.0";
+            var action1HitSem = new ManualResetEventSlim();
+            var action1Sem = new ManualResetEventSlim();
+            var action2Sem = new ManualResetEventSlim();
+
+            Func<CancellationToken, Task<bool>> action1 = (ct) => {
+                action1HitSem.Set();
+                action1Sem.Wait();
+                return Task.FromResult(true);
+            };
+
+            Func<CancellationToken, Task<bool>> action2 = (ct) =>
+            {
+                action2Sem.Set();
+                return Task.FromResult(true);
+            };
+
+            // Act
+            var task1 = Task.Run(async () => await ConcurrencyUtilities.ExecuteWithFileLockedAsync<bool>(
+                path1,
+                action1,
+                token));
+
+            var task2Started = action1HitSem.Wait(60 * 1000 * 5, token);
+            Assert.True(task2Started);
+
+            var task2 = Task.Run(async () => await ConcurrencyUtilities.ExecuteWithFileLockedAsync<bool>(
+                path2,
+                action2,
+                token));
+
+            // Wait 1s to verify that task2 has not started
+            await Task.Delay(1000);
+
+            var task2blocked = !action2Sem.IsSet;
+            action1Sem.Set();
+
+            await task1;
+            var result = await task2;
+
+            // Assert
+            Assert.True(task2blocked);
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
This change makes file locks case-insensitive. On case-insensitive file systems this may be less efficient for extreme cases where files are being locked in folders that purposely have different cases, but for NuGet's purposes this should be done case insensitively so that locking can be done for all package ids regardless of case, and the correct case determined after the download when the nuspec is available.

Also in this change is a fix to enable delete on close for file locks. Previously this change had caused a performance regression. I've narrowed the cause of that down to async and flushing the file contents. Sync calls for the file lock gives slightly better perf than with async turned on. Writing to the file lock and flushing it to disk causes a major slow down. Previously the process id was written to the file but not actually flushed to disk which made it difficult to use, since flushing cannot occur I've removed all of this.

On windows writing out diagnostic info to the lock file and flushing to disk takes 100x longer than writing without flushing.
### Flush perf

| Write, flush=false (3000x) | Write, flush=true (3000x) |
| --- | --- |
| 00:00:01.7420411 | 00:03:18.3661697 |
### Lock perf

Ubuntu and OSX perf is better when the file already exists and was not cleaned up. Windows on the other hand is slower. Overall cleaning up temp lock files gives a more consistent experience across all platforms.
#### Windows lock perf

| Test (3000x) | Lock | Time |
| --- | --- | --- |
| Lock on same file | Current dev branch | 00:00:01.5977811 |
| Lock on unique file | Current dev branch | 00:00:07.7445677 |
| Lock on same file | dev + delete on close only | 00:00:00.8687587 |
| Lock on unique file | dev + delete on close only | 00:00:00.8644937 |
| Lock on same file | PR change | 00:00:00.7324826 |
| Lock on unique file | PR change | 00:00:00.6334258 |
#### Ubuntu lock perf

| Test (3000x) | Lock | Time |
| --- | --- | --- |
| Lock on same file | Current dev branch | 00:00:00.1354701 |
| Lock on unique file | Current dev branch | 00:00:00.5042673 |
| Lock on same file | dev + delete on close only | 00:00:00.4773786 |
| Lock on unique file | dev + delete on close only | 00:00:00.4201801 |
| Lock on same file | PR change | 00:00:00.2798910 |
| Lock on unique file | PR change | 00:00:00.2732335 |
#### Mac OSX lock perf

| Test (3000x) | Lock | Time |
| --- | --- | --- |
| Lock on same file | Current dev branch | 00:00:00.1832304 |
| Lock on unique file | Current dev branch | 00:00:00.8673274 |
| Lock on same file | dev + delete on close only | 00:00:18.3217699 |
| Lock on unique file | dev + delete on close only | 00:00:01.1989051 |
| Lock on same file | PR change | 00:00:00.3276610 |
| Lock on unique file | PR change | 00:00:00.3370809 |

https://github.com/NuGet/Home/issues/2102

//cc @yishaigalatzer @joelverhagen @zhili1208 
