### PR TITLE
Improve .nupkg validations

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpStreamValidation.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpStreamValidation.cs
@@ -2,10 +2,12 @@
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using Newtonsoft.Json;
+using NuGet.Packaging;
 
 namespace NuGet.Protocol.Core.v3
 {
@@ -54,11 +56,12 @@ namespace NuGet.Protocol.Core.v3
         {
             try
             {
-                using (var reader = new ZipArchive(
+                using (var reader = new PackageArchiveReader(
                     stream: stream,
-                    mode: ZipArchiveMode.Read,
-                    leaveOpen: true))
+                    leaveStreamOpen: true))
+                using (var nuspec = reader.GetNuspec()) // This method throws if no .nuspec exists.
                 {
+                    new NuspecReader(nuspec); // This method throws if reading the .nuspec fails
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Use `PackageArchiveReader` and `NuspecReader` to validate a .nupkg before putting it in the cache. It turns out some byte streams are accepted by the old validation but fail in `PackageArchiveReader` (invoked by the caller).

@anurse, can I give you a private build to verify that this fix addresses your issue?

@emgarten
