### PR TITLE
Reset loading status when exception is thrown.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/LoadingStatusIndicator.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/LoadingStatusIndicator.cs
@@ -83,7 +83,5 @@ namespace NuGet.PackageManagement.UI
             Status = LoadingStatus.ErrorOccured;
             ErrorMessage = message;
         }
-
-        public void SetError(IEnumerable<string> lines) => SetError(string.Join(Environment.NewLine, lines));
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/LoadingStatusViewModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/LoadingStatusViewModel.cs
@@ -68,7 +68,7 @@ namespace NuGet.PackageManagement.UI
             nameof(IsMultiSource),
             typeof(bool),
             typeof(LoadingStatusViewModel),
-            new PropertyMetadata(true, OnIsMultiSourcePropertyChanged));
+            new PropertyMetadata(false, OnIsMultiSourcePropertyChanged));
 
         private static void OnIsMultiSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/LoadingStatusBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/LoadingStatusBar.xaml.cs
@@ -82,6 +82,22 @@ namespace NuGet.PackageManagement.UI
             };
         }
 
+        public void SetError()
+        {
+            DataContext = new LoadingStatusViewModel
+            {
+                PackageSearchStatus = PackageSearchStatus.ErrorOccured
+            };
+        }
+
+        public void SetCancelled()
+        {
+            DataContext = new LoadingStatusViewModel
+            {
+                PackageSearchStatus = PackageSearchStatus.Cancelled
+            };
+        }
+
         private void ShowMoreResultsButton_Click(object sender, RoutedEventArgs e) => RaiseEvent(new RoutedEventArgs(ShowMoreResultsClickEvent));
 
         private void DismissButton_Click(object sender, RoutedEventArgs e) => RaiseEvent(new RoutedEventArgs(DismissClickEvent));


### PR DESCRIPTION
//Fixes https://github.com/NuGet/Home/issues/2271.

Catch-all exceptions in package items loading task and reset the status
bar.
