### PR TITLE
Fix clipping of Installed textbox when narrow.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
@@ -49,7 +49,6 @@
     <Border
       Grid.Row="0"
       Grid.Column="2"
-      MinWidth="150"
       MinHeight="22"
       BorderBrush="{DynamicResource {x:Static local:Brushes.ComboBoxBorderKey}}"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}}"


### PR DESCRIPTION
When the Installed textbox gets sized too narrow, the right border is clipped.
