### PR TITLE
WIP - Add download timeout

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/DownloadTimeoutStream.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public class DownloadTimeoutStream : Stream
+    {
+        private readonly Stream _networkStream;
+
+        public DownloadTimeoutStream(Stream networkStream)
+        {
+            _networkStream = networkStream;
+        }
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _networkStream.Read(buffer, offset, count);
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return await _networkStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _networkStream.Dispose();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead { get; } = true;
+
+        public override bool CanSeek { get; } = false;
+
+        public override bool CanWrite { get; } = false;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
@@ -1,0 +1,10 @@
+using System.IO;
+
+namespace NuGet.Protocol
+{
+    public class HttpCacheResult
+    {
+        public string CacheFileName { get; set; }
+        public Stream Stream { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
@@ -1,15 +1,20 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using System;
+﻿using System;
 using System.IO;
 
 namespace NuGet.Protocol
 {
     public class HttpSourceResult : IDisposable
     {
-        public string CacheFileName { get; set; }
-        public Stream Stream { get; set; }
+        public Stream Stream { get; private set; }
+        public HttpSourceResultStatus Status { get; }
+        public string CacheFileName { get; }
+
+        public HttpSourceResult(HttpSourceResultStatus status, string cacheFileName, Stream stream)
+        {
+            Stream = stream;
+            Status = status;
+            CacheFileName = cacheFileName;
+        }
 
         public void Dispose()
         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace NuGet.Protocol
+{
+    public enum HttpSourceResultStatus
+    {
+        NotFound,
+        OpenedFromDisk,
+        OpenedFromNetwork
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -75,14 +77,22 @@ namespace NuGet.Protocol
             Logging.ILogger logger,
             CancellationToken token)
         {
-            using (var httpResponseMessage = await _httpSource.GetAsync(apiEndpointUri, logger, token))
-            {
-                httpResponseMessage.EnsureSuccessStatusCode();
-
-                var json = await httpResponseMessage.Content.ReadAsStringAsync();
-
-                return JsonConvert.DeserializeObject<string[]>(json);
-            }
+            return await _httpSource.ProcessStreamAsync(
+                   uri: apiEndpointUri,
+                   ignoreNotFounds: false,
+                   bufferContent: true,
+                   log: logger,
+                   process: stream =>
+                   {
+                       using (var reader = new StreamReader(stream))
+                       using (var jsonReader = new JsonTextReader(reader))
+                       {
+                           var serializer = JsonSerializer.Create();
+                           var json = serializer.Deserialize<string[]>(jsonReader);
+                           return Task.FromResult(json);
+                       }
+                   },
+                   token: token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -80,9 +80,7 @@ namespace NuGet.Protocol
             return await _httpSource.ProcessStreamAsync(
                    uri: apiEndpointUri,
                    ignoreNotFounds: false,
-                   bufferContent: true,
-                   log: logger,
-                   process: stream =>
+                   processAsync: stream =>
                    {
                        using (var reader = new StreamReader(stream))
                        using (var jsonReader = new JsonTextReader(reader))
@@ -92,6 +90,7 @@ namespace NuGet.Protocol
                            return Task.FromResult(json);
                        }
                    },
+                   log: logger,
                    token: token);
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -351,7 +351,11 @@ namespace NuGet.Protocol
                 {
                     try
                     {
-                        var doc = LoadXml(await data.Content.ReadAsStreamAsync());
+                        var doc = await _httpSource.DownloadUtility.BufferAndProcessAsync(
+                            source: await data.Content.ReadAsStreamAsync(),
+                            process: stream => Task.FromResult(LoadXml(stream)),
+                            downloadName: uri,
+                            token: token);
 
                         // find results on the page
                         var result = ParsePage(doc, id);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -337,54 +337,57 @@ namespace NuGet.Protocol
             var page = 1;
 
             // first request
-            Task<HttpResponseMessage> urlRequest = _httpSource.GetAsync(new Uri(uri), log, token);
+            Task<XDocument> docRequestTask = _httpSource.ProcessStreamAsync(
+                new Uri(uri),
+                ignoreNotFounds: false,
+                processAsync: stream => Task.FromResult(LoadXml(stream)),
+                log: log, 
+                token: token);
 
             // TODO: re-implement caching at a higher level for both v2 and v3
-            while (!token.IsCancellationRequested && urlRequest != null)
+            while (!token.IsCancellationRequested && docRequestTask != null)
             {
                 // TODO: Pages for a package Id are cached separately.
                 // So we will get inaccurate data when a page shrinks.
                 // However, (1) In most cases the pages grow rather than shrink;
                 // (2) cache for pages is valid for only 30 min.
                 // So we decide to leave current logic and observe.
-                using (var data = await urlRequest)
+                try
                 {
-                    try
+                    var doc = await docRequestTask;
+
+                    // find results on the page
+                    var result = ParsePage(doc, id);
+                    results.AddRange(result);
+
+                    var nextUri = GetNextUrl(doc);
+
+                    docRequestTask = null;
+                    if (max < 0 || results.Count < max)
                     {
-                        var doc = await _httpSource.DownloadUtility.BufferAndProcessAsync(
-                            source: await data.Content.ReadAsStreamAsync(),
-                            process: stream => Task.FromResult(LoadXml(stream)),
-                            downloadName: uri,
-                            token: token);
-
-                        // find results on the page
-                        var result = ParsePage(doc, id);
-                        results.AddRange(result);
-
-                        var nextUri = GetNextUrl(doc);
-
-                        urlRequest = null;
-                        if (max < 0 || results.Count < max)
+                        // Request the next url in parallel to parsing the current page
+                        if (!string.IsNullOrEmpty(nextUri) && uri != nextUri)
                         {
-                            // Request the next url in parallel to parsing the current page
-                            if (!string.IsNullOrEmpty(nextUri) && uri != nextUri)
-                            {
-                                // a bug on the server side causes the same next link to be returned 
-                                // for every page. To avoid falling into an infinite loop we must
-                                // keep track here.
-                                uri = nextUri;
+                            // a bug on the server side causes the same next link to be returned 
+                            // for every page. To avoid falling into an infinite loop we must
+                            // keep track here.
+                            uri = nextUri;
 
-                                urlRequest = _httpSource.GetAsync(new Uri(nextUri), log, token);
-                            }
-
-                            page++;
+                            docRequestTask = _httpSource.ProcessStreamAsync(
+                                new Uri(nextUri),
+                                ignoreNotFounds: false,
+                                processAsync: stream => Task.FromResult(LoadXml(stream)),
+                                log: log,
+                                token: token);
                         }
+
+                        page++;
                     }
-                    catch (XmlException ex)
-                    {
-                        log.LogVerbose(ex.ToString());
-                        throw;
-                    }
+                }
+                catch (XmlException ex)
+                {
+                    log.LogVerbose(ex.ToString());
+                    throw;
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
@@ -48,7 +48,11 @@ namespace NuGet.Protocol
             queryUrl.Query = queryString;
 
             var queryUri = queryUrl.Uri;
-            var results = await _client.GetJObjectAsync(queryUri, Logging.NullLogger.Instance, token);
+            var results = await _client.GetJObjectAsync(
+                uri: queryUri,
+                ignoreNotFounds: false,
+                log: Logging.NullLogger.Instance,
+                token: token);
             token.ThrowIfCancellationRequested();
             if (results == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -245,15 +245,10 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
-            var response = await _httpSource.SendAsync(
+            await _httpSource.SendAsync(
                 () => CreateRequest(source, pathToPackage, apiKey),
                 logger,
                 token);
-
-            using (response)
-            {
-                response.EnsureSuccessStatusCode();
-            }
         }
 
         private HttpRequestMessage CreateRequest(string source,
@@ -335,7 +330,7 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
-            var response = await _httpSource.SendAsync(
+            await _httpSource.SendAsync(
                 () =>
                 {
                     // Review: Do these values need to be encoded in any way?
@@ -349,11 +344,6 @@ namespace NuGet.Protocol.Core.Types
                 },
                 logger,
                 token);
-
-            using (response)
-            {
-                response.EnsureSuccessStatusCode();
-            }
         }
 
         // Deletes a package from a FileSystem.

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
@@ -79,7 +79,11 @@ namespace NuGet.Protocol.Core.v3
                     JObject searchJson = null;
                     try
                     {
-                        searchJson = await _client.GetJObjectAsync(queryUrl.Uri, log, cancellationToken);
+                        searchJson = await _client.GetJObjectAsync(
+                            uri: queryUrl.Uri,
+                            ignoreNotFounds: false,
+                            log: log,
+                            token: cancellationToken);
                     }
                     catch when (i < _searchEndpoints.Length - 1)
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
@@ -204,6 +204,15 @@ namespace NuGet.Protocol.Core.v3 {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The download of &apos;{0}&apos; took more than {1}ms and therefore timed out..
+        /// </summary>
+        internal static string DownloadTimeout {
+            get {
+                return ResourceManager.GetString("DownloadTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to {0} {1}.
         /// </summary>
         internal static string Http_RequestLog {
@@ -344,6 +353,15 @@ namespace NuGet.Protocol.Core.v3 {
         internal static string Log_RetryingFindPackagesById {
             get {
                 return ResourceManager.GetString("Log_RetryingFindPackagesById", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to An error was encountered when fetching &apos;{0} {1}&apos;. The request will now be retried..
+        /// </summary>
+        internal static string Log_RetryingHttp {
+            get {
+                return ResourceManager.GetString("Log_RetryingHttp", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
@@ -305,4 +305,14 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>Parameters in order: non-localizable HTTP status, non-localizable HTTP request URI, request duration in milliseconds.
 The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
+  <data name="Log_RetryingHttp" xml:space="preserve">
+    <value>An error was encountered when fetching '{0} {1}'. The request will now be retried.</value>
+    <comment>'{0}' is replaced with the HTTP method used.
+'{1}' is replaced with the URL that failed to be reached.</comment>
+  </data>
+  <data name="DownloadTimeout" xml:space="preserve">
+    <value>The download of '{0}' took more than {1}ms and therefore timed out.</value>
+    <comment>'{0}' is replaced with the resource that could not be downloaded.
+'{1}' is replaced with the integer (in milliseconds) of the timeout duration.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadUtility.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.v3;
+
+namespace NuGet.Protocol
+{
+    public class DownloadUtility
+    {
+        private const string DownloadTimeoutKey = "nuget_download_timeout";
+
+        private IEnvironmentVariableReader _environmentVariableReader;
+
+        public IEnvironmentVariableReader EnvironmentVariableReader 
+        {
+            get
+            {
+                if (_environmentVariableReader == null)
+                {
+                    _environmentVariableReader = new EnvironmentVariableWrapper();
+                }
+
+                return _environmentVariableReader;
+            }
+
+            set { _environmentVariableReader = value; }
+        }
+
+        private TimeSpan? _downloadTimeout;
+
+        public TimeSpan DownloadTimeout
+        {
+            get
+            {
+                if (!_downloadTimeout.HasValue)
+                {
+                    var unparsedTimeout = EnvironmentVariableReader.GetEnvironmentVariable(DownloadTimeoutKey);
+                    int timeoutMilliseconds;
+                    if (!int.TryParse(unparsedTimeout, out timeoutMilliseconds))
+                    {
+                        _downloadTimeout = TimeSpan.FromMinutes(5);
+                    }
+                    else if(timeoutMilliseconds <= 0)
+                    {
+                        _downloadTimeout = Timeout.InfiniteTimeSpan;
+                    }
+                    else
+                    {
+                        _downloadTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds);
+                    }
+                }
+
+                return _downloadTimeout.Value;
+            }
+
+            set { _downloadTimeout = value; }
+        }
+
+        public async Task DownloadAsync(Stream source, Stream destination, string downloadName, CancellationToken token)
+        {
+            var timeoutMessage = string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.DownloadTimeout,
+                downloadName,
+                (int) DownloadTimeout.TotalMilliseconds);
+
+            await TimeoutUtility.StartWithTimeout(
+                timeoutToken => source.CopyToAsync(destination, bufferSize: 8192, cancellationToken: timeoutToken),
+                DownloadTimeout,
+                timeoutMessage,
+                token);
+
+            await destination.FlushAsync(token);
+        }
+
+        public async Task<T> BufferAndProcessAsync<T>(Stream source, Func<Stream, Task<T>> process, string downloadName, CancellationToken token)
+        {
+            using (var memoryStream = new MemoryStream())
+            {
+                await DownloadAsync(source, memoryStream, downloadName, token);
+
+                memoryStream.Seek(0, SeekOrigin.Begin);
+
+                return await process(memoryStream);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
@@ -43,8 +43,7 @@ namespace NuGet.Protocol
                     return await client.ProcessStreamAsync(
                         uri: uri,
                         ignoreNotFounds: true,
-                        bufferContent: false,
-                        process: async packageStream =>
+                        processAsync: async packageStream =>
                         {
                             if (packageStream == null)
                             {
@@ -52,7 +51,6 @@ namespace NuGet.Protocol
                             }
 
                             return await GlobalPackagesFolderUtility.AddPackageAsync(
-                                client.DownloadUtility,
                                 identity,
                                 packageStream,
                                 settings,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
@@ -70,7 +70,9 @@ namespace NuGet.Protocol
             return null;
         }
 
-        public static async Task<DownloadResourceResult> AddPackageAsync(PackageIdentity packageIdentity,
+        public static async Task<DownloadResourceResult> AddPackageAsync(
+            DownloadUtility downloadUtility,
+            PackageIdentity packageIdentity,
             Stream packageStream,
             ISettings settings,
             ILogger logger,
@@ -107,7 +109,11 @@ namespace NuGet.Protocol
                 xmlDocFileSaveMode: PackageExtractionBehavior.XmlDocFileSaveMode);
 
             await PackageExtractor.InstallFromSourceAsync(
-                stream => packageStream.CopyToAsync(stream, bufferSize: 8192, cancellationToken: token),
+                stream => downloadUtility.DownloadAsync(
+                        source: packageStream,
+                        destination: stream,
+                        downloadName: packageIdentity.ToString(),
+                        token: token),
                 versionFolderPathContext,
                 token: token);
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
@@ -71,7 +71,6 @@ namespace NuGet.Protocol
         }
 
         public static async Task<DownloadResourceResult> AddPackageAsync(
-            DownloadUtility downloadUtility,
             PackageIdentity packageIdentity,
             Stream packageStream,
             ISettings settings,
@@ -109,11 +108,7 @@ namespace NuGet.Protocol
                 xmlDocFileSaveMode: PackageExtractionBehavior.XmlDocFileSaveMode);
 
             await PackageExtractor.InstallFromSourceAsync(
-                stream => downloadUtility.DownloadAsync(
-                        source: packageStream,
-                        destination: stream,
-                        downloadName: packageIdentity.ToString(),
-                        token: token),
+                stream => packageStream.CopyToAsync(stream, 8192, token),
                 versionFolderPathContext,
                 token: token);
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/TimeoutUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/TimeoutUtility.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public static class TimeoutUtility
+    {
+        /// <summary>
+        /// Starts a task with a timeout. If the timeout occurs, a <see cref="TimeoutException"/>
+        /// with no message will be thrown.
+        /// </summary>
+        public static async Task<T> StartWithTimeout<T>(
+            Func<CancellationToken, Task<T>> getTask,
+            TimeSpan timeout,
+            string timeoutMessage,
+            CancellationToken token)
+        {                        
+            /*
+             * Implement timeout. Two operations are started and run in parallel:
+             *
+             *   1) The callers's task.
+             *   2) A timer that fires after the duration of the timeout.
+             *
+             * If the timeout occurs first, the caller's task should be cancelled. If the 
+             * caller's task completes before the timeout, the timeout should be cancelled.
+             * If the timeout occurs first, consider the caller's task should be considered
+             * a failure and a timeout exception is thrown. If the caller's task completes
+             * first, it could be that the response came back or that the caller cancelled
+             * the task.
+             */
+            using (var timeoutTcs = new CancellationTokenSource())
+            using (var taskTcs = new CancellationTokenSource())
+            using (token.Register(() => taskTcs.Cancel()))
+            {
+                var timeoutTask = Task.Delay(timeout, timeoutTcs.Token);
+                var responseTask = getTask(taskTcs.Token);
+
+                if (timeoutTask == await Task.WhenAny(responseTask, timeoutTask))
+                {
+                    taskTcs.Cancel();
+
+                    throw new TimeoutException(timeoutMessage);
+                }
+
+                timeoutTcs.Cancel();
+                return await responseTask;
+            }
+        }
+
+        /// <summary>
+        /// Starts a task with a timeout. If the timeout occurs, a <see cref="TimeoutException"/>
+        /// with no message will be thrown.
+        /// </summary>
+        public static async Task StartWithTimeout(
+            Func<CancellationToken, Task> getTask,
+            TimeSpan timeout,
+            string timeoutMessage,
+            CancellationToken token)
+        {
+            await StartWithTimeout(
+                async timeoutToken =>
+                {
+                    await getTask(timeoutToken);
+                    return true;
+                },
+                timeout,
+                timeoutMessage,
+                token);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -26,14 +26,14 @@ namespace Test.Utility
             _responses = responses;
         }
         
-        protected override Task<HttpSourceResult> TryReadCacheFile(
+        protected override Task<HttpCacheResult> TryReadCacheFile(
             string uri,
             string cacheKey,
             HttpSourceCacheContext context,
             ILogger log,
             CancellationToken token)
         {
-            var result = new HttpSourceResult();
+            var result = new HttpCacheResult();
 
             string s;
             if (_responses.TryGetValue(uri, out s) && !string.IsNullOrEmpty(s))

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadUtilityTests.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Configuration;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class DownloadUtilityTests
+    {
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+
+        [Fact]
+        public void DownloadUtility_ReadsEnvironmentVariable()
+        {
+            VerifyEnvironmentVariable("42", TimeSpan.FromMilliseconds(42));
+        }
+
+        [Fact]
+        public void DownloadUtility_DefaultTimeoutWhenInvalid()
+        {
+            VerifyEnvironmentVariable("10.99", DefaultTimeout);
+        }
+
+        [Fact]
+        public void DownloadUtility_DefaultTimeoutWhenEmpty()
+        {
+            VerifyEnvironmentVariable("", DefaultTimeout);
+        }
+
+        [Fact]
+        public void DownloadUtility_NegativeDisablesTimeout()
+        {
+            VerifyEnvironmentVariable("-42", Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public void DownloadUtility_ZeroDisablesTimeout()
+        {
+            VerifyEnvironmentVariable("0", Timeout.InfiniteTimeSpan);
+        }
+
+        [Fact]
+        public async Task DownloadUtility_TimesOutDownload()
+        {
+            // Arrange
+            var target = new DownloadUtility { DownloadTimeout = TimeSpan.FromMilliseconds(500) };
+            var content = "test content";
+            var source = new SlowStream(new MemoryStream(Encoding.UTF8.GetBytes(content)))
+            {
+                DelayPerByte = TimeSpan.FromMilliseconds(100)
+            };
+            var destination = new MemoryStream();
+
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<TimeoutException>(async () =>
+            {
+                await target.DownloadAsync(source, destination, "test", CancellationToken.None);
+            });
+
+            Assert.Equal("The download of 'test' took more than 500ms and therefore timed out.", actual.Message);
+        }
+
+        [Fact]
+        public async Task DownloadUtility_TimesOutBufferAndProcess()
+        {
+            // Arrange
+            var target = new DownloadUtility { DownloadTimeout = TimeSpan.FromMilliseconds(500) };
+            var content = "test content";
+            var source = new SlowStream(new MemoryStream(Encoding.UTF8.GetBytes(content)))
+            {
+                DelayPerByte = TimeSpan.FromMilliseconds(100)
+            };
+            var processed = false;
+
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<TimeoutException>(async () =>
+            {
+                await target.BufferAndProcessAsync(
+                    source,
+                    stream =>
+                    {
+                        processed = true;
+                        return Task.FromResult(0);
+                    },
+                    "test",
+                    CancellationToken.None);
+            });
+
+            Assert.False(processed, "The content should not have been processed because the buffering should have timed out.");
+            Assert.Equal("The download of 'test' took more than 500ms and therefore timed out.", actual.Message);
+        }
+
+        [Fact]
+        public async Task DownloadUtility_AllowsNormalDownload()
+        {
+            // Arrange
+            var target = new DownloadUtility();
+            var expected = "test content";
+            var source = new MemoryStream(Encoding.UTF8.GetBytes(expected));
+            var destination = new MemoryStream();
+
+            // Act
+            await target.DownloadAsync(source, destination, "test", CancellationToken.None);
+
+            // Assert
+            var actual = Encoding.UTF8.GetString(destination.ToArray());
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async Task DownloadUtility_AllowsNormalBufferAndProcess()
+        {
+            // Arrange
+            var target = new DownloadUtility();
+            var expected = "test content";
+            var source = new MemoryStream(Encoding.UTF8.GetBytes(expected));
+
+            // Act
+            var output = await target.BufferAndProcessAsync(
+                source,
+                stream => new StreamReader(stream, Encoding.UTF8).ReadToEndAsync(),
+                "test",
+                CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expected, output);
+        }
+
+        private static void VerifyEnvironmentVariable(string value, TimeSpan expected)
+        {
+            // Arrange
+            var mock = new Mock<IEnvironmentVariableReader>();
+            mock.Setup(x => x.GetEnvironmentVariable(It.IsAny<string>())).Returns(value);
+
+            var target = new DownloadUtility { EnvironmentVariableReader = mock.Object };
+
+            // Act
+            var actual = target.DownloadTimeout;
+
+            // Assert
+            Assert.Equal(expected, actual);
+            mock.Verify(x => x.GetEnvironmentVariable("nuget_download_timeout"), Times.Exactly(1));
+        }
+
+        private class SlowStream : Stream
+        {
+            private readonly Stream _innerStream;
+
+            public SlowStream(Stream innerStream)
+            {
+                _innerStream = innerStream;
+            }
+
+            public TimeSpan DelayPerByte { get; set; }
+
+            public override void Flush()
+            {
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var read = _innerStream.Read(buffer, offset, count);
+                Thread.Sleep(new TimeSpan(DelayPerByte.Ticks * read));
+                return read;
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length
+            {
+                get
+                {
+                    throw new NotSupportedException();
+                }
+            }
+
+            public override long Position
+            {
+                get
+                {
+                    throw new NotSupportedException();
+                }
+                set
+                {
+                    throw new NotSupportedException();
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -11,10 +11,15 @@
     "test": "xunit.runner.dnx"
   },
   "frameworks": {
-    "dnx451": { },
+    "dnx451": {
+      "dependencies": {
+        "Moq": "4.2.1510.2205"
+      }
+    },
     "dnxcore50": {
       "imports": [ "portable-net45+win8" ],
       "dependencies": {
+        "moq.netcore": "4.4.0-beta8",
         "System.Collections": "4.0.10-beta-23109",
         "System.Net.Requests": "4.0.11-beta-23516"
       }


### PR DESCRIPTION
This changes to the code to use a single `DownloadUtility` which manages processing the stream gotten from an `HttpResponseMessage`.

The timeout mechanism I have in place right now throws a timeout exception if the _whole_ download takes more than 5 minutes (controllable to the millisecond by the `nuget_download_timeout` environment variable). This is the mitigation I put in place since the CI was blocked. It should be noted that this mitigation is probably not appropriate for cases where downloads are very slow and can be expected to take more than 5 minutes.

Since there is now one place that handles all network stream downloads, we can choose a different timeout strategy (thus the **WIP** prefix on this PR), such as timing out if a single `ReadAsync` takes too long (thus allowing a slow trickle of bytes from the HTTP server).

Since the CI now seems to be unblocked, I don't think we should force this change through and should step back and think about the right approach long term.

@emgarten @yishaigalatzer @tratcher
