### PR TITLE
Restore tools to the .tools directory

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.ProjectModel;
+
+namespace NuGet.Commands
+{
+    public class ToolRestoreResult
+    {
+        public ToolRestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs, string lockFilePath, LockFile lockFile)
+        {
+            Success = success;
+            RestoreGraphs = restoreGraphs;
+            LockFilePath = lockFilePath;
+            LockFile = lockFile;
+        }
+        
+        public bool Success { get; }
+        public IEnumerable<RestoreTargetGraph> RestoreGraphs { get; }
+        public string LockFilePath { get; }
+        public LockFile LockFile { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/IncludeFlagUtils.cs
@@ -11,6 +11,21 @@ namespace NuGet.Commands
     internal static class IncludeFlagUtils
     {
         internal static Dictionary<string, LibraryIncludeFlags> FlattenDependencyTypes(
+            Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs,
+            PackageSpec project,
+            RestoreTargetGraph graph)
+        {
+            Dictionary<string, LibraryIncludeFlags> flattenedFlags;
+            if (!includeFlagGraphs.TryGetValue(graph, out flattenedFlags))
+            {
+                flattenedFlags = FlattenDependencyTypes(graph, project);
+                includeFlagGraphs.Add(graph, flattenedFlags);
+            }
+
+            return flattenedFlags;
+        }
+
+        internal static Dictionary<string, LibraryIncludeFlags> FlattenDependencyTypes(
             RestoreTargetGraph targetGraph,
             PackageSpec spec)
         {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -11,7 +11,6 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
-using NuGet.RuntimeModel;
 
 namespace NuGet.Commands
 {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -375,6 +375,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Restoring packages for tool &apos;{0}&apos; in {1}....
+        /// </summary>
+        internal static string Log_RestoringToolPackages {
+            get {
+                return ResourceManager.GetString("Log_RestoringToolPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Running non-parallel restore..
         /// </summary>
         internal static string Log_RunningNonParallelRestore {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -255,4 +255,10 @@
   <data name="Error_InvalidCommandLineInput" xml:space="preserve">
     <value>Invalid input '{0}'. The file type was not recognized.</value>
   </data>
+  <data name="Log_RestoringToolPackages" xml:space="preserve">
+    <value>Restoring packages for tool '{0}' in {1}...</value>
+    <comment>String format parameters:
+{0} is replaced with the tool ID.
+{1} is replaced with a path to the project that is being restored.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -17,46 +17,46 @@ namespace NuGet.Packaging
             _normalizePackageId = normalizePackageId;
         }
 
-        public virtual string GetInstallPath(string packageId, SemanticVersion version)
+        public virtual string GetInstallPath(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return Path.Combine(_path, GetPackageDirectory(packageId, version));
         }
 
-        public string GetPackageFilePath(string packageId, SemanticVersion version)
+        public string GetPackageFilePath(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return Path.Combine(GetInstallPath(packageId, version),
                 GetPackageFileName(packageId, version));
         }
 
-        public string GetManifestFilePath(string packageId, SemanticVersion version)
+        public string GetManifestFilePath(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return Path.Combine(GetInstallPath(packageId, version),
                 GetManifestFileName(packageId, version));
         }
 
-        public string GetHashPath(string packageId, SemanticVersion version)
+        public string GetHashPath(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return Path.Combine(GetInstallPath(packageId, version),
-                string.Format("{0}.{1}.nupkg.sha512", packageId, version.ToNormalizedString()));
+                $"{packageId}.{version.ToNormalizedString()}.nupkg.sha512");
         }
 
-        public virtual string GetPackageDirectory(string packageId, SemanticVersion version)
+        public virtual string GetPackageDirectory(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return Path.Combine(packageId, version.ToNormalizedString());
         }
 
-        public virtual string GetPackageFileName(string packageId, SemanticVersion version)
+        public virtual string GetPackageFileName(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
-            return string.Format("{0}.{1}.nupkg", packageId, version.ToNormalizedString());
+            return $"{packageId}.{version.ToNormalizedString()}.nupkg";
         }
 
-        public virtual string GetManifestFileName(string packageId, SemanticVersion version)
+        public virtual string GetManifestFileName(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
             return packageId + ".nuspec";

--- a/src/NuGet.Core/NuGet.ProjectModel/ToolPathResolver.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ToolPathResolver.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public class ToolPathResolver
+    {
+        private readonly string _packagesDirectory;
+
+        public ToolPathResolver(string packagesDirectory)
+        {
+            _packagesDirectory = packagesDirectory;
+        }
+
+        public string GetLockFilePath(string packageId, NuGetVersion version, NuGetFramework framework)
+        {
+            return Path.Combine(
+                _packagesDirectory,
+                ".tools",
+                packageId,
+                version.ToNormalizedString(),
+                framework.GetShortFolderName(),
+                LockFileFormat.LockFileName);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -79,5 +79,10 @@ namespace NuGet.Test.Utility
         {
             return string.Join(Environment.NewLine, ErrorMessages);
         }
+
+        public string ShowMessages()
+        {
+            return string.Join(Environment.NewLine, Messages);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
@@ -123,6 +126,218 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.True(result.Success);
                 Assert.Equal(0, lockFile.Libraries.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_RestoresTools()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            var project1Json = @"
+            {
+              ""frameworks"": {
+                ""net45"": { }
+              },
+              ""tools"": {
+                ""packageB"": ""*""
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/netstandard1.3/a.dll");
+
+                var packageB = new SimpleTestPackageContext("packageB");
+                packageB.AddFile("lib/netstandard1.4/b.dll");
+                packageB.Dependencies.Add(packageA);
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA, packageB);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(
+                    result.Success,
+                    "The command did not succeed. Error messages: "
+                    + Environment.NewLine + logger.ShowErrors());
+                Assert.Equal(1, result.ToolRestoreResults.Count());
+
+                var toolResult = result.ToolRestoreResults.First();
+                Assert.NotNull(toolResult.LockFilePath);
+                Assert.True(
+                    File.Exists(toolResult.LockFilePath),
+                    $"The tool lock file at {toolResult.LockFilePath} does not exist.");
+                Assert.NotNull(toolResult.LockFile);
+                Assert.Equal(1, toolResult.LockFile.Targets.Count);
+
+                var target = toolResult.LockFile.Targets[0];
+                Assert.Null(target.RuntimeIdentifier);
+                Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandardApp15, target.TargetFramework);
+                Assert.Equal(2, target.Libraries.Count);
+
+                var library = target.Libraries.First(l => l.Name == "packageB");
+                Assert.NotNull(library);
+                Assert.Equal("lib/netstandard1.4/b.dll", library.RuntimeAssemblies[0].Path);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_FailsCommandWhenToolRestoreFails()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            var project1Json = @"
+            {
+              ""frameworks"": {
+                ""net45"": { }
+              },
+              ""tools"": {
+                ""packageA"": ""*""
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // The tool is not available on the source.
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.False(result.Success,
+                    "The command should not have succeeded. Messages: "
+                    + Environment.NewLine + logger.ShowMessages());
+                Assert.Equal(1, result.ToolRestoreResults.Count());
+
+                var toolResult = result.ToolRestoreResults.First();
+                Assert.Null(toolResult.LockFilePath);
+                Assert.NotNull(toolResult.LockFile);
+                Assert.Equal(1, toolResult.LockFile.Targets.Count);
+
+                var target = toolResult.LockFile.Targets[0];
+                Assert.Null(target.RuntimeIdentifier);
+                Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandardApp15, target.TargetFramework);
+                Assert.Equal(0, target.Libraries.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_HandlesMultipleToolRestores()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+            var project1Json = @"
+            {
+              ""frameworks"": {
+                ""net45"": { }
+              },
+              ""tools"": {
+                ""packageA"": ""*"",
+                ""packageB"": ""*"",
+                ""packageC"": ""*""
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // packageA is not on the source
+
+                var packageB = new SimpleTestPackageContext("packageB");
+                packageB.AddFile("lib/netstandard1.3/a.dll");
+
+                // packageC is not on the source
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageB);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                result.Commit(logger);
+
+                // Assert
+                Assert.False(result.Success,
+                    "The command should not have succeeded. Messages: "
+                    + Environment.NewLine + logger.ShowMessages());
+                Assert.Equal(3, result.ToolRestoreResults.Count());
+
+                var packageAResult = result.ToolRestoreResults.ElementAt(0);
+                Assert.Null(packageAResult.LockFilePath);
+                Assert.NotNull(packageAResult.LockFile);
+                Assert.Equal(1, packageAResult.LockFile.Targets.Count);
+                Assert.False(packageAResult.Success, "packageA tool restore should not have succeeded.");
+
+                var packageBResult = result.ToolRestoreResults.ElementAt(1);
+                Assert.NotNull(packageBResult.LockFilePath);
+                Assert.NotNull(packageBResult.LockFile);
+                Assert.Equal(1, packageBResult.LockFile.Targets.Count);
+                Assert.True(packageBResult.Success, "packageB tool restore should have succeeded.");
+
+                var packageCResult = result.ToolRestoreResults.ElementAt(2);
+                Assert.Null(packageCResult.LockFilePath);
+                Assert.NotNull(packageCResult.LockFile);
+                Assert.Equal(1, packageCResult.LockFile.Targets.Count);
+                Assert.False(packageCResult.Success, "packageC tool restore should not have succeeded.");
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
@@ -141,6 +141,19 @@ namespace NuGet.Packaging.Test
             Assert.False(isValid);
         }
 
+        [Fact]
+        public void DotToolsIsNotAllowed()
+        {
+            // Arrange
+            string packageId = ".tools";
+
+            // Act
+            bool isValid = PackageIdValidator.IsValidPackageId(packageId);
+
+            // Assert
+            Assert.False(isValid);
+        }
+
         [Theory]
         [InlineData(101)]
         [InlineData(102)]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ToolPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ToolPathResolverTests.cs
@@ -1,0 +1,33 @@
+﻿using System.IO;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class ToolPathResolverTests
+    {
+        [Fact]
+        public void ToolPathResolver_BuildsLockFilePath()
+        {
+            // Arrange
+            var target = new ToolPathResolver("packages");
+            var expected = Path.Combine(
+                "packages",
+                ".tools",
+                "packageA",
+                "3.1.4",
+                "netstandard1.3",
+                "project.lock.json");
+
+            // Act
+            var actual = target.GetLockFilePath(
+                "packageA",
+                NuGetVersion.Parse("3.1.4"),
+                FrameworkConstants.CommonFrameworks.NetStandard13);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Done:
1. Added a step at the end of `RestoreCommand` to look at the `tools` node in the `project.json` and restore each tool.
2. During the commit of the `RestoreResult`, each tool gets a `project.lock.json` file written to `(packages folder)/.tools/{tool ID}/{tool version}/netstandardapp1.5/project.lock.json`.
3. Failures in tool restore cause the whole restore to fail.

~~Open questions for this PR (thus the **WIP** prefix):~~
1. ~~Should we have guardrails of any kind for tool restore? For example, what happens if a `net45` package is put in the project.json as a tool and then restored? Success? Error? Warning? Current functionality is that no error at is thrown and NuGet is expecting the CLI to detect the problem.~~
2. ~~What other tests should we have?~~

Future PRs:
1. Add the notion of package type to the nuspec. This will be the flag that tells the install tooling that a package should be added to the `tools` node rather than the `dependencies` node.
2. Determine if the restore should always be for `netstandardapp1.5` with a null RID. 
3. Update the project.json schema in [SchemaStore](https://github.com/schemastore/schemastore/) to have `tools` so editors are nicer.
4. Add tools section to the lock file so a consistent tool version can be used.

@emgarten @brthor @yishaigalatzer @davidfowl @piotrp
