### PR TITLE
Allow overriding CommonApplicationData on Linux

### DIFF
--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -87,6 +87,13 @@ namespace NuGet.Common
                     }
                     else
                     {
+                        string commonApplicationDataOverride = Environment.GetEnvironmentVariable("NUGET_COMMON_APPLICATION_DATA");
+
+                        if (!string.IsNullOrEmpty(commonApplicationDataOverride))
+                        {
+                            return commonApplicationDataOverride;
+                        }
+
                         return @"/etc/opt";
                     }
 


### PR DESCRIPTION
Red Hat has requested a way to override the location of nuget
configuation data due to how they plan to package components on their
end. This allows them to set an environment varible as the root of the
common application data folder, which will also control where the
machine wide settings come from.
