### PR TITLE
Fix NRE in PrunePackageTree.PruneByUpdateConstraints() when update.

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -750,7 +750,10 @@ namespace NuGet.PackageManagement
                     foreach (var installedPackage in projectInstalledPackageReferences)
                     {
                         var packageInfo = await packagesFolderResource.ResolvePackage(installedPackage.PackageIdentity, targetFramework, log, token);
-                        availablePackageDependencyInfoWithSourceSet.Add(packageInfo);
+                        if (packageInfo != null)
+                        {
+                            availablePackageDependencyInfoWithSourceSet.Add(packageInfo);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2249

`DependencyInfoResource.ResolvePackage()` can return `null` if the package is not found. `NuGetPackageManager.PreviewUpdatePackagesForClassicAsync()` adds the result to a list whether or not `null`. `PrunePackageTree.PruneByUpdateConstraints()` assumes all entries in the list are non-null.

Note, I have not repro'd the problem - this fix is based on a stack trace from the reporter.
