### PR TITLE
Fix crash report in options dialog. Argument out of range error when …

### DIFF
--- a/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
+++ b/src/NuGet.Clients/Options/PackageSourcesOptionsControl.cs
@@ -471,7 +471,11 @@ namespace NuGet.Options
             var currentListBox = (ListBox)sender;
             if (e.Button == MouseButtons.Right)
             {
-                currentListBox.SelectedIndex = currentListBox.IndexFromPoint(e.Location);
+                int itemIndexToSelect = currentListBox.IndexFromPoint(e.Location);
+                if (itemIndexToSelect >= 0 && itemIndexToSelect < currentListBox.Items.Count)
+                {
+                    currentListBox.SelectedIndex = itemIndexToSelect;
+                }
             }
             else if (e.Button == MouseButtons.Left)
             {


### PR DESCRIPTION
…setting selectedIndex from a mouseUp handler.

Fixes https://github.com/NuGet/Home/issues/2359
