### PR TITLE
Add IVS API to get the short framework name

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.Designer.cs
@@ -61,6 +61,15 @@ namespace NuGet.VisualStudio.Implementation.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The framework name &apos;{0}&apos; cannot be converted to a short framework name..
+        /// </summary>
+        internal static string CouldNotGetShortFrameworkName {
+            get {
+                return ResourceManager.GetString("CouldNotGetShortFrameworkName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified framework name &apos;{0}&apos; must be .NETStandard..
         /// </summary>
         internal static string InvalidNetStandardFramework {

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Resources/VsResources.resx
@@ -171,4 +171,9 @@
   <data name="InvalidNetStandardFramework" xml:space="preserve">
     <value>The specified framework name '{0}' must be .NETStandard.</value>
   </data>
+  <data name="CouldNotGetShortFrameworkName" xml:space="preserve">
+    <value>The framework name '{0}' cannot be converted to a short framework name.</value>
+    <comment>Arguments in order:
+The string representation of the user's input framework name.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkParser.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkParser.cs
@@ -21,5 +21,21 @@ namespace NuGet.VisualStudio
         /// <exception cref="ArgumentException">If the provided string cannot be parsed.</exception>
         /// <returns>The parsed framework.</returns>
         FrameworkName ParseFrameworkName(string shortOrFullName);
+
+        /// <summary>
+        /// Gets the shortened version of the framework name from a <see cref="FrameworkName"/>
+        /// instance.
+        /// </summary>
+        /// <remarks>
+        /// For example, ".NETFramework,Version=v4.5" is converted to "net45". This is the value
+        /// used inside of .nupkg folder structures as well as in project.json files.
+        /// </remarks>
+        /// <param name="frameworkName">The framework name.</param>
+        /// <exception cref="ArgumentNullException">If the input is null.</exception>
+        /// <exception cref="ArgumentException">
+        /// If the provided framework name cannot be converted to a short name.
+        /// </exception>
+        /// <returns>The short framework name. </returns>
+        string GetShortFrameworkName(FrameworkName frameworkName);
     }
 }

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -434,6 +434,20 @@ function Test-ParseFrameworkName
     Assert-AreEqual ".NETFramework,Version=v4.5" $actual.ToString()
 }
 
+function Test-GetShortFolderName
+{
+    # Arrange
+    $cm = Get-VsComponentModel
+    $service = $cm.GetService([NuGet.VisualStudio.IVsFrameworkParser])
+    $framework = [System.Runtime.Versioning.FrameworkName](".NETStandard,Version=v1.3")
+    
+    # Act
+    $actual = $service.GetShortFrameworkName($framework)
+
+    # Assert
+    Assert-AreEqual "netstandard1.3" $actual.ToString()
+}
+
 function Test-GetNearest
 {
     # Arrange

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkParserTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkParserTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.Versioning;
 using Xunit;
 
 namespace NuGet.VisualStudio.Implementation.Test.Extensibility
@@ -6,7 +7,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
     public class VsFrameworkParserTests
     {
         [Fact]
-        public void VsFrameworkParser_RejectsNullInput()
+        public void VsFrameworkParser_ParseFrameworkName_RejectsNullInput()
         {
             // Arrange
             var target = new VsFrameworkParser();
@@ -16,7 +17,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         }
 
         [Fact]
-        public void VsFrameworkParser_RejectsInvalidVersion()
+        public void VsFrameworkParser_ParseFrameworkName_RejectsInvalidVersion()
         {
             // Arrange
             var target = new VsFrameworkParser();
@@ -26,7 +27,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         }
 
         [Fact]
-        public void VsFrameworkParser_RejectsInvalidProfile()
+        public void VsFrameworkParser_ParseFrameworkName_RejectsInvalidProfile()
         {
             // Arrange
             var target = new VsFrameworkParser();
@@ -36,7 +37,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         }
 
         [Fact]
-        public void VsFrameworkParser_ParsesShortFrameworkName()
+        public void VsFrameworkParser_ParseFrameworkName_ParsesShortFrameworkName()
         {
             // Arrange
             var target = new VsFrameworkParser();
@@ -49,7 +50,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
         }
 
         [Fact]
-        public void VsFrameworkParser_ParsesLongFrameworkName()
+        public void VsFrameworkParser_ParseFrameworkName_ParsesLongFrameworkName()
         {
             // Arrange
             var target = new VsFrameworkParser();
@@ -59,6 +60,52 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
             // Assert
             Assert.Equal(".NETFramework,Version=v4.5", frameworkName.ToString());
+        }
+
+        [Fact]
+        public void VsFrameworkParser_GetShortFrameworkName_Success()
+        {
+            // Arrange
+            var target = new VsFrameworkParser();
+            var frameworkName = new FrameworkName(".NETStandard", Version.Parse("1.3"));
+
+            // Act
+            var actual = target.GetShortFrameworkName(frameworkName);
+
+            // Assert
+            Assert.Equal("netstandard1.3", actual);
+        }
+
+        [Fact]
+        public void VsFrameworkParser_GetShortFrameworkName_RejectsNull()
+        {
+            // Arrange
+            var target = new VsFrameworkParser();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => target.GetShortFrameworkName(null));
+        }
+
+        [Fact]
+        public void VsFrameworkParser_GetShortFrameworkName_RejectsInvalidFrameworkIdentifier()
+        {
+            // Arrange
+            var target = new VsFrameworkParser();
+            var frameworkName = new FrameworkName("!?", Version.Parse("4.5"));
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => target.GetShortFrameworkName(frameworkName));
+        }
+
+        [Fact]
+        public void VsFrameworkParser_GetShortFrameworkName_RejectsInvalidPortable()
+        {
+            // Arrange
+            var target = new VsFrameworkParser();
+            var frameworkName = new FrameworkName(".NETPortable", Version.Parse("4.5"), "net45+portable-net451");
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => target.GetShortFrameworkName(frameworkName));
         }
     }
 }


### PR DESCRIPTION
This method allows for a component in Visual Studio to take the full framework name to a short framework name, like the kind used in `project.json`. For example, `.NETStandard,Version=v1.3` is converted to `netstandard1.3`.

@yishaigalatzer @emgarten @zhili1208 @rchande @alpaix 
