### PR TITLE
Properly handle cancelled-by-user response in HttpSource

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio.Threading;
+using NuGet.Common;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
@@ -74,6 +75,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 ExecutionContext = new IDEExecutionContext(_commonOperations);
             }
+
+            ActivityCorrelationContext.StartNew();
         }
 
         #region Properties

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
@@ -58,8 +58,6 @@ namespace NuGet.PackageManagement.UI
 
         public async Task<SearchResult<IPackageSearchMetadata>> SearchAsync(string searchText, SearchFilter filter, CancellationToken cancellationToken)
         {
-            ActivityCorrelationContext.StartNew();
-
             var searchTasks = TaskCombinators.ObserveErrorsAsync(
                 _sourceRepositories,
                 r => r.PackageSource.Name,

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
@@ -58,6 +58,8 @@ namespace NuGet.PackageManagement.UI
 
         public async Task<SearchResult<IPackageSearchMetadata>> SearchAsync(string searchText, SearchFilter filter, CancellationToken cancellationToken)
         {
+            ActivityCorrelationContext.StartNew();
+
             var searchTasks = TaskCombinators.ObserveErrorsAsync(
                 _sourceRepositories,
                 r => r.PackageSource.Name,

--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -147,6 +147,8 @@ namespace NuGet.PackageManagement.UI
             // Go off the UI thread to perform non-UI operations
             await TaskScheduler.Default;
 
+            ActivityCorrelationContext.StartNew();
+
             int totalCount = 0;
             ContinuationToken nextToken = null;
             do
@@ -167,6 +169,8 @@ namespace NuGet.PackageManagement.UI
         {
             // Go off the UI thread to perform non-UI operations
             await TaskScheduler.Default;
+
+            ActivityCorrelationContext.StartNew();
 
             var packages = new List<IPackageSearchMetadata>();
             ContinuationToken nextToken = null;
@@ -189,6 +193,8 @@ namespace NuGet.PackageManagement.UI
 
         public async Task LoadNextAsync(IProgress<IItemLoaderState> progress, CancellationToken cancellationToken)
         {
+            ActivityCorrelationContext.StartNew();
+
             cancellationToken.ThrowIfCancellationRequested();
 
             NuGetEventTrigger.Instance.TriggerEvent(NuGetEvent.PackageLoadBegin);

--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -60,7 +60,7 @@ namespace NuGet.PackageManagement.UI
                     if (_results == null)
                     {
                         // initial status when no load called before
-                        return LoadingStatus.Ready;
+                        return LoadingStatus.Unknown;
                     }
 
                     return AggregateLoadingStatus(SourceLoadingStatus?.Values);

--- a/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
+++ b/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
@@ -16,7 +16,7 @@ namespace NuGet.Common
     /// Single activity engages multiple method calls at different layers. 
     /// Sometimes it's necessary to identify separate calls belonging to the same activity if shared state is needed.
     /// </summary>
-    public class ActivityCorrelationContext
+    public class ActivityCorrelationContext : IDisposable
     {
         private static readonly string DataSlotId = "NuGet.ActivityCorrelationContext";
 
@@ -67,6 +67,18 @@ namespace NuGet.Common
             CallContext.LogicalSetData(DataSlotId, context);
 #endif
             return context;
+        }
+
+        public void Dispose()
+        {
+#if !DNXCORE50
+            var context = CallContext.LogicalGetData(DataSlotId);
+
+            if (this == context)
+            { 
+                CallContext.FreeNamedDataSlot(DataSlotId);
+            }
+#endif
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
+++ b/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+#if DNXCORE50
+using System.Threading;
+#else
+using System.Runtime.Remoting.Messaging;
+#endif
+
+namespace NuGet.Common
+{
+    public class ActivityCorrelationContext
+    {
+        private static readonly string DataSlotId = "NuGet.ActivityCorrelationContext";
+
+#if DNXCORE50
+        private static readonly AsyncLocal<ActivityCorrelationContext> _instance = new AsyncLocal<ActivityCorrelationContext>();
+#endif
+
+        public string CorrelationId { get; private set; }
+
+        public static ActivityCorrelationContext Current
+        {
+            get
+            {
+#if DNXCORE50
+                return _instance.Value;
+#else
+                var context = CallContext.LogicalGetData(DataSlotId);
+                return (ActivityCorrelationContext)context;
+#endif
+            }
+        }
+
+        public static ActivityCorrelationContext StartNew()
+        {
+            var context = new ActivityCorrelationContext
+            {
+                CorrelationId = Guid.NewGuid().ToString("N")
+            };
+
+#if DNXCORE50
+            _instance.Value = context;
+#else
+            CallContext.LogicalSetData(DataSlotId, context);
+#endif
+            return context;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
+++ b/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
@@ -11,6 +11,11 @@ using System.Runtime.Remoting.Messaging;
 
 namespace NuGet.Common
 {
+    /// <summary>
+    /// Ambient context contains properties pertaining to a current activity.
+    /// Single activity engages multiple method calls at different layers. 
+    /// Sometimes it's necessary to identify separate calls belonging to the same activity if shared state is needed.
+    /// </summary>
     public class ActivityCorrelationContext
     {
         private static readonly string DataSlotId = "NuGet.ActivityCorrelationContext";
@@ -19,26 +24,41 @@ namespace NuGet.Common
         private static readonly AsyncLocal<ActivityCorrelationContext> _instance = new AsyncLocal<ActivityCorrelationContext>();
 #endif
 
+        private static readonly ActivityCorrelationContext _globalInstance = new ActivityCorrelationContext
+        {
+            CorrelationId = default(Guid).ToString()
+        };
+
+        /// <summary>
+        /// Represents activity unique ID.
+        /// </summary>
         public string CorrelationId { get; private set; }
 
+        /// <summary>
+        /// Returns ambient context value or global instance if not set earlier.
+        /// </summary>
         public static ActivityCorrelationContext Current
         {
             get
             {
 #if DNXCORE50
-                return _instance.Value;
+                return _instance.Value ?? _globalInstance;
 #else
                 var context = CallContext.LogicalGetData(DataSlotId);
-                return (ActivityCorrelationContext)context;
+                return (ActivityCorrelationContext)context ?? _globalInstance;
 #endif
             }
         }
 
+        /// <summary>
+        /// Instantiates activity context instance with new identifier. Updates ambient context value.
+        /// </summary>
+        /// <returns>New instance</returns>
         public static ActivityCorrelationContext StartNew()
         {
             var context = new ActivityCorrelationContext
             {
-                CorrelationId = Guid.NewGuid().ToString("N")
+                CorrelationId = Guid.NewGuid().ToString()
             };
 
 #if DNXCORE50

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -285,6 +286,8 @@ namespace NuGet.PackageManagement
             {
                 throw new ArgumentNullException(nameof(nuGetProjectContext));
             }
+
+            ActivityCorrelationContext.StartNew();
 
             var missingPackages = packageRestoreContext.Packages.Where(p => p.IsMissing).ToList();
             if (!missingPackages.Any())

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -216,6 +216,8 @@ namespace NuGet.PackageManagement
             INuGetProjectContext nuGetProjectContext, IEnumerable<SourceRepository> primarySources,
             IEnumerable<SourceRepository> secondarySources, CancellationToken token)
         {
+            ActivityCorrelationContext.StartNew();
+
             // Step-1 : Call PreviewInstallPackageAsync to get all the nuGetProjectActions
             var nuGetProjectActions = await PreviewInstallPackageAsync(nuGetProject, packageIdentity, resolutionContext,
                 nuGetProjectContext, primarySources, secondarySources, token);
@@ -231,6 +233,8 @@ namespace NuGet.PackageManagement
         public async Task UninstallPackageAsync(NuGetProject nuGetProject, string packageId, UninstallationContext uninstallationContext,
             INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
+            ActivityCorrelationContext.StartNew();
+
             // Step-1 : Call PreviewUninstallPackagesAsync to get all the nuGetProjectActions
             var nuGetProjectActions = await PreviewUninstallPackageAsync(nuGetProject, packageId, uninstallationContext, nuGetProjectContext, token);
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/AmbientAuthenticationState.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/AmbientAuthenticationState.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol.Core.v3
+{
+    /// <summary>
+    /// Represents source authentication status per active operation
+    /// </summary>
+    public class AmbientAuthenticationState
+    {
+        public bool IsBlocked { get; set; }
+        public int AuthenticationRetriesCount { get; set; }
+
+        public void Increment()
+        {
+            AuthenticationRetriesCount++;
+
+            if (AuthenticationRetriesCount > HttpHandlerResourceV3Provider.MaxAuthRetries)
+            {
+                IsBlocked = true;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -366,6 +366,11 @@ namespace NuGet.Protocol
                             await UpdateHttpClient(promptCredentials);
                             continue;
                         }
+
+                        // null means cancelled by user
+                        // block subsequent attempts to annoy user with prompts
+                        _authRetries = HttpHandlerResourceV3Provider.MaxAuthRetries;
+                        return response;
                     }
                     finally
                     {
@@ -395,6 +400,11 @@ namespace NuGet.Protocol
 
                     promptCredentials =
                         await HttpHandlerResourceV3.PromptForCredentials(_baseUri, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    // A valid response for VS dialog when user hits cancel button
+                    promptCredentials = null;
                 }
                 finally
                 {


### PR DESCRIPTION
VS credential dialog throws OperationCanceledException when user hits cancel.
Added special catch to reset authentication state of HttpSource retry loop.
After the change "cancelled" source will be blocked for following authentication attempts.

//cc @yishaigalatzer @emgarten @deepakaravindr 
