### PR TITLE
Ignoring DTDs in V2FeedParser.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -412,7 +412,8 @@ namespace NuGet.Protocol
                 CloseInput = true,
                 IgnoreWhitespace = true,
                 IgnoreComments = true,
-                IgnoreProcessingInstructions = true
+                IgnoreProcessingInstructions = true,
+                DtdProcessing = DtdProcessing.Ignore, // for consistency with earlier behavior (v3.3 and before)
             });
 
             return XDocument.Load(xmlReader, LoadOptions.None);


### PR DESCRIPTION
Keeping behavior compatible with v3.3 behavior.
(fixing the DTD regression discovered in the discussion of https://github.com/NuGet/Home/issues/2054)
