### PR TITLE
When a partial list item is displayed at the bottom of the listbox,

### DIFF
--- a/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
@@ -475,7 +475,7 @@ namespace NuGet.Options
             }
             else if (e.Button == MouseButtons.Left)
             {
-                int itemIndex = currentListBox.IndexFromPoint(e.Location);
+                int itemIndex = currentListBox.SelectedIndex;
                 if (itemIndex >= 0
                     && itemIndex < currentListBox.Items.Count)
                 {


### PR DESCRIPTION
... clicking on the checkbox of item will scroll it into view, but then toggle the item below it.

Fixes could have been:
1) make the listbox integral height, so no partial items are ever shown...but that causes layout issues.
2) determine when the listbox is scrolled. but it appears that isn't easily possible.

In the end, was simplest just to change from a hittest at point to get the current item, to getting the selecteditem.
The checkbox doesn't toggle at all, which doesn't feel great...but that is what WPF would do in the same scenario.
