### PR TITLE
Normalize project path to fix problems with projects in parent directories

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -692,7 +692,8 @@ namespace NuGet.CommandLine
                 restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
             }
 
-            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, _msbuildDirectory.Value);
+            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, _msbuildDirectory.Value)
+                .Select(Path.GetFullPath); // normalize path
             foreach (var projectFile in projectFiles)
             {
                 if (!File.Exists(projectFile))


### PR DESCRIPTION
This fixes the issue NuGet/Home#2257 by "normalizing" the returned path, i.e., in this case converting
"C:\Projects\Foo\B..\A\A.Util\A.Util.csproj" to "C:\Projects\Foo\A\A.Util\A.Util.csproj". Also added a unit test to confirm this now restores the correct dependencies for a solution with references to projects like this.
