### PR TITLE
fixed https://github.com/NuGet/Home/issues/2070

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -108,9 +108,7 @@ namespace NuGet.Configuration
 
                 var isEnabled = true;
                 SettingValue disabledSource;
-                if (disabledSources.TryGetValue(name, out disabledSource)
-                    &&
-                    disabledSource.Priority >= setting.Priority)
+                if (disabledSources.TryGetValue(name, out disabledSource))
                 {
                     isEnabled = false;
                 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1552,11 +1552,11 @@ namespace NuGet.Configuration.Test
         <add key='a' value='http://a' />
     </packageSources>
 </configuration>";
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, @"a\b"), configContent1);
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, @"a\b\c"), configContent2);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b"), configContent1);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b","c"), configContent2);
 
                 var settings = Settings.LoadDefaultSettings(
-                    Path.Combine(mockBaseDirectory, @"a\b\c"),
+                    Path.Combine(mockBaseDirectory, "a","b","c"),
                     configFileName: null,
                     machineWideSettings: null,
                     loadAppDataSettings: false,

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -1537,7 +1537,7 @@ namespace NuGet.Configuration.Test
         // Test that a source added in a high priority config file is not
         // disabled by <disabledPackageSources> in a low priority file.
         [Fact]
-        public void HighPrioritySourceNotDisabled()
+        public void HighPrioritySourceDisabled()
         {
             // Arrange
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
@@ -1568,7 +1568,7 @@ namespace NuGet.Configuration.Test
 
                 // Assert
                 Assert.Equal(1, values.Count);
-                Assert.True(values[0].IsEnabled);
+                Assert.False(values[0].IsEnabled);
                 Assert.Equal("a", values[0].Name);
                 Assert.Equal("http://a", values[0].Source);
             }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2070

bring back nuget 2 behavior for disable source.

this fix allows user to disable local source from global config
