### PR TITLE
add 'platform' as an allowed dependency type

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyType.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyType.cs
@@ -8,23 +8,23 @@ namespace NuGet.LibraryModel
 {
     public class LibraryDependencyType
     {
-        private readonly LibraryDependencyTypeFlag[] _keywords;
+        private readonly HashSet<LibraryDependencyTypeFlag> _keywords;
 
         public static LibraryDependencyType Default;
 
         static LibraryDependencyType()
         {
-            Default = new LibraryDependencyType(LibraryDependencyTypeKeyword.Default.FlagsToAdd as LibraryDependencyTypeFlag[]);
+            Default = new LibraryDependencyType(LibraryDependencyTypeKeyword.Default.FlagsToAdd);
         }
 
         public LibraryDependencyType()
         {
-            _keywords = new LibraryDependencyTypeFlag[0];
+            _keywords = new HashSet<LibraryDependencyTypeFlag>();
         }
 
-        private LibraryDependencyType(LibraryDependencyTypeFlag[] flags)
+        private LibraryDependencyType(IEnumerable<LibraryDependencyTypeFlag> flags)
         {
-            _keywords = flags;
+            _keywords = new HashSet<LibraryDependencyTypeFlag>(flags);
         }
 
         public bool Contains(LibraryDependencyTypeFlag flag)
@@ -48,6 +48,19 @@ namespace NuGet.LibraryModel
         {
             return new LibraryDependencyType(
                 _keywords.Except(remove).Union(add).ToArray());
+        }
+
+        public override bool Equals(object obj)
+        {
+            LibraryDependencyType other = obj as LibraryDependencyType;
+            return other != null &&
+                _keywords.All(other.Contains) &&
+                other._keywords.All(_keywords.Contains);
+        }
+
+        public override int GetHashCode()
+        {
+            return _keywords.GetHashCode();
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeFlag.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeFlag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 
 namespace NuGet.LibraryModel
@@ -14,6 +15,7 @@ namespace NuGet.LibraryModel
         public static readonly LibraryDependencyTypeFlag MainSource = Declare("MainSource");
         public static readonly LibraryDependencyTypeFlag MainExport = Declare("MainExport");
         public static readonly LibraryDependencyTypeFlag PreprocessReference = Declare("PreprocessReference");
+        public static readonly LibraryDependencyTypeFlag SharedFramework = Declare("SharedFramework");
 
         public static readonly LibraryDependencyTypeFlag RuntimeComponent = Declare("RuntimeComponent");
         public static readonly LibraryDependencyTypeFlag DevComponent = Declare("DevComponent");
@@ -28,6 +30,17 @@ namespace NuGet.LibraryModel
         public static LibraryDependencyTypeFlag Declare(string keyword)
         {
             return _flags.GetOrAdd(keyword, x => new LibraryDependencyTypeFlag(x));
+        }
+
+        public override bool Equals(object obj)
+        {
+            LibraryDependencyTypeFlag other = obj as LibraryDependencyTypeFlag;
+            return other != null && string.Equals(_value, other._value, System.StringComparison.Ordinal);
+        }
+
+        public override int GetHashCode()
+        {
+            return StringComparer.Ordinal.GetHashCode(_value);
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeKeyword.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTypeKeyword.cs
@@ -13,6 +13,7 @@ namespace NuGet.LibraryModel
         private static ConcurrentDictionary<string, LibraryDependencyTypeKeyword> _keywords = new ConcurrentDictionary<string, LibraryDependencyTypeKeyword>();
 
         public static readonly LibraryDependencyTypeKeyword Default;
+        public static readonly LibraryDependencyTypeKeyword Platform;
         public static readonly LibraryDependencyTypeKeyword Build;
         public static readonly LibraryDependencyTypeKeyword Preprocess;
         public static readonly LibraryDependencyTypeKeyword Private;
@@ -45,6 +46,19 @@ namespace NuGet.LibraryModel
                         LibraryDependencyTypeFlag.MainExport,
                         LibraryDependencyTypeFlag.RuntimeComponent,
                         LibraryDependencyTypeFlag.BecomesNupkgDependency,
+                    },
+                flagsToRemove: emptyFlags);
+
+            Platform = Declare(
+                "platform",
+                flagsToAdd: new[]
+                    {
+                        LibraryDependencyTypeFlag.MainReference,
+                        LibraryDependencyTypeFlag.MainSource,
+                        LibraryDependencyTypeFlag.MainExport,
+                        LibraryDependencyTypeFlag.RuntimeComponent,
+                        LibraryDependencyTypeFlag.BecomesNupkgDependency,
+                        LibraryDependencyTypeFlag.SharedFramework
                     },
                 flagsToRemove: emptyFlags);
 
@@ -93,6 +107,11 @@ namespace NuGet.LibraryModel
             DeclareOnOff("DevComponent", LibraryDependencyTypeFlag.DevComponent, emptyFlags);
             DeclareOnOff("PreprocessComponent", LibraryDependencyTypeFlag.PreprocessComponent, emptyFlags);
             DeclareOnOff("BecomesNupkgDependency", LibraryDependencyTypeFlag.BecomesNupkgDependency, emptyFlags);
+        }
+
+        public LibraryDependencyType CreateType()
+        {
+            return LibraryDependencyType.Default.Combine(FlagsToAdd, FlagsToRemove);
         }
 
         private static void DeclareOnOff(string name, LibraryDependencyTypeFlag flag, IEnumerable<LibraryDependencyTypeFlag> emptyFlags)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -236,6 +236,13 @@ namespace NuGet.ProjectModel
                             {
                                 suppressParentFlagsValue = LibraryIncludeFlags.All;
                             }
+                            else if(dependencyTypeValue.Contains(LibraryDependencyTypeFlag.SharedFramework))
+                            {
+                                dependencyIncludeFlagsValue =
+                                    LibraryIncludeFlags.Build |
+                                    LibraryIncludeFlags.Compile |
+                                    LibraryIncludeFlags.Analyzers;
+                            }
                         }
 
                         if (TryGetStringEnumerable(dependencyValue["include"], out strings))


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2303

The `platform` value is identical to the default except it adds the `runtime` and `native` exclude flags and sets a new `SharedFramework` library dependency type flag (which `dotnet publish` will be using)

/cc @davidfowl @emgarten
