### PR TITLE
fixes #2235: only set Client profile when test targets .NET framework…

### DIFF
--- a/test/EndToEnd/ProjectTemplates/WPFApplication.zip/WPFApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/WPFApplication.zip/WPFApplication.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>$safeprojectname$</RootNamespace>
     <AssemblyName>$safeprojectname$</AssemblyName>
     <TargetFrameworkVersion>v$targetframeworkversion$</TargetFrameworkVersion>
-    $if$ ($targetframeworkversion$ >= 4.0)
+    $if$ ($targetframeworkversion$ == 4.0)
       <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     $endif$
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
See notes on issue 2235. Removing the Client profile element for 4.5 fixes the test, because the Client profile doesn't exist post .NET framework 4.0. Suspect that, since update 1, DTE has changed under the hood to not resolve project references for non-existent platforms.
