### PR TITLE
Fix duplicate dependencies in project.lock.json

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -170,15 +170,7 @@ namespace NuGet.DependencyResolver
                             return false;
                         }
 
-                        // HACK(anurse): Reference nodes win all battles.
-                        if (node.Item.Key.Type == LibraryTypes.Reference)
-                        {
-                            tracker.Lock(node.Item);
-                        }
-                        else
-                        {
-                            tracker.Track(node.Item);
-                        }
+                        tracker.Track(node.Item);
                         return true;
                     });
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -4,18 +4,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.LibraryModel;
 
 namespace NuGet.DependencyResolver
 {
     public class Tracker<TItem>
     {
-        private readonly Dictionary<string, Entry> _entries 
+        private readonly Dictionary<string, Entry> _entries
             = new Dictionary<string, Entry>(StringComparer.OrdinalIgnoreCase);
 
         public void Track(GraphItem<TItem> item)
         {
             var entry = GetEntry(item);
-            if (!entry.List.Contains(item) && !entry.Locked)
+            if (!entry.List.Contains(item))
             {
                 entry.List.Add(item);
             }
@@ -39,7 +40,19 @@ namespace NuGet.DependencyResolver
         public bool IsBestVersion(GraphItem<TItem> item)
         {
             var entry = GetEntry(item);
-            return entry.List.All(known => item.Key.Version >= known.Key.Version);
+
+            // If there are any references then that's the only list we need to consider since
+            // it always wins over non-references
+            var candidates = entry.List.Where(known => known.Key.Type == LibraryTypes.Reference);
+
+            if (!candidates.Any())
+            {
+                // No references, just use the entire set
+                candidates = entry.List;
+            }
+
+            // Normal version check
+            return candidates.Contains(item) && candidates.All(known => item.Key.Version >= known.Key.Version);
         }
 
         public IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) => GetEntry(item).List;
@@ -55,14 +68,6 @@ namespace NuGet.DependencyResolver
             return itemList;
         }
 
-        internal void Lock(GraphItem<TItem> item)
-        {
-            var entry = GetEntry(item);
-            entry.List.Clear();
-            entry.List.Add(item);
-            entry.Locked = true;
-        }
-
         private class Entry
         {
             public Entry()
@@ -73,7 +78,6 @@ namespace NuGet.DependencyResolver
             public HashSet<GraphItem<TItem>> List { get; set; }
 
             public bool Ambiguous { get; set; }
-            public bool Locked { get; set; }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/RemoteDependencyWalkerTests.cs
@@ -690,6 +690,120 @@ namespace NuGet.DependencyResolver.Tests
         }
 
         [Fact]
+        public async Task FrameworkAssemblyWinsOverPackageWithSameName()
+        {
+            var context = new RemoteWalkContext();
+            var provider = new DependencyProvider();
+
+            provider.Package("A", "1.0")
+                    .DependsOn("B", "1.0.0")
+                    .DependsOn("C", "1.0.0")
+                    .DependsOn("D", "1.0.0");
+
+            provider.Package("B", "1.0.0")
+                    .DependsOn("System.Runtime", "4.0.0", LibraryDependencyTarget.Package);
+
+            provider.Package("C", "1.0.0")
+                    .DependsOn("System.Runtime", "4.0.1", LibraryDependencyTarget.Package);
+
+            provider.Package("D", "1.0.0")
+                    .DependsOn("System.Runtime", LibraryDependencyTarget.Reference);
+
+            provider.Package("System.Runtime", "4.0.0");
+            provider.Package("System.Runtime", "4.0.1");
+
+            context.LocalLibraryProviders.Add(provider);
+            var walker = new RemoteDependencyWalker(context);
+            var node = await DoWalkAsync(walker, "A");
+
+            var result = node.Analyze();
+            var set = new HashSet<string>();
+            GraphNode<RemoteResolveResult> systemRuntimeNode = null;
+            node.ForEach(n =>
+            {
+                if (n.Disposition == Disposition.Accepted)
+                {
+                    systemRuntimeNode = n;
+                    Assert.True(set.Add(n.Key.Name), n.Key.Name + " was duplicated in the graph");
+                }
+            });
+            Assert.Equal("System.Runtime", systemRuntimeNode.Key.Name);
+            Assert.Equal(LibraryDependencyTarget.Reference, systemRuntimeNode.Key.TypeConstraint);
+        }
+
+        [Fact]
+        public async Task MultipleFrameworkAssembliesPicksHighestVersion()
+        {
+            var context = new RemoteWalkContext();
+            var provider = new DependencyProvider();
+
+            provider.Package("A", "1.0")
+                    .DependsOn("B", "1.0.0")
+                    .DependsOn("C", "1.0.0");
+
+            provider.Package("B", "1.0.0")
+                    .DependsOn("System.Runtime", "4.0.0.0", LibraryDependencyTarget.Reference);
+
+            provider.Package("C", "1.0.0")
+                    .DependsOn("System.Runtime", "4.0.10.0", LibraryDependencyTarget.Reference);
+
+            context.LocalLibraryProviders.Add(provider);
+            var walker = new RemoteDependencyWalker(context);
+            var node = await DoWalkAsync(walker, "A");
+
+            var result = node.Analyze();
+            var set = new HashSet<string>();
+            GraphNode<RemoteResolveResult> systemRuntimeNode = null;
+            node.ForEach(n =>
+            {
+                if (n.Disposition == Disposition.Accepted)
+                {
+                    systemRuntimeNode = n;
+                    Assert.True(set.Add(n.Key.Name), n.Key.Name + " was duplicated in the graph");
+                }
+            });
+            Assert.Equal("System.Runtime", systemRuntimeNode.Key.Name);
+            Assert.Equal("4.0.10.0", systemRuntimeNode.Item.Key.Version.ToString());
+            Assert.Equal(LibraryDependencyTarget.Reference, systemRuntimeNode.Key.TypeConstraint);
+        }
+
+        [Fact]
+        public async Task VersionedAndNonVersionedFrameworkAssemblyVersionedWins()
+        {
+            var context = new RemoteWalkContext();
+            var provider = new DependencyProvider();
+
+            provider.Package("A", "1.0")
+                    .DependsOn("B", "1.0.0")
+                    .DependsOn("C", "1.0.0");
+
+            provider.Package("B", "1.0.0")
+                    .DependsOn("System.Runtime", LibraryDependencyTarget.Reference);
+
+            provider.Package("C", "1.0.0")
+                    .DependsOn("System.Runtime", "4.0.10.0", LibraryDependencyTarget.Reference);
+
+            context.LocalLibraryProviders.Add(provider);
+            var walker = new RemoteDependencyWalker(context);
+            var node = await DoWalkAsync(walker, "A");
+
+            var result = node.Analyze();
+            var set = new HashSet<string>();
+            GraphNode<RemoteResolveResult> systemRuntimeNode = null;
+            node.ForEach(n =>
+            {
+                if (n.Disposition == Disposition.Accepted)
+                {
+                    systemRuntimeNode = n;
+                    Assert.True(set.Add(n.Key.Name), n.Key.Name + " was duplicated in the graph");
+                }
+            });
+            Assert.Equal("System.Runtime", systemRuntimeNode.Key.Name);
+            Assert.Equal("4.0.10.0", systemRuntimeNode.Item.Key.Version.ToString());
+            Assert.Equal(LibraryDependencyTarget.Reference, systemRuntimeNode.Key.TypeConstraint);
+        }
+
+        [Fact]
         public void IsGreaterThanEqualTo_ReturnsTrue_IfLeftVersionIsUnbound()
         {
             // Arrange
@@ -873,27 +987,29 @@ namespace NuGet.DependencyResolver.Tests
                     _dependencies = dependencies;
                 }
 
-                public TestPackage DependsOn(string id)
-                {
-                    _dependencies.Add(new LibraryDependency
-                    {
-                        LibraryRange = new LibraryRange
-                        {
-                            Name = id
-                        }
-                    });
-
-                    return this;
-                }
-
-                public TestPackage DependsOn(string id, string version)
+                public TestPackage DependsOn(string id, LibraryDependencyTarget target = LibraryDependencyTarget.All)
                 {
                     _dependencies.Add(new LibraryDependency
                     {
                         LibraryRange = new LibraryRange
                         {
                             Name = id,
-                            VersionRange = VersionRange.Parse(version)
+                            TypeConstraint = target
+                        }
+                    });
+
+                    return this;
+                }
+
+                public TestPackage DependsOn(string id, string version, LibraryDependencyTarget target = LibraryDependencyTarget.All)
+                {
+                    _dependencies.Add(new LibraryDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = id,
+                            VersionRange = VersionRange.Parse(version),
+                            TypeConstraint = target
                         }
                     });
 


### PR DESCRIPTION
- Today when we encounter a framework assembly with the same name as a
  package we prefer the reference assembly over the packages. Today we do
  this incorrectly and as a result, the resolved graph ends up with
  multiple versions of packages in the project.lock.json. During conflict
  resolution consider the "best" version to be the reference assembly
  which will mark all other nodes as rejected.
- Added tests

/cc @emgarten @yishaigalatzer 
