### PR TITLE
include/exclude for compatibility checks

### DIFF
--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
@@ -12,6 +12,15 @@ namespace NuGet.Test.Utility
 {
     public class SimpleTestPackageContext
     {
+        public SimpleTestPackageContext(string packageId)
+        {
+            Id = packageId;
+        }
+
+        public SimpleTestPackageContext()
+        {
+        }
+
         public string Id { get; set; } = "packageA";
         public string Version { get; set; } = "1.0.0";
         public List<SimpleTestPackageContext> Dependencies { get; set; } = new List<SimpleTestPackageContext>();

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -156,11 +156,11 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
-        /// Create package.
+        /// Create packages.
         /// </summary>
-        public static void CreatePackages(SimpleTestPackageContext package, string repositoryPath)
+        public static void CreatePackages(string repositoryPath, params SimpleTestPackageContext[] package)
         {
-            CreatePackages(new List<SimpleTestPackageContext>() { package }, repositoryPath);
+            CreatePackages(package.ToList(), repositoryPath);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 
 namespace NuGet.Test.Utility
 {
@@ -8,6 +9,7 @@ namespace NuGet.Test.Utility
         /// Logged messages
         /// </summary>
         public ConcurrentQueue<string> Messages { get; } = new ConcurrentQueue<string>();
+        public ConcurrentQueue<string> ErrorMessages { get; } = new ConcurrentQueue<string>();
 
         public int Errors { get; set; }
 
@@ -23,6 +25,7 @@ namespace NuGet.Test.Utility
         {
             Errors++;
             Messages.Enqueue(data);
+            ErrorMessages.Enqueue(data);
             DumpMessage("ERROR", data);
         }
 
@@ -70,6 +73,11 @@ namespace NuGet.Test.Utility
             {
                 // do nothing
             }
+        }
+
+        public string ShowErrors()
+        {
+            return string.Join(Environment.NewLine, ErrorMessages);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -1,0 +1,447 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class CompatilibityCheckerTests
+    {
+        [Fact]
+        public async Task CompatilibityChecker_PackageExcludeCompileRuntime_Success()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0"",
+                            ""exclude"": ""compile,runtime""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/net45/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                // Verify no compatibility issues
+                Assert.True(result.CompatibilityCheckResults.All(check => check.Success));
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_PackageCompatibility_Fail()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/net45/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.False(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                // Verify no compatibility issues
+                Assert.False(result.CompatibilityCheckResults.All(check => check.Success));
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_MissingRuntimeAssemblyCompileOnly_Success()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0"",
+                            ""include"": ""compile""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("ref/netstandard1.3/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                // Verify no compatibility issues
+                Assert.True(result.CompatibilityCheckResults.All(check => check.Success));
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_MissingRuntimeAssembly_Fail()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("ref/netstandard1.3/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                var failure = result.CompatibilityCheckResults.Where(r => !r.Success).Single().Issues.Single();
+
+                // Assert
+                Assert.False(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                // Verify compatibility issue
+                Assert.Equal("a", failure.AssemblyName);
+                Assert.Equal("win7-x86", failure.RuntimeIdentifier);
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_RuntimeFoundInAnotherPackage_Success()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        },
+                        ""packageB"": {
+                            ""version"": ""1.0.0""
+                        },
+                        ""packageC"": {
+                            ""version"": ""1.0.0""
+                        },
+                        ""packageD"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("ref/netstandard1.3/a.dll");
+                packageA.AddFile("ref/netstandard1.3/b.dll");
+                packageA.AddFile("ref/netstandard1.3/c.dll");
+
+                var packageB = new SimpleTestPackageContext("packageB");
+                packageB.AddFile("runtimes/win7-x86/lib/netstandard1.1/a.dll");
+
+                var packageC = new SimpleTestPackageContext("packageC");
+                packageC.AddFile("lib/netstandard1.1/b.ni.dll");
+
+                var packageD = new SimpleTestPackageContext("packageD");
+                packageD.AddFile("lib/netstandard1.1/c.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA, packageB, packageC, packageD);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(4, result.LockFile.Libraries.Count);
+
+                // Verify no compatibility issues
+                Assert.True(result.CompatibilityCheckResults.All(check => check.Success));
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_RuntimeFoundInSamePackage_Success()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("ref/netstandard1.3/a.dll");
+                packageA.AddFile("ref/netstandard1.3/b.dll");
+                packageA.AddFile("ref/netstandard1.3/c.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.1/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.1/b.ni.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.1/c.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                // Verify no compatibility issues
+                Assert.True(result.CompatibilityCheckResults.All(check => check.Success));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
@@ -67,7 +67,7 @@ namespace NuGet.Commands.Test
                 packageA.AddFile("ref/netstandard1.5/a.dll");
                 packageA.AddFile("contentFiles/any/any/a.dll");
 
-                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
 
                 // Act
                 var command = new RestoreCommand(request);
@@ -141,7 +141,7 @@ namespace NuGet.Commands.Test
                 packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/a.dll");
                 packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/en-us/a.resources.dll");
 
-                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
 
                 // Act
                 var command = new RestoreCommand(request);
@@ -235,7 +235,7 @@ namespace NuGet.Commands.Test
                 packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/a.dll");
                 packageA.AddFile("runtimes/win7-x86/lib/netstandard1.5/en-us/a.resources.dll");
 
-                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
 
                 // Act
                 var command = new RestoreCommand(request);
@@ -330,8 +330,7 @@ namespace NuGet.Commands.Test
 
                 packageA.AddFile("runtimes/win-any/lib/net45/a.dll");
 
-
-                SimpleTestPackageUtility.CreatePackages(packageA, packageSource.FullName);
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
 
                 // Act
                 var command = new RestoreCommand(request);


### PR DESCRIPTION
Include/exclude flags can be used to provide some user control over the guard rail checks.
- For compile only references the runtime assembly check should be skipped.
- When compile and runtime references are excluded the compatibility check is not needed since it is verifying ref and lib assemblies

https://github.com/NuGet/Home/issues/2242

//cc @anurse @joelverhagen @yishaigalatzer @zhili1208 
