### PR TITLE
Make PackageId in DetailControl.xaml copyable to clipboard.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml
@@ -52,8 +52,13 @@
         <Image
           Margin="0,0,8,0"
           Style="{StaticResource PackageIconImageStyle}" />
-        <TextBlock
-          Text="{Binding Path=Id}"
+        <TextBox
+          Background="Transparent"
+          Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+          BorderThickness="0"
+          Margin="-2,0,-2,0"
+          Text="{Binding Path=Id, Mode=OneWay}"
+          IsReadOnly="True"
           FontSize="{Binding ElementName=_self,Path=FontSize,Converter={StaticResource Font155PercentSizeConverter}}" />
       </StackPanel>
 


### PR DESCRIPTION
Changed the textblock into a readonly textbox that looks like a textblock, but is selectable, and copyable.

Addresses: https://github.com/NuGet/Home/issues/655
