### PR TITLE
Add tools section to project.json and deserialize it

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/ToolDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/ToolDependency.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.LibraryModel
+{
+    public class ToolDependency
+    {
+        public LibraryRange LibraryRange { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -58,6 +58,8 @@ namespace NuGet.ProjectModel
 
         public IList<LibraryDependency> Dependencies { get; set; }
 
+        public IList<ToolDependency> Tools { get; set; }
+
         public IDictionary<string, IEnumerable<string>> Scripts { get; private set; }
 
         public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; }

--- a/src/NuGet.Core/NuGet.ProjectModel/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/Strings.Designer.cs
@@ -105,11 +105,29 @@ namespace NuGet.ProjectModel {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Unable to resolve tool &apos;&apos;..
+        /// </summary>
+        internal static string MissingToolName {
+            get {
+                return ResourceManager.GetString("MissingToolName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package dependencies must specify a version range..
         /// </summary>
-        internal static string MissingVersionProperty {
+        internal static string MissingVersionOnDependency {
             get {
-                return ResourceManager.GetString("MissingVersionProperty", resourceCulture);
+                return ResourceManager.GetString("MissingVersionOnDependency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Tools must specify a version range..
+        /// </summary>
+        internal static string MissingVersionOnTool {
+            get {
+                return ResourceManager.GetString("MissingVersionOnTool", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/Strings.resx
+++ b/src/NuGet.Core/NuGet.ProjectModel/Strings.resx
@@ -132,7 +132,13 @@
   <data name="Log_InvalidImportFramework" xml:space="preserve">
     <value>Imports contains an invalid framework: '{0}' in '{1}'.</value>
   </data>
-  <data name="MissingVersionProperty" xml:space="preserve">
+  <data name="MissingToolName" xml:space="preserve">
+    <value>Unable to resolve tool ''.</value>
+  </data>
+  <data name="MissingVersionOnDependency" xml:space="preserve">
     <value>Package dependencies must specify a version range.</value>
+  </data>
+  <data name="MissingVersionOnTool" xml:space="preserve">
+    <value>Tools must specify a version range.</value>
   </data>
 </root>


### PR DESCRIPTION
This adds the `tools` node to the project.json. The goal of this PR is only to parse the tools information into our in-memory `ProjectSpec` model. Upcoming PRs will actually do the interesting stuff...

The tools node looks like this:

``` json
{
    "tools": {
        "packageA": "1.2.0-*",
        "packageB": {
            "version": "1.3.0-*"
        }
    }
}
```

@emgarten @yishaigalatzer @brthor
