### PR TITLE
NuGet.Config Error Message Fix

### DIFF
--- a/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Common;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 
@@ -227,15 +228,12 @@ namespace NuGet.Options
                     _packageSourceProvider.SavePackageSources(packageSources);
                 }
             }
-            catch (InvalidOperationException)
+            catch (Configuration.NuGetConfigurationException e)
             {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigInvalidOperation, Resources.ErrorDialogBoxTitle);
+                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(e), Resources.ErrorDialogBoxTitle);
                 return false;
             }
-            catch (UnauthorizedAccessException)
-            {
-                MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
-            }
+
             // find the enabled package source 
             return true;
         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -70,6 +70,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to NuGet operation failed.
+        /// </summary>
+        public static string ConfigErrorDialogBoxTitle {
+            get {
+                return ResourceManager.GetString("ConfigErrorDialogBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Added file &apos;{0}&apos; to project &apos;{1}&apos;..
         /// </summary>
         public static string Debug_AddedFileToProject {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -195,4 +195,7 @@
   <data name="FailedToUpdateBindingRedirects" xml:space="preserve">
     <value>Failed to update binding redirects for {0} : {1}</value>
   </data>
+  <data name="ConfigErrorDialogBoxTitle" xml:space="preserve">
+    <value>NuGet operation failed</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
+using NuGet.Common;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -50,7 +51,14 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 root = Path.Combine(SolutionManager.SolutionDirectory, EnvDTEProjectUtility.NuGetSolutionSettingsFolder);
             }
-            SolutionSettings = Configuration.Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
+            try
+            {
+                SolutionSettings = Configuration.Settings.LoadDefaultSettings(root, configFileName: null, machineWideSettings: MachineWideSettings);
+            }
+            catch (Configuration.NuGetConfigurationException ex)
+            {
+                MessageHelper.ShowErrorMessage(ExceptionUtilities.DisplayMessage(ex), Strings.ConfigErrorDialogBoxTitle);
+            }
         }
 
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)

--- a/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Exceptions/NuGetConfigurationException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.Configuration
+{
+    public class NuGetConfigurationException : Exception
+    {
+        public NuGetConfigurationException(string message)
+            : base(message)
+        {
+        }
+
+        public NuGetConfigurationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 
 namespace NuGet.Configuration
 {
@@ -32,7 +33,30 @@ namespace NuGet.Configuration
 
         public string UserName { get; set; }
 
-        public string Password { get; set; }
+        public string Password
+        {
+            get
+            {
+                if (PasswordText != null && !IsPasswordClearText)
+                {
+                    try
+                    {
+                        return EncryptionUtility.DecryptString(PasswordText);
+                    }
+                    catch (NotSupportedException e)
+                    {
+                        throw new NuGetConfigurationException(
+                            string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedDecryptPassword, Source), e);
+                    }
+                }
+                else
+                {
+                    return PasswordText;
+                }
+            }
+        }
+
+        public string PasswordText { get; set; }
 
         public bool IsPasswordClearText { get; set; }
 
@@ -167,7 +191,7 @@ namespace NuGet.Configuration
                 {
                     Description = Description,
                     UserName = UserName,
-                    Password = Password,
+                    PasswordText = PasswordText,
                     IsPasswordClearText = IsPasswordClearText,
                     IsMachineWide = IsMachineWide,
                     ProtocolVersion = ProtocolVersion

--- a/src/NuGet.Core/NuGet.Configuration/Properties/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Properties/Resources.Designer.cs
@@ -131,6 +131,68 @@ namespace NuGet.Configuration
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to NuGet.Config is malformed, Please check NuGet.Config.
+        /// </summary>
+        public static string ShowError_ConfigInvalidOperation
+        {
+            get
+            {
+                return GetString("ShowError_ConfigInvalidOperation");
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Can not access NuGet.Config, Please check NuGet.Config.
+        /// </summary>
+        public static string ShowError_ConfigUnauthorizedAccess
+        {
+            get
+            {
+                return GetString("ShowError_ConfigUnauthorizedAccess");
+            }
+        }
+
+        public static string ShowError_ConfigInvalidXml
+        {
+            get
+            {
+                return GetString("ShowError_ConfigInvalidXml");
+            }
+        }
+
+        public static string Unknown_Config_Exception
+        {
+            get
+            {
+                return GetString("Unknown_Config_Exception");
+            }
+        }
+
+        public static string ShowError_ConfigRootInvalid
+        {
+            get
+            {
+                return GetString("ShowError_ConfigRootInvalid");
+            }
+        }
+
+        public static string UnsupportedDecryptPassword
+        {
+            get
+            {
+                return GetString("UnsupportedDecryptPassword");
+            }
+        }
+
+        public static string UnsupportedEncryptPassword
+        {
+            get
+            {
+                return GetString("UnsupportedEncryptPassword");
+            }
+        }
+
+        /// <summary>
         /// Unable to parse config file '{0}'.
         /// </summary>
         internal static string FormatUserSettings_UnableToParseConfigFile(object p0)

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -135,6 +135,27 @@
   <data name="Settings_FileName_Cannot_Be_A_Path" xml:space="preserve">
     <value>Parameter 'fileName' to Settings must be just a fileName and not a path</value>
   </data>
+  <data name="ShowError_ConfigInvalidOperation" xml:space="preserve">
+    <value>NuGet.Config is malformed. Path: '{0}'.</value>
+  </data>
+  <data name="ShowError_ConfigInvalidXml" xml:space="preserve">
+    <value>NuGet.Config is invalid XML. Path: '{0}'.</value>
+  </data>
+  <data name="ShowError_ConfigRootInvalid" xml:space="preserve">
+    <value>NuGet.Config does not contain the expected root element: 'configuration'.  Path: '{0}'.</value>
+  </data>
+  <data name="ShowError_ConfigUnauthorizedAccess" xml:space="preserve">
+    <value>Failed to read NuGet.Config due to unaothirized access. Path: '{0}'.</value>
+  </data>
+  <data name="Unknown_Config_Exception" xml:space="preserve">
+    <value>Unexpected failure reading NuGet.Config. Path: '{0}'.</value>
+  </data>
+  <data name="UnsupportedDecryptPassword" xml:space="preserve">
+    <value>Password decryption failed for source : '{0}' is unsupported on this platform. A clear text password may be used instead.</value>
+  </data>
+  <data name="UnsupportedEncryptPassword" xml:space="preserve">
+    <value>Password encryption failed for source : '{0}' is unsupported on this platform. A clear text password may be used instead.</value>
+  </data>
   <data name="UnsupportedHashAlgorithm" xml:space="preserve">
     <value>Hash algorithm '{0}' is unsupported. Supported algorithms include: SHA512 and SHA256.</value>
   </data>

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -78,7 +78,7 @@ namespace NuGet.Configuration
                 var defaultPushSource = "<add key='DefaultPushSource' value='" + feed2 + "' />";
                 File.WriteAllText(nugetConfigFilePath, CreateNuGetConfigContent(enabledReplacement, disabledReplacement, defaultPushSource));
 
-                Assert.Throws<XmlException>(() =>
+                Assert.Throws<NuGetConfigurationException>(() =>
                 {
                     ConfigurationDefaults configDefaults = new ConfigurationDefaults(nugetConfigFileFolder, nugetConfigFile);
                 });

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -557,7 +557,7 @@ namespace NuGet.Configuration.Test
     <add key=""key2"" value=""https://test.org/2"" />
   </packageSources>
 </configuration>";
-                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "dir1","dir2"), config);
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "dir1", "dir2"), config);
                 config = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
@@ -567,7 +567,7 @@ namespace NuGet.Configuration.Test
 </configuration>";
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, Path.Combine(mockBaseDirectory, "dir1"), config);
 
-                var rootPath = Path.Combine(Path.Combine(mockBaseDirectory, "dir1","dir2"), Path.GetRandomFileName());
+                var rootPath = Path.Combine(Path.Combine(mockBaseDirectory, "dir1", "dir2"), Path.GetRandomFileName());
                 var settings = Settings.LoadDefaultSettings(rootPath,
                     configFileName: null,
                     machineWideSettings: null,
@@ -592,7 +592,7 @@ namespace NuGet.Configuration.Test
     <add key=""test3"" value=""https://test3.net"" />
   </packageSources>
 </configuration>".Replace("\r\n", "\n"),
-                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "dir1","dir2","NuGet.Config")).Replace("\r\n", "\n"));
+                   File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "dir1", "dir2", "NuGet.Config")).Replace("\r\n", "\n"));
 
                 Assert.Equal(
                      @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -602,7 +602,7 @@ namespace NuGet.Configuration.Test
     <clear />
   </packageSources>
 </configuration>".Replace("\r\n", "\n"),
-                  File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "dir1","NuGet.Config")).Replace("\r\n", "\n"));
+                  File.ReadAllText(Path.Combine(mockBaseDirectory.Path, "dir1", "NuGet.Config")).Replace("\r\n", "\n"));
             }
         }
 
@@ -887,7 +887,7 @@ namespace NuGet.Configuration.Test
             settings.Setup(s => s.GetNestedValues("packageSourceCredentials", It.IsAny<string>())).Returns(new KeyValuePair<string, string>[0]);
             settings.Setup(s => s.GetSettingValues("disabledPackageSources", false)).Returns(new SettingValue[0]);
 
-            var provider = CreatePackageSourceProvider(settings.Object, 
+            var provider = CreatePackageSourceProvider(settings.Object,
                 migratePackageSources: new Dictionary<PackageSource, PackageSource>
                     {
                         { new PackageSource("https://nuget.org/api/v2", "NuGet official package source"), new PackageSource("https://www.nuget.org/api/v2", "nuget.org") }
@@ -1445,7 +1445,7 @@ namespace NuGet.Configuration.Test
             var sources = new[]
                 {
                     new PackageSource("one"),
-                    new PackageSource("twosource", "twoname") { UserName = "User", Password = "password" },
+                    new PackageSource("twosource", "twoname") { UserName = "User", PasswordText = "password" },
                     new PackageSource("three")
                 };
             var settings = new Mock<ISettings>();
@@ -1482,7 +1482,7 @@ namespace NuGet.Configuration.Test
             var sources = new[]
                 {
                     new PackageSource("one"),
-                    new PackageSource("twosource", "twoname") { UserName = "User", Password = "password", IsPasswordClearText = true },
+                    new PackageSource("twosource", "twoname") { UserName = "User", PasswordText = "password", IsPasswordClearText = true },
                     new PackageSource("three")
                 };
             var settings = new Mock<ISettings>();
@@ -1553,11 +1553,11 @@ namespace NuGet.Configuration.Test
         <add key='a' value='http://a' />
     </packageSources>
 </configuration>";
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b"), configContent1);
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b","c"), configContent2);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a", "b"), configContent1);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a", "b", "c"), configContent2);
 
                 var settings = Settings.LoadDefaultSettings(
-                    Path.Combine(mockBaseDirectory, "a","b","c"),
+                    Path.Combine(mockBaseDirectory, "a", "b", "c"),
                     configFileName: null,
                     machineWideSettings: null,
                     loadAppDataSettings: false,
@@ -1593,8 +1593,8 @@ namespace NuGet.Configuration.Test
         <add key='a' value='http://a' />
     </packageSources>
 </configuration>";
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b"), configContent2);
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a","b","c"), configContent1);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a", "b"), configContent2);
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "a", "b", "c"), configContent1);
 
                 var settings = Settings.LoadDefaultSettings(
                     Path.Combine(mockBaseDirectory, "a", "b", "c"),
@@ -1662,7 +1662,7 @@ namespace NuGet.Configuration.Test
 </configuration>
 ";
                 File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.config"), configContents);
-                
+
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                    configFileName: "NuGet.config",
                    machineWideSettings: null,
@@ -2241,6 +2241,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+
         public void SavePackageSource_IgnoreSettingBeforeClear()
         {
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
@@ -2265,6 +2266,7 @@ namespace NuGet.Configuration.Test
 
                 // Act
                 var sources = packageSourceProvider.LoadPackageSources().ToList();
+
                 packageSourceProvider.SavePackageSources(sources);
 
                 // Assert
@@ -2278,6 +2280,163 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(result, text);
             }
         }
+
+        public void SavePackageSources_ThrowWhenConfigReadOnly()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <clear />
+      <add key=""test"" value=""https://nuget/test"" />
+    </packageSources>
+</configuration>
+";
+
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents);
+                File.SetAttributes(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), FileAttributes.ReadOnly);
+
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                sources.Add(new PackageSource("https://test3.net", "test3"));
+
+                var ex = Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
+
+                // Assert
+                var path = Path.Combine(mockBaseDirectory, "NuGet.Config");
+                Assert.Equal($"Can not access NuGet.Config, Please check NuGet.Config at '{path}'.", ex.Message);
+            }
+        }
+
+#if DNXCORE50
+        [Fact]
+        public void LoadPackageSource_NotDecryptPassword() 
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <clear />
+      <add key=""test"" value=""https://nuget/test"" />
+    </packageSources>
+<packageSourceCredentials>
+    <test>
+      <add key='Username' value='myusername' />
+      <add key='Password' value='removed' />
+    </test>
+  </packageSourceCredentials>
+</configuration>
+";
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: false,
+                                  useTestingGlobalPath: false);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(1, sources.Count);
+                Assert.Equal("test", sources[0].Name);
+                Assert.Equal("https://nuget/test", sources[0].Source);
+                Assert.Equal("removed", sources[0].PasswordText);
+                Assert.Throws<NuGetConfigurationException>(()=> sources[0].Password);
+            }
+        }
+
+        [Fact]
+        public void LoadPackageSource_NotLoadClearedSource()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var configContents =
+                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <add key=""test"" value=""https://nuget/test"" />
+    </packageSources>
+<packageSourceCredentials>
+    <test>
+      <add key='Username' value='myusername' />
+      <add key='Password' value='removed' />
+    </test>
+  </packageSourceCredentials>
+</configuration>
+";
+                var configContents1 =
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+    <packageSources>
+      <clear />
+      <add key=""test2"" value=""https://nuget/test2"" />
+    </packageSources>
+</configuration>
+";
+                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "TestingGlobalPath"), configContents);
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents1);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                // Act
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(1, sources.Count);
+                Assert.Equal("test2", sources[0].Name);
+                Assert.Equal("https://nuget/test2", sources[0].Source);
+                Assert.Null(sources[0].PasswordText);
+                Assert.Null(sources[0].Password);
+            }
+        }
+
+        [Fact]
+        public void SavePackageSource_EncryptPasswordGetException()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                                  configFileName: null,
+                                  machineWideSettings: null,
+                                  loadAppDataSettings: true,
+                                  useTestingGlobalPath: true);
+                var packageSourceProvider = new PackageSourceProvider(settings);
+
+                var newSource = new PackageSource("https://test", "test")
+                {
+                    PasswordText = "password",
+                    UserName = "username"
+                };
+                var sources = packageSourceProvider.LoadPackageSources().ToList();
+                sources.Add(newSource);
+
+                // Act & Assert
+                Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
+            }
+        }
+#endif
 
         private string CreateNuGetConfigContent(string enabledReplacement = "", string disabledReplacement = "", string activeSourceReplacement = "")
         {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTest.cs
@@ -14,7 +14,7 @@ namespace NuGet.Configuration
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
                 {
                     IsPasswordClearText = true,
-                    Password = "password",
+                    PasswordText = "password",
                     UserName = "username",
                     ProtocolVersion = 43,
                 };


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2012
https://github.com/NuGet/Home/issues/1567
https://github.com/NuGet/Home/issues/2158

This fix added NuGet.Config path and file name to error message and Exception for corrupted or writing to read-only config file
