### PR TITLE
fixed https://github.com/NuGet/Home/issues/2298

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -127,7 +127,7 @@ namespace NuGet.Protocol
                 package.Id,
                 package.Version.ToNormalizedString());
 
-            var packages = new List<V2FeedPackageInfo>();
+            IReadOnlyList<V2FeedPackageInfo> packages = new List<V2FeedPackageInfo>();
 
             try
             {
@@ -145,7 +145,7 @@ namespace NuGet.Protocol
             // If not found use FindPackagesById
             if (packages.Count < 1)
             {
-                var allPackages = await FindPackagesByIdAsync(package.Id, log, token);
+                packages = await FindPackagesByIdAsync(package.Id, log, token);
 
                 return packages.Where(p => p.Version == package.Version)
                     .FirstOrDefault();

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -127,9 +127,20 @@ namespace NuGet.Protocol
                 package.Id,
                 package.Version.ToNormalizedString());
 
-            // Try to find the package directly
-            // Set max count to -1, get all packages 
-            var packages = await QueryV2Feed(uri, package.Id, -1, log, token);
+            var packages = new List<V2FeedPackageInfo>();
+
+            try
+            {
+                // Try to find the package directly for better perf
+                // Set max count to -1, get all packages 
+                packages = await QueryV2Feed(uri, package.Id, -1, log, token);
+            }
+            catch(Exception e)
+            {
+                // ProGet does not support normalized version
+                // Catch all exceptions for /Packages endpoint when server throw
+                log.LogDebug(e.ToString());
+            }
 
             // If not found use FindPackagesById
             if (packages.Count < 1)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -135,10 +135,10 @@ namespace NuGet.Protocol
                 // Set max count to -1, get all packages 
                 packages = await QueryV2Feed(uri, package.Id, -1, log, token);
             }
-            catch(Exception e)
+            catch(XmlException e)
             {
                 // ProGet does not support normalized version
-                // Catch all exceptions for /Packages endpoint when server throw
+                // Catch all XMl exceptions for ProGet
                 log.LogDebug(e.ToString());
             }
 


### PR DESCRIPTION
 https://github.com/NuGet/Home/issues/2298

catch all exception from /Packages endpoint, fall back to findpackagebyid
