### PR TITLE
Remove support for SSLv3.0

### DIFF
--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -16,7 +16,6 @@ namespace NuGet.Common
         {
 #if !DNXCORE50
             ServicePointManager.SecurityProtocol =
-                SecurityProtocolType.Ssl3 |
                 SecurityProtocolType.Tls |
                 SecurityProtocolType.Tls11 |
                 SecurityProtocolType.Tls12;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -9,23 +9,25 @@ namespace NuGet.CommandLine.Test
     public class NuGetListCommandTest
     {
         [Theory]
-        [InlineData("https://www.ssllabs.com:10300/index.json")] // SSLv3.0
-        [InlineData("https://www.ssllabs.com:10301/index.json")] // TLSv1.0
-        [InlineData("https://www.ssllabs.com:10302/index.json")] // TLSv1.1
-        [InlineData("https://www.ssllabs.com:10303/index.json")] // TLSv1.2
-        public void ListCommand_SupportsServersWithSsl(string source)
+        [InlineData("https://www.ssllabs.com:10200/index.json", false)] // SSLv2.0
+        [InlineData("https://www.ssllabs.com:10300/index.json", false)] // SSLv3.0
+        [InlineData("https://www.ssllabs.com:10301/index.json", true)]  // TLSv1.0
+        [InlineData("https://www.ssllabs.com:10302/index.json", true)]  // TLSv1.1
+        [InlineData("https://www.ssllabs.com:10303/index.json", true)]  // TLSv1.2
+        public void ListCommand_SupportsServersWithAcceptableSsl(string source, bool supported)
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
 
-            // The following source URL is not a valid NuGet source but is a HTTP server known
-            // to support only a single SSL protocol (it is a test server for this specific
-            // purpose). Since it is not a valid NuGet server, the command should fail but should
-            // fail with an error that indicates a successful HTTP connection. In this case, a 404
-            // Not Found is returned.
+            // The following URLs for this test are not valid NuGet sources but are HTTP servers
+            // known to support only a single SSL protocol (they are test servers for this specific
+            // purpose). Since they are not a valid NuGet servers, the command should always fails,
+            // but the error indicates whether a successful HTTP session was made. In this case, a
+            // 404 Not Found is returned if nuget.exe can talk to the source.
             //
             // http://stackoverflow.com/a/29221439/52749
-            string[] args = { "list", Guid.NewGuid().ToString(), "-Source", source };
+            var args = new[] { "list", Guid.NewGuid().ToString(), "-Source", source };
+            var supportedIndicator = "Response status code does not indicate success: 404 (Not Found).";
 
             // Act
             var result = CommandRunner.Run(
@@ -37,7 +39,14 @@ namespace NuGet.CommandLine.Test
             // Assert
             Assert.Equal(1, result.Item1);
             Assert.Contains($"Unable to load the service index for source {source}.", result.Item3);
-            Assert.Contains("Response status code does not indicate success: 404 (Not Found).", result.Item3);
+            if (supported)
+            {
+                Assert.Contains(supportedIndicator, result.Item3);
+            }
+            else
+            {
+                Assert.DoesNotContain(supportedIndicator, result.Item3);
+            }
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
@@ -39,10 +39,9 @@ namespace NuGet.Common.Test
                     supported = RuntimeEnvironmentHelper.IsLinux;
                 }
 #else
-                // Backwards compatibility.
                 if (name == Ssl30Name)
                 {
-                    supported = true;
+                    supported = false;
                 }
 #endif
             }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2261.

> Kill ssl 2 & 3 with fire

:fire: 

@emgarten @yishaigalatzer @blowdart 
