### PR TITLE
Fix Select all checkbox visibility; Remove Ready message.

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml
@@ -35,12 +35,6 @@
           Text="{x:Static nuget:Resources.Text_NoPackagesFound}"
           Visibility="Collapsed" />
 
-        <TextBlock
-          Name="_ready"
-          HorizontalAlignment="Center"
-          Text="{x:Static nuget:Resources.Text_Ready}"
-          Visibility="Collapsed" />
-
         <Grid
           Name="_progressBar"
           Visibility="Collapsed"
@@ -78,7 +72,7 @@
           Binding="{Binding Path=Status}"
           Value="Ready">
           <Setter
-            TargetName="_ready"
+            TargetName="_progressBar"
             Property="Visibility"
             Value="Visible" />
         </DataTrigger>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -94,7 +94,6 @@ namespace NuGet.PackageManagement.UI
 
             var selectedPackageItem = SelectedPackageItem;
             ClearPackageList();
-            UpdateCheckBoxStatus();
 
             _selectedCount = 0;
 
@@ -173,6 +172,8 @@ namespace NuGet.PackageManagement.UI
                     _loadingStatusBar.SetError();
                     _loadingStatusBar.Visibility = Visibility.Visible;
                 }
+
+                UpdateCheckBoxStatus();
             });
         }
 


### PR DESCRIPTION
Fixes:
1) Select All checkbox wasn't been shown on initial switch to installed tab. (https://github.com/NuGet/Home/issues/2336)
2) Also removed Ready message, which should never be visible.
