### PR TITLE
Update Settings.cs

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -246,7 +246,7 @@ namespace NuGet.Configuration
                 }
                 else
                 {
-                    var userSettingsDir = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+                    var userSettingsDir = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory) ?? String.Empty;
                     defaultSettingsFilePath = Path.Combine(userSettingsDir, DefaultSettingsFileName);
                 }
 


### PR DESCRIPTION
Since the user settings may not be needed, and APPDATA environment variable may be null, set the userSettingsDir to String.Empty if GetFolderPath returns null.  This prevents crashing for the Path.Combine in the next line.
