### PR TITLE
Xplat client now also sets osVersion on Mono

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -4,7 +4,7 @@ namespace NuGet.Common
 {
     public static class RuntimeEnvironmentHelper
     {
-        private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+        private static readonly Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
 
         public static bool IsWindows
         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/OperatingSystemHelper.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/OperatingSystemHelper.cs
@@ -1,0 +1,121 @@
+using System;
+
+#if DNXCORE50
+using System.Diagnostics;
+using System.IO;
+#endif
+
+namespace NuGet.Protocol.Core.Types
+{
+    internal class OperatingSystemHelper
+    {
+#if !DNXCORE50
+        public static string GetVersion()
+        {
+            return Environment.OSVersion.ToString();
+        }
+#else
+        private static readonly Lazy<OperatingSystemInfo> _osInfo = new Lazy<OperatingSystemInfo>(GetOsDetails);
+
+        public static string GetVersion()
+        {
+            return _osInfo.Value.ToString();
+        }
+
+        private static OperatingSystemInfo GetOsDetails()
+        {
+            var unameOutput = RunProgram("uname", "-s -m").Split(' ');
+
+            var operatingSystem = unameOutput[0];
+            string osVersion;
+
+            if (operatingSystem == "Darwin")
+            {
+                // sw_vers returns versions in format "10.10{.4}" so ".4" needs to be removed if exists
+                osVersion = RunProgram("sw_vers", "-productVersion");
+                var firstDot = osVersion.IndexOf('.');
+                var lastDot = osVersion.LastIndexOf('.');
+                osVersion = lastDot >= 0 && firstDot != lastDot ? osVersion.Substring(0, lastDot) : osVersion;
+
+                return new OperatingSystemInfo(operatingSystem, osVersion);
+            }
+
+            osVersion = string.Empty;
+            var qualifiers = new[] { "ID=", "VERSION_ID=" };
+            try
+            {
+                var osRelease = File.ReadAllLines("/etc/os-release");
+                foreach (var qualifier in qualifiers)
+                {
+                    foreach (var line in osRelease)
+                    {
+                        if (line.StartsWith(qualifier))
+                        {
+                            if (osVersion.Length != 0)
+                            {
+                                osVersion += " ";
+                            }
+                            osVersion += line.Substring(qualifier.Length).Trim('"', '\'');
+                        }
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            if (osVersion.Length == 0)
+            {
+                // Could not determine OS version information. Defaulting to the empty string.
+                return new OperatingSystemInfo(null, null);
+            }
+
+            return new OperatingSystemInfo(operatingSystem, osVersion);
+        }
+
+        private static string RunProgram(string name, string args)
+        {
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = name,
+                Arguments = args,
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(processStartInfo);
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+            return output.Trim();
+        }
+
+        private class OperatingSystemInfo
+        {
+            public OperatingSystemInfo(string operatingSystem, string operatingSystemVersion)
+            {
+                OperatingSystem = operatingSystem;
+                OperatingSystemVersion = operatingSystemVersion;
+            }
+
+            public string OperatingSystem { get; }
+
+            public string OperatingSystemVersion { get; }
+
+            public override string ToString()
+            {
+                if (string.IsNullOrEmpty(OperatingSystem))
+                {
+                    return string.Empty;
+                }
+
+                if (string.IsNullOrEmpty(OperatingSystemVersion))
+                {
+                    return OperatingSystem;
+                }
+
+                return $"{OperatingSystem} {OperatingSystemVersion}";
+            }
+        }
+#endif
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/OperatingSystemHelper.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/OperatingSystemHelper.cs
@@ -1,8 +1,8 @@
 using System;
-
 #if DNXCORE50
 using System.Diagnostics;
 using System.IO;
+using NuGet.Common;
 #endif
 
 namespace NuGet.Protocol.Core.Types
@@ -15,14 +15,25 @@ namespace NuGet.Protocol.Core.Types
             return Environment.OSVersion.ToString();
         }
 #else
-        private static readonly Lazy<OperatingSystemInfo> _osInfo = new Lazy<OperatingSystemInfo>(GetOsDetails);
+        private static readonly Lazy<OperatingSystemInfo> _osInfo = new Lazy<OperatingSystemInfo>(GetOperatingSystemInfo);
 
         public static string GetVersion()
         {
             return _osInfo.Value.ToString();
         }
 
-        private static OperatingSystemInfo GetOsDetails()
+        private static OperatingSystemInfo GetOperatingSystemInfo()
+        {
+            if (!RuntimeEnvironmentHelper.IsWindows && RuntimeEnvironmentHelper.IsMono)
+            {
+                return GetOperatingSystemInfoOnMono();
+            }
+
+            // Could not determine OS version information. Defaulting to the empty string.
+            return new OperatingSystemInfo(null, null);
+        }
+
+        private static OperatingSystemInfo GetOperatingSystemInfoOnMono()
         {
             var unameOutput = RunProgram("uname", "-s -m").Split(' ');
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/UserAgent.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/UserAgent.cs
@@ -112,7 +112,7 @@ namespace NuGet.Protocol.Core.Types
             {
                 if (_OSVersion == null)
                 {
-                    _OSVersion = GetOSVersion();
+                    _OSVersion = OperatingSystemHelper.GetVersion();
                 }
                 return _OSVersion;
             }
@@ -135,17 +135,6 @@ namespace NuGet.Protocol.Core.Types
             NuGetVersion.TryParse(attr.ToString(), out version);
 
             return version;
-        }
-
-        private static string GetOSVersion()
-        {
-            string osVersion = string.Empty;
-
-#if !DNXCORE50
-            osVersion = Environment.OSVersion.ToString();
-#endif
-            // TODO: return OSVersion for DNXCORE50.
-            return osVersion;
         }
 
         private static class NuGetTestMode


### PR DESCRIPTION
Related to https://github.com/NuGet/Home/issues/2044

Ported osVersion detection on Mono from DNX ([found here](https://github.com/aspnet/dnx/blob/1.0.0-rc1-update1/src/Microsoft.Dnx.Host.Mono/EntryPoint.cs#L211))

CoreClr seems to be calling into native code ([see code](https://github.com/aspnet/dnx/blob/1.0.0-rc1-update1/src/Microsoft.Dnx.Host.CoreClr/DomainManager.cs#L22)), which may deserve its own PR. Do we want to go down that path?

Suggestions on how to create tests for these? I may be missing something, but couldn't immediately find any in dnx that add coverage for this codepath. I did manually verify this works on Linux CentOS with Mono v4.2.2.30.

@emgarten @yishaigalatzer 
