### PR TITLE
Show errors in output implementation

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -553,7 +553,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 IncludeDelisted = false
             };
 
-            var packageFeed = new MultiSourcePackageFeed(PrimarySourceRepositories, Logging.NullLogger.Instance);
+            var packageFeed = new MultiSourcePackageFeed(PrimarySourceRepositories, logger: null);
             var searchTask = packageFeed.SearchAsync(searchString, searchFilter, Token);
             return PackageFeedEnumerator.Enumerate(packageFeed, searchTask, Token);
         }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageManagerModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageManagerModel.cs
@@ -20,14 +20,15 @@ namespace NuGet.PackageManagement.UI
     /// </remarks>
     public class PackageManagerModel : IVsPersistDocData, INotifyPropertyChanged
     {
-        internal const string EditorFactoryGuidString = "EC269AD5-3EA8-4A13-AAF8-76741843B3CD";
-        public static readonly Guid EditorFactoryGuid = new Guid(EditorFactoryGuidString);
+        private readonly Guid _editorFactoryGuid;
 
-        public PackageManagerModel(INuGetUI uiController, INuGetUIContext context, bool isSolution)
+        public PackageManagerModel(INuGetUI uiController, INuGetUIContext context, bool isSolution, Guid editorFactoryGuid)
         {
             Context = context;
             UIController = uiController;
             IsSolution = isSolution;
+
+            _editorFactoryGuid = editorFactoryGuid;
         }
 
         public INuGetUIContext Context { get; }
@@ -63,7 +64,7 @@ namespace NuGet.PackageManagement.UI
 
         public int GetGuidEditorType(out Guid pClassID)
         {
-            pClassID = EditorFactoryGuid;
+            pClassID = _editorFactoryGuid;
             return VSConstants.S_OK;
         }
 

--- a/src/NuGet.Clients/PackageManagement.UI/Resources/Commands.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources/Commands.cs
@@ -5,18 +5,20 @@ using System.Windows.Input;
 
 namespace NuGet.PackageManagement.UI
 {
-    internal static class Commands
+    public static class Commands
     {
-        public static readonly RoutedCommand FocusOnSearchBox = new RoutedCommand();
+        public static ICommand FocusOnSearchBox { get; } = new RoutedCommand();
 
         // The parameter of this command is PackageItemListViewModel
-        public static readonly RoutedCommand UninstallPackageCommand = new RoutedCommand();
+        public static ICommand UninstallPackageCommand { get; } = new RoutedCommand();
 
         // The parameter of this command is PackageItemListViewModel
-        public static readonly RoutedCommand InstallPackageCommand = new RoutedCommand();
+        public static ICommand InstallPackageCommand { get; } = new RoutedCommand();
 
-        public static readonly RoutedCommand RestartSearchCommand = new RoutedCommand();
+        // no parameters
+        public static ICommand RestartSearchCommand { get; } = new RoutedCommand();
 
-        public static readonly RoutedCommand ShowErrorsCommand = new RoutedCommand();
+        // no parameters. Overridable by hosting app.
+        public static ICommand ShowErrorsCommand { get; set; } = new RoutedCommand();
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -274,7 +274,8 @@
                       Style="{StaticResource buttonStyle}"
                       Grid.Row="0"
                       Grid.Column="1"
-                      Click="UninstallButtonClicked"
+                      Command="{x:Static nuget:Commands.UninstallPackageCommand}"
+                      CommandParameter="{Binding}"
                       Visibility="Hidden"
                       ToolTip="{x:Static nuget:Resources.ToolTip_UninstallButton}">
                       <nuget:UninstallButton
@@ -288,7 +289,8 @@
                       Grid.Row="0"
                       Grid.Column="1"
                       Style="{StaticResource buttonStyle}"
-                      Click="InstallButtonClicked"
+                      Command="{x:Static nuget:Commands.InstallPackageCommand}"
+                      CommandParameter="{Binding}"
                       Visibility="Hidden">
                       <Button.ToolTip>
                         <MultiBinding Converter="{StaticResource StringFormatConverter}">
@@ -328,7 +330,8 @@
                       Grid.Column="2"
                       Style="{StaticResource buttonStyle}"
                       Margin="0,5,0,0"
-                      Click="InstallButtonClicked"
+                      Command="{x:Static nuget:Commands.InstallPackageCommand}"
+                      CommandParameter="{Binding}"
                       Visibility="Hidden">
                       <Button.ToolTip>
                         <MultiBinding Converter="{StaticResource StringFormatConverter}">

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Windows;
 using System.Windows.Controls;
 
 namespace NuGet.PackageManagement.UI
@@ -20,16 +19,6 @@ namespace NuGet.PackageManagement.UI
         private void Package_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             throw new System.NotImplementedException();
-        }
-
-        private void UninstallButtonClicked(object sender, RoutedEventArgs e)
-        {
-            Commands.UninstallPackageCommand.Execute(this.DataContext, this);
-        }
-
-        private void InstallButtonClicked(object sender, RoutedEventArgs e)
-        {
-            Commands.InstallPackageCommand.Execute(this.DataContext, this);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml
@@ -31,17 +31,11 @@
     <CommandBinding
       Command="{x:Static nuget:Commands.RestartSearchCommand}" 
       Executed="ExecuteRestartSearchCommand"/>
-    <CommandBinding
-      Command="{x:Static nuget:Commands.ShowErrorsCommand}" 
-      Executed="ExecuteShowErrorsCommand"/>
   </UserControl.CommandBindings>
   <UserControl.InputBindings>
     <KeyBinding
       Command="{x:Static nuget:Commands.FocusOnSearchBox}"
       Gesture="CTRL+E" />
-    <KeyBinding
-      Command="{x:Static nuget:Commands.RestartSearchCommand}"
-      Gesture="F5" />
   </UserControl.InputBindings>
   <DockPanel
     x:Name="_root"

--- a/src/NuGet.Clients/StandaloneUI/MainWindow.xaml.cs
+++ b/src/NuGet.Clients/StandaloneUI/MainWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace StandaloneUI
                 context,
                 new NuGetUIProjectContext(new StandaloneUILogger(_textBox, _scrollViewer), _sourceControlManagerProvider, _commonOperations));
 
-            var model = new PackageManagerModel(uiController, context, isSolution: false);
+            var model = new PackageManagerModel(uiController, context, isSolution: false, editorFactoryGuid: Guid.Empty);
             model.SolutionName = "test solution";
             _packageManagerControl =
                 new PackageManagerControl(model, _settings, new SimpleSearchBoxFactory(), vsShell: null);

--- a/src/NuGet.Clients/VsConsole/Console/Guids.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Guids.cs
@@ -14,5 +14,8 @@ namespace NuGetConsole.Implementation
         // GUID for the Package Manager Console category in the Font and Colors options page
         public const string GuidPackageManagerConsoleFontAndColorCategoryString = "{F9D6BCE6-C669-41DB-8EE7-DD953828685B}";
         internal static readonly Guid guidPackageManagerConsoleFontAndColorCategory = new Guid(GuidPackageManagerConsoleFontAndColorCategoryString);
+
+        // NuGet Output window pane
+        public static Guid guidNuGetOutputWindowPaneGuid = Guid.Parse("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB");
     }
 }

--- a/src/NuGet.Clients/VsConsole/Console/OutputConsole/OutputConsole.cs
+++ b/src/NuGet.Clients/VsConsole/Console/OutputConsole/OutputConsole.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Windows.Media;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGetConsole.Implementation;
 
 namespace NuGetConsole
 {
@@ -15,9 +16,6 @@ namespace NuGetConsole
     /// </summary>
     internal class OutputConsole : IConsole, IConsoleDispatcher
     {
-        // guid for our Output window pane
-        private static Guid _outputWindowPaneGuid = new Guid("CEC55EC8-CC51-40E7-9243-57B87A6F6BEB");
-
         private readonly IVsOutputWindow _outputWindow;
         private IVsOutputWindowPane _outputWindowPane;
 
@@ -123,10 +121,10 @@ namespace NuGetConsole
             if (_outputWindowPane == null)
             {
                 // create the Package Manager pane within the Output window
-                int result = _outputWindow.CreatePane(ref _outputWindowPaneGuid, Resources.OutputConsolePaneName, fInitVisible: 1, fClearWithSolution: 0);
+                int result = _outputWindow.CreatePane(ref GuidList.guidNuGetOutputWindowPaneGuid, Resources.OutputConsolePaneName, fInitVisible: 1, fClearWithSolution: 0);
                 if (result == VSConstants.S_OK)
                 {
-                    result = _outputWindow.GetPane(ref _outputWindowPaneGuid, out _outputWindowPane);
+                    result = _outputWindow.GetPane(ref GuidList.guidNuGetOutputWindowPaneGuid, out _outputWindowPane);
 
                     Debug.Assert(result == VSConstants.S_OK);
                     Debug.Assert(_outputWindowPane != null);

--- a/src/NuGet.Clients/VsExtension/Guids.cs
+++ b/src/NuGet.Clients/VsExtension/Guids.cs
@@ -8,25 +8,27 @@ namespace NuGetVSExtension
     internal static class GuidList
     {
         public const string guidNuGetPkgString = "5fcc8577-4feb-4d04-ad72-d6c629b083cc";
-        public const string guidNuGetVSEventsPackagePkgString = "38ebd926-b8b6-44e9-952d-1cfd38c84209";
+        private const string guidNuGetVSEventsPackagePkgString = "38ebd926-b8b6-44e9-952d-1cfd38c84209";
 
-        public const string guidNuGetConsoleCmdSetString = "1E8A55F6-C18D-407F-91C8-94B02AE1CED6";
-        public const string guidNuGetDialogCmdSetString = "25fd982b-8cae-4cbd-a440-e03ffccde106";
-        public const string guidNuGetToolsGroupString = "C0D88179-5D25-4982-BFE6-EC5FD59AC103";
-        public const string guidNuGetDebugConsoleCmdSetString = "DDC61543-6CA7-4A6F-A5B7-984BE723C52F";
+        private const string guidNuGetConsoleCmdSetString = "1E8A55F6-C18D-407F-91C8-94B02AE1CED6";
+        private const string guidNuGetDialogCmdSetString = "25fd982b-8cae-4cbd-a440-e03ffccde106";
+        private const string guidNuGetToolsGroupString = "C0D88179-5D25-4982-BFE6-EC5FD59AC103";
+        private const string guidNuGetDebugConsoleCmdSetString = "DDC61543-6CA7-4A6F-A5B7-984BE723C52F";
 
         // any project system that wants to load NuGet when its project opens needs to activate a UI context with this GUID
         public const string guidAutoLoadNuGetString = "65B1D035-27A5-4BBA-BAB9-5F61C1E2BC4A";
 
         // Unique identifier of the editor factory that created an instance of the document view and document data objects.
         // Used when creating document windows of Package Manager
-        public const string guidNuGetEditorTypeString = "95501c48-a850-47c1-a785-2aaa96637f81";
+        private const string guidNuGetEditorTypeString = "95501c48-a850-47c1-a785-2aaa96637f81";
 
         public static readonly Guid guidNuGetConsoleCmdSet = new Guid(guidNuGetConsoleCmdSetString);
         public static readonly Guid guidNuGetDialogCmdSet = new Guid(guidNuGetDialogCmdSetString);
         public static readonly Guid guidNuGetToolsGroupCmdSet = new Guid(guidNuGetToolsGroupString);
         public static readonly Guid guidNuGetDebugConsoleCmdSet = new Guid(guidNuGetDebugConsoleCmdSetString);
-
         public static readonly Guid guidNuGetEditorType = Guid.Parse(guidNuGetEditorTypeString);
+
+        // Visual Studio output tool window (Copied from EnvDTE interop)
+        public static Guid guidVsWindowKindOutput = Guid.Parse("34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3");
     }
 }

--- a/src/NuGet.Clients/VsExtension/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/VsExtension/OutputConsoleLogger.cs
@@ -15,9 +15,6 @@ namespace NuGetVSExtension
 {
     internal class OutputConsoleLogger : INuGetUILogger
     {
-        // Copied from EnvDTE interop
-        private const string vsWindowKindOutput = "{34E76E81-EE4A-11D0-AE2E-00A0C90FFFC3}";
-
         // keeps a reference to BuildEvents so that our event handler
         // won't get disconnected because of GC.
         private BuildEvents _buildEvents;
@@ -69,20 +66,12 @@ namespace NuGetVSExtension
         private void ActivateOutputWindow()
         {
             var uiShell = ServiceLocator.GetGlobalService<SVsUIShell, IVsUIShell>();
-            if (uiShell == null)
+            if (uiShell != null)
             {
-                return;
+                IVsWindowFrame toolWindow = null;
+                uiShell.FindToolWindow(0, ref GuidList.guidVsWindowKindOutput, out toolWindow);
+                toolWindow?.Show();
             }
-
-            var guid = new Guid(vsWindowKindOutput);
-            IVsWindowFrame f = null;
-            uiShell.FindToolWindow(0, ref guid, out f);
-            if (f == null)
-            {
-                return;
-            }
-
-            f.Show();
         }
 
         public void Start()

--- a/src/NuGet.Clients/VsExtension/ShowErrorsCommand.cs
+++ b/src/NuGet.Clients/VsExtension/ShowErrorsCommand.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Windows.Input;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace NuGetVSExtension
+{
+    /// <summary>
+    /// UI command to show output window switched to PM output.
+    /// Allows binding to any control.
+    /// </summary>
+    internal sealed class ShowErrorsCommand : ICommand
+    {
+        private readonly IVsOutputWindow _vsOutputWindow;
+        private readonly IVsUIShell _vsUiShell;
+
+        public ShowErrorsCommand(IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+            // get all services we need for displaytion and activation of the NuGet output pane
+            _vsOutputWindow = (IVsOutputWindow)serviceProvider.GetService(typeof(SVsOutputWindow));
+            _vsUiShell = (IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell));
+        }
+
+        // Actually never raised
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        // False if services were unavailable during instantiation. Never change.
+        public bool CanExecute(object parameter)
+        {
+            return _vsUiShell != null && _vsOutputWindow != null;
+        }
+
+        public void Execute(object parameter)
+        {
+            IVsWindowFrame toolWindow = null;
+            _vsUiShell.FindToolWindow(0, ref GuidList.guidVsWindowKindOutput, out toolWindow);
+            toolWindow?.Show();
+
+            IVsOutputWindowPane pane;
+            if (_vsOutputWindow.GetPane(ref NuGetConsole.Implementation.GuidList.guidNuGetOutputWindowPaneGuid, out pane) == VSConstants.S_OK)
+            {
+                pane.Activate();
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/VsExtension/VsExtension.csproj
+++ b/src/NuGet.Clients/VsExtension/VsExtension.csproj
@@ -71,6 +71,7 @@
       <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="SettingsToLegacySettings.cs" />
+    <Compile Include="ShowErrorsCommand.cs" />
     <Compile Include="VisualStudioAccountProvider.cs" />
     <Compile Include="VisualStudioCredentialProvider.cs" />
     <Compile Include="VisualStudioUIContext.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.UI.Test
             var repositories = sourceRepositoryProvider.GetRepositories();
 
             var context = new PackageLoadContext(repositories, false, uiContext);
-            var packageFeed = new MultiSourcePackageFeed(repositories, new NuGet.Logging.NullLogger());
+            var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
             var loader = new PackageItemLoader(context, packageFeed, "nuget");
 
             var loaded = new List<PackageItemListViewModel>();
@@ -68,7 +68,7 @@ namespace NuGet.PackageManagement.UI.Test
             var repositories = sourceRepositoryProvider.GetRepositories();
 
             var context = new PackageLoadContext(repositories, false, uiContext);
-            var packageFeed = new MultiSourcePackageFeed(repositories, new NuGet.Logging.NullLogger());
+            var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
             var loader = new PackageItemLoader(context, packageFeed, "nuget");
 
             var totalCount = await loader.GetTotalCountAsync(100, CancellationToken.None);


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2272.
- Added show errors pluggable command to locate and display PM output
  window pane
- Used INuGetUILogger for sending error messages to the output window.
- Added PM output window pane GUID as a constant to share across
  components.
- Fixed editor window GUID discrepancy.

//cc @yishaigalatzer @emgarten @rrelyea 
