### PR TITLE
Observer status code in V2FeedParser

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,14 +130,21 @@ namespace NuGet.Protocol
 
             // Try to find the package directly
             // Set max count to -1, get all packages 
-            var packages = await QueryV2Feed(uri, package.Id, -1, log, token);
+            var packages = await QueryV2Feed(
+                uri,
+                package.Id,
+                max: -1,
+                ignoreNotFounds: true,
+                log: log,
+                token: token);
 
             // If not found use FindPackagesById
             if (packages.Count < 1)
             {
                 var allPackages = await FindPackagesByIdAsync(package.Id, log, token);
 
-                return packages.Where(p => p.Version == package.Version)
+                return allPackages
+                    .Where(p => p.Version == package.Version)
                     .FirstOrDefault();
             }
 
@@ -170,7 +178,13 @@ namespace NuGet.Protocol
 
             var uri = string.Format(CultureInfo.InvariantCulture, _findPackagesByIdFormat, id);
             // Set max count to -1, get all packages
-            var packages = await QueryV2Feed(uri, id, -1, log, token);
+            var packages = await QueryV2Feed(
+                uri,
+                id,
+                max: -1,
+                ignoreNotFounds: false,
+                log: log,
+                token: token);
 
             var filtered = packages.Where(p => (includeUnlisted || p.IsListed)
                 && (includePrerelease || !p.Version.IsPrerelease));
@@ -197,7 +211,13 @@ namespace NuGet.Protocol
                                     skip,
                                     take);
 
-            return await QueryV2Feed(uri, null, take, log, cancellationToken);
+            return await QueryV2Feed(
+                uri,
+                id: null,
+                max: take,
+                ignoreNotFounds: false,
+                log: log,
+                token: cancellationToken);
         }
 
         public async Task<DownloadResourceResult> DownloadFromUrl(PackageIdentity package,
@@ -331,7 +351,13 @@ namespace NuGet.Protocol
             return value;
         }
 
-        private async Task<List<V2FeedPackageInfo>> QueryV2Feed(string uri, string id, int max, ILogger log, CancellationToken token)
+        private async Task<List<V2FeedPackageInfo>> QueryV2Feed(
+            string uri,
+            string id,
+            int max,
+            bool ignoreNotFounds,
+            ILogger log,
+            CancellationToken token)
         {
             var results = new List<V2FeedPackageInfo>();
             var page = 1;
@@ -351,13 +377,32 @@ namespace NuGet.Protocol
                 {
                     try
                     {
-                        var doc = LoadXml(await data.Content.ReadAsStreamAsync());
+                        string nextUri = null;
+                        if (data.StatusCode == HttpStatusCode.OK)
+                        {
+                            var doc = LoadXml(await data.Content.ReadAsStreamAsync());
 
-                        // find results on the page
-                        var result = ParsePage(doc, id);
-                        results.AddRange(result);
+                            // find results on the page
+                            var result = ParsePage(doc, id);
+                            results.AddRange(result);
 
-                        var nextUri = GetNextUrl(doc);
+                            nextUri = GetNextUrl(doc);
+                        }
+                        else if (ignoreNotFounds &&
+                                 (data.StatusCode == HttpStatusCode.NotFound ||
+                                  data.StatusCode == HttpStatusCode.NoContent))
+                        {
+                            // Treat "404 Not Found" and "204 No Content" as empty responses.
+                        }
+                        else
+                        {
+                            throw new FatalProtocolException(string.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.Log_FailedToFetchV2Feed,
+                                uri,
+                                (int)data.StatusCode,
+                                data.ReasonPhrase));
+                        }
 
                         urlRequest = null;
                         if (max < 0 || results.Count < max)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
@@ -276,6 +276,15 @@ namespace NuGet.Protocol.Core.v3 {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The V2 feed at &apos;{0}&apos; returned an unexpected status code &apos;{1} {2}&apos;..
+        /// </summary>
+        internal static string Log_FailedToFetchV2Feed {
+            get {
+                return ResourceManager.GetString("Log_FailedToFetchV2Feed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Unable to load package &apos;{0}&apos;..
         /// </summary>
         internal static string Log_FailedToGetNupkgStream {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
@@ -305,4 +305,10 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>Parameters in order: non-localizable HTTP status, non-localizable HTTP request URI, request duration in milliseconds.
 The "ms" should be localized to the abbreviation for milliseconds.</comment>
   </data>
+  <data name="Log_FailedToFetchV2Feed" xml:space="preserve">
+    <value>The V2 feed at '{0}' returned an unexpected status code '{1} {2}'.</value>
+    <comment>{0} is the URL that failed.
+{1} is the HTTP status code (an integer).
+{2} is the HTTP reason phrase (a non-translated string).</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -125,7 +125,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", null);
+            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", null);
+            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
@@ -199,7 +199,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceIdentityExistInvalidIdentity()
         {
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", null);
+            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 


### PR DESCRIPTION
There are three endpoints hit here with slightly different HTTP status code requirements.
1. `/api/v2/Search` - expects only 200. Everything else should cause an exception. 404 is never expected.
2. `/api/v2/FindPackagesById` - expects only 200. Everything else should cause an exception. 404 is never expected.
3. `/api/v2/Packages(Id='...',Version='...')` - expects 200 for success and 404/204 for no match. Everything else should cause an exception.

Verified on NuGet.org functionality.

@zhili1208 @emgarten @johnataylor @yishaigalatzer 
