### PR TITLE
Smooth show and hide of restore bar

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -6,8 +6,7 @@
     <UserControl.Resources>
       <Storyboard x:Key="ShowSmoothly">
         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
-        <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
-          <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Visible}"/>
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
         </ObjectAnimationUsingKeyFrames>
         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
           <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
@@ -23,7 +22,7 @@
         </ObjectAnimationUsingKeyFrames>
       </Storyboard>
     </UserControl.Resources>
-    <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="Collapsed" BorderThickness="0,0,0,1">
+    <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="Collapsed" Opacity="0" BorderThickness="0,0,0,1">
         <Grid Margin="0,4,0,6">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -10,15 +10,15 @@
         </ObjectAnimationUsingKeyFrames>
         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
           <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
-          <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="1"/>
+          <EasingDoubleKeyFrame KeyTime="0:0:0.9" Value="1"/>
         </DoubleAnimationUsingKeyFrames>
       </Storyboard>
       <Storyboard x:Key="HideSmoothly">
         <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
-          <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+          <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="0"/>
         </DoubleAnimationUsingKeyFrames>
         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
-          <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}"/>
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Collapsed}"/>
         </ObjectAnimationUsingKeyFrames>
       </Storyboard>
     </UserControl.Resources>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml
@@ -3,6 +3,26 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Loaded="UserControl_Loaded"
              xmlns:resx="clr-namespace:NuGet.PackageManagement.UI">
+    <UserControl.Resources>
+      <Storyboard x:Key="ShowSmoothly">
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
+        <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Visible}"/>
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.6" Value="{x:Static Visibility.Visible}"/>
+        </ObjectAnimationUsingKeyFrames>
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+          <EasingDoubleKeyFrame KeyTime="0:0:0.6" Value="1"/>
+        </DoubleAnimationUsingKeyFrames>
+      </Storyboard>
+      <Storyboard x:Key="HideSmoothly">
+        <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="RestoreBar">
+          <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="0"/>
+        </DoubleAnimationUsingKeyFrames>
+        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(UIElement.Visibility)" Storyboard.TargetName="RestoreBar">
+          <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}"/>
+        </ObjectAnimationUsingKeyFrames>
+      </Storyboard>
+    </UserControl.Resources>
     <Border x:Name="RestoreBar" VerticalAlignment="Center" Visibility="Collapsed" BorderThickness="0,0,0,1">
         <Grid Margin="0,4,0,6">
             <Grid.ColumnDefinitions>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Shell;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using VsBrushes = Microsoft.VisualStudio.Shell.VsBrushes;
+using System.Windows.Media.Animation;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -25,6 +26,8 @@ namespace NuGet.PackageManagement.UI
         private ISolutionManager SolutionManager { get; }
         private Dispatcher UIDispatcher { get; }
         private Exception RestoreException { get; set; }
+        private Storyboard showRestoreBar;
+        private Storyboard hideRestoreBar;
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
 
@@ -55,6 +58,9 @@ namespace NuGet.PackageManagement.UI
             StatusMessage.SetResourceReference(TextBlock.ForegroundProperty, VsBrushes.InfoTextKey);
             RestoreBar.SetResourceReference(Border.BackgroundProperty, VsBrushes.InfoBackgroundKey);
             RestoreBar.SetResourceReference(Border.BorderBrushProperty, VsBrushes.ActiveBorderKey);
+
+            showRestoreBar = this.FindResource("ShowSmoothly") as Storyboard;
+            hideRestoreBar = this.FindResource("HideSmoothly") as Storyboard;
         }
 
         public void CleanUp()
@@ -110,7 +116,8 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                RestoreBar.Visibility = Visibility.Collapsed;
+                showRestoreBar.Stop();
+                hideRestoreBar.Begin();
             }
         }
 
@@ -184,7 +191,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ResetUI()
         {
-            RestoreBar.Visibility = Visibility.Visible;
+            if (RestoreBar.Visibility != Visibility.Visible)
+            {
+                showRestoreBar.Begin();                                
+            }
+
             RestoreButton.Visibility = Visibility.Visible;
             ProgressBar.Visibility = Visibility.Collapsed;
             StatusMessage.Text = UI.Resources.AskForRestoreMessage;
@@ -192,7 +203,11 @@ namespace NuGet.PackageManagement.UI
 
         private void ShowProgressUI()
         {
-            RestoreBar.Visibility = Visibility.Visible;
+            if (RestoreBar.Visibility != Visibility.Visible)
+            {
+                showRestoreBar.Begin();
+            }
+
             RestoreButton.Visibility = Visibility.Collapsed;
             ProgressBar.Visibility = Visibility.Visible;
             StatusMessage.Text = UI.Resources.PackageRestoreProgressMessage;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -7,13 +7,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using VsBrushes = Microsoft.VisualStudio.Shell.VsBrushes;
-using System.Windows.Media.Animation;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -116,6 +116,9 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                // In order to hide the restore bar:
+                // * stop the reveal animation, in case it was still going.
+                // * begin the hide animation.
                 showRestoreBar.Stop();
                 hideRestoreBar.Begin();
             }
@@ -189,13 +192,18 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
-        private void ResetUI()
+        private void RevealRestoreBar()
         {
+            // If the restoreBar isn't visible, begin the animation to reveal it.
             if (RestoreBar.Visibility != Visibility.Visible)
             {
-                showRestoreBar.Begin();                                
+                showRestoreBar.Begin();
             }
+        }
 
+        private void ResetUI()
+        {
+            RevealRestoreBar();
             RestoreButton.Visibility = Visibility.Visible;
             ProgressBar.Visibility = Visibility.Collapsed;
             StatusMessage.Text = UI.Resources.AskForRestoreMessage;
@@ -203,11 +211,7 @@ namespace NuGet.PackageManagement.UI
 
         private void ShowProgressUI()
         {
-            if (RestoreBar.Visibility != Visibility.Visible)
-            {
-                showRestoreBar.Begin();
-            }
-
+            RevealRestoreBar();
             RestoreButton.Visibility = Visibility.Collapsed;
             ProgressBar.Visibility = Visibility.Visible;
             StatusMessage.Text = UI.Resources.PackageRestoreProgressMessage;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -59,6 +59,7 @@ namespace NuGet.PackageManagement.UI
             RestoreBar.SetResourceReference(Border.BackgroundProperty, VsBrushes.InfoBackgroundKey);
             RestoreBar.SetResourceReference(Border.BorderBrushProperty, VsBrushes.ActiveBorderKey);
 
+            // Find storyboards that will be used to smoothly show and hide the restore bar.
             showRestoreBar = this.FindResource("ShowSmoothly") as Storyboard;
             hideRestoreBar = this.FindResource("HideSmoothly") as Storyboard;
         }


### PR DESCRIPTION
Primary goal was to not do a jarring insertion of the RestoreBar if it will be immediately collapsed.
Implemented via animations (via storyboards) -- added some Opacity animation while under the hood.

Addresses: https://github.com/NuGet/Home/issues/2161
