### PR TITLE
Fix broken NuGet.Core.sln (with ',' as decimal separator)

### DIFF
--- a/build/common.xproj.props
+++ b/build/common.xproj.props
@@ -31,7 +31,7 @@
     <Ticks2>$([System.DateTime]::Now.Ticks)</Ticks2>
     <SpanTicks>$([MSBuild]::Subtract($(Ticks2), $(Ticks1)))</SpanTicks>
     <SpanMinutes>$([System.TimeSpan]::FromTicks($(SpanTicks)).TotalMinutes)</SpanMinutes>
-    <BuildNumber>$([System.String]::Format('{0:F0}', $([MSBuild]::Divide($(SpanMinutes), 5))))</BuildNumber>
+    <BuildNumber>$([System.String]::Format('{0:F0}', $([MSBuild]::Divide($([System.Convert]::ToDouble($(SpanMinutes))), 5))))</BuildNumber>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(ReleaseLabel)' == ''">


### PR DESCRIPTION
Convert SpanMinutes string explicitly back to double using Convert.ToDouble.

Fixes issue with double strings with ',' as decimal separator reported in https://github.com/NuGet/Home/issues/2179 .
