### PR TITLE
Add functional test to verify installation of prerelease packages works

### DIFF
--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -228,6 +228,20 @@ function VsPackageInstallerEvents {
     }
 }
 
+function Test-InstallPrereleasePackageAPI 
+{
+    param($context)
+
+    # Arrange
+    $p = New-ClassLibrary
+
+    # Act
+    [API.Test.InternalAPITestHook]::InstallPackageApi("AutoMapper", "4.0.0-alpha1") 
+
+    # Assert
+    Assert-Package $p AutoMapper 4.0.0-alpha1
+}
+
 function Test-InstallPackageAPI 
 {
     param($context)


### PR DESCRIPTION
It was not immediately clear to me that installing pre-release packages was supported by the IVS APIs because passing a `null` version only ever installs a stable version.

@CyrusNajmabadi @emgarten @zhili1208 @deepakaravindr @yishaigalatzer 
