### PR TITLE
Fix tool restore race condition

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -4,6 +4,9 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.Logging;
 using NuGet.ProjectModel;
@@ -97,9 +100,9 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>If <see cref="PreviousLockFile"/> and <see cref="LockFile"/> are identical
         ///  the file will not be written to disk.</remarks>
-        public void Commit(ILogger log)
+        public async Task CommitAsync(ILogger log, CancellationToken token)
         {
-            Commit(log, forceWrite: false);
+            await CommitAsync(log, forceWrite: false, token: token);
         }
 
         /// <summary>
@@ -108,8 +111,10 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>If <see cref="PreviousLockFile"/> and <see cref="LockFile"/> are identical
         ///  the file will not be written to disk.</remarks>
+        /// <param name="log">The logger.</param>
         /// <param name="forceWrite">Write out the lock file even if no changes exist.</param>
-        public void Commit(ILogger log, bool forceWrite)
+        /// <param name="token">The cancellation token.</param>
+        public async Task CommitAsync(ILogger log, bool forceWrite, CancellationToken token)
         {
             // Write the lock file
             var lockFileFormat = new LockFileFormat();
@@ -140,9 +145,16 @@ namespace NuGet.Commands
                 {
                     log.LogDebug($"Writing tool lock file to disk. Path: {toolRestoreResult.LockFilePath}");
 
-                    var lockFileDirectory = Path.GetDirectoryName(toolRestoreResult.LockFilePath);
-                    Directory.CreateDirectory(lockFileDirectory);
-                    lockFileFormat.Write(toolRestoreResult.LockFilePath, toolRestoreResult.LockFile);
+                    await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                        toolRestoreResult.LockFilePath,
+                        lockedToken =>
+                        {
+                            var lockFileDirectory = Path.GetDirectoryName(toolRestoreResult.LockFilePath);
+                            Directory.CreateDirectory(lockFileDirectory);
+                            lockFileFormat.Write(toolRestoreResult.LockFilePath, toolRestoreResult.LockFile);
+                            return Task.FromResult((object)null);
+                        },
+                        token);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.ProjectModel;
@@ -137,7 +138,7 @@ namespace NuGet.Commands
 
             // Commit the result
             log.LogInformation(Strings.Log_Committing);
-            result.Commit(request.Log);
+            await result.CommitAsync(request.Log, CancellationToken.None);
 
             sw.Stop();
 

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement
                 token.ThrowIfCancellationRequested();
 
                 // Write out the lock file and msbuild files
-                result.Commit(context.Logger);
+                await result.CommitAsync(context.Logger, token);
 
                 return result;
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1870,7 +1870,7 @@ namespace NuGet.PackageManagement
 
                 // Write out the lock file
                 var logger = new ProjectContextLogger(nuGetProjectContext);
-                restoreResult.Commit(logger);
+                await restoreResult.CommitAsync(logger, token);
 
                 // Write out a message for each action
                 foreach (var action in nuGetProjectActions)

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
@@ -56,7 +57,7 @@ namespace NuGet.Commands.FuncTest
                 // Act
 
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, framework, null);
                 var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
 
@@ -111,7 +112,7 @@ namespace NuGet.Commands.FuncTest
                 // Act
 
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, framework, null);
                 var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
 
@@ -163,7 +164,7 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 logger.Clear();
 
                 // Act
@@ -173,7 +174,7 @@ namespace NuGet.Commands.FuncTest
                 request.ExistingLockFile = result.LockFile;
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -279,7 +280,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, framework, null);
                 var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
 
@@ -328,7 +329,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var runtimeAssemblies = GetRuntimeAssemblies(result.LockFile.Targets, framework, null);
                 var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
                 var dependencies = string.Join("|", result.GetAllInstalled().Select(dependency => dependency.Name)
@@ -378,7 +379,7 @@ namespace NuGet.Commands.FuncTest
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Act
                 var valid = result.LockFile.IsValidForPackageSpec(spec);
@@ -423,12 +424,12 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var assemblies = GetRuntimeAssemblies(result.LockFile.Targets, "net46", null);
 
                 // Build again to verify the noop works also
                 result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var assemblies2 = GetRuntimeAssemblies(result.LockFile.Targets, "net46", null);
 
                 // Assert
@@ -474,7 +475,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
                 var assemblies = GetRuntimeAssemblies(result.LockFile.Targets, "net46", null);
 
                 // Assert
@@ -525,7 +526,7 @@ namespace NuGet.Commands.FuncTest
 
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFileFromDisk = lockFormat.Read(lockFilePath);
 
@@ -558,7 +559,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -575,7 +576,7 @@ namespace NuGet.Commands.FuncTest
 
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
-                result.Commit(logger, true);
+                await result.CommitAsync(logger, true, CancellationToken.None);
 
                 var output = File.ReadAllText(lockFilePath);
 
@@ -608,7 +609,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -630,7 +631,7 @@ namespace NuGet.Commands.FuncTest
 
                 command = new RestoreCommand(request);
                 result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var currentDate = File.GetLastWriteTime(lockFilePath);
 
@@ -802,7 +803,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFile = result.LockFile;
                 var installed = result.GetAllInstalled();
                 var unresolved = result.GetAllUnresolved();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
@@ -95,7 +96,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -151,7 +152,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
 
@@ -240,7 +241,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
 
@@ -300,7 +301,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
 
@@ -367,7 +368,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFileJson = JObject.Parse(File.OpenText(request.LockFilePath).ReadToEnd());
 
@@ -422,7 +423,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));
@@ -480,7 +481,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.Equal(0, result.CompatibilityCheckResults.Sum(checkResult => checkResult.Issues.Count));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
@@ -67,7 +68,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());
@@ -134,7 +135,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success, logger.ShowErrors());
@@ -202,7 +203,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());
@@ -269,7 +270,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var failure = result.CompatibilityCheckResults.Where(r => !r.Success).Single().Issues.Single();
 
@@ -359,7 +360,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());
@@ -431,7 +432,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success, logger.ShowErrors());

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
@@ -73,7 +74,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -142,7 +143,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -218,7 +219,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -314,7 +315,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -413,7 +414,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -509,7 +510,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -598,7 +599,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var fromDisk = format.Read(request.LockFilePath);
 
@@ -673,7 +674,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var fromDisk = format.Read(request.LockFilePath);
 
@@ -743,7 +744,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
                 var count = target.Libraries.Single().ContentFiles.Count;
@@ -813,7 +814,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
                 var contentFile = target.Libraries.Single().ContentFiles.Single();
@@ -961,7 +962,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
                 var files = target.Libraries.Single().ContentFiles;
@@ -1036,7 +1037,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1114,7 +1115,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1193,7 +1194,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1273,7 +1274,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1354,7 +1355,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1437,7 +1438,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1520,7 +1521,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1597,7 +1598,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1669,7 +1670,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1724,7 +1725,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var target = result.LockFile.GetTarget(NuGetFramework.Parse(framework), null);
 
@@ -1881,7 +1882,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 return result;
             }
@@ -1938,7 +1939,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 return result;
             }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -66,7 +67,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -161,7 +162,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success);
@@ -271,7 +272,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var packageALib = lockFile.GetLibrary("packageA", NuGetVersion.Parse("1.0.0"));
 
@@ -380,7 +381,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var packageALib = lockFile.GetLibrary("packageA", NuGetVersion.Parse("1.0.0"));
 
@@ -483,7 +484,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var packageALib = lockFile.GetLibrary("packageA", NuGetVersion.Parse("1.0.0"));
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Configuration;
@@ -1635,7 +1636,7 @@ namespace NuGet.Commands.Test
 
             // Act
             var result = await command.ExecuteAsync();
-            result.Commit(logger);
+            await result.CommitAsync(logger, CancellationToken.None);
 
             return result;
         }
@@ -1698,7 +1699,7 @@ namespace NuGet.Commands.Test
 
             // Act
             var result = await command.ExecuteAsync();
-            result.Commit(logger);
+            await result.CommitAsync(logger, CancellationToken.None);
 
             return result;
         }
@@ -1739,7 +1740,7 @@ namespace NuGet.Commands.Test
 
             // Act
             var result = await command.ExecuteAsync();
-            result.Commit(logger);
+            await result.CommitAsync(logger, CancellationToken.None);
 
             return result;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -75,7 +76,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -161,7 +162,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -286,7 +287,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -382,7 +383,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -459,7 +460,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -545,7 +546,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -654,7 +655,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -775,7 +776,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 
@@ -903,7 +904,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var lockFile = format.Read(request.LockFilePath, logger);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.LibraryModel;
@@ -79,7 +80,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -154,7 +155,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -229,7 +230,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -346,7 +347,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var project3Lib = lockFile.GetLibrary("project3", NuGetVersion.Parse("1.0.0"));
 
@@ -416,7 +417,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -491,7 +492,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -581,7 +582,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success);
@@ -656,7 +657,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var project2Lib = lockFile.GetLibrary("project2", NuGetVersion.Parse("1.0.0"));
 
@@ -717,7 +718,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var project2Lib = lockFile.GetLibrary("project2", NuGetVersion.Parse("1.0.0"));
 
@@ -805,7 +806,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var project2Lib = lockFile.GetLibrary("project2", NuGetVersion.Parse("1.0.0"));
 
@@ -890,7 +891,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var project2Lib = lockFile.GetLibrary("project2", NuGetVersion.Parse("1.0.0"));
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -69,7 +70,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -121,7 +122,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);
@@ -176,7 +177,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(
@@ -244,7 +245,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success,
@@ -313,7 +314,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -9,6 +9,7 @@ using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
 using System.Linq;
+using System.Threading;
 
 namespace NuGet.Commands.Test
 {
@@ -140,7 +141,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var runtimeGraph = result.RestoreGraphs.Single(graph => graph.RuntimeIdentifier == "unix").RuntimeGraph;
 
@@ -207,7 +208,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(result.Success);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
@@ -73,7 +74,7 @@ namespace NuGet.Commands.Test
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var lockFile = result.LockFile;
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var targetLib = lockFile.Targets.Single(graph => graph.RuntimeIdentifier == null).Libraries.Single();
 
@@ -146,7 +147,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var format = new LockFileFormat();
                 var lockFile = format.Read(request.LockFilePath);
@@ -240,7 +241,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var format = new LockFileFormat();
                 var lockFile = format.Read(request.LockFilePath);
@@ -335,7 +336,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                result.Commit(logger);
+                await result.CommitAsync(logger, CancellationToken.None);
 
                 var format = new LockFileFormat();
                 var lockFile = format.Read(request.LockFilePath);


### PR DESCRIPTION
We must lock around writing the project.lock.json. To lock, `RestoreResult.Commit(...)` method needs to be made `async` since our global locking mechanism is `async`. Most of the changes are test changes.

https://github.com/NuGet/Home/issues/2304

@emgarten 
