### PR TITLE
Minimal v2 protocol fixes

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -5,11 +5,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.Logging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -203,10 +205,13 @@ namespace NuGet.Protocol
         public async Task<IReadOnlyList<V2FeedPackageInfo>> Search(string searchTerm, SearchFilter filters, int skip, int take, ILogger log, CancellationToken cancellationToken)
         {
             var targetFramework = String.Join(@"/", filters.SupportedFrameworks);
+
+            var shortFormTargetFramework = NuGetFramework.Parse(targetFramework).GetShortFolderName();
+
             var uri = String.Format(CultureInfo.InvariantCulture, _searchEndPointFormat,
                                     filters.IncludePrerelease ? IsAbsoluteLatestVersionFilterFlag : IsLatestVersionFilterFlag,
                                     searchTerm,
-                                    targetFramework,
+                                    shortFormTargetFramework,
                                     filters.IncludePrerelease.ToString().ToLowerInvariant(),
                                     skip,
                                     take);
@@ -363,7 +368,11 @@ namespace NuGet.Protocol
             var page = 1;
 
             // first request
-            Task<HttpResponseMessage> urlRequest = _httpSource.GetAsync(new Uri(uri), log, token);
+            Task<HttpResponseMessage> urlRequest = _httpSource.GetAsync(
+                new Uri(uri),
+                new[] { new MediaTypeWithQualityHeaderValue("application/atom+xml"), new MediaTypeWithQualityHeaderValue("application/xml") },
+                log,
+                token);
 
             // TODO: re-implement caching at a higher level for both v2 and v3
             while (!token.IsCancellationRequested && urlRequest != null)
@@ -388,11 +397,13 @@ namespace NuGet.Protocol
 
                             nextUri = GetNextUrl(doc);
                         }
-                        else if (ignoreNotFounds &&
-                                 (data.StatusCode == HttpStatusCode.NotFound ||
-                                  data.StatusCode == HttpStatusCode.NoContent))
+                        else if (ignoreNotFounds && data.StatusCode == HttpStatusCode.NotFound)
                         {
                             // Treat "404 Not Found" and "204 No Content" as empty responses.
+                        }
+                        else if (data.StatusCode == HttpStatusCode.NoContent)
+                        {
+                            // Always treat "204 No Content" as exactly that.
                         }
                         else
                         {
@@ -415,7 +426,11 @@ namespace NuGet.Protocol
                                 // keep track here.
                                 uri = nextUri;
 
-                                urlRequest = _httpSource.GetAsync(new Uri(nextUri), log, token);
+                                urlRequest = _httpSource.GetAsync(
+                                    new Uri(nextUri), 
+                                    new[] { new MediaTypeWithQualityHeaderValue("application/atom+xml"), new MediaTypeWithQualityHeaderValue("application/xml") },
+                                    log, 
+                                    token);
                             }
 
                             page++;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -126,6 +127,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         // So we decide to leave current logic and observe.
                         using (var data = await _httpSource.GetAsync(
                             uri,
+                            new[] { new MediaTypeWithQualityHeaderValue("application/atom+xml"), new MediaTypeWithQualityHeaderValue("application/xml") },
                             $"list_{id}_page{page}",
                             CreateCacheContext(retry),
                             Logger,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -58,7 +58,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=100",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
      TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -154,7 +154,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -197,9 +197,9 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=100",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
-            responses.Add("https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$filter=IsLatestVersion&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
+            responses.Add("https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$filter=IsLatestVersion&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearchNext100.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -222,7 +222,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -244,7 +244,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -254,7 +254,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 null);
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -276,7 +276,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-Client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }


### PR DESCRIPTION
@yishaigalatzer 
This pull request represents the minimal working changes for Klondike.
1) we send Accept headers correctly and 2) for search we send short name for target framework

@csharpfritz
We are also expecting users to have to use Klondike with host/api/odata and not host/api because for 3.4 because _we are not fixing the fact that we don't correctly processes odata base address_. If the initial request is redirected our client won't work because the base address specified in the root OData ServiceDocument will not be picked up.
