### PR TITLE
Not Found and Cancelled package downloads should not be logged as errors

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -149,7 +149,7 @@ namespace NuGet.PackageManagement
                 {
                     var message = ExceptionUtilities.DisplayMessage(task.Exception);
 
-                    errors.AppendLine($"{tasksLookup[task].PackageSource.Source}: {message}");
+                    errors.AppendLine($"  {tasksLookup[task].PackageSource.Source}: {message}");
                 }
 
                 throw new FatalProtocolException(errors.ToString());
@@ -193,18 +193,45 @@ namespace NuGet.PackageManagement
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.DownloadResourceNotFound, sourceRepository.PackageSource.Source));
             }
 
-            DownloadResourceResult result = null;
-
             token.ThrowIfCancellationRequested();
 
-            result
-                = await downloadResource.GetDownloadResourceResultAsync(packageIdentity, settings, logger, token);
+            DownloadResourceResult result;
+            try
+            {
+                result = await downloadResource.GetDownloadResourceResultAsync(
+                   packageIdentity,
+                   settings,
+                   logger,
+                   token);
+            }
+            catch (OperationCanceledException)
+            {
+                result = new DownloadResourceResult(DownloadResourceResultStatus.Cancelled);
+            }
 
             if (result == null)
             {
                 throw new FatalProtocolException(string.Format(
                     CultureInfo.CurrentCulture,
                     Strings.DownloadStreamNotAvailable,
+                    packageIdentity,
+                    sourceRepository.PackageSource.Source));
+            }
+
+            if (result.Status == DownloadResourceResultStatus.Cancelled)
+            {
+                throw new RetriableProtocolException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.PackageCancelledFromSource,
+                    packageIdentity,
+                    sourceRepository.PackageSource.Source));
+            }
+
+            if (result.Status == DownloadResourceResultStatus.NotFound)
+            {
+                throw new FatalProtocolException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.PackageNotFoundOnSource,
                     packageIdentity,
                     sourceRepository.PackageSource.Source));
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -249,6 +249,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Getting package &apos;{0}&apos; from source &apos;{1}&apos; was cancelled..
+        /// </summary>
+        internal static string PackageCancelledFromSource {
+            get {
+                return ResourceManager.GetString("PackageCancelledFromSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package &apos;{0}&apos; could not be installed.
         /// </summary>
         internal static string PackageCouldNotBeInstalled {
@@ -299,6 +308,15 @@ namespace NuGet.PackageManagement {
         internal static string PackageNotFoundInPrimarySources {
             get {
                 return ResourceManager.GetString("PackageNotFoundInPrimarySources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is not found on source &apos;{1}&apos;..
+        /// </summary>
+        internal static string PackageNotFoundOnSource {
+            get {
+                return ResourceManager.GetString("PackageNotFoundOnSource", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -276,4 +276,10 @@
   <data name="Warning_ErrorFindingRepository" xml:space="preserve">
     <value>Error finding repository for '{0}': {1}</value>
   </data>
+  <data name="PackageCancelledFromSource" xml:space="preserve">
+    <value>Getting package '{0}' from source '{1}' was cancelled.</value>
+  </data>
+  <data name="PackageNotFoundOnSource" xml:space="preserve">
+    <value>Package '{0}' is not found on source '{1}'.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResult.cs
@@ -8,12 +8,22 @@ using NuGet.Packaging;
 namespace NuGet.Protocol.Core.Types
 {
     /// <summary>
-    /// The result of <see cref="DownloadResource.DownloadResource"/>.
+    /// The result of <see cref="DownloadResource"/>.
     /// </summary>
     public class DownloadResourceResult : IDisposable
     {
         private readonly Stream _stream;
         private readonly PackageReaderBase _packageReader;
+
+        public DownloadResourceResult(DownloadResourceResultStatus status)
+        {
+            if (status == DownloadResourceResultStatus.Available)
+            {
+                throw new ArgumentException("A stream should be provided when the result is available.");
+            }
+
+            Status = status;
+        }
 
         public DownloadResourceResult(Stream stream)
         {
@@ -22,6 +32,7 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            Status = DownloadResourceResultStatus.Available;
             _stream = stream;
         }
 
@@ -30,6 +41,8 @@ namespace NuGet.Protocol.Core.Types
         {
             _packageReader = packageReader;
         }
+
+        public DownloadResourceResultStatus Status { get; }
 
         /// <summary>
         /// Gets the package <see cref="PackageStream"/>.
@@ -44,7 +57,7 @@ namespace NuGet.Protocol.Core.Types
 
         public void Dispose()
         {
-            _stream.Dispose();
+            _stream?.Dispose();
             _packageReader?.Dispose();
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResultStatus.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Core.Types
+{
+    public enum DownloadResourceResultStatus
+    {
+        Available,
+        NotFound,
+        Cancelled
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
@@ -14,6 +14,13 @@ namespace NuGet.Protocol.Core.Types
     /// </summary>
     public abstract class DownloadResource : INuGetResource
     {
+        /// <summary>
+        /// Downloads a package .nupkg with the provided identity. If the package is not available
+        /// on the source but the source itself is not down or unavailable, the
+        /// <see cref="DownloadResourceResult.Status"/> will be <see cref="DownloadResourceResultStatus.NotFound"/>.
+        /// If the operation was cancelled, the <see cref="DownloadResourceResult.Status"/> will be
+        /// <see cref="DownloadResourceResultStatus.Cancelled"/>.
+        /// </summary>
         public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(
             PackageIdentity identity,
             ISettings settings,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DownloadResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DownloadResourceV2.cs
@@ -60,8 +60,8 @@ namespace NuGet.Protocol.Core.v2
                         var repository = V2Client as DataServicePackageRepository;
 
                         bool isFromUri = repository != null
-                            && sourcePackage?.PackageHash != null
-                            && sourcePackage?.DownloadUri != null;
+                                         && sourcePackage?.PackageHash != null
+                                         && sourcePackage?.DownloadUri != null;
 
                         if (isFromUri)
                         {
@@ -75,6 +75,10 @@ namespace NuGet.Protocol.Core.v2
                             // Look up the package from the id and version and download it.
                             return DownloadFromIdentity(identity, V2Client, logger, token);
                         }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return new DownloadResourceResult(DownloadResourceResultStatus.Cancelled);
                     }
                     catch (IOException ex) when (ex.InnerException is SocketException && i < 2)
                     {
@@ -210,7 +214,7 @@ namespace NuGet.Protocol.Core.v2
                 }
             }
 
-            return null;
+            return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
@@ -14,9 +14,6 @@ namespace NuGet.Protocol
 {
     public class HttpRetryHandler
     {
-        public const string RequestLogFormat = "  {0} {1}";
-        public static readonly string ResponseLogFormat = "  {0} {1} {2}" + Strings.Milliseconds;
-
         /// <summary>
         /// The <see cref="HttpRetryHandler"/> is for retrying and HTTP request if it times out, has any exception,
         /// or returns a status code of 500 or greater.
@@ -92,11 +89,12 @@ namespace NuGet.Protocol
                         {
                             var timeoutTask = Task.Delay(RequestTimeout, timeoutTcs.Token);
 
+                            string requestUri = request.RequestUri.ToString();
                             log.LogInformation(string.Format(
                                 CultureInfo.InvariantCulture,
-                                RequestLogFormat,
+                                Strings.Http_RequestLog,
                                 request.Method,
-                                request.RequestUri));
+                                requestUri));
 
                             var stopwatch = Stopwatch.StartNew();
                             var responseTask = client.SendAsync(request, completionOption, responseTcs.Token);
@@ -112,9 +110,8 @@ namespace NuGet.Protocol
                                         CultureInfo.CurrentCulture,
                                         Strings.Http_Timeout,
                                         request.Method,
-                                        request.RequestUri,
-                                        (int)RequestTimeout.TotalMilliseconds,
-                                        Strings.Milliseconds);
+                                        requestUri,
+                                        (int)RequestTimeout.TotalMilliseconds);
                                     throw new TimeoutException(message);
                                 }
                             }
@@ -125,9 +122,9 @@ namespace NuGet.Protocol
 
                                 log.LogInformation(string.Format(
                                     CultureInfo.InvariantCulture,
-                                    ResponseLogFormat,
+                                    Strings.Http_ResponseLog,
                                     response.StatusCode,
-                                    request.RequestUri,
+                                    requestUri,
                                     stopwatch.ElapsedMilliseconds));
 
                                 if ((int)response.StatusCode >= 500)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2Feed.cs
@@ -69,6 +69,10 @@ namespace NuGet.Protocol
                     return await _feedParser.DownloadFromIdentity(identity, settings, logger, token);
                 }
             }
+            catch (OperationCanceledException)
+            {
+                return new DownloadResourceResult(DownloadResourceResultStatus.Cancelled);
+            }
             catch (Exception ex) when (!(ex is FatalProtocolException))
             {
                 // if the expcetion is not FatalProtocolException, catch it.

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -218,10 +218,9 @@ namespace NuGet.Protocol
 
             if (packageInfo == null)
             {
-                string message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToFindPackage, package, _source.Source);
-
-                throw new FatalProtocolException(message);
+                return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
             }
+
             return await GetDownloadResultUtility.GetDownloadResultAsync(_httpSource, package, new Uri(packageInfo.DownloadUrl), settings, log, token);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DownloadResourceV3.cs
@@ -126,7 +126,7 @@ namespace NuGet.Protocol.Core.v3
                 return await GetDownloadResultUtility.GetDownloadResultAsync(_client, identity, uri, settings, logger, token);
             }
 
-            return null;
+            return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -248,6 +248,7 @@ namespace NuGet.Protocol.Core.Types
         {
             var response = await _httpSource.SendAsync(
                 () => CreateRequest(source, pathToPackage, apiKey),
+                logger,
                 token);
 
             using (response)
@@ -345,7 +346,8 @@ namespace NuGet.Protocol.Core.Types
                         request.Headers.Add(ApiKeyHeader, apiKey);
                     }
                     return request;
-                }, 
+                },
+                logger,
                 token);
 
             using (response)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
@@ -204,7 +204,25 @@ namespace NuGet.Protocol.Core.v3 {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to The HTTP request to &apos;{0} {1}&apos; has timed out after {2}{3}..
+        ///    Looks up a localized string similar to {0} {1}.
+        /// </summary>
+        internal static string Http_RequestLog {
+            get {
+                return ResourceManager.GetString("Http_RequestLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to {0} {1} {2}ms.
+        /// </summary>
+        internal static string Http_ResponseLog {
+            get {
+                return ResourceManager.GetString("Http_ResponseLog", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to The HTTP request to &apos;{0} {1}&apos; has timed out after {2}ms..
         /// </summary>
         internal static string Http_Timeout {
             get {
@@ -254,15 +272,6 @@ namespace NuGet.Protocol.Core.v3 {
         internal static string Log_FailedToDownloadPackage {
             get {
                 return ResourceManager.GetString("Log_FailedToDownloadPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to Can&apos;t find Package &apos;{0}&apos; from source &apos;{1}&apos;..
-        /// </summary>
-        internal static string Log_FailedToFindPackage {
-            get {
-                return ResourceManager.GetString("Log_FailedToFindPackage", resourceCulture);
             }
         }
         
@@ -344,15 +353,6 @@ namespace NuGet.Protocol.Core.v3 {
         internal static string Log_RetryingServiceIndex {
             get {
                 return ResourceManager.GetString("Log_RetryingServiceIndex", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to ms.
-        /// </summary>
-        internal static string Milliseconds {
-            get {
-                return ResourceManager.GetString("Milliseconds", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
@@ -151,7 +151,9 @@
     <value>No download URL could be found for {0}.</value>
   </data>
   <data name="Http_Timeout" xml:space="preserve">
-    <value>The HTTP request to '{0} {1}' has timed out after {2}{3}.</value>
+    <value>The HTTP request to '{0} {1}' has timed out after {2}ms.</value>
+    <comment>Parameters in order: non-localizable HTTP method, non-localizable HTTP request URI, timeout duration in milliseconds.
+The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
   <data name="InvalidVersionFolder" xml:space="preserve">
     <value>The folder '{0}' contains an invalid version.</value>
@@ -179,9 +181,6 @@
   </data>
   <data name="Log_RetryingFindPackagesById" xml:space="preserve">
     <value>Retrying '{0}' for source '{1}'.</value>
-  </data>
-  <data name="Milliseconds" xml:space="preserve">
-    <value>ms</value>
   </data>
   <data name="NoApiKeyFound" xml:space="preserve">
     <value>No API Key was provided and no API Key could be found for {0}. To save an API Key for a source use the 'setApiKey' command.</value>
@@ -249,9 +248,6 @@
   <data name="LiveFeed" xml:space="preserve">
     <value>the NuGet gallery</value>
   </data>
-  <data name="Log_FailedToFindPackage" xml:space="preserve">
-    <value>Can't find Package '{0}' from source '{1}'.</value>
-  </data>
   <data name="Log_InvalidCacheEntry" xml:space="preserve">
     <value>An invalid cache entry was found for URL '{0}' and will be replaced.</value>
   </data>
@@ -299,5 +295,14 @@
   </data>
   <data name="Path_Invalid_NotFileNotUnc" xml:space="preserve">
     <value>'{0}' should be a local path or a UNC share path.</value>
+  </data>
+  <data name="Http_RequestLog" xml:space="preserve">
+    <value>{0} {1}</value>
+    <comment>Parameters in order: non-localizable HTTP method, non-localizable HTTP request URI</comment>
+  </data>
+  <data name="Http_ResponseLog" xml:space="preserve">
+    <value>{0} {1} {2}ms</value>
+    <comment>Parameters in order: non-localizable HTTP status, non-localizable HTTP request URI, request duration in milliseconds.
+The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
@@ -172,6 +173,74 @@ namespace NuGet.CommandLine.Test
                 var packageFileB = Path.Combine(workingPath, @"outputDir\packageB.2.2.0\packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
                 Assert.True(File.Exists(packageFileB));
+            }
+        }
+
+        [Fact]
+        public void RestoreCommand_NoCancelledOrNotFoundMessages()
+        {
+            // Arrange
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nugetexe = Util.GetNuGetExePath();
+
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+
+                var sourcePath = Path.Combine(workingPath, "source");
+                Directory.CreateDirectory(sourcePath);
+
+                var packagesPath = Path.Combine(workingPath, "packages");
+                Directory.CreateDirectory(packagesPath);
+                
+                var packageA = new ZipPackage(Util.CreateTestPackage("PackageA", "1.1.0", sourcePath));
+                var packageB = new ZipPackage(Util.CreateTestPackage("PackageB", "2.2.0", sourcePath));
+
+                Util.CreateFile(workingPath, "packages.config",
+@"<packages>
+  <package id=""PackageA"" version=""1.1.0"" targetFramework=""net45"" />
+</packages>");
+
+                using (var serverWithPackage = Util.CreateMockServer(new[] { packageA }))
+                using (var serverWithoutPackage = Util.CreateMockServer(new[] { packageB }))
+                using (var slowServer = new MockServer())
+                {
+                    slowServer.Get.Add("/", request =>
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            Thread.Sleep(TimeSpan.FromSeconds(5));
+                            response.StatusCode = 500;
+                        });
+                    });
+
+                    serverWithPackage.Start();
+                    serverWithoutPackage.Start();
+                    slowServer.Start();
+
+                    string[] args =
+                    {
+                        "restore",
+                        "-PackagesDirectory", packagesPath,
+                        "-Source", serverWithPackage.Uri + "nuget",
+                        "-Source", serverWithoutPackage.Uri + "nuget",
+                        "-Source", slowServer.Uri + "nuget"
+                    };
+
+                    // Act
+                    var result = CommandRunner.Run(
+                        nugetexe,
+                        workingPath,
+                        string.Join(" ", args),
+                        waitForExit: true);
+
+                    // Assert
+                    Assert.Equal(0, result.Item1);
+                    Assert.NotEmpty(result.Item2);
+                    Assert.DoesNotContain("cancel", result.Item2.ToLower());
+                    Assert.DoesNotContain("not found", result.Item2.ToLower());
+                    Assert.Empty(result.Item3);
+                    Assert.True(File.Exists(Path.Combine(packagesPath, @"PackageA.1.1.0\PackageA.1.1.0.nupkg")));
+                }
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -279,7 +279,24 @@ namespace NuGet.CommandLine.Test
                     }));
             }
 
-            server.Get.Add("/nuget", r => "OK");
+            // fall through to "package not found"
+            server.Get.Add("/nuget/Packages(Id='", r =>
+                new Action<HttpListenerResponse>(response =>
+                {
+                    response.StatusCode = 404;
+                    MockServer.SetResponseContent(response, @"<?xml version=""1.0"" encoding=""utf-8""?>
+<m:error xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"">
+  <m:code />
+  <m:message xml:lang=""en-US"">Resource not found for the segment 'Packages'.</m:message>
+</m:error>");
+                }));
+
+            server.Get.Add("/nuget", r =>
+                new Action<HttpListenerResponse>(response =>
+                {
+                    response.StatusCode = 404;
+                }));
+
             return server;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -71,14 +71,15 @@ namespace NuGet.Protocol.FuncTest
             var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), null, true, repo, new Uri("https://www.nuget.org/api/v2/package/not-found/6.2.0"), "");
 
             // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            var actual = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                NullSettings.Instance,
+                NullLogger.Instance,
+                CancellationToken.None);
 
             // Assert
-            Assert.NotNull(ex);
-            Assert.Equal("Error downloading 'not-found.6.2.0' from 'https://www.nuget.org/api/v2/package/not-found/6.2.0'.", ex.Message);
+            Assert.NotNull(actual);
+            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -17,6 +17,7 @@ namespace NuGet.Protocol.FuncTest
         public async Task V2FeedParser_DownloadFromInvalidUrl()
         {
             // Arrange
+            var randomName = Guid.NewGuid().ToString();
             var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v2/");
 
             var httpSource = HttpSource.Create(repo);
@@ -25,14 +26,14 @@ namespace NuGet.Protocol.FuncTest
 
             // Act 
             Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await parser.DownloadFromUrl(new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
-                                                              new Uri("https://www.invalid.org/api/v2"),
+                                                              new Uri($"https://www.{randomName}.org/api/v2/"),
                                                               Configuration.NullSettings.Instance,
                                                               NullLogger.Instance,
                                                               CancellationToken.None));
 
             // Assert
             Assert.NotNull(ex);
-            Assert.Equal("Error downloading 'not-found.6.2.0' from 'https://www.invalid.org/api/v2'.", ex.Message);
+            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
         }
 
         [Fact]
@@ -46,15 +47,15 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, "https://www.nuget.org/api/v2/");
 
             // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await parser.DownloadFromUrl(new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
-                                                              new Uri("https://www.nuget.org/api/v2/package/not-found/6.2.0"),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            var actual = await parser.DownloadFromUrl(new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
+                new Uri("https://www.nuget.org/api/v2/package/not-found/6.2.0"),
+                Configuration.NullSettings.Instance,
+                NullLogger.Instance,
+                CancellationToken.None);
 
             // Assert
-            Assert.NotNull(ex);
-            Assert.Equal("Error downloading 'not-found.6.2.0' from 'https://www.nuget.org/api/v2/package/not-found/6.2.0'.", ex.Message);
+            Assert.NotNull(actual);
+            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -31,14 +31,14 @@ namespace NuGet.Protocol.Core.v3.Tests
             var downloadResource = await repo.GetResourceAsync<DownloadResource>();
 
             // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            var actual = await downloadResource.GetDownloadResourceResultAsync(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
+                NullSettings.Instance,
+                NullLogger.Instance,
+                CancellationToken.None);
 
             // Assert
-            Assert.NotNull(ex);
-            Assert.Equal("Can't find Package 'xunit.1.0.0-notfound' from source 'http://testsource/v2/'.", ex.Message);
+            Assert.NotNull(actual);
+            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Test.Server;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Core.v3.Tests
@@ -107,6 +108,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(), 
                 CancellationToken.None);
 
             // Assert
@@ -135,6 +137,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -162,6 +165,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -189,6 +193,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -217,6 +222,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
             timer.Stop();
 
@@ -248,6 +254,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -275,6 +282,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -303,6 +311,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -342,6 +351,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 httpClient,
                 () => new HttpRequestMessage(HttpMethod.Get, TestUrl),
                 HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                 CancellationToken.None);
 
             // Assert
@@ -364,6 +374,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                     httpClient,
                     () => new HttpRequestMessage(HttpMethod.Get, address),
                     HttpCompletionOption.ResponseHeadersRead,
+                new TestLogger(),
                     CancellationToken.None);
 
                 // Act & Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -142,15 +142,15 @@ namespace NuGet.Protocol.Core.v3.Tests
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
             V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
 
-            // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await parser.DownloadFromIdentity(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            // Act
+            var actual = await parser.DownloadFromIdentity(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
+                NullSettings.Instance,
+                NullLogger.Instance,
+                CancellationToken.None);
 
             // Assert
-            Assert.NotNull(ex);
-            Assert.Equal("Can't find Package 'xunit.1.0.0-notfound' from source 'http://testsource/v2/'.", ex.Message);
+            Assert.NotNull(actual);
+            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
         }
 
         [Fact]


### PR DESCRIPTION
This change makes two common cases in `PackageDownloader` handled explicitly without exceptions, as they are not _exceptional_ situations. The situations are:
1. A package cannot be found on the source. That is, a `404 Not Found` was returned. This just means that one of the other sources needs to have the package. If all sources do not have the package, then the normal error occurs.
2. A package is found on a source, so all other requests to download the package from the other sources are cancelled. 

This allows us to use the latest NuGet.exe on our own build and fixes https://github.com/NuGet/Home/issues/2174.

@emgarten @deepakaravindr @zhili1208 @yishaigalatzer 

Example output (generated by restoring NuGet.Client's `.nuget\packages.config`):

```
Restoring NuGet package xunit.runner.msbuild.2.1.0.
Restoring NuGet package NuGet.MsBuild.Integration.3.1.0-beta-001.
Restoring NuGet package ILMerge.2.14.1208.
  GET https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/xunit.runner.msbuild/2.1.0/xunit.runner.msbuild.2.1.0.nupkg
  GET https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/ilmerge/2.14.1208/ilmerge.2.14.1208.nupkg
  GET https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/nuget.msbuild.integration/3.1.0-beta-001/nuget.msbuild.integration.3.1.0-beta-001.nupkg
  GET https://api.nuget.org/v3-flatcontainer/xunit.runner.msbuild/2.1.0/xunit.runner.msbuild.2.1.0.nupkg
  GET https://api.nuget.org/v3-flatcontainer/nuget.msbuild.integration/3.1.0-beta-001/nuget.msbuild.integration.3.1.0-beta-001.nupkg
  NotFound https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/xunit.runner.msbuild/2.1.0/xunit.runner.msbuild.2.1.0.nupkg 168ms
  OK https://api.nuget.org/v3-flatcontainer/xunit.runner.msbuild/2.1.0/xunit.runner.msbuild.2.1.0.nupkg 239ms
Acquiring lock for the installation of xunit.runner.msbuild 2.1.0
Acquired lock for the installation of xunit.runner.msbuild 2.1.0
Installing xunit.runner.msbuild 2.1.0.
  NotFound https://api.nuget.org/v3-flatcontainer/nuget.msbuild.integration/3.1.0-beta-001/nuget.msbuild.integration.3.1.0-beta-001.nupkg 317ms
Completed installation of xunit.runner.msbuild 2.1.0
Adding package 'xunit.runner.msbuild.2.1.0' to folder 'C:\trash\2016-02-24\restore\packages'
Added package 'xunit.runner.msbuild.2.1.0' to folder 'C:\trash\2016-02-24\restore\packages'
  NotFound https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/ilmerge/2.14.1208/ilmerge.2.14.1208.nupkg 687ms
  OK https://www.myget.org/F/nuget-volatile/api/v3/flatcontainer/nuget.msbuild.integration/3.1.0-beta-001/nuget.msbuild.integration.3.1.0-beta-001.nupkg 730ms
Acquiring lock for the installation of NuGet.MsBuild.Integration 3.1.0-beta-001
Acquired lock for the installation of NuGet.MsBuild.Integration 3.1.0-beta-001
Installing NuGet.MsBuild.Integration 3.1.0-beta-001.
Completed installation of NuGet.MsBuild.Integration 3.1.0-beta-001
  GET https://api.nuget.org/v3-flatcontainer/ilmerge/2.14.1208/ilmerge.2.14.1208.nupkg
Adding package 'NuGet.MsBuild.Integration.3.1.0-beta-001' to folder 'C:\trash\2016-02-24\restore\packages'
  OK https://api.nuget.org/v3-flatcontainer/ilmerge/2.14.1208/ilmerge.2.14.1208.nupkg 269ms
Acquiring lock for the installation of ILMerge 2.14.1208
Added package 'NuGet.MsBuild.Integration.3.1.0-beta-001' to folder 'C:\trash\2016-02-24\restore\packages'
Acquired lock for the installation of ILMerge 2.14.1208
Installing ILMerge 2.14.1208.
Completed installation of ILMerge 2.14.1208
Adding package 'ILMerge.2.14.1208' to folder 'C:\trash\2016-02-24\restore\packages'
Added package 'ILMerge.2.14.1208' to folder 'C:\trash\2016-02-24\restore\packages'

NuGet Config files used:
    C:\trash\2016-02-24\restore\NuGet.Config
    C:\Users\jver\AppData\Roaming\NuGet\NuGet.Config

Feeds used:
    C:\Users\jver\AppData\Local\NuGet\Cache
    C:\trash\2016-02-24\restore\Nupkgs
    https://www.myget.org/F/nuget-volatile/api/v3/index.json
    https://api.nuget.org/v3/index.json
    https://www.myget.org/F/aspnetvnext/api/v3/index.json

Installed:
    3 package(s) to packages.config projects
```
