### PR TITLE
fix RID detection on OSX when using latest PlatformAbstractions

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/RuntimeEnvironmentExtensions.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/RuntimeEnvironmentExtensions.cs
@@ -53,7 +53,7 @@ namespace NuGet.CommandLine.XPlat
 
                 return os + ver;
             }
-            else if (string.Equals(env.OperatingSystem, "Darwin", StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(env.OperatingSystem, "Darwin", StringComparison.OrdinalIgnoreCase) || string.Equals(env.OperatingSystem, "Mac OS X", StringComparison.OrdinalIgnoreCase))
             {
                 os = "osx";
             }


### PR DESCRIPTION
We changed what `IRuntimeEnvironment.OperatingSystem` reports on Mac OS X in RC2, it now returns "Mac OS X" instead of "Darwin", and the RID inference hack needs to be updated to match.

Technically, NuGet builds against RC1 (which is why NuGet can't use the more stable `IRuntimeEnvironment.OperatingSystemPlatform` property we added in RC2) but in the CLI we use an RC2 build of PlatformAbstractions which stomps the dependency. The ideal solution would probably be to get NuGet over to RC2, but that's got a whole lot of other stuff behind it :).

/cc @emgarten @yishaigalatzer @davidfowl - If we can get this small change in ASAP that would be awesome :)
