### PR TITLE
Project name conflict handling

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreGraph.cs
@@ -126,7 +126,11 @@ namespace NuGet.Commands
                                 ranges = new HashSet<ResolverRequest>();
                                 conflicts[node.Key.Name] = ranges;
                             }
-                            ranges.Add(new ResolverRequest(node.OuterNode.Item.Key, node.Key));
+
+                            // OuterNode may be null if the project itself conflicts with a package name
+                            var requestor = node.OuterNode == null ? node.Item.Key : node.OuterNode.Item.Key;
+
+                            ranges.Add(new ResolverRequest(requestor, node.Key));
                         }
 
                         if (string.Equals(node?.Item?.Key?.Type, LibraryTypes.Unresolved))

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -14,6 +14,63 @@ namespace NuGet.Commands.Test
     public class RestoreCommandTests
     {
         [Fact]
+        public async Task RestoreCommand_PackageWithSameName()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project1"": { ""version"": ""1.0.0"", ""target"": ""package"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "project1", "1.0.0");
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(1, result.GetAllUnresolved().Count);
+                Assert.True(logger.ErrorMessages.Contains("Unable to resolve project1 (>= 1.0.0) for .NETFramework,Version=v4.5."));
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_PackageAndReferenceWithSameNameAndVersion()
         {
             // Arrange


### PR DESCRIPTION
This contains a small fix for creating error messages where the conflict involves the top level project.
https://github.com/NuGet/Home/issues/2189

Also adds a test for error messages around missing projects. This seems to be fixed already but it needed a test.
https://github.com/NuGet/Home/issues/2106

//cc @joelverhagen @zhili1208 @alpaix 
