### PR TITLE
Update tab perf

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageManagerModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageManagerModel.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -37,6 +39,9 @@ namespace NuGet.PackageManagement.UI
         public bool IsSolution { get; private set; }
 
         public INuGetUI UIController { get; }
+
+        // Cached Package Metadata collected when we set the "count" of updates in the background
+        public PackageSearchMetadataCache CachedUpdates { get; set; }
 
         public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSearchMetadataCache.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSearchMetadataCache.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class PackageSearchMetadataCache
+    {
+        // Cached Package Metadata
+        public IReadOnlyList<IPackageSearchMetadata> Packages { get; set; }
+
+        // Remember the IncludePrerelease setting corresponding to the Cached Metadata
+        public bool IncludePrerelease { get; set; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -159,6 +159,27 @@ namespace NuGet.PackageManagement.UI
             return totalCount;
         }
 
+        public async Task<IReadOnlyList<IPackageSearchMetadata>> GetAllPackagesAsync(CancellationToken cancellationToken)
+        {
+            var packages = new List<IPackageSearchMetadata>();
+            ContinuationToken nextToken = null;
+            do
+            {
+                var searchResult = await SearchAsync(nextToken, cancellationToken);
+                while (searchResult.RefreshToken != null)
+                {
+                    searchResult = await _packageFeed.RefreshSearchAsync(searchResult.RefreshToken, cancellationToken);
+                }
+
+                nextToken = searchResult.NextToken;
+
+                packages.AddRange(searchResult.Items);
+
+            } while (nextToken != null);
+
+            return packages;
+        }
+
         public async Task LoadNextAsync(IProgress<IItemLoaderState> progress, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/NuGet.Clients/PackageManagement.UI/PackageLoadContext.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageLoadContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -24,6 +27,8 @@ namespace NuGet.PackageManagement.UI
         public bool IsSolution { get; private set; }
 
         public IEnumerable<IVsPackageManagerProvider> PackageManagerProviders { get; private set; }
+
+        public PackageSearchMetadataCache CachedPackages { get; set; }
 
         public PackageLoadContext(
             IEnumerable<SourceRepository> sourceRepositories,

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Converters\CollectionToStringConverter.cs" />
     <Compile Include="Converters\EnumDescriptionValueConverter.cs" />
     <Compile Include="Models\LoadingStatusViewModel.cs" />
+    <Compile Include="Models\PackageSearchMetadataCache.cs" />
     <Compile Include="Models\PackageSearchStatus.cs" />
     <Compile Include="Resources\Domain.cs" />
     <Compile Include="Resources\Resources.xaml.cs">

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
-using NuGet.Configuration;
-using NuGet.PackageManagement.UI;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerProviderTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerProviderTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using Xunit;
 using NuGet.VisualStudio;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/TestPackageManagerProviders.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/TestPackageManagerProviders.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
This change cached the updates we fetched for displaying the "count" of updates in the Model (that's Model with a capital "M")

Any changes around threading will be a separate chechin this is specifically about the caching.

Also added a couple of missing copyright headers - and noticed we need a few more - I can do those also as a separate commit.
