### PR TITLE
Functional (E2E) Test Tweaks

### DIFF
--- a/scripts/e2etests/Utils.ps1
+++ b/scripts/e2etests/Utils.ps1
@@ -75,7 +75,8 @@ function SetRegistryKey
             return $false
         }
 
-        New-Item -Path $RegKey -Name $RegName -Value $ExpectedValue -Force
+        New-Item -Path $RegKey -Force | Out-Null
+        New-ItemProperty -Path $RegKey -Name $RegName -Value $ExpectedValue -Force | Out-Null
     }
 
     return $true

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -133,11 +133,11 @@ function UninstallVSIX
     $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
 
     Write-Host 'Uninstalling VSIX...'
-    & $VSIXInstallerPath /q /a /u:$vsixID
+    $p = start-process "$VSIXInstallerPath" -Wait -PassThru -NoNewWindow -ArgumentList "/q /a /u:$vsixID"
 
-    if ($lastexitcode)
+    if ($p.ExitCode -ne 0)
     {
-        Write-Error "Error uninstalling the VSIX! Exit code: $lastexitcode"
+        Write-Error "Error uninstalling the VSIX! Exit code: " $p.ExitCode
         return $false
     }
 
@@ -162,11 +162,11 @@ function InstallVSIX
     $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
 
     Write-Host "Installing VSIX from $vsixpath..."
-    & $VSIXInstallerPath /q /a $vsixpath
+    $p = start-process "$VSIXInstallerPath" -Wait -PassThru -NoNewWindow -ArgumentList "/q /a $vsixpath"
 
-    if ($lastexitcode)
+    if ($p.ExitCode -ne 0)
     {
-        Write-Error "Error installing the VSIX! Exit code: $lastexitcode"
+        Write-Error "Error installing the VSIX! Exit code: " $p.ExitCode
         return $false
     }
 


### PR DESCRIPTION
Made a couple of fixes
1. Use Process.ExitCode when checking if VSIX installer has succeeded.
   There are some random failures on VSIX installation. This change will
   help identify it
2. Update the logic to set registry keys. Need to create the key first
   before creating the value

@alpaix  @emgarten 
