### PR TITLE
When doing a restore, output error if target folders have no projects.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -63,7 +63,17 @@ namespace NuGet.Commands
             // Create requests
             foreach (var input in inputs)
             {
-                foreach (var request in await CreateRequests(input, restoreContext))
+                var inputRequests = await CreateRequests(input, restoreContext);
+                if (inputRequests.Count == 0)
+                {
+                    // No need to throw here - the situation is harmless, and we want to report all possible
+                    // inputs that don't resolve to a project.
+                    log.LogWarning(string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.Error_UnableToLocateRestoreTarget,
+                            Path.GetFullPath(input)));
+                }
+                foreach (var request in inputRequests)
                 {
                     // De-dupe requests
                     if (uniqueRequest.Add(request.Request.LockFilePath))

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -69,6 +69,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The folder &apos;{0}&apos; does not contain a project to restore..
+        /// </summary>
+        internal static string Error_UnableToLocateRestoreTarget {
+            get {
+                return ResourceManager.GetString("Error_UnableToLocateRestoreTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package &apos;{0}&apos; specifies an invalid build action &apos;{1}&apos; for file &apos;{2}&apos;..
         /// </summary>
         internal static string Error_UnknownBuildAction {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -261,4 +261,7 @@
 {0} is replaced with the tool ID.
 {1} is replaced with a path to the project that is being restored.</comment>
   </data>
+  <data name="Error_UnableToLocateRestoreTarget" xml:space="preserve">
+    <value>The folder '{0}' does not contain a project to restore.</value>
+  </data>
 </root>


### PR DESCRIPTION
We do this check already in `nuget.exe`, but this provides a check in a more central location for when we come in via `CommandLine.XPlat`.

Fixes https://github.com/NuGet/Home/issues/2280
