### PR TITLE
Limit dependency warnings to packages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -860,10 +860,14 @@ namespace NuGet.Commands
             foreach (var dependency in dependencies)
             {
                 // Ignore floating or version-less (project) dependencies
-                if (dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
+                // Avoid warnings for non-packages
+                if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                    && dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
                 {
                     var match = result.Flattened.FirstOrDefault(g => g.Key.Name.Equals(dependency.LibraryRange.Name));
-                    if (match != null && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
+                    if (match != null 
+                        && LibraryTypes.Package == match.Key.Type
+                        && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
                     {
                         _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp, 
                             dependency.LibraryRange.Name,


### PR DESCRIPTION
Project references in project.json are allowed to leave out the version. Example:

``` json
{
  "dependencies": {
    "myProject": { "target": "project" }
  }
}
```

This leads to invalid warnings such as:
`warn : Dependency specified was myProject but ended up with myProject 3.4.0.`

The fix in this PR skips this warning for all non-package types. Projects and framework references (the version is determined by your TFM).

//cc @joelverhagen @zhili1208 @alpaix 
