### PR TITLE
'dotnet restore --packages' should be relative to cwd

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -68,18 +68,15 @@ namespace NuGet.Commands
 
         public string GetEffectiveGlobalPackagesFolder(string rootDirectory, ISettings settings)
         {
-            string globalPath = null;
-
             if (!string.IsNullOrEmpty(GlobalPackagesFolder))
             {
-                globalPath = GlobalPackagesFolder;
-            }
-            else
-            {
-                globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
+                // Resolve as relative to the CWD
+                return Path.GetFullPath(GlobalPackagesFolder);
             }
 
-            // Resolve relative paths
+            // Load from environment, nuget.config or default location, and resolve relative paths
+            // to the project root.
+            string globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
             return Path.GetFullPath(Path.Combine(rootDirectory, globalPath));
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
@@ -39,6 +39,28 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void RequestFactory_RestorePackagesArgRelativeToCwd()
+        {
+            // If a packages argument is provided, GetEffectiveGlobalPackagesFolder() should ignore
+            // the provided root path and any configuration information and resolve relative to the
+            // current working directory.
+
+            // Arrange
+            var globalPackagesFolder = "MyPackages";
+            var restoreArgs = new RestoreArgs()
+            {
+                GlobalPackagesFolder = globalPackagesFolder
+            };
+
+            // Act
+            var resolvedGlobalPackagesFolder = restoreArgs.GetEffectiveGlobalPackagesFolder("C:\\Dummy", null);
+
+            // Assert
+            var expectedResolvedGlobalPackagesFolder = Path.GetFullPath(globalPackagesFolder);
+            Assert.Equal(expectedResolvedGlobalPackagesFolder, resolvedGlobalPackagesFolder);
+        }
+
+        [Fact]
         public async Task RequestFactory_FindProjectJsonFilesInDirectory()
         {
             // Arrange


### PR DESCRIPTION
Fix for https://github.com/NuGet/Home/issues/2282

This works fine going via `nuget.exe`, since we resolve it as relative to the current working directory in `NuGet.CommandLine.RestoreCommand.ExecuteCommandAsync()`. However, when called from dotnet.exe that is bypassed.

Updated `RestoreArgs.GetEffectiveGlobalPackagesFolder()` to resolve a provided packages path as relative to the cwd.
