### PR TITLE
End-to-End test fixes

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
@@ -189,7 +189,10 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 Task.Run(async () =>
                 {
                     var metadata = await GetLatestPackageFromRemoteSourceAsync(installedPackage.PackageIdentity, IncludePrerelease.IsPresent);
-                    await metadata?.GetVersionsAsync();
+                    if (metadata != null)
+                    {
+                        await metadata.GetVersionsAsync();
+                    }
                     return metadata;
                 }));
 

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
@@ -61,9 +61,8 @@ namespace NuGet.PackageManagement.UI
                 ?? completed.FirstOrDefault()
                 ?? PackageSearchMetadataBuilder.FromIdentity(identity).Build();
 
-            var mergedVersions = await MergeVersionsAsync(identity, completed);
-
-            return master.WithVersions(mergedVersions);
+            return master.WithVersions(
+                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
         }
 
         public async Task<IPackageSearchMetadata> GetLatestPackageMetadataAsync(PackageIdentity identity,
@@ -83,9 +82,8 @@ namespace NuGet.PackageManagement.UI
                 .OrderByDescending(e => e.Identity.Version, VersionComparer.VersionRelease)
                 .FirstOrDefault();
 
-            var mergedVersions = await MergeVersionsAsync(identity, completed);
-
-            return highest?.WithVersions(mergedVersions);
+            return highest?.WithVersions(
+                asyncValueFactory: () => MergeVersionsAsync(identity, completed));
         }
 
         public async Task<IEnumerable<IPackageSearchMetadata>> GetPackageMetadataListAsync(string packageId, bool includePrerelease, bool includeUnlisted, CancellationToken cancellationToken)
@@ -113,7 +111,8 @@ namespace NuGet.PackageManagement.UI
 
             return allVersions
                 .GroupBy(v => v.Version, v => v.DownloadCount)
-                .Select(g => new VersionInfo(g.Key, g.Max()));
+                .Select(g => new VersionInfo(g.Key, g.Max()))
+                .ToArray();
         }
 
         private void LogError(Task task)

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/SourceRepositoryExtensions.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.UI
             var autoCompleteResource = await sourceRepository.GetResourceAsync<AutoCompleteResource>(cancellationToken);
             var packageIds = await autoCompleteResource?.IdStartsWith(
                 packageIdPrefix,
-                includePrerelease: true,
+                includePrerelease: includePrerelease,
                 log: Logging.NullLogger.Instance,
                 token: cancellationToken);
 
@@ -181,7 +181,7 @@ namespace NuGet.PackageManagement.UI
             var versions = await autoCompleteResource?.VersionStartsWith(
                 packageId,
                 versionPrefix,
-                includePrerelease: true,
+                includePrerelease: includePrerelease,
                 log: Logging.NullLogger.Instance,
                 token: cancellationToken);
 


### PR DESCRIPTION
TabExpansionForInstallPackageSupportsVersion
- IncludePrerelease flag was ignored

GetPackageUpdatesAfterSwitchToSourceThatDoesNotContainInstalledPackageId
- Test itself referenced curated feed which DOES have Antlr package
  updates. Changed it to NuGet-Volatile feed instead.
- Also fixed nullref when package metadata is not found.

//cc @deepakaravindr @emgarten 
