### PR TITLE
Add download timeout to all network streams

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace NuGet.Protocol
+{
+    public class HttpCacheResult
+    {
+        public string CacheFileName { get; set; }
+        public Stream Stream { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResource.cs
@@ -1,4 +1,7 @@
-﻿using NuGet.Protocol.Core.Types;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResourceProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
@@ -8,8 +8,23 @@ namespace NuGet.Protocol
 {
     public class HttpSourceResult : IDisposable
     {
-        public string CacheFileName { get; set; }
-        public Stream Stream { get; set; }
+        public Stream Stream { get; private set; }
+        public HttpSourceResultStatus Status { get; }
+        public string CacheFileName { get; }
+        
+        public HttpSourceResult(HttpSourceResultStatus status)
+        {
+            Status = status;
+            Stream = null;
+            CacheFileName = null;
+        }
+
+        public HttpSourceResult(HttpSourceResultStatus status, string cacheFileName, Stream stream)
+        {
+            Status = status;
+            Stream = stream;
+            CacheFileName = cacheFileName;
+        }
 
         public void Dispose()
         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol
+{
+    public enum HttpSourceResultStatus
+    {
+        NotFound,
+        OpenedFromDisk,
+        OpenedFromNetwork
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpStreamValidation.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpStreamValidation.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Text;
 using System.Xml;
-using System.Xml.Linq;
 using Newtonsoft.Json;
 using NuGet.Packaging;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -120,7 +120,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
                 try
                 {
-                    using (var data = await _httpSource.GetAsync(
+                    using (var result = await _httpSource.GetAsync(
                         uri,
                         $"list_{id}",
                         CreateCacheContext(retry),
@@ -129,18 +129,18 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         ensureValidContents: stream => HttpStreamValidation.ValidateJObject(uri, stream),
                         cancellationToken: cancellationToken))
                     {
-                        if (data.Stream == null)
+                        if (result.Status == HttpSourceResultStatus.NotFound)
                         {
                             return new SortedDictionary<NuGetVersion, PackageInfo>();
                         }
 
                         try
                         {
-                            return ConsumeFlatContainerIndex(data.Stream, id, baseUri);
+                            return ConsumeFlatContainerIndex(result.Stream, id, baseUri);
                         }
                         catch
                         {
-                            Logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_FileIsCorrupt, data.CacheFileName));
+                            Logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_FileIsCorrupt, result.CacheFileName));
 
                             throw;
                         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
@@ -48,7 +48,11 @@ namespace NuGet.Protocol
             queryUrl.Query = queryString;
 
             var queryUri = queryUrl.Uri;
-            var results = await _client.GetJObjectAsync(queryUri, Logging.NullLogger.Instance, token);
+            var results = await _client.GetJObjectAsync(
+                uri: queryUri,
+                ignoreNotFounds: false,
+                log: Logging.NullLogger.Instance,
+                token: token);
             token.ThrowIfCancellationRequested();
             if (results == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -255,15 +255,15 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
-            var response = await _httpSource.SendAsync(
+            await _httpSource.ProcessResponseAsync(
                 () => CreateRequest(source, pathToPackage, apiKey),
+                response =>
+                {
+                    response.EnsureSuccessStatusCode();
+                    return Task.FromResult(0);
+                },
                 logger,
                 token);
-
-            using (response)
-            {
-                response.EnsureSuccessStatusCode();
-            }
         }
 
         private HttpRequestMessage CreateRequest(string source,
@@ -345,7 +345,7 @@ namespace NuGet.Protocol.Core.Types
             ILogger logger,
             CancellationToken token)
         {
-            var response = await _httpSource.SendAsync(
+            await _httpSource.ProcessResponseAsync(
                 () =>
                 {
                     // Review: Do these values need to be encoded in any way?
@@ -357,13 +357,13 @@ namespace NuGet.Protocol.Core.Types
                     }
                     return request;
                 },
+                response =>
+                {
+                    response.EnsureSuccessStatusCode();
+                    return Task.FromResult(0);
+                },
                 logger,
                 token);
-
-            using (response)
-            {
-                response.EnsureSuccessStatusCode();
-            }
         }
 
         // Deletes a package from a FileSystem.

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
@@ -79,7 +79,11 @@ namespace NuGet.Protocol.Core.v3
                     JObject searchJson = null;
                     try
                     {
-                        searchJson = await _client.GetJObjectAsync(queryUrl.Uri, log, cancellationToken);
+                        searchJson = await _client.GetJObjectAsync(
+                            uri: queryUrl.Uri,
+                            ignoreNotFounds: false,
+                            log: log,
+                            token: cancellationToken);
                     }
                     catch when (i < _searchEndpoints.Length - 1)
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
@@ -204,6 +204,15 @@ namespace NuGet.Protocol.Core.v3 {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The download of &apos;{0}&apos; timed out because no data was received for {1}ms..
+        /// </summary>
+        internal static string Error_DownloadTimeout {
+            get {
+                return ResourceManager.GetString("Error_DownloadTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to {0} {1}.
         /// </summary>
         internal static string Http_RequestLog {
@@ -353,6 +362,15 @@ namespace NuGet.Protocol.Core.v3 {
         internal static string Log_RetryingFindPackagesById {
             get {
                 return ResourceManager.GetString("Log_RetryingFindPackagesById", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to An error was encountered when fetching &apos;{0} {1}&apos;. The request will now be retried..
+        /// </summary>
+        internal static string Log_RetryingHttp {
+            get {
+                return ResourceManager.GetString("Log_RetryingHttp", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
@@ -311,4 +311,14 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
 {1} is the HTTP status code (an integer).
 {2} is the HTTP reason phrase (a non-translated string).</comment>
   </data>
+  <data name="Log_RetryingHttp" xml:space="preserve">
+    <value>An error was encountered when fetching '{0} {1}'. The request will now be retried.</value>
+    <comment>'{0}' is replaced with the HTTP method used.
+'{1}' is replaced with the URL that failed to be reached.</comment>
+  </data>
+  <data name="Error_DownloadTimeout" xml:space="preserve">
+    <value>The download of '{0}' timed out because no data was received for {1}ms.</value>
+    <comment>'{0}' is replaced with the resource that could not be downloaded.
+'{1}' is replaced with the integer (in milliseconds) of the timeout duration.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
@@ -1,0 +1,117 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.v3;
+
+namespace NuGet.Protocol
+{
+    public class DownloadTimeoutStream : Stream
+    {
+        private readonly string _downloadName;
+        private readonly Stream _networkStream;
+        private readonly TimeSpan _timeout;
+
+        public DownloadTimeoutStream(string downloadName, Stream networkStream, TimeSpan timeout)
+        {
+            if (downloadName == null)
+            {
+                throw new ArgumentNullException(nameof(downloadName));
+            }
+
+            if (networkStream == null)
+            {
+                throw new ArgumentNullException(nameof(networkStream));
+            }
+            
+            _downloadName = downloadName;
+            _networkStream = networkStream;
+            _timeout = timeout;
+        }
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            try
+            {
+                return ReadAsync(buffer, offset, count, CancellationToken.None).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            var timeoutMessage = string.Format(
+                Strings.Error_DownloadTimeout,
+                _downloadName,
+                _timeout.TotalMilliseconds);
+
+            try
+            {
+                var result = await TimeoutUtility.StartWithTimeout(
+                    getTask: timeoutToken => _networkStream.ReadAsync(buffer, offset, count, timeoutToken),
+                    timeout: _timeout,
+                    timeoutMessage: null,
+                    token: cancellationToken).ConfigureAwait(false);
+                    
+                return result;
+            }
+            catch (TimeoutException e)
+            {
+                // Failed stream operations should throw an IOException.
+                throw new IOException(timeoutMessage, e);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _networkStream.Dispose();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead { get; } = true;
+
+        public override bool CanSeek { get; } = false;
+
+        public override bool CanWrite { get; } = false;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
@@ -48,6 +48,23 @@ namespace NuGet.Protocol
                 throw e.InnerException;
             }
         }
+        
+#if !NETSTANDARD1_5
+        public override IAsyncResult BeginRead(
+            byte[] buffer,
+            int offset,
+            int count,
+            AsyncCallback callback,
+            object state)
+        {
+            throw new NotSupportedException();
+        }
+        
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            throw new NotSupportedException();
+        }
+#endif
 
         public override async Task<int> ReadAsync(
             byte[] buffer,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedAddContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedAddContext.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Globalization;
 using NuGet.Protocol.Core.v3;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/TimeoutUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/TimeoutUtility.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public static class TimeoutUtility
+    {
+        /// <summary>
+        /// Starts a task with a timeout. If the timeout occurs, a <see cref="TimeoutException"/>
+        /// with no message will be thrown.
+        /// </summary>
+        public static async Task<T> StartWithTimeout<T>(
+            Func<CancellationToken, Task<T>> getTask,
+            TimeSpan timeout,
+            string timeoutMessage,
+            CancellationToken token)
+        {                        
+            /*
+             * Implement timeout. Two operations are started and run in parallel:
+             *
+             *   1) The callers's task.
+             *   2) A timer that fires after the duration of the timeout.
+             *
+             * If the timeout occurs first, the caller's task should be cancelled. If the 
+             * caller's task completes before the timeout, the timeout should be cancelled.
+             * If the timeout occurs first, consider the caller's task should be considered
+             * a failure and a timeout exception is thrown. If the caller's task completes
+             * first, it could be that the response came back or that the caller cancelled
+             * the task.
+             */
+            using (var timeoutTcs = new CancellationTokenSource())
+            using (var taskTcs = new CancellationTokenSource())
+            using (token.Register(() => taskTcs.Cancel()))
+            {
+                var timeoutTask = Task.Delay(timeout, timeoutTcs.Token);
+                var responseTask = getTask(taskTcs.Token);
+
+                if (timeoutTask == await Task.WhenAny(responseTask, timeoutTask))
+                {
+                    taskTcs.Cancel();
+
+                    throw new TimeoutException(timeoutMessage);
+                }
+
+                timeoutTcs.Cancel();
+                return await responseTask;
+            }
+        }
+
+        /// <summary>
+        /// Starts a task with a timeout. If the timeout occurs, a <see cref="TimeoutException"/>
+        /// with no message will be thrown.
+        /// </summary>
+        public static async Task StartWithTimeout(
+            Func<CancellationToken, Task> getTask,
+            TimeSpan timeout,
+            string timeoutMessage,
+            CancellationToken token)
+        {
+            await StartWithTimeout(
+                async timeoutToken =>
+                {
+                    await getTask(timeoutToken);
+                    return true;
+                },
+                timeout,
+                timeoutMessage,
+                token);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -26,14 +26,14 @@ namespace Test.Utility
             _responses = responses;
         }
         
-        protected override Task<HttpSourceResult> TryReadCacheFile(
+        protected override Task<HttpCacheResult> TryReadCacheFile(
             string uri,
             string cacheKey,
             HttpSourceCacheContext context,
             ILogger log,
             CancellationToken token)
         {
-            var result = new HttpSourceResult();
+            var result = new HttpCacheResult();
 
             string s;
             if (_responses.TryGetValue(uri, out s) && !string.IsNullOrEmpty(s))

--- a/src/NuGet.Core/NuGet.Test.Server/ITestServer.cs
+++ b/src/NuGet.Core/NuGet.Test.Server/ITestServer.cs
@@ -7,7 +7,8 @@ namespace NuGet.Test.Server
     {
         ConnectFailure,
         ServerProtocolViolation,
-        NameResolutionFailure
+        NameResolutionFailure,
+        SlowResponseBody
     }
 
     public interface ITestServer

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpStreamValidationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpStreamValidationTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Text;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/SlowStream.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/SlowStream.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class SlowStream : Stream
+    {
+        private readonly Stream _innerStream;
+
+        public SlowStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+        }
+
+        public TimeSpan DelayPerByte { get; set; }
+        public Action<byte[], int, int> OnRead { get; set;}
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            OnRead?.Invoke(buffer, offset, count);
+            var read = _innerStream.Read(buffer, offset, count);
+            Task.Delay(new TimeSpan(DelayPerByte.Ticks * read)).Wait();
+            return read;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
@@ -1,0 +1,148 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using System.Diagnostics;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class DownloadTimeoutStreamTests
+    {
+        [Fact]
+        public void DownloadTimeoutStream_RejectsNullDownloadName()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new DownloadTimeoutStream(null, new MemoryStream(), TimeSpan.Zero));
+            Assert.Equal("downloadName", exception.ParamName);
+        }
+        
+        [Fact]
+        public void DownloadTimeoutStream_RejectsNullStream()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                new DownloadTimeoutStream("downloadName", null, TimeSpan.Zero));
+            Assert.Equal("networkStream", exception.ParamName);
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_SuccessAsync()
+        {
+            await VerifySuccessfulReadAsync(ReadStreamAsync);
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_TimeoutAsync()
+        {
+            await VerifyTimeoutOnReadAsync(ReadStreamAsync);
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_FailureAsync()
+        {
+            await VerifyFailureOnReadAsync(ReadStreamAsync);
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_SuccessSync()
+        {
+            await VerifySuccessfulReadAsync(stream => Task.FromResult(ReadStream(stream)));
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_TimeoutSync()
+        {
+            await VerifyTimeoutOnReadAsync(stream => Task.FromResult(ReadStream(stream)));
+        }
+        
+        [Fact]
+        public async Task DownloadTimeoutStream_FailureSync()
+        {
+            await VerifyFailureOnReadAsync(stream => Task.FromResult(ReadStream(stream)));
+        }
+        
+        public async Task VerifyFailureOnReadAsync(Func<Stream, Task<string>> readAsync)
+        {
+            // Arrange
+            var expected = new IOException();
+            var memoryStream = GetStream("foobar");
+            var slowStream = new SlowStream(memoryStream)
+            {
+                OnRead = (buffer, offset, count) => { throw expected; } 
+            };
+            var timeoutStream = new DownloadTimeoutStream("download", slowStream, TimeSpan.FromSeconds(1));
+            
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<IOException>(() =>
+                readAsync(timeoutStream));
+            Assert.Same(expected, actual);
+        }
+        
+        public async Task VerifyTimeoutOnReadAsync(Func<Stream, Task<string>> readAsync)
+        {
+            // Arrange
+            var expectedDownload = "download";
+            var expectedMilliseconds = 25;
+            var memoryStream = GetStream("foobar");
+            var slowStream = new SlowStream(memoryStream)
+            {
+                DelayPerByte = TimeSpan.FromMilliseconds(expectedMilliseconds * 2)
+            };
+            var timeoutStream = new DownloadTimeoutStream(
+                expectedDownload,
+                slowStream,
+                TimeSpan.FromMilliseconds(expectedMilliseconds));
+            
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<IOException>(() =>
+                readAsync(timeoutStream));
+            Assert.Equal(
+                $"The download of '{expectedDownload}' timed out because " +
+                $"no data was received for {expectedMilliseconds}ms.",
+                exception.Message);
+            Assert.IsType<TimeoutException>(exception.InnerException);
+        }
+        
+        private async Task VerifySuccessfulReadAsync(Func<Stream, Task<string>> readAsync)
+        {
+            // Arrange
+            var expected = "foobar";
+            var memoryStream = GetStream(expected);
+            var timeoutStream = new DownloadTimeoutStream(
+                "download",
+                memoryStream,
+                TimeSpan.FromMilliseconds(100));
+            
+            // Act
+            var actual = await readAsync(timeoutStream);
+            
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+        
+        private MemoryStream GetStream(string content)
+        {
+            return new MemoryStream(Encoding.ASCII.GetBytes(content));
+        }
+        
+        private string ReadStream(Stream stream)
+        {
+            var destination = new MemoryStream();
+            stream.CopyTo(destination, 1);
+            return Encoding.ASCII.GetString(destination.ToArray());
+        }
+        
+        private async Task<string> ReadStreamAsync(Stream stream)
+        {
+            var destination = new MemoryStream();
+            await stream.CopyToAsync(destination, 1, CancellationToken.None);
+            return Encoding.ASCII.GetString(destination.ToArray());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/TimeoutUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/TimeoutUtilityTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class TimeoutUtilityTests
+    {
+        [Fact]
+        public async Task TimeoutUtility_SucceedsWithResult()
+        {
+            // Arrange
+            var expected = 23;
+            CancellationToken timeoutToken = CancellationToken.None;
+            Func<CancellationToken, Task<int>> actionAsync = token =>
+            {
+                timeoutToken = token;
+                return Task.FromResult(expected);
+            };
+            
+            // Act
+            var actual = await TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromSeconds(1),
+                "message",
+                CancellationToken.None);
+                
+            // Assert
+            Assert.Equal(expected, actual);
+            Assert.False(timeoutToken.IsCancellationRequested);
+        }
+        
+        [Fact]
+        public async Task TimeoutUtility_FailsWithResult()
+        {
+            // Arrange
+            var expected = new Exception();
+            CancellationToken timeoutToken = CancellationToken.None;
+            Func<CancellationToken, Task<int>> actionAsync = token =>
+            {
+                timeoutToken = token;
+                throw expected;
+            };
+            
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<Exception>(() => TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromSeconds(1),
+                "message",
+                CancellationToken.None));
+            Assert.Same(expected, actual);
+            Assert.False(timeoutToken.IsCancellationRequested);
+        }
+        
+        [Fact]
+        public async Task TimeoutUtility_TimesOutWithResult()
+        {
+            // Arrange
+            var expected = "timeout message";
+            CancellationToken timeoutToken = CancellationToken.None;
+            Func<CancellationToken, Task<int>> actionAsync = async token =>
+            {
+                timeoutToken = token;
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+                return 23;
+            }; 
+            
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<TimeoutException>(() => TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromTicks(1),
+                expected,
+                CancellationToken.None));
+            Assert.Equal(expected, exception.Message);
+            Assert.True(timeoutToken.IsCancellationRequested);
+        }
+        
+        [Fact]
+        public async Task TimeoutUtility_SucceedsWithoutResult()
+        {
+            // Arrange
+            CancellationToken timeoutToken = CancellationToken.None;
+            Func<CancellationToken, Task> actionAsync = token =>
+            {
+                timeoutToken = token;
+                return Task.FromResult(0);
+            };
+            
+            // Act
+            await TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromSeconds(1),
+                "message",
+                CancellationToken.None);
+                
+            // Assert
+            Assert.False(timeoutToken.IsCancellationRequested);
+        }
+        
+        [Fact]
+        public async Task TimeoutUtility_FailsWithoutResult()
+        {
+            // Arrange
+            var expected = new Exception();
+            CancellationToken timeoutToken = CancellationToken.None;
+            Func<CancellationToken, Task> actionAsync = token =>
+            {
+                timeoutToken = token;
+                throw expected;
+            };
+            
+            // Act & Assert
+            var actual = await Assert.ThrowsAsync<Exception>(() => TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromSeconds(1),
+                "message",
+                CancellationToken.None));
+            Assert.Same(expected, actual);
+            Assert.False(timeoutToken.IsCancellationRequested);
+        }
+        
+        [Fact]
+        public async Task TimeoutUtility_TimesOutWithoutResult()
+        {
+            // Arrange
+            var expected = "timeout message";
+            CancellationToken timeoutToken = CancellationToken.None; 
+            Func<CancellationToken, Task> actionAsync = async token =>
+            {
+                timeoutToken = token;
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
+            }; 
+            
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<TimeoutException>(() => TimeoutUtility.StartWithTimeout(
+                actionAsync,
+                TimeSpan.FromTicks(1),
+                expected,
+                CancellationToken.None));
+            Assert.Equal(expected, exception.Message);
+            Assert.True(timeoutToken.IsCancellationRequested);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -22,11 +22,15 @@
         "portable-net45+win8"
       ],
       "dependencies": {
+        "moq.netcore": "4.4.0-beta8",
         "NETStandard.Library": "1.5.0-rc2-23911",
         "dotnet-test-xunit": "1.0.0-dev-48273-16"
       }
     },
     "net46": {
+      "dependencies": {
+        "Moq": "4.2.1510.2205"
+      },
       "frameworkAssemblies": {
         "Microsoft.CSharp": "",
         "System": "",


### PR DESCRIPTION
This is implemented by wrapping the stream and applying a timeout to the inner `ReadAsync`. I have added a lot of unit tests and a functional tests that hits a real (in-process) HTTP server.

The wrapper stream is `DownloadTimeoutStream`. If a `ReadAsync` takes more than 60 seconds, an `IOException` with a timeout message is thrown.
