### PR TITLE
Rtm build label fixes

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -378,11 +378,9 @@ Function Invoke-DnuPack {
         [string]$Output
     )
     Begin {
-        $BuildNumber = Format-BuildNumber $BuildNumber
-
         ## Setting the DNX build version
         if($ReleaseLabel -ne 'Release') {
-            $env:DNX_BUILD_VERSION="${ReleaseLabel}-${BuildNumber}"
+            $env:DNX_BUILD_VERSION="${ReleaseLabel}-$(Format-BuildNumber $BuildNumber)"
         }
 
         # Setting the DNX AssemblyFileVersion

--- a/src/NuGet.Clients/NuGet.CommandLine/project.json
+++ b/src/NuGet.Clients/NuGet.CommandLine/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.PackageManagement": "3.4.0-rtm-*"
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.Credentials/project.json
+++ b/src/NuGet.Clients/NuGet.Credentials/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*"
+    "NuGet.PackageManagement": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-rtm-*",
+    "NuGet.Resolver": "3.4.0-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-rtm-*"
+    "NuGet.Resolver": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.UI/project.json
+++ b/src/NuGet.Clients/PackageManagement.UI/project.json
@@ -13,11 +13,11 @@
     "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
-    "NuGet.Indexing": "3.4.0-rtm-*",
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*",
-    "NuGet.Resolver": "3.4.0-rtm-*"
+    "NuGet.Indexing": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*",
+    "NuGet.Resolver": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
-    "NuGet.Common": "3.4.0-rtm-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.Common": "3.4.0-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/SampleCommandLineExtensions/project.json
+++ b/src/NuGet.Clients/SampleCommandLineExtensions/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.PackageManagement": "3.4.0-rtm-*"
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/StandaloneConsole/project.json
+++ b/src/NuGet.Clients/StandaloneConsole/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*",
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
     "System.Management.Automation_PowerShell_3.0": "6.3.9600.17400",
-    "Test.Utility": "3.4.0-rtm-*"
+    "Test.Utility": "3.4.0-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/StandaloneUI/project.json
+++ b/src/NuGet.Clients/StandaloneUI/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "Test.Utility": "3.4.0-rtm-*"
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "Test.Utility": "3.4.0-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/VisualStudio/project.json
+++ b/src/NuGet.Clients/VisualStudio/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*"
+    "NuGet.Protocol.VisualStudio": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/Console.Types/project.json
+++ b/src/NuGet.Clients/VsConsole/Console.Types/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*"
+    "NuGet.PackageManagement": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-rtm-*"
+    "NuGet.Resolver": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*"
+    "NuGet.PackageManagement": "3.4.0-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsExtension/project.json
+++ b/src/NuGet.Clients/VsExtension/project.json
@@ -19,8 +19,8 @@
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Microsoft.VSSDK.BuildTools": "14.0.23107",
     "Microsoft.WindowsAzure.ConfigurationManager": "1.7.0",
-    "NuGet.Commands": "3.4.0-rtm-*",
-    "NuGet.Indexing": "3.4.0-rtm-*",
+    "NuGet.Commands": "3.4.0-*",
+    "NuGet.Indexing": "3.4.0-*",
     "System.IdentityModel.Tokens.Jwt": "4.0.0"
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,25 +1,23 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-rtm-*",
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Repositories": "3.4.0-rtm-*",
-    "NuGet.RuntimeModel": "3.4.0-rtm-*",
-    "NuGet.ContentModel": "3.4.0-rtm-*",
+    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Repositories": "3.4.0-*",
+    "NuGet.RuntimeModel": "3.4.0-*",
+    "NuGet.ContentModel": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     }
   },
   "frameworks": {
-    "net45": {},
+    "net45": { },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "compilationOptions": {
     "emitEntryPoint": true,
@@ -8,9 +8,9 @@
   "dependencies": {
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
     "Microsoft.NETCore.Platforms": "1.0.1-beta-*",
-    "NuGet.Commands": "3.4.0-rtm-*",
+    "NuGet.Commands": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     },
     "System.Runtime.Serialization.Primitives": "4.0.0",
@@ -31,9 +31,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Threading.Tasks": "4.0.11-beta-23516",
         "System.Console": "4.0.0-beta-23409"

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "compilationOptions": {
     "warningsAsErrors": true
@@ -17,14 +17,14 @@
     "../../../tools/compiler/preprocess/Internalization.cs"
   ],
   "dependencies": {
-    "NuGet.Client": "3.4.0-rtm-*",
-    "NuGet.ContentModel": "3.4.0-rtm-*",
-    "NuGet.ProjectModel": "3.4.0-rtm-*",
-    "NuGet.Configuration": "3.4.0-rtm-*",
-    "NuGet.DependencyResolver": "3.4.0-rtm-*",
-    "NuGet.RuntimeModel": "3.4.0-rtm-*",
+    "NuGet.Client": "3.4.0-*",
+    "NuGet.ContentModel": "3.4.0-*",
+    "NuGet.ProjectModel": "3.4.0-*",
+    "NuGet.Configuration": "3.4.0-*",
+    "NuGet.DependencyResolver": "3.4.0-*",
+    "NuGet.RuntimeModel": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     }
   },
@@ -56,9 +56,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Collections": "4.0.10-beta-23109",
         "System.Linq.Parallel": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,26 +1,26 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
-  "frameworks": {
-    "net45": {
-      "frameworkAssemblies": {
-        "System.IO.Compression": ""
-      }
-    },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23225",
-        "System.Collections": "4.0.0-beta-23109",
-        "System.IO.Compression": "4.0.0-beta-23109",
-        "System.IO.FileSystem": "4.0.0-beta-23109",
-        "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
-        "System.Linq": "4.0.0-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109",
-        "System.Text.RegularExpressions": "4.0.10-beta-23109",
-        "System.Threading": "4.0.10-beta-23109",
-        "System.Threading.Thread": "4.0.0-beta-23109",
-        "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
-        "System.Diagnostics.Process": "4.0.0-beta-23109"
-      }
+  "version": "3.4.0-*",
+    "frameworks": {
+        "net45": {
+            "frameworkAssemblies": {
+                "System.IO.Compression": ""
+            }
+        },
+        "dnxcore50": {
+          "dependencies": {
+               "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23225",
+               "System.Collections": "4.0.0-beta-23109",
+               "System.IO.Compression": "4.0.0-beta-23109",
+               "System.IO.FileSystem": "4.0.0-beta-23109",
+               "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
+               "System.Linq": "4.0.0-beta-23109",
+               "System.Runtime.Extensions": "4.0.10-beta-23109",
+               "System.Text.RegularExpressions": "4.0.10-beta-23109",
+               "System.Threading": "4.0.10-beta-23109",
+               "System.Threading.Thread": "4.0.0-beta-23109",
+               "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
+               "System.Diagnostics.Process": "4.0.0-beta-23109"
+          }
+        }
     }
-  }
 }

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -16,10 +16,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*",
+    "NuGet.Common": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,12 +1,12 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,25 +1,23 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.LibraryModel": "3.4.0-rtm-*",
-    "NuGet.Frameworks": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*",
-    "NuGet.Repositories": "3.4.0-rtm-*",
-    "NuGet.RuntimeModel": "3.4.0-rtm-*",
+    "NuGet.LibraryModel": "3.4.0-*",
+    "NuGet.Frameworks": "3.4.0-*",
+    "NuGet.Protocol.Core.v3": "3.4.0-*",
+    "NuGet.Repositories": "3.4.0-*",
+    "NuGet.RuntimeModel": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,23 +1,21 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*",
-    "NuGet.DependencyResolver.Core": "3.4.0-rtm-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Protocol.Core.v3": "3.4.0-*",
+    "NuGet.DependencyResolver.Core": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "The understanding of target frameworks for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-rtm-*",
+    "NuGet.Versioning": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet.Indexing Class Library",
   "compile": [
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
@@ -16,10 +16,10 @@
   ],
   "dependencies": {
     "Lucene.Net": "3.0.3",
-    "NuGet.Versioning": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*"
+    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*"
   },
   "frameworks": {
-    "net45": {}
+    "net45": { }
   }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,10 +1,10 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-rtm-*",
+    "NuGet.Versioning": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -13,7 +13,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,16 +1,16 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet Package Management",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.Commands": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.v2": "3.4.0-rtm-*",
-    "NuGet.Resolver": "3.4.0-rtm-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.Commands": "3.4.0-*",
+    "NuGet.Protocol.Core.v2": "3.4.0-*",
+    "NuGet.Resolver": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,11 +1,11 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     },
-    "NuGet.Frameworks": "3.4.0-rtm-*"
+    "NuGet.Frameworks": "3.4.0-*"
   },
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "The core data structures for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging.Core.Types": "3.4.0-rtm-*",
+    "NuGet.Packaging.Core.Types": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet's implementation for reading nupkg package and nuspec package specification files.",
   "authors": [
     "NuGet"
@@ -15,15 +15,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*",
-    "NuGet.Frameworks": "3.4.0-rtm-*",
+    "NuGet.Common": "3.4.0-*",
+    "NuGet.Frameworks": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     },
-    "NuGet.Packaging.Core": "3.4.0-rtm-*",
-    "NuGet.Logging": "3.4.0-rtm-*",
-    "NuGet.Versioning": "3.4.0-rtm-*"
+    "NuGet.Packaging.Core": "3.4.0-*",
+    "NuGet.Logging": "3.4.0-*",
+    "NuGet.Versioning": "3.4.0-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,14 +1,14 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet Project Management",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
-    "NuGet.ProjectModel": "3.4.0-rtm-*",
+    "NuGet.ProjectModel": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,11 +1,11 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.DependencyResolver.Core": "3.4.0-rtm-*",
+    "NuGet.DependencyResolver.Core": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "compilationOptions": {
@@ -14,9 +14,7 @@
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Dynamic.Runtime": "4.0.10-*"
       }

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*",
-    "NuGet.Configuration": "3.4.0-rtm-*",
-    "NuGet.Packaging": "3.4.0-rtm-*",
+    "NuGet.Common": "3.4.0-*",
+    "NuGet.Configuration": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -14,13 +14,13 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.0-rtm-*",
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*",
+    "NuGet.Configuration": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*",
     "NuGet.Core": "2.11.0",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -16,11 +16,11 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     },
-    "NuGet.Logging": "3.4.0-rtm-*",
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*",
+    "NuGet.Logging": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*",
     "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {
@@ -34,9 +34,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Dynamic.Runtime": "4.0.10-beta-23109",
         "System.Net.Http.WinHttpHandler": "4.0.0-beta-23409",

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -4,16 +4,14 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*"
+    "NuGet.Protocol.Core.v3": "3.4.0-*"
   },
   "frameworks": {
     "dnx451": {
       "dependencies": {}
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Runtime": "4.0.20-beta-23109",
         "System.Net.Http": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.v2": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*",
+    "NuGet.Configuration": "3.4.0-*",
+    "NuGet.Protocol.Core.v2": "3.4.0-*",
+    "NuGet.Protocol.Core.v3": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,10 +1,10 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-rtm-*",
+    "NuGet.Packaging": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "description": "NuGet's dependency resolver within the NuGet.Packaging package",
   "authors": [
     "NuGet"
@@ -11,11 +11,11 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-rtm-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Protocol.Core.Types": "3.4.0-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -7,10 +7,10 @@
     "Newtonsoft.Json": "6.0.4",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     },
-    "NuGet.Versioning": "3.4.0-rtm-*",
-    "NuGet.Frameworks": "3.4.0-rtm-*"
+    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Frameworks": "3.4.0-*"
   },
   "frameworks": {
     "net45": {
@@ -19,9 +19,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.IO.FileSystem": "4.0.0-beta-23109",
         "System.Collections": "4.0.10-beta-23109",

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -1,25 +1,25 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
-  "shared": "*.cs",
-  "frameworks": {
-    "net45": {
-      "frameworkAssemblies": {
-        "System.IO.Compression": ""
-      }
-    },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23225",
-        "System.Collections": "4.0.0-beta-23109",
-        "System.IO.Compression": "4.0.0-beta-23109",
-        "System.IO.FileSystem": "4.0.0-beta-23109",
-        "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109",
-        "System.Threading": "4.0.10-beta-23109",
-        "System.Threading.Thread": "4.0.0-beta-23109",
-        "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
-        "System.Diagnostics.Process": "4.0.0-beta-23109"
-      }
+  "version": "3.4.0-*",
+    "shared": "*.cs",
+    "frameworks": {
+        "net45": {
+            "frameworkAssemblies": {
+                "System.IO.Compression": ""
+            }
+        },
+        "dnxcore50": {
+          "dependencies": {
+            "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23225",
+            "System.Collections": "4.0.0-beta-23109",
+            "System.IO.Compression": "4.0.0-beta-23109",
+            "System.IO.FileSystem": "4.0.0-beta-23109",
+            "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
+            "System.Runtime.Extensions": "4.0.10-beta-23109",
+            "System.Threading": "4.0.10-beta-23109",
+            "System.Threading.Thread": "4.0.0-beta-23109",
+            "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
+            "System.Diagnostics.Process": "4.0.0-beta-23109"
+          }
+        }
     }
-  }
 }

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*"
+    "NuGet.Common": "3.4.0-*"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
       "dependencies": {
         "System.Net.NetworkInformation": "4.0.10-beta-23019",

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,11 +1,11 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "xunit": "2.1.0",
-    "NuGet.Packaging": "3.4.0-rtm-*"
+    "NuGet.Packaging": "3.4.0-*"
   },
   "frameworks": {
     "net45": {
@@ -14,9 +14,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.IO.Compression.ZipFile": "4.0.0-beta-23109",
         "System.IO.FileSystem": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "authors": [
     "NuGet"
   ],
@@ -17,7 +17,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-rtm-*"
+      "version": "3.4.0-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -1,39 +1,39 @@
 ﻿{
-  "version": "1.0.0-*",
-  "description": "SynchronizationTestApp Console Application",
-  "authors": [
-    "yigalatz"
-  ],
-  "tags": [
-    ""
-  ],
-  "projectUrl": "",
-  "licenseUrl": "",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
+    "version": "1.0.0-*",
+    "description": "SynchronizationTestApp Console Application",
+    "authors": [ "yigalatz" ],
+    "tags": [ "" ],
+    "projectUrl": "",
+    "licenseUrl": "",
+
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*",
+    "NuGet.Common": "3.4.0-*",
     "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
+      "version": "3.4.0-*",
       "type": "build"
     }
   },
-  "commands": {
-    "SynchronizationTestApp": "SynchronizationTestApp"
-  },
-  "frameworks": {
-    "dnx451": {},
-    "dnxcore50": {
-      "dependencies": {
-        "Microsoft.CSharp": "4.0.0-beta-23109",
-        "System.Collections": "4.0.0-beta-23109",
-        "System.Console": "4.0.0-beta-23109",
-        "System.Linq": "4.0.0-beta-23109",
-        "System.Threading": "4.0.0-beta-23109",
-        "System.Net.Sockets": "4.1.0-beta-23516",
-        "System.Diagnostics.Process": "4.0.0-beta-23109"
-      }
+
+    "commands": {
+        "SynchronizationTestApp": "SynchronizationTestApp"
+    },
+
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": {
+          "dependencies": {
+            "Microsoft.CSharp": "4.0.0-beta-23109",
+            "System.Collections": "4.0.0-beta-23109",
+            "System.Console": "4.0.0-beta-23109",
+            "System.Linq": "4.0.0-beta-23109",
+            "System.Threading": "4.0.0-beta-23109",
+            "System.Net.Sockets": "4.1.0-beta-23516",
+            "System.Diagnostics.Process": "4.0.0-beta-23109"
+          }
+        }
     }
-  }
 }

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,15 +1,15 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
     "Microsoft.VisualStudio.ProjectSystem.Interop": "",
     "xunit": "2.1.0",
-    "NuGet.Test.Utility": "3.4.0-rtm-*"
+    "NuGet.Test.Utility": "3.4.0-*"
   },
   "frameworks": {
     "net45": {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-rtm-*",
+    "Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-rtm-*",
+    "Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-rtm-*",
+    "Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
@@ -16,7 +16,7 @@
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-rtm-*",
+    "Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Commands": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -10,11 +10,9 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Protocol.Core.v3": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -10,11 +10,9 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Client": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Client": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -10,11 +10,9 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.CommandLine.XPlat": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.CommandLine.XPlat": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -10,6 +10,6 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {}
+    "dnx451": { }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Commands": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -12,9 +12,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Common": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Common": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -1,26 +1,26 @@
-﻿{
-  "dependencies": {
-    "NuGet.Configuration": "3.4.0-rtm-*",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
-    "NuGet.Common": "3.4.0-rtm-*"
-  },
-  "commands": {
-    "test": "xunit.runner.dnx"
-  },
-  "frameworks": {
-    "dnx451": {
-      "dependencies": {
-        "Moq": "4.2.1510.2205"
-      }
+{
+    "dependencies": {
+        "NuGet.Configuration": "3.4.0-*",
+        "xunit": "2.1.0",
+        "xunit.runner.dnx": "2.1.0-rc1-build204",
+        "NuGet.Test.Utility": "3.4.0-*",
+        "NuGet.Common": "3.4.0-*"
     },
-    "dnxcore50": {
-      "imports": "portable-net45+win8",
-      "dependencies": {
-        "moq.netcore": "4.4.0-beta8",
-        "System.Threading.Tasks.Parallel": "4.0.1-beta-23516"
-      }
+    "commands": {
+        "test": "xunit.runner.dnx"
+    },
+    "frameworks": {
+        "dnx451": {
+          "dependencies": {
+            "Moq": "4.2.1510.2205"
+          }
+        },
+        "dnxcore50": {
+            "imports": "portable-net45+win8",
+            "dependencies": {
+                "moq.netcore": "4.4.0-beta8",
+                "System.Threading.Tasks.Parallel": "4.0.1-beta-23516"
+            }
+        }
     }
-  }
 }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver.Core": "3.4.0-rtm-*",
+    "NuGet.DependencyResolver.Core": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver": "3.4.0-rtm-*",
+    "NuGet.DependencyResolver": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-rtm-*",
+{
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Frameworks": "3.4.0-rtm-*",
-    "NuGet.Packaging": "3.4.0-rtm-*",
+    "NuGet.Frameworks": "3.4.0-*",
+    "NuGet.Packaging": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -16,9 +16,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8"
       }

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
@@ -1,9 +1,9 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Indexing": "3.4.0-rtm-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
+    "NuGet.Indexing": "3.4.0-*",
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,6 +11,6 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {}
+    "dnx451": { }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -1,7 +1,7 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.0-rtm-*",
+    "NuGet.ProjectModel": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Logging": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Logging": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -16,9 +16,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8"
       }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -1,9 +1,9 @@
-﻿{
-  "version": "3.4.0-rtm-*",
+{
+  "version": "3.4.0-*",
   "dependencies": {
     "Moq": "4.2.1510.2205",
-    "NuGet.PackageManagement": "3.4.0-rtm-*",
-    "Test.Utility": "3.4.0-rtm-*",
+    "NuGet.PackageManagement": "3.4.0-*",
+    "Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,6 +11,7 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {}
+    "dnx451": {
+    }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Packaging.Core": "3.4.0-rtm-*",
+    "NuGet.Packaging.Core": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-rtm-*",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
+    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Test.Utility": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -16,9 +16,7 @@
       }
     },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8"
       }

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -1,15 +1,16 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-rtm-*",
+    "NuGet.ProjectManagement": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "Test.Utility": "3.4.0-rtm-*"
+    "Test.Utility": "3.4.0-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {}
+    "dnx451": {
+    }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.0-rtm-*",
+    "NuGet.ProjectModel": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -1,21 +1,19 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-rtm-*",
+    "NuGet.Protocol.Core.v3": "3.4.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
-    "NuGet.Test.Server": "3.4.0-rtm-*"
+    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Test.Server": "3.4.0-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": {},
+    "dnx451": { },
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Collections": "4.0.10-beta-23109",
         "System.Net.Requests": "4.0.11-beta-23516"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -1,8 +1,8 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Protocol.VisualStudio": "3.4.0-rtm-*",
+    "NuGet.Protocol.VisualStudio": "3.4.0-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-rtm-*",
+    "NuGet.Resolver": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
+  "version": "3.4.0-*",
   "dependencies": {
-    "NuGet.RuntimeModel": "3.4.0-rtm-*",
+    "NuGet.RuntimeModel": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -11,9 +11,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ]
+      "imports": [ "portable-net45+win8" ]
     }
   }
 }

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -1,28 +1,26 @@
 ﻿{
-  "version": "3.4.0-rtm-*",
-  "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
-    "NuGet.Shared": {
-      "version": "3.4.0-rtm-*",
-      "type": "build"
+    "version": "3.4.0-*",
+    "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+        "NuGet.Shared": {
+            "version": "3.4.0-*",
+            "type": "build"
+        },
+        "NuGet.Test.Utility": "3.4.0-*",
+        "SynchronizationTestApp": "1.0.0-*",
+        "xunit": "2.1.0",
+        "xunit.runner.dnx": "2.1.0-rc1-build204"
     },
-    "NuGet.Test.Utility": "3.4.0-rtm-*",
-    "SynchronizationTestApp": "1.0.0-*",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204"
-  },
-  "commands": {
-    "test": "xunit.runner.dnx"
-  },
-  "frameworks": {
-    "dnx451": {},
-    "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
-      "dependencies": {
-        "System.Runtime": "4.0.21-beta-23516"
+    "commands": {
+        "test": "xunit.runner.dnx"
+    },
+    "frameworks": {
+        "dnx451": { },
+      "dnxcore50": {
+        "imports": [ "portable-net45+win8" ],
+        "dependencies": {
+          "System.Runtime": "4.0.21-beta-23516"
+        }
       }
     }
-  }
 }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-rtm-*",
+    "NuGet.Versioning": "3.4.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
@@ -10,9 +10,7 @@
   "frameworks": {
     "dnx451": {},
     "dnxcore50": {
-      "imports": [
-        "portable-net45+win8"
-      ],
+      "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "System.Collections": "4.0.0-beta-23109"
       }


### PR DESCRIPTION
-   Revert "3.4.0-\* -> 3.4.0-rtm-*".
-   Fixed build number format to be precisely 4 digits.

// @yishaigalatzer @emgarten @deepakaravindr 
