### PR TITLE
Adding runtimeTargets to non-RID lock file target graphs

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
@@ -37,6 +37,7 @@ namespace NuGet.ProjectModel
         private const string CompileProperty = "compile";
         private const string NativeProperty = "native";
         private const string ContentFilesProperty = "contentFiles";
+        private const string RuntimeTargetsProperty = "runtimeTargets";
         private const string ResourceProperty = "resource";
         private const string TypeProperty = "type";
         private const string PathProperty = "path";
@@ -282,6 +283,7 @@ namespace NuGet.ProjectModel
             library.ResourceAssemblies = ReadObject(json[ResourceProperty] as JObject, ReadFileItem);
             library.NativeLibraries = ReadObject(json[NativeProperty] as JObject, ReadFileItem);
             library.ContentFiles = ReadObject(json[ContentFilesProperty] as JObject, ReadFileItem);
+            library.RuntimeTargets = ReadObject(json[RuntimeTargetsProperty] as JObject, ReadFileItem);
 
             return library;
         }
@@ -347,6 +349,13 @@ namespace NuGet.ProjectModel
                 var ordered = library.ContentFiles.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
 
                 json[ContentFilesProperty] = WriteObject(ordered, WriteFileItem);
+            }
+
+            if (library.RuntimeTargets.Count > 0)
+            {
+                var ordered = library.RuntimeTargets.OrderBy(assembly => assembly.Path, StringComparer.Ordinal);
+
+                json[RuntimeTargetsProperty] = WriteObject(ordered, WriteFileItem);
             }
 
             return new JProperty(library.Name + "/" + library.Version.ToNormalizedString(), json);

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileTargetLibrary.cs
@@ -33,6 +33,8 @@ namespace NuGet.ProjectModel
 
         public IList<LockFileItem> ContentFiles { get; set; } = new List<LockFileItem>();
 
+        public IList<LockFileItem> RuntimeTargets { get; set; } = new List<LockFileItem>();
+
         public bool Equals(LockFileTargetLibrary other)
         {
             if (other == null)
@@ -62,7 +64,9 @@ namespace NuGet.ProjectModel
                 && NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
                     .SequenceEqual(other.NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
                 && ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase));
+                    .SequenceEqual(other.ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+                && RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
+                    .SequenceEqual(other.RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase));
         }
 
         public override bool Equals(object obj)
@@ -110,6 +114,11 @@ namespace NuGet.ProjectModel
             }
 
             foreach (var item in ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                combiner.AddObject(item);
+            }
+
+            foreach (var item in RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
             {
                 combiner.AddObject(item);
             }

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
@@ -14,6 +17,8 @@ namespace NuGet.Test.Utility
         public List<SimpleTestPackageContext> Dependencies { get; set; } = new List<SimpleTestPackageContext>();
         public string Include { get; set; } = string.Empty;
         public string Exclude { get; set; } = string.Empty;
+        public List<KeyValuePair<string, byte[]>> Files { get; set; } = new List<KeyValuePair<string, byte[]>>();
+        public XDocument Nuspec { get; set; }
 
         /// <summary>
         /// runtime.json
@@ -26,6 +31,29 @@ namespace NuGet.Test.Utility
             {
                 return new PackageIdentity(Id, NuGetVersion.Parse(Version));
             }
+        }
+
+        /// <summary>
+        /// Add a file to the zip. Ex: lib/net45/a.dll
+        /// </summary>
+        public void AddFile(string path)
+        {
+            AddFile(path, new byte[] { 0 });
+        }
+
+        public void AddFile(string path, string content)
+        {
+            AddFile(path, Encoding.UTF8.GetBytes(content));
+        }
+
+        public void AddFile(string path, byte[] bytes)
+        {
+            if (string.IsNullOrEmpty(path) || path.StartsWith("/") || path.IndexOf('\\') > -1)
+            {
+                throw new ArgumentException(nameof(path));
+            }
+
+            Files.Add(new KeyValuePair<string, byte[]>(path, bytes));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -68,20 +68,30 @@ namespace NuGet.Test.Utility
 
             using (var zip = new ZipArchive(File.Create(file.FullName), ZipArchiveMode.Create))
             {
-                zip.AddEntry("contentFiles/any/any/config.xml", new byte[] { 0 });
-                zip.AddEntry("contentFiles/cs/net45/code.cs", new byte[] { 0 });
-                zip.AddEntry("lib/net45/a.dll", new byte[] { 0 });
-                zip.AddEntry("lib/netstandard1.0/a.dll", new byte[] { 0 });
-                zip.AddEntry($"build/net45/{id}.targets", @"<targets />", Encoding.UTF8);
-                zip.AddEntry("native/net45/a.dll", new byte[] { 0 });
-                zip.AddEntry("tools/a.exe", new byte[] { 0 });
+                if (packageContext.Files.Any())
+                {
+                    foreach (var entryFile in packageContext.Files)
+                    {
+                        zip.AddEntry(entryFile.Key, entryFile.Value);
+                    }
+                }
+                else
+                {
+                    zip.AddEntry("contentFiles/any/any/config.xml", new byte[] { 0 });
+                    zip.AddEntry("contentFiles/cs/net45/code.cs", new byte[] { 0 });
+                    zip.AddEntry("lib/net45/a.dll", new byte[] { 0 });
+                    zip.AddEntry("lib/netstandard1.0/a.dll", new byte[] { 0 });
+                    zip.AddEntry($"build/net45/{id}.targets", @"<targets />", Encoding.UTF8);
+                    zip.AddEntry("native/net45/a.dll", new byte[] { 0 });
+                    zip.AddEntry("tools/a.exe", new byte[] { 0 });
+                }
 
                 if (!string.IsNullOrEmpty(runtimeJson))
                 {
                     zip.AddEntry("runtime.json", runtimeJson, Encoding.UTF8);
                 }
 
-                var nuspecXml = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                var nuspecXml = packageContext.Nuspec?.ToString() ?? $@"<?xml version=""1.0"" encoding=""utf-8""?>
                         <package>
                         <metadata>
                             <id>{id}</id>
@@ -143,6 +153,14 @@ namespace NuGet.Test.Utility
             }
 
             return file;
+        }
+
+        /// <summary>
+        /// Create package.
+        /// </summary>
+        public static void CreatePackages(SimpleTestPackageContext package, string repositoryPath)
+        {
+            CreatePackages(new List<SimpleTestPackageContext>() { package }, repositoryPath);
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
@@ -121,6 +121,60 @@
           "lib/netcore50/System.Xml.Serialization.dll": {},
           "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Core.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Net.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Numerics.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Windows.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {},
@@ -228,6 +282,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Collections.Concurrent/4.0.10": {
@@ -371,6 +431,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -382,6 +448,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.StackTrace/4.0.0": {
@@ -393,6 +465,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tools/4.0.0": {
@@ -401,6 +479,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
@@ -421,6 +505,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.10": {
@@ -443,6 +533,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization/4.0.10": {
@@ -454,6 +550,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Calendars/4.0.0": {
@@ -466,6 +568,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Extensions/4.0.0": {
@@ -497,6 +605,12 @@
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.IO.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.IO.Compression/4.0.0": {
@@ -644,6 +758,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Linq.Parallel/4.0.0": {
@@ -858,6 +978,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.DataContractSerialization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Private.Networking/4.0.0": {
@@ -941,6 +1067,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.Uri.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection/4.0.10": {
@@ -954,6 +1086,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Context/4.0.0": {
@@ -985,6 +1123,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -1002,6 +1146,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Metadata/1.0.22": {
@@ -1038,6 +1188,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.TypeExtensions/4.0.0": {
@@ -1056,6 +1212,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -1069,6 +1231,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime/4.0.20": {
@@ -1080,6 +1248,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Extensions/4.0.10": {
@@ -1091,6 +1265,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Handles/4.0.0": {
@@ -1102,6 +1282,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices/4.0.20": {
@@ -1116,6 +1302,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
@@ -1124,6 +1316,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Numerics/4.0.0": {
@@ -1149,6 +1347,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
@@ -1173,6 +1377,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
@@ -1193,6 +1403,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
@@ -1308,6 +1524,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.Encoding.CodePages/4.0.0": {
@@ -1341,6 +1563,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.RegularExpressions/4.0.10": {
@@ -1369,6 +1597,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Overlapped/4.0.0": {
@@ -1396,6 +1630,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
@@ -1443,6 +1683,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Xml.ReaderWriter/4.0.10": {
@@ -1534,6 +1780,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       }
     },

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
@@ -126,6 +126,60 @@
           "lib/netcore50/System.Xml.Serialization.dll": {},
           "lib/netcore50/System.Xml.dll": {},
           "lib/netcore50/System.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/aot/lib/netcore50/System.ComponentModel.DataAnnotations.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Core.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Net.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Numerics.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Runtime.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.Web.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.ServiceModel.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Windows.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Linq.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.Serialization.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/System.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          },
+          "runtimes/aot/lib/netcore50/mscorlib.dll": {
+            "assetType": "runtime",
+            "rid": "aot"
+          }
         }
       },
       "Microsoft.NETCore.Runtime/1.0.0": {
@@ -243,6 +297,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Collections.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Collections.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Collections.Concurrent/4.0.10": {
@@ -395,6 +455,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -407,6 +473,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.StackTrace/4.0.0": {
@@ -419,6 +491,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tools/4.0.0": {
@@ -428,6 +506,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
@@ -449,6 +533,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Dynamic.Runtime/4.0.10": {
@@ -472,6 +562,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Dynamic.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization/4.0.10": {
@@ -484,6 +580,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Globalization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Calendars/4.0.0": {
@@ -497,6 +599,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Globalization.Calendars.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Globalization.Extensions/4.0.0": {
@@ -530,6 +638,12 @@
         },
         "runtime": {
           "lib/netcore50/System.IO.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.IO.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.IO.Compression/4.0.0": {
@@ -685,6 +799,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Linq.Expressions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Linq.Parallel/4.0.0": {
@@ -912,6 +1032,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.DataContractSerialization.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Private.Networking/4.0.0": {
@@ -998,6 +1124,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Private.Uri.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection/4.0.10": {
@@ -1012,6 +1144,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Context/4.0.0": {
@@ -1045,6 +1183,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -1063,6 +1207,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.Metadata/1.0.22": {
@@ -1101,6 +1251,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Reflection.TypeExtensions/4.0.0": {
@@ -1120,6 +1276,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Resources.ResourceManager/4.0.0": {
@@ -1134,6 +1296,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime/4.0.20": {
@@ -1146,6 +1314,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Extensions/4.0.10": {
@@ -1158,6 +1332,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Handles/4.0.0": {
@@ -1170,6 +1350,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Handles.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices/4.0.20": {
@@ -1185,6 +1371,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
@@ -1194,6 +1386,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Numerics/4.0.0": {
@@ -1221,6 +1419,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.Serialization.Primitives/4.0.10": {
@@ -1247,6 +1451,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime/4.0.10": {
@@ -1268,6 +1478,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Runtime.WindowsRuntime.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
@@ -1392,6 +1608,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.Encoding.CodePages/4.0.0": {
@@ -1427,6 +1649,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Text.RegularExpressions/4.0.10": {
@@ -1457,6 +1685,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Overlapped/4.0.0": {
@@ -1486,6 +1720,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Tasks.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Threading.Tasks.Dataflow/4.5.25": {
@@ -1536,6 +1776,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Threading.Timer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       },
       "System.Xml.ReaderWriter/4.0.10": {
@@ -1631,6 +1877,12 @@
         },
         "runtime": {
           "lib/netcore50/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtimeTargets": {
+          "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll": {
+            "assetType": "runtime",
+            "rid": "win8-aot"
+          }
         }
       }
     },

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreTargetsTests.cs
@@ -1,0 +1,268 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class RestoreTargetsTests
+    {
+        [Fact]
+        public async Task RestoreTargets_RestoreWithNoRuntimes()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageA = new SimpleTestPackageContext()
+                {
+                    Id = "packageA"
+                };
+
+                packageA.AddFile("lib/a.dll");
+                packageA.AddFile("lib/netstandard1.5/a.dll");
+                packageA.AddFile("lib/netstandard1.5/en-us/a.resource.dll");
+                packageA.AddFile("native/a.dll");
+                packageA.AddFile("ref/netstandard1.5/a.dll");
+                packageA.AddFile("contentFiles/any/any/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                var targetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier == null).Libraries.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, lockFile.Libraries.Count);
+                Assert.Equal(0, targetLib.RuntimeTargets.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreTargets_RestoreWithRuntimes()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext()
+                {
+                    Id = "packageA"
+                };
+
+                packageA.AddFile("lib/netstandard1.5/a.dll");
+                packageA.AddFile("native/a.dll");
+                packageA.AddFile("runtimes/unix/native/a.dll");
+                packageA.AddFile("runtimes/unix/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/en-us/a.resources.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                var targetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier == null).Libraries.Single();
+                var ridTargetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier != null).Libraries.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(5, targetLib.RuntimeTargets.Count);
+
+                Assert.Equal("runtimes/unix/lib/netstandard1.5/a.dll", targetLib.RuntimeTargets[0].Path);
+                Assert.Equal("runtime", targetLib.RuntimeTargets[0].Properties["assetType"]);
+                Assert.Equal("unix", targetLib.RuntimeTargets[0].Properties["rid"]);
+
+                Assert.Equal("runtimes/win7-x86/lib/netstandard1.5/en-us/a.resources.dll", targetLib.RuntimeTargets[3].Path);
+                Assert.Equal("resource", targetLib.RuntimeTargets[3].Properties["assetType"]);
+                Assert.Equal("win7-x86", targetLib.RuntimeTargets[3].Properties["rid"]);
+
+                Assert.Equal("runtimes/unix/native/a.dll", targetLib.RuntimeTargets[4].Path);
+                Assert.Equal("native", targetLib.RuntimeTargets[4].Properties["assetType"]);
+                Assert.Equal("unix", targetLib.RuntimeTargets[4].Properties["rid"]);
+
+                // This section does not exist for RID graphs
+                Assert.Equal(0, ridTargetLib.RuntimeTargets.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreTargets_RestoreWithRuntimes_ExcludeAll()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0"",
+                            ""exclude"": ""all""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext()
+                {
+                    Id = "packageA"
+                };
+
+                packageA.AddFile("lib/netstandard1.5/a.dll");
+                packageA.AddFile("native/a.dll");
+                packageA.AddFile("runtimes/unix/native/a.dll");
+                packageA.AddFile("runtimes/unix/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/en-us/a.resources.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                var targetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier == null).Libraries.Single();
+                var ridTargetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier != null).Libraries.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(3, targetLib.RuntimeTargets.Count);
+
+                Assert.Equal("runtimes/unix/lib/netstandard1.5/_._", targetLib.RuntimeTargets[0].Path);
+                Assert.Equal("runtime", targetLib.RuntimeTargets[0].Properties["assetType"]);
+                Assert.Equal("unix", targetLib.RuntimeTargets[0].Properties["rid"]);
+
+                Assert.Equal("runtimes/win7-x86/lib/netstandard1.5/en-us/_._", targetLib.RuntimeTargets[1].Path);
+                Assert.Equal("resource", targetLib.RuntimeTargets[1].Properties["assetType"]);
+                Assert.Equal("win7-x86", targetLib.RuntimeTargets[1].Properties["rid"]);
+
+                Assert.Equal("runtimes/unix/native/_._", targetLib.RuntimeTargets[2].Path);
+                Assert.Equal("native", targetLib.RuntimeTargets[2].Properties["assetType"]);
+                Assert.Equal("unix", targetLib.RuntimeTargets[2].Properties["rid"]);
+
+                // This section does not exist for RID graphs
+                Assert.Equal(0, ridTargetLib.RuntimeTargets.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change adds runtime specific assets to the lock file target for non-RID specific graphs.

Runtime, Resource, and Native assets will be added to a section called `runtimeTargets`, the items are the same as they would be for the runtime graphs.
- Include/Exclude is applied in the same way, runtimeTargets is not special cased.
- The lock file section the item would appear in is stored as `assetType`
- The RID is stored under `rid`

Example output:

``` json
{
  "System.Threading.Tasks/4.0.10": {
    "type": "package",
    "dependencies": {
      "System.Runtime": "4.0.0"
    },
    "compile": {
      "ref/dotnet/System.Threading.Tasks.dll": { }
    },
    "runtime": {
      "lib/netcore50/System.Threading.Tasks.dll": { }
    },
    "runtimeTargets": {
      "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll": {
        "assetType": "runtime",
        "rid": "win8-aot"
      }
    }
  }
}
```

https://github.com/NuGet/Home/issues/2171

// cc @anurse @yishaigalatzer @joelverhagen @zhili1208 @pakrym @davidfowl 
