### PR TITLE
fix ordering of Packages in the UI

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.UI
                 (p, t) => _metadataProvider.GetPackageMetadataAsync(p, searchToken.SearchFilter.IncludePrerelease, t), 
                 cancellationToken);
 
-            //  The pachkages were originally sorted which is important because we Skip and Take based on that sort
+            //  The packages were originally sorted which is important because we Skip and Take based on that sort
             //  however the asynchronous execution has randomly reordered the set. So we need to resort. 
             var result = SearchResult.FromItems(items.OrderBy(p => p.Identity.Id).ToArray());
 

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.UI
                 (p, t) => _metadataProvider.GetPackageMetadataAsync(p, searchToken.SearchFilter.IncludePrerelease, t), 
                 cancellationToken);
 
-            var result = SearchResult.FromItems(items.ToArray());
+            var result = SearchResult.FromItems(items.OrderBy(p => p.Identity.Id).ToArray());
 
             var loadingStatus = hasMoreItems
                 ? LoadingStatus.Ready

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
@@ -70,6 +70,8 @@ namespace NuGet.PackageManagement.UI
                 (p, t) => _metadataProvider.GetPackageMetadataAsync(p, searchToken.SearchFilter.IncludePrerelease, t), 
                 cancellationToken);
 
+            //  The pachkages were originally sorted which is important because we Skip and Take based on that sort
+            //  however the asynchronous execution has randomly reordered the set. So we need to resort. 
             var result = SearchResult.FromItems(items.OrderBy(p => p.Identity.Id).ToArray());
 
             var loadingStatus = hasMoreItems


### PR DESCRIPTION
Fix ordering of installed Packages. Note that this works because the original set was ordered. Its important that the window of packages is take from the ordered set.

This change just undoes the damage done to the ordering done by the async work.
