### PR TITLE
Add support for DefaultPushSource with push command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -7,8 +7,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Common;
-using NuGet.Logging;
-using NuGet.Protocol;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -54,16 +52,17 @@ namespace NuGet.CommandLine.XPlat
             NetworkProtocolUtility.ConfigureSupportedSslProtocols();
 
             //register push and delete command
-            new PushCommand(app, () =>
-            {
-                return Log;
-            });
-            new DeleteCommand(app, () =>
+            PushCommand.Register(app, () =>
             {
                 return Log;
             });
 
-            RestoreCommand.Register(app,() =>
+            DeleteCommand.Register(app, () =>
+            {
+                return Log;
+            });
+
+            RestoreCommand.Register(app, () =>
             {
                 return Log;
             });

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/PushCommand.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
-using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Logging;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.Core.v3;
 
 namespace NuGet.CommandLine.XPlat
 {
-    class PushCommand:Command
+    internal static class PushCommand
     {
-        public PushCommand(CommandLineApplication app, Func<ILogger> getLogger)
+        public static void Register(CommandLineApplication app, Func<ILogger> getLogger)
         {
             app.Command("push", push =>
             {
@@ -42,37 +37,36 @@ namespace NuGet.CommandLine.XPlat
 
                 push.OnExecute(async () =>
                 {
-                    var logger = getLogger();
-                    
                     if (arguments.Values.Count < 1)
                     {
                         throw new ArgumentException(Strings.Push_MissingArguments);
                     }
-                    var packagePath = arguments.Values[0];
 
-                    if (!source.HasValue())
+                    ISettings settings = Settings.LoadDefaultSettings(Directory.GetCurrentDirectory(), configFileName: null, machineWideSettings: null);
+                    PackageSourceProvider provider = new PackageSourceProvider(settings);
+
+                    string packagePath = arguments.Values[0];
+                    string sourcePath = source.HasValue() ? source.Value() : provider.DefaultPushSource;
+
+                    if (sourcePath == null)
                     {
                         throw new ArgumentException(Strings.Error_MissingSourceParameter);
                     }
 
-                    int t = 0;
+                    int timeoutValue = 0;
                     if (timeout.HasValue())
                     {
-                        if (!int.TryParse(timeout.Value(), out t))
+                        if (!int.TryParse(timeout.Value(), out timeoutValue))
                         {
                             throw new ArgumentException(Strings.Push_InvalidTimeout);
                         }
                     }
 
-                    var setting = Settings.LoadDefaultSettings(Path.GetFullPath("."),
-                                configFileName: null,
-                                machineWideSettings: null);
-                    var pushCommandResource = await GetPushCommandResource(source, setting);
-
+                    PackageUpdateResource pushCommandResource = await CommandUtility.GetPushCommandResource(sourcePath, settings);
                     await pushCommandResource.Push(packagePath,
-                        t,
+                        timeoutValue,
                         (s) => apikey.Value(),
-                        logger);
+                        getLogger());
 
                     return 0;
                 });

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/RestoreCommand.cs
@@ -4,11 +4,9 @@ using System.Linq;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.Extensions.PlatformAbstractions;
 using NuGet.Commands;
-using NuGet.Configuration;
 using NuGet.Logging;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.Core.v3;
 
 namespace NuGet.CommandLine.XPlat
 {
@@ -92,7 +90,7 @@ namespace NuGet.CommandLine.XPlat
                             RequestProviders = providers,
                             Sources = sources.Values,
                             FallbackSources = fallBack.Values,
-                            CachingSourceProvider = _sourceProvider
+                            CachingSourceProvider = CommandUtility.CachingSourceProvider
                         };
 
                         var defaultRuntimes = RequestRuntimeUtility.GetDefaultRestoreRuntimes(
@@ -110,10 +108,5 @@ namespace NuGet.CommandLine.XPlat
                 });
             }));
         }
-
-        // Create a caching source provider with the default settings, the sources will be passed in
-        private static CachingSourceProvider _sourceProvider = new CachingSourceProvider(
-            new PackageSourceProvider(
-                Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null)));
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -50,7 +50,7 @@ namespace NuGet.Commands
             // If there are no inputs, use the current directory
             if (!inputs.Any())
             {
-                inputs.Add(Path.GetFullPath("."));
+                inputs.Add(Directory.GetCurrentDirectory());
             }
 
             // Ignore casing on windows and mac

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
@@ -17,6 +17,7 @@ namespace NuGet.Configuration
         bool IsPackageSourceEnabled(PackageSource source);
 
         string ActivePackageSourceName { get; }
+        string DefaultPushSource { get; }
 
         void SaveActivePackageSource(PackageSource source);
     }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -433,6 +433,14 @@ namespace NuGet.Configuration
             }
         }
 
+        public string DefaultPushSource
+        {
+            get
+            {
+                return Settings.GetValue(ConfigurationConstants.Config, ConfigurationConstants.DefaultPushSource);
+            }
+        }
+
         public void DisablePackageSource(PackageSource source)
         {
             if (source == null)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -2320,6 +2320,52 @@ namespace NuGet.Configuration.Test
             }
         }
 
+        [Fact]
+        public void DefaultPushSourceInNuGetConfig()
+        {
+            using (TestDirectory mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                string configContentsWithDefault =
+@"<?xml version='1.0'?>
+<configuration>
+    <config>
+        <add key='DefaultPushSource' value='\\myshare\packages' />
+    </config>
+    <packageSources>
+        <add key='NuGet.org' value='https://NuGet.org' />
+    </packageSources>
+</configuration>";
+                string configContentWithoutDefault = configContentsWithDefault.Replace("DefaultPushSource", "WithoutDefaultPushSource");
+
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "WithDefaultPushSource.config"), configContentsWithDefault);
+                File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "WithoutDefaultPushSource.config"), configContentWithoutDefault);
+
+                ISettings settingsWithDefault = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                   configFileName: "WithDefaultPushSource.config",
+                   machineWideSettings: null,
+                   loadAppDataSettings: true,
+                   useTestingGlobalPath: false);
+
+                ISettings settingsWithoutDefault = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
+                   configFileName: "WithoutDefaultPushSource.config",
+                   machineWideSettings: null,
+                   loadAppDataSettings: true,
+                   useTestingGlobalPath: false);
+
+                PackageSourceProvider packageSourceProviderWithDefault = new PackageSourceProvider(settingsWithDefault);
+                PackageSourceProvider packageSourceProviderWithoutDefault = new PackageSourceProvider(settingsWithoutDefault);
+
+                // Act
+                string defaultPushSourceWithDefault = packageSourceProviderWithDefault.DefaultPushSource;
+                string defaultPushSourceWithoutDefault = packageSourceProviderWithoutDefault.DefaultPushSource;
+
+                // Assert
+                Assert.Equal(@"\\myshare\packages", defaultPushSourceWithDefault);
+                Assert.Null(defaultPushSourceWithoutDefault);
+            }
+        }
+
 #if DNXCORE50
         [Fact]
         public void LoadPackageSource_NotDecryptPassword() 


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2288
Have PushCommand use PackageSourceProvider to check for DefaultPushSource.

Also change PushCommand and DeleteCommand so that they don't derive from a useless base class called Command. It only had statics and has no benefit as a base class.

Made Push and DeleteCommand follow the same pattern as RestoreCommand where it has a static Register function.
