### PR TITLE
Add support for TLSv1.1 and TLSv1.2 in nuget.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Program.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using NuGet.Common;
+using NuGet.Protocol;
 
 namespace NuGet.CommandLine
 {
@@ -66,6 +67,8 @@ namespace NuGet.CommandLine
                 // Keep mono limited to a single download to avoid issues.
                 ServicePointManager.DefaultConnectionLimit = 1;
             }
+
+            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
 
             var console = new Common.Console();
             var fileSystem = new PhysicalFileSystem(workingDirectory);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Common;
 using NuGet.Logging;
+using NuGet.Protocol;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -48,6 +49,9 @@ namespace NuGet.CommandLine.XPlat
             XPlatUtility.SetConnectionLimit();
 
             XPlatUtility.SetUserAgent();
+
+            // This method has no effect on .NET Core.
+            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
 
             //register push and delete command
             new PushCommand(app, () =>

--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+
+namespace NuGet.Common
+{
+    public static class NetworkProtocolUtility
+    {
+        /// <summary>
+        /// This only has effect on .NET Framework (desktop). On .NET Core,
+        /// <see cref="ServicePointManager"/> is not available. Additionally,
+        /// no API is available to configure the supported SSL protocols.
+        /// </summary>
+        public static void ConfigureSupportedSslProtocols()
+        {
+#if !DNXCORE50
+            ServicePointManager.SecurityProtocol =
+                SecurityProtocolType.Ssl3 |
+                SecurityProtocolType.Tls |
+                SecurityProtocolType.Tls11 |
+                SecurityProtocolType.Tls12;
+#endif
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class NetworkProtocolUtilityTests
+    {
+        private const string Ssl20Name = "SSLv2.0";
+        private const string Ssl20TestUrl = "https://www.ssllabs.com:10200/";
+        private const string Ssl30Name = "SSLv3.0";
+        private const string Ssl30TestUrl = "https://www.ssllabs.com:10300/";
+        private const string Tls10Name = "TLSv1.0";
+        private const string Tls10TestUrl = "https://www.ssllabs.com:10301/";
+        private const string Tls11Name = "TLSv1.1";
+        private const string Tls11TestUrl = "https://www.ssllabs.com:10302/";
+        private const string Tls12Name = "TLSv1.2";
+        private const string Tls12TestUrl = "https://www.ssllabs.com:10303/";
+
+        [Theory]
+        [InlineData(Ssl20Name, Ssl20TestUrl, false)] // not supported
+        [InlineData(Ssl30Name, Ssl30TestUrl, null)]  // platform-specific support
+        [InlineData(Tls10Name, Tls10TestUrl, true)]  // supported everywhere
+        [InlineData(Tls11Name, Tls11TestUrl, true)]  // supported everywhere
+        [InlineData(Tls12Name, Tls12TestUrl, true)]  // supported everywhere
+        public async Task NetworkProtocolUtility_SupportedProtocols(string name, string url, bool? supported)
+        {
+            // Arrange
+            NetworkProtocolUtility.ConfigureSupportedSslProtocols();
+            var client = new HttpClient();
+
+            if (!supported.HasValue)
+            {
+#if DNXCORE50
+                // .NET Core bug: https://github.com/dotnet/corefx/issues/6668
+                if (name == Ssl30Name)
+                {
+                    supported = RuntimeEnvironmentHelper.IsLinux;
+                }
+#else
+                // Backwards compatibility.
+                if (name == Ssl30Name)
+                {
+                    supported = true;
+                }
+#endif
+            }
+
+            if (supported.Value)
+            {
+                // Act
+                using (var response = await client.GetAsync(url))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+            else
+            {
+                // Act & Assert
+                await Assert.ThrowsAsync<HttpRequestException>(() => client.GetAsync(url));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "3.4.0-rtm-*",
   "dependencies": {
     "NuGet.Common": "3.4.0-rtm-*",
@@ -13,11 +13,15 @@
     "dnx451": {
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "frameworkAssemblies": {
+        "System.Net.Http": ""
       }
     },
     "dnxcore50": {
       "dependencies": {
-        "moq.netcore": "4.4.0-beta8"
+        "moq.netcore": "4.4.0-beta8",
+        "System.Net.Http": "4.0.0-beta-23109"
       }
     }
   }


### PR DESCRIPTION
Fixes:
https://github.com/NuGet/Home/issues/2253
https://github.com/NuGet/Home/issues/390

@emgarten @yishaigalatzer @deepakaravindr @zhili1208 @alpaix 
