### PR TITLE
Log project.lock.json commit at the minimal level

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -128,13 +128,13 @@ namespace NuGet.Commands
                     || PreviousLockFile == null
                     || !PreviousLockFile.Equals(LockFile))
                 {
-                    log.LogDebug($"Writing lock file to disk. Path: {LockFilePath}");
+                    log.LogMinimal($"Writing lock file to disk. Path: {LockFilePath}");
 
                     lockFileFormat.Write(LockFilePath, LockFile);
                 }
                 else
                 {
-                    log.LogDebug($"Lock file has not changed. Skipping lock file write. Path: {LockFilePath}");
+                    log.LogMinimal($"Lock file has not changed. Skipping lock file write. Path: {LockFilePath}");
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -9,6 +9,8 @@ namespace NuGet.Test.Utility
         /// Logged messages
         /// </summary>
         public ConcurrentQueue<string> Messages { get; } = new ConcurrentQueue<string>();
+        public ConcurrentQueue<string> DebugMessages { get; } = new ConcurrentQueue<string>();
+        public ConcurrentQueue<string> MinimalMessages { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> ErrorMessages { get; } = new ConcurrentQueue<string>();
 
         public int Errors { get; set; }
@@ -18,6 +20,7 @@ namespace NuGet.Test.Utility
         public void LogDebug(string data)
         {
             Messages.Enqueue(data);
+            DebugMessages.Enqueue(data);
             DumpMessage("DEBUG", data);
         }
 
@@ -38,6 +41,7 @@ namespace NuGet.Test.Utility
         public void LogMinimal(string data)
         {
             Messages.Enqueue(data);
+            MinimalMessages.Enqueue(data);
             DumpMessage("LOG  ", data);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Xunit;
+using NuGet.Commands;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+
+namespace NuGet.Commands.Test
+{
+    public class RestoreResultTests
+    {
+        [Fact]
+        public async Task RestoreResult_WritesCommitToMinimal()
+        {
+            // Arrange
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var path = Path.Combine(td, "project.lock.json");
+                var logger = new TestLogger();
+                var result = new RestoreResult(
+                    success: true,
+                    restoreGraphs: null,
+                    compatibilityCheckResults: null,
+                    lockFile: new LockFile(),
+                    previousLockFile: null, // different lock file
+                    lockFilePath: path,
+                    msbuild: new MSBuildRestoreResult("project", td, true),
+                    toolRestoreResults: Enumerable.Empty<ToolRestoreResult>());
+                
+                // Act
+                await result.CommitAsync(logger, CancellationToken.None);
+                
+                // Assert
+                Assert.Contains(
+                    $"Writing lock file to disk. Path: {path}",
+                    logger.MinimalMessages);
+                Assert.True(File.Exists(path), $"The lock file should have been written: {path}");
+                Assert.Equal(1, logger.Messages.Count);
+            }
+        }
+        
+        [Fact]
+        public async Task RestoreResult_WritesSkipCommitToMinimal()
+        {
+            // Arrange
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var path = Path.Combine(td, "project.lock.json");
+                var logger = new TestLogger();
+                var result = new RestoreResult(
+                    success: true,
+                    restoreGraphs: null,
+                    compatibilityCheckResults: null,
+                    lockFile: new LockFile(),
+                    previousLockFile: new LockFile(), // same lock file
+                    lockFilePath: path,
+                    msbuild: new MSBuildRestoreResult("project", td, true),
+                    toolRestoreResults: Enumerable.Empty<ToolRestoreResult>());
+                
+                // Act
+                await result.CommitAsync(logger, CancellationToken.None);
+                
+                // Assert
+                Assert.Contains(
+                    $"Lock file has not changed. Skipping lock file write. Path: {path}",
+                    logger.MinimalMessages);
+                Assert.False(File.Exists(path), $"The lock file should not have been written: {path}");
+                Assert.Equal(1, logger.Messages.Count);
+            }
+        }
+        
+        [Fact]
+        public async Task RestoreResult_WritesToolCommitToDebug()
+        {
+            // Arrange
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var path = Path.Combine(td, "project.lock.json");
+                var logger = new TestLogger();
+                var toolResult = new ToolRestoreResult(
+                    success: true,
+                    restoreGraphs: null,
+                    lockFilePath: path,
+                    lockFile: new LockFile());
+                var result = new RestoreResult(
+                    success: true,
+                    restoreGraphs: null,
+                    compatibilityCheckResults: null,
+                    lockFile: new LockFile(),
+                    previousLockFile: new LockFile(), // same lock file
+                    lockFilePath: null,
+                    msbuild: new MSBuildRestoreResult("project", td, true),
+                    toolRestoreResults: new[] { toolResult });
+                
+                // Act
+                await result.CommitAsync(logger, CancellationToken.None);
+                
+                // Assert
+                Assert.Contains(
+                    $"Writing tool lock file to disk. Path: {path}",
+                    logger.DebugMessages);
+                Assert.True(File.Exists(path), $"The tool lock file should have been written: {path}");
+                Assert.Equal(1, logger.DebugMessages.Count);
+                Assert.Equal(1, logger.MinimalMessages.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will be used by @abpiskunov to detect when a project restore has finished.

@yishaigalatzer, this is the change that will unblock Anton.
@emgarten 
