### PR TITLE
Write tool version to consuming project lock file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreResult.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.ProjectModel;
+
+namespace NuGet.Commands
+{
+    public interface IRestoreResult
+    {
+        bool Success { get; }
+
+        /// <summary>
+        /// Gets the path that the lock file will be written to.
+        /// </summary>
+        string LockFilePath { get; }
+
+        /// <summary>
+        /// Gets a boolean indicating if the lock file will be re-written on <see cref="Commit"/>
+        /// because the file needs to be re-locked.
+        /// </summary>
+        bool RelockFile { get; }
+
+        /// <summary>
+        /// Gets the lock file that was generated during the restore or, in the case of a locked lock file,
+        /// was used to determine the packages to install during the restore.
+        /// </summary>
+        LockFile LockFile { get; }
+
+        /// <summary>
+        /// The existing lock file. This is null if no lock file was provided on the <see cref="RestoreRequest"/>.
+        /// </summary>
+        LockFile PreviousLockFile { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -1,0 +1,424 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Logging;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+using NuGet.RuntimeModel;
+using NuGet.Versioning;
+
+namespace NuGet.Commands
+{
+    internal class ProjectRestoreCommand
+    {
+        private readonly ILogger _logger;
+
+        private readonly ProjectRestoreRequest _request;
+
+        public ProjectRestoreCommand(ILogger logger, ProjectRestoreRequest request)
+        {
+            _logger = logger;
+            _request = request;
+        }
+
+        public async Task<Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph>> TryRestore(LibraryRange projectRange,
+            IEnumerable<FrameworkRuntimePair> frameworkRuntimePairs,
+            HashSet<LibraryIdentity> allInstalledPackages,
+            NuGetv3LocalRepository localRepository,
+            RemoteDependencyWalker remoteWalker,
+            RemoteWalkContext context,
+            bool writeToLockFile,
+            CancellationToken token)
+        {
+            var allRuntimes = RuntimeGraph.Empty;
+            var frameworkTasks = new List<Task<RestoreTargetGraph>>();
+            var graphs = new List<RestoreTargetGraph>();
+            var runtimesByFramework = frameworkRuntimePairs.ToLookup(p => p.Framework, p => p.RuntimeIdentifier);
+
+            foreach (var pair in runtimesByFramework)
+            {
+                _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoringPackages, pair.Key.DotNetFrameworkName));
+
+                frameworkTasks.Add(WalkDependenciesAsync(projectRange,
+                    pair.Key,
+                    remoteWalker,
+                    context,
+                    writeToLockFile: writeToLockFile,
+                    token: token));
+            }
+
+            var frameworkGraphs = await Task.WhenAll(frameworkTasks);
+
+            graphs.AddRange(frameworkGraphs);
+
+            if (!ResolutionSucceeded(frameworkGraphs))
+            {
+                return Tuple.Create(false, graphs, allRuntimes);
+            }
+
+            await InstallPackagesAsync(graphs,
+                _request.PackagesDirectory,
+                allInstalledPackages,
+                _request.MaxDegreeOfConcurrency,
+                token);
+
+            // Clear the in-memory cache for newly installed packages
+            localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
+
+            // Resolve runtime dependencies
+            var runtimeGraphs = new List<RestoreTargetGraph>();
+            if (runtimesByFramework.Count > 0)
+            {
+                var runtimeTasks = new List<Task<RestoreTargetGraph[]>>();
+                foreach (var graph in graphs)
+                {
+                    // Get the runtime graph for this specific tfm graph
+                    var runtimeGraph = GetRuntimeGraph(graph, localRepository);
+                    var runtimeIds = runtimesByFramework[graph.Framework];
+
+                    // Merge all runtimes for the output
+                    allRuntimes = RuntimeGraph.Merge(allRuntimes, runtimeGraph);
+
+                    runtimeTasks.Add(WalkRuntimeDependenciesAsync(projectRange,
+                        graph,
+                        runtimeIds.Where(rid => !string.IsNullOrEmpty(rid)),
+                        remoteWalker,
+                        context,
+                        localRepository,
+                        runtimeGraph,
+                        writeToLockFile: writeToLockFile,
+                        token: token));
+                }
+
+                foreach (var runtimeSpecificGraph in (await Task.WhenAll(runtimeTasks)).SelectMany(g => g))
+                {
+                    runtimeGraphs.Add(runtimeSpecificGraph);
+                }
+
+                graphs.AddRange(runtimeGraphs);
+
+                if (!ResolutionSucceeded(runtimeGraphs))
+                {
+                    return Tuple.Create(false, graphs, allRuntimes);
+                }
+
+                // Install runtime-specific packages
+                await InstallPackagesAsync(runtimeGraphs,
+                    _request.PackagesDirectory,
+                    allInstalledPackages,
+                    _request.MaxDegreeOfConcurrency,
+                    token);
+
+                // Clear the in-memory cache for newly installed packages
+                localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
+            }
+
+            return Tuple.Create(true, graphs, allRuntimes);
+        }
+
+        private Task<RestoreTargetGraph> WalkDependenciesAsync(LibraryRange projectRange,
+            NuGetFramework framework,
+            RemoteDependencyWalker walker,
+            RemoteWalkContext context,
+            bool writeToLockFile,
+            CancellationToken token)
+        {
+            return WalkDependenciesAsync(projectRange,
+                framework,
+                runtimeIdentifier: null,
+                runtimeGraph: RuntimeGraph.Empty,
+                walker: walker,
+                context: context,
+                writeToLockFile: writeToLockFile,
+                token: token);
+        }
+
+        private async Task<RestoreTargetGraph> WalkDependenciesAsync(LibraryRange projectRange,
+            NuGetFramework framework,
+            string runtimeIdentifier,
+            RuntimeGraph runtimeGraph,
+            RemoteDependencyWalker walker,
+            RemoteWalkContext context,
+            bool writeToLockFile,
+            CancellationToken token)
+        {
+            var name = FrameworkRuntimePair.GetName(framework, runtimeIdentifier);
+            var graphs = new List<GraphNode<RemoteResolveResult>>();
+            if (_request.ExistingLockFile != null && _request.ExistingLockFile.IsLocked)
+            {
+                // Walk all the items in the lock file target and just synthesize the outer graph
+                var target = _request.ExistingLockFile.GetTarget(framework, runtimeIdentifier);
+
+                token.ThrowIfCancellationRequested();
+                if (target != null)
+                {
+                    foreach (var targetLibrary in target.Libraries)
+                    {
+                        token.ThrowIfCancellationRequested();
+
+                        var library = _request.ExistingLockFile.GetLibrary(targetLibrary.Name, targetLibrary.Version);
+                        if (library == null)
+                        {
+                            _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_LockFileMissingLibraryForTargetLibrary,
+                                targetLibrary.Name,
+                                targetLibrary.Version,
+                                target.Name));
+                            continue; // This library is not in the main lockfile?
+                        }
+
+                        var range = new LibraryRange()
+                        {
+                            Name = library.Name,
+                            TypeConstraint = LibraryDependencyTargetUtils.Parse(library.Type),
+                            VersionRange = new VersionRange(
+                                minVersion: library.Version,
+                                includeMinVersion: true,
+                                maxVersion: library.Version,
+                                includeMaxVersion: true)
+                        };
+                        graphs.Add(await walker.WalkAsync(
+                            range,
+                            framework,
+                            runtimeIdentifier,
+                            runtimeGraph,
+                            recursive: false));
+                    }
+                }
+            }
+            else
+            {
+                graphs.Add(await walker.WalkAsync(
+                    projectRange,
+                    framework,
+                    runtimeIdentifier,
+                    runtimeGraph,
+                    recursive: true));
+            }
+
+            // Resolve conflicts
+            _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_ResolvingConflicts, name));
+
+            // Flatten and create the RestoreTargetGraph to hold the packages
+            var result = RestoreTargetGraph.Create(writeToLockFile, runtimeGraph, graphs, context, _logger, framework, runtimeIdentifier);
+
+            // Check if the dependencies got bumped up
+            // ...but not if there is an existing locked lock file.
+            if (_request.ExistingLockFile == null || !_request.ExistingLockFile.IsLocked)
+            {
+                // No lock file, OR the lock file is unlocked, so check dependencies
+                CheckDependencies(result, _request.Project.Dependencies);
+
+                var fxInfo = _request.Project.GetTargetFramework(framework);
+                if (fxInfo != null)
+                {
+                    CheckDependencies(result, fxInfo.Dependencies);
+                }
+            }
+
+            return result;
+        }
+
+        private bool ResolutionSucceeded(IEnumerable<RestoreTargetGraph> graphs)
+        {
+            var success = true;
+            foreach (var graph in graphs)
+            {
+                if (graph.Conflicts.Any())
+                {
+                    success = false;
+                    _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToResolveConflicts, graph.Name));
+                    foreach (var conflict in graph.Conflicts)
+                    {
+                        _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_ResolverConflict,
+                            conflict.Name,
+                            string.Join(", ", conflict.Requests)));
+                    }
+                }
+                if (graph.Unresolved.Any())
+                {
+                    success = false;
+                    foreach (var unresolved in graph.Unresolved)
+                    {
+                        _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_UnresolvedDependency, unresolved.Name,
+                            unresolved.VersionRange.ToNonSnapshotRange().PrettyPrint(),
+                            graph.Name));
+                    }
+                }
+            }
+
+            return success;
+        }
+
+        private async Task InstallPackagesAsync(IEnumerable<RestoreTargetGraph> graphs,
+            string packagesDirectory,
+            HashSet<LibraryIdentity> allInstalledPackages,
+            int maxDegreeOfConcurrency,
+            CancellationToken token)
+        {
+            var packagesToInstall = graphs.SelectMany(g => g.Install.Where(match => allInstalledPackages.Add(match.Library)));
+            if (maxDegreeOfConcurrency <= 1)
+            {
+                foreach (var match in packagesToInstall)
+                {
+                    await InstallPackageAsync(match, packagesDirectory, token);
+                }
+            }
+            else
+            {
+                var bag = new ConcurrentBag<RemoteMatch>(packagesToInstall);
+                var tasks = Enumerable.Range(0, maxDegreeOfConcurrency)
+                    .Select(async _ =>
+                    {
+                        RemoteMatch match;
+                        while (bag.TryTake(out match))
+                        {
+                            await InstallPackageAsync(match, packagesDirectory, token);
+                        }
+                    });
+                await Task.WhenAll(tasks);
+            }
+        }
+
+        private async Task InstallPackageAsync(RemoteMatch installItem, string packagesDirectory, CancellationToken token)
+        {
+            var packageIdentity = new PackageIdentity(installItem.Library.Name, installItem.Library.Version);
+
+            var versionFolderPathContext = new VersionFolderPathContext(
+                packageIdentity,
+                packagesDirectory,
+                _logger,
+                fixNuspecIdCasing: true,
+                packageSaveMode: _request.PackageSaveMode,
+                normalizeFileNames: false,
+                xmlDocFileSaveMode: _request.XmlDocFileSaveMode);
+
+            await PackageExtractor.InstallFromSourceAsync(
+                stream => installItem.Provider.CopyToAsync(installItem.Library, stream, token),
+                versionFolderPathContext,
+                token);
+        }
+
+        private void CheckDependencies(RestoreTargetGraph result, IEnumerable<LibraryDependency> dependencies)
+        {
+            foreach (var dependency in dependencies)
+            {
+                // Ignore floating or version-less (project) dependencies
+                if (dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
+                {
+                    var match = result.Flattened.FirstOrDefault(g => g.Key.Name.Equals(dependency.LibraryRange.Name));
+                    if (match != null && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
+                    {
+                        _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
+                            dependency.LibraryRange.Name,
+                            dependency.LibraryRange.VersionRange.PrettyPrint(),
+                            match.Key.Name,
+                            match.Key.Version));
+                    }
+                }
+            }
+        }
+
+        private Task<RestoreTargetGraph[]> WalkRuntimeDependenciesAsync(LibraryRange projectRange,
+            RestoreTargetGraph graph,
+            IEnumerable<string> runtimeIds,
+            RemoteDependencyWalker walker,
+            RemoteWalkContext context,
+            NuGetv3LocalRepository localRepository,
+            RuntimeGraph runtimes,
+            bool writeToLockFile,
+            CancellationToken token)
+        {
+            var resultGraphs = new List<Task<RestoreTargetGraph>>();
+            foreach (var runtimeName in runtimeIds)
+            {
+                _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoringPackages, FrameworkRuntimePair.GetName(graph.Framework, runtimeName)));
+
+                resultGraphs.Add(WalkDependenciesAsync(projectRange,
+                    graph.Framework,
+                    runtimeName,
+                    runtimes,
+                    walker,
+                    context,
+                    writeToLockFile,
+                    token));
+            }
+
+            return Task.WhenAll(resultGraphs);
+        }
+
+        private RuntimeGraph GetRuntimeGraph(RestoreTargetGraph graph, NuGetv3LocalRepository localRepository)
+        {
+            // TODO: Caching!
+            RuntimeGraph runtimeGraph;
+            if (_request.RuntimeGraphCache.TryGetValue(graph.Framework, out runtimeGraph))
+            {
+                return runtimeGraph;
+            }
+
+            _logger.LogVerbose(Strings.Log_ScanningForRuntimeJson);
+            runtimeGraph = RuntimeGraph.Empty;
+            graph.Graphs.ForEach(node =>
+            {
+                var match = node?.Item?.Data?.Match;
+                if (match == null)
+                {
+                    return;
+                }
+
+                // Ignore runtime.json from rejected nodes
+                if (node.Disposition == Disposition.Rejected)
+                {
+                    return;
+                }
+
+                // Locate the package in the local repository
+                var package = localRepository.FindPackagesById(match.Library.Name)
+                    .FirstOrDefault(p => p.Version == match.Library.Version);
+
+                if (package != null)
+                {
+                    var nextGraph = LoadRuntimeGraph(package);
+                    if (nextGraph != null)
+                    {
+                        _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_MergingRuntimes, match.Library));
+                        runtimeGraph = RuntimeGraph.Merge(runtimeGraph, nextGraph);
+                    }
+                }
+            });
+            _request.RuntimeGraphCache[graph.Framework] = runtimeGraph;
+            return runtimeGraph;
+        }
+
+        private RuntimeGraph LoadRuntimeGraph(LocalPackageInfo package)
+        {
+            var id = new PackageIdentity(package.Id, package.Version);
+            return _request.RuntimeGraphCacheByPackage.GetOrAdd(id, (x) => LoadRuntimeGraphCore(package));
+        }
+
+        private static RuntimeGraph LoadRuntimeGraphCore(LocalPackageInfo package)
+        {
+            var runtimeGraphFile = Path.Combine(package.ExpandedPath, RuntimeGraph.RuntimeGraphFileName);
+            if (File.Exists(runtimeGraphFile))
+            {
+                using (var stream = File.OpenRead(runtimeGraphFile))
+                {
+                    return JsonRuntimeFormat.ReadRuntimeGraph(stream);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -316,10 +316,14 @@ namespace NuGet.Commands
             foreach (var dependency in dependencies)
             {
                 // Ignore floating or version-less (project) dependencies
-                if (dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
+                // Avoid warnings for non-packages
+                if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                    && dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
                 {
                     var match = result.Flattened.FirstOrDefault(g => g.Key.Name.Equals(dependency.LibraryRange.Name));
-                    if (match != null && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
+                    if (match != null
+                        && LibraryTypes.Package == match.Key.Type
+                        && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
                     {
                         _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
                             dependency.LibraryRange.Name,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Commands
+{
+    internal class ProjectRestoreRequest
+    {
+        public ProjectRestoreRequest(
+            RestoreRequest request,
+            PackageSpec packageSpec,
+            LockFile existingLockFile,
+            Dictionary<NuGetFramework, RuntimeGraph> runtimeGraphCache,
+            ConcurrentDictionary<PackageIdentity, RuntimeGraph> runtimeGraphCacheByPackage)
+        {
+            PackagesDirectory = request.PackagesDirectory;
+            ExistingLockFile = existingLockFile;
+            RuntimeGraphCache = runtimeGraphCache;
+            RuntimeGraphCacheByPackage = runtimeGraphCacheByPackage;
+            MaxDegreeOfConcurrency = request.MaxDegreeOfConcurrency;
+            PackageSaveMode = request.PackageSaveMode;
+            Project = packageSpec;
+            XmlDocFileSaveMode = request.XmlDocFileSaveMode;
+        }
+
+        public string PackagesDirectory { get; }
+        public int MaxDegreeOfConcurrency { get; }
+        public LockFile ExistingLockFile { get; }
+        public PackageSpec Project { get; }
+        public PackageSaveMode PackageSaveMode { get; }
+        public XmlDocFileSaveMode XmlDocFileSaveMode { get; }
+        public Dictionary<NuGetFramework, RuntimeGraph> RuntimeGraphCache { get; }
+        public ConcurrentDictionary<PackageIdentity, RuntimeGraph> RuntimeGraphCacheByPackage { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
@@ -257,14 +258,22 @@ namespace NuGet.Commands
                 var allInstalledPackages = new HashSet<LibraryIdentity>();
                 var contextForTool = CreateRemoteWalkContext(_request);
                 var walker = new RemoteDependencyWalker(contextForTool);
-                var result = await TryRestore(tool.LibraryRange,
-                                              projectFrameworkRuntimePairs,
-                                              allInstalledPackages,
-                                              localRepository,
-                                              walker,
-                                              contextForTool,
-                                              writeToLockFile: true,
-                                              token: token);
+                var projectRestoreRequest = new ProjectRestoreRequest(
+                    _request,
+                    toolPackageSpec,
+                    null,
+                    new Dictionary<NuGetFramework, RuntimeGraph>(), 
+                    _runtimeGraphCacheByPackage);
+                var projectRestoreCommand = new ProjectRestoreCommand(_logger, projectRestoreRequest);
+                var result = await projectRestoreCommand.TryRestore(
+                    tool.LibraryRange,
+                    projectFrameworkRuntimePairs,
+                    allInstalledPackages,
+                    localRepository,
+                    walker,
+                    contextForTool,
+                    writeToLockFile: true,
+                    token: token);
 
                 var graphs = result.Item2;
                 if (!result.Item1)
@@ -397,14 +406,22 @@ namespace NuGet.Commands
             var runtimeIds = RequestRuntimeUtility.GetRestoreRuntimes(_request);
             var projectFrameworkRuntimePairs = CreateFrameworkRuntimePairs(_request.Project, runtimeIds);
 
-            var result = await TryRestore(projectRange,
-                                          projectFrameworkRuntimePairs,
-                                          allInstalledPackages,
-                                          localRepository,
-                                          remoteWalker,
-                                          context,
-                                          writeToLockFile: true,
-                                          token: token);
+            var projectRestoreRequest = new ProjectRestoreRequest(
+                _request,
+                _request.Project,
+                _request.ExistingLockFile,
+                _runtimeGraphCache,
+                _runtimeGraphCacheByPackage);
+            var projectRestoreCommand = new ProjectRestoreCommand(_logger, projectRestoreRequest);
+            var result = await projectRestoreCommand.TryRestore(
+                projectRange,
+                projectFrameworkRuntimePairs,
+                allInstalledPackages,
+                localRepository,
+                remoteWalker,
+                context,
+                writeToLockFile: true,
+                token: token);
 
             var success = result.Item1;
             var runtimes = result.Item3;
@@ -439,7 +456,7 @@ namespace NuGet.Commands
             // Walk additional runtime graphs for supports checks
             if (_success && _request.CompatibilityProfiles.Any())
             {
-                var compatibilityResult = await TryRestore(projectRange,
+                var compatibilityResult = await projectRestoreCommand.TryRestore(projectRange,
                                                           _request.CompatibilityProfiles,
                                                           allInstalledPackages,
                                                           localRepository,
@@ -511,132 +528,6 @@ namespace NuGet.Commands
             }
 
             return context;
-        }
-
-        private async Task<Tuple<bool, List<RestoreTargetGraph>, RuntimeGraph>> TryRestore(LibraryRange projectRange,
-            IEnumerable<FrameworkRuntimePair> frameworkRuntimePairs,
-            HashSet<LibraryIdentity> allInstalledPackages,
-            NuGetv3LocalRepository localRepository,
-            RemoteDependencyWalker remoteWalker,
-            RemoteWalkContext context,
-            bool writeToLockFile,
-            CancellationToken token)
-        {
-            var allRuntimes = RuntimeGraph.Empty;
-            var frameworkTasks = new List<Task<RestoreTargetGraph>>();
-            var graphs = new List<RestoreTargetGraph>();
-            var runtimesByFramework = frameworkRuntimePairs.ToLookup(p => p.Framework, p => p.RuntimeIdentifier);
-
-            foreach (var pair in runtimesByFramework)
-            {
-                _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoringPackages, pair.Key.DotNetFrameworkName));
-
-                frameworkTasks.Add(WalkDependenciesAsync(projectRange,
-                    pair.Key,
-                    remoteWalker,
-                    context,
-                    writeToLockFile: writeToLockFile,
-                    token: token));
-            }
-
-            var frameworkGraphs = await Task.WhenAll(frameworkTasks);
-
-            graphs.AddRange(frameworkGraphs);
-
-            if (!ResolutionSucceeded(frameworkGraphs))
-            {
-                return Tuple.Create(false, graphs, allRuntimes);
-            }
-
-            await InstallPackagesAsync(graphs,
-                    _request.PackagesDirectory,
-                    allInstalledPackages,
-                    _request.MaxDegreeOfConcurrency,
-                    token);
-
-            // Clear the in-memory cache for newly installed packages
-            localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
-
-            // Resolve runtime dependencies
-            var runtimeGraphs = new List<RestoreTargetGraph>();
-            if (runtimesByFramework.Count > 0)
-            {
-                var runtimeTasks = new List<Task<RestoreTargetGraph[]>>();
-                foreach (var graph in graphs)
-                {
-                    // Get the runtime graph for this specific tfm graph
-                    var runtimeGraph = GetRuntimeGraph(graph, localRepository);
-                    var runtimeIds = runtimesByFramework[graph.Framework];
-
-                    // Merge all runtimes for the output
-                    allRuntimes = RuntimeGraph.Merge(allRuntimes, runtimeGraph);
-
-                    runtimeTasks.Add(WalkRuntimeDependenciesAsync(projectRange,
-                        graph,
-                        runtimeIds.Where(rid => !string.IsNullOrEmpty(rid)),
-                        remoteWalker,
-                        context,
-                        localRepository,
-                        runtimeGraph,
-                        writeToLockFile: writeToLockFile,
-                        token: token));
-                }
-
-                foreach (var runtimeSpecificGraph in (await Task.WhenAll(runtimeTasks)).SelectMany(g => g))
-                {
-                    runtimeGraphs.Add(runtimeSpecificGraph);
-                }
-
-                graphs.AddRange(runtimeGraphs);
-
-                if (!ResolutionSucceeded(runtimeGraphs))
-                {
-                    return Tuple.Create(false, graphs, allRuntimes);
-                }
-
-                // Install runtime-specific packages
-                await InstallPackagesAsync(runtimeGraphs,
-                    _request.PackagesDirectory,
-                    allInstalledPackages,
-                    _request.MaxDegreeOfConcurrency,
-                    token);
-
-                // Clear the in-memory cache for newly installed packages
-                localRepository.ClearCacheForIds(allInstalledPackages.Select(package => package.Name));
-            }
-
-            return Tuple.Create(true, graphs, allRuntimes);
-        }
-
-        private bool ResolutionSucceeded(IEnumerable<RestoreTargetGraph> graphs)
-        {
-            var success = true;
-            foreach (var graph in graphs)
-            {
-                if (graph.Conflicts.Any())
-                {
-                    success = false;
-                    _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToResolveConflicts, graph.Name));
-                    foreach (var conflict in graph.Conflicts)
-                    {
-                        _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_ResolverConflict, 
-                            conflict.Name,
-                            string.Join(", ", conflict.Requests)));
-                    }
-                }
-                if (graph.Unresolved.Any())
-                {
-                    success = false;
-                    foreach (var unresolved in graph.Unresolved)
-                    {
-                        _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_UnresolvedDependency, unresolved.Name,
-                            unresolved.VersionRange.ToNonSnapshotRange().PrettyPrint(),
-                            graph.Name));
-                    }
-                }
-            }
-
-            return success;
         }
 
         private MSBuildRestoreResult RestoreMSBuildFiles(PackageSpec project,
@@ -760,272 +651,6 @@ namespace NuGet.Commands
                 // Null out all target types, these did not exist in v1
                 library.Type = null;
             }
-        }
-        
-
-        private Task<RestoreTargetGraph> WalkDependenciesAsync(LibraryRange projectRange,
-            NuGetFramework framework,
-            RemoteDependencyWalker walker,
-            RemoteWalkContext context,
-            bool writeToLockFile,
-            CancellationToken token)
-        {
-            return WalkDependenciesAsync(projectRange,
-                framework,
-                runtimeIdentifier: null,
-                runtimeGraph: RuntimeGraph.Empty,
-                walker: walker,
-                context: context,
-                writeToLockFile: writeToLockFile,
-                token: token);
-        }
-
-        private async Task<RestoreTargetGraph> WalkDependenciesAsync(LibraryRange projectRange,
-            NuGetFramework framework,
-            string runtimeIdentifier,
-            RuntimeGraph runtimeGraph,
-            RemoteDependencyWalker walker,
-            RemoteWalkContext context,
-            bool writeToLockFile,
-            CancellationToken token)
-        {
-            var name = FrameworkRuntimePair.GetName(framework, runtimeIdentifier);
-            var graphs = new List<GraphNode<RemoteResolveResult>>();
-            if (_request.ExistingLockFile != null && _request.ExistingLockFile.IsLocked)
-            {
-                // Walk all the items in the lock file target and just synthesize the outer graph
-                var target = _request.ExistingLockFile.GetTarget(framework, runtimeIdentifier);
-
-                token.ThrowIfCancellationRequested();
-                if (target != null)
-                {
-                    foreach (var targetLibrary in target.Libraries)
-                    {
-                        token.ThrowIfCancellationRequested();
-
-                        var library = _request.ExistingLockFile.GetLibrary(targetLibrary.Name, targetLibrary.Version);
-                        if (library == null)
-                        {
-                            _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_LockFileMissingLibraryForTargetLibrary, 
-                                targetLibrary.Name,
-                                targetLibrary.Version,
-                                target.Name));
-                            continue; // This library is not in the main lockfile?
-                        }
-
-                        var range = new LibraryRange()
-                        {
-                            Name = library.Name,
-                            TypeConstraint = LibraryDependencyTargetUtils.Parse(library.Type),
-                            VersionRange = new VersionRange(
-                                minVersion: library.Version,
-                                includeMinVersion: true,
-                                maxVersion: library.Version,
-                                includeMaxVersion: true)
-                        };
-                        graphs.Add(await walker.WalkAsync(
-                            range,
-                            framework,
-                            runtimeIdentifier,
-                            runtimeGraph,
-                            recursive: false));
-                    }
-                }
-            }
-            else
-            {
-                graphs.Add(await walker.WalkAsync(
-                    projectRange,
-                    framework,
-                    runtimeIdentifier,
-                    runtimeGraph,
-                    recursive: true));
-            }
-
-            // Resolve conflicts
-            _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_ResolvingConflicts, name));
-
-            // Flatten and create the RestoreTargetGraph to hold the packages
-            var result = RestoreTargetGraph.Create(writeToLockFile, runtimeGraph, graphs, context, _logger, framework, runtimeIdentifier);
-
-            // Check if the dependencies got bumped up
-            // ...but not if there is an existing locked lock file.
-            if (_request.ExistingLockFile == null || !_request.ExistingLockFile.IsLocked)
-            {
-                // No lock file, OR the lock file is unlocked, so check dependencies
-                CheckDependencies(result, _request.Project.Dependencies);
-
-                var fxInfo = _request.Project.GetTargetFramework(framework);
-                if (fxInfo != null)
-                {
-                    CheckDependencies(result, fxInfo.Dependencies);
-                }
-            }
-
-            return result;
-        }
-
-        private void CheckDependencies(RestoreTargetGraph result, IEnumerable<LibraryDependency> dependencies)
-        {
-            foreach (var dependency in dependencies)
-            {
-                // Ignore floating or version-less (project) dependencies
-                // Avoid warnings for non-packages
-                if (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
-                    && dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating)
-                {
-                    var match = result.Flattened.FirstOrDefault(g => g.Key.Name.Equals(dependency.LibraryRange.Name));
-                    if (match != null 
-                        && LibraryTypes.Package == match.Key.Type
-                        && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
-                    {
-                        _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp, 
-                            dependency.LibraryRange.Name,
-                            dependency.LibraryRange.VersionRange.PrettyPrint(),
-                            match.Key.Name,
-                            match.Key.Version));
-                    }
-                }
-            }
-        }
-
-        private Task<RestoreTargetGraph[]> WalkRuntimeDependenciesAsync(LibraryRange projectRange,
-            RestoreTargetGraph graph,
-            IEnumerable<string> runtimeIds,
-            RemoteDependencyWalker walker,
-            RemoteWalkContext context,
-            NuGetv3LocalRepository localRepository,
-            RuntimeGraph runtimes,
-            bool writeToLockFile,
-            CancellationToken token)
-        {
-            var resultGraphs = new List<Task<RestoreTargetGraph>>();
-            foreach (var runtimeName in runtimeIds)
-            {
-                _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_RestoringPackages, FrameworkRuntimePair.GetName(graph.Framework, runtimeName)));
-
-                resultGraphs.Add(WalkDependenciesAsync(projectRange,
-                    graph.Framework,
-                    runtimeName,
-                    runtimes,
-                    walker,
-                    context,
-                    writeToLockFile,
-                    token));
-            }
-
-            return Task.WhenAll(resultGraphs);
-        }
-
-        private RuntimeGraph GetRuntimeGraph(RestoreTargetGraph graph, NuGetv3LocalRepository localRepository)
-        {
-            // TODO: Caching!
-            RuntimeGraph runtimeGraph;
-            if (_runtimeGraphCache.TryGetValue(graph.Framework, out runtimeGraph))
-            {
-                return runtimeGraph;
-            }
-
-            _logger.LogVerbose(Strings.Log_ScanningForRuntimeJson);
-            runtimeGraph = RuntimeGraph.Empty;
-            graph.Graphs.ForEach(node =>
-            {
-                var match = node?.Item?.Data?.Match;
-                if (match == null)
-                {
-                    return;
-                }
-
-                // Ignore runtime.json from rejected nodes
-                if (node.Disposition == Disposition.Rejected)
-                {
-                    return;
-                }
-
-                // Locate the package in the local repository
-                var package = localRepository.FindPackagesById(match.Library.Name)
-                    .FirstOrDefault(p => p.Version == match.Library.Version);
-
-                if (package != null)
-                {
-                    var nextGraph = LoadRuntimeGraph(package);
-                    if (nextGraph != null)
-                    {
-                        _logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_MergingRuntimes, match.Library));
-                        runtimeGraph = RuntimeGraph.Merge(runtimeGraph, nextGraph);
-                    }
-                }
-            });
-            _runtimeGraphCache[graph.Framework] = runtimeGraph;
-            return runtimeGraph;
-        }
-
-        private RuntimeGraph LoadRuntimeGraph(LocalPackageInfo package)
-        {
-            var id = new PackageIdentity(package.Id, package.Version);
-            return _runtimeGraphCacheByPackage.GetOrAdd(id, (x) => LoadRuntimeGraphCore(package));
-        }
-
-        private RuntimeGraph LoadRuntimeGraphCore(LocalPackageInfo package)
-        {
-            var runtimeGraphFile = Path.Combine(package.ExpandedPath, RuntimeGraph.RuntimeGraphFileName);
-            if (File.Exists(runtimeGraphFile))
-            {
-                using (var stream = File.OpenRead(runtimeGraphFile))
-                {
-                    return JsonRuntimeFormat.ReadRuntimeGraph(stream);
-                }
-            }
-            return null;
-        }
-
-        private async Task InstallPackagesAsync(IEnumerable<RestoreTargetGraph> graphs,
-            string packagesDirectory,
-            HashSet<LibraryIdentity> allInstalledPackages,
-            int maxDegreeOfConcurrency,
-            CancellationToken token)
-        {
-            var packagesToInstall = graphs.SelectMany(g => g.Install.Where(match => allInstalledPackages.Add(match.Library)));
-            if (maxDegreeOfConcurrency <= 1)
-            {
-                foreach (var match in packagesToInstall)
-                {
-                    await InstallPackageAsync(match, packagesDirectory, token);
-                }
-            }
-            else
-            {
-                var bag = new ConcurrentBag<RemoteMatch>(packagesToInstall);
-                var tasks = Enumerable.Range(0, maxDegreeOfConcurrency)
-                    .Select(async _ =>
-                        {
-                            RemoteMatch match;
-                            while (bag.TryTake(out match))
-                            {
-                                await InstallPackageAsync(match, packagesDirectory, token);
-                            }
-                        });
-                await Task.WhenAll(tasks);
-            }
-        }
-
-        private async Task InstallPackageAsync(RemoteMatch installItem, string packagesDirectory, CancellationToken token)
-        {
-            var packageIdentity = new PackageIdentity(installItem.Library.Name, installItem.Library.Version);
-
-            var versionFolderPathContext = new VersionFolderPathContext(
-                packageIdentity,
-                packagesDirectory,
-                _logger,
-                fixNuspecIdCasing: true,
-                packageSaveMode: _request.PackageSaveMode,
-                normalizeFileNames: false,
-                xmlDocFileSaveMode: _request.XmlDocFileSaveMode);
-
-            await PackageExtractor.InstallFromSourceAsync(
-                stream => installItem.Provider.CopyToAsync(installItem.Library, stream, token),
-                versionFolderPathContext,
-                token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -13,7 +13,7 @@ using NuGet.ProjectModel;
 
 namespace NuGet.Commands
 {
-    public class RestoreResult
+    public class RestoreResult : IRestoreResult
     {
         public bool Success { get; }
 
@@ -111,54 +111,102 @@ namespace NuGet.Commands
         /// </summary>
         /// <remarks>If <see cref="PreviousLockFile"/> and <see cref="LockFile"/> are identical
         ///  the file will not be written to disk.</remarks>
-        /// <param name="log">The logger.</param>
         /// <param name="forceWrite">Write out the lock file even if no changes exist.</param>
-        /// <param name="token">The cancellation token.</param>
         public async Task CommitAsync(ILogger log, bool forceWrite, CancellationToken token)
         {
             // Write the lock file
             var lockFileFormat = new LockFileFormat();
 
-            // Don't write the lock file if it is Locked AND we're not re-locking the file
-            if (!LockFile.IsLocked || RelockFile)
-            {
-                // Avoid writing out the lock file if it is the same to avoid triggering an intellisense
-                // update on a restore with no actual changes.
-                if (forceWrite
-                    || PreviousLockFile == null
-                    || !PreviousLockFile.Equals(LockFile))
-                {
-                    log.LogMinimal($"Writing lock file to disk. Path: {LockFilePath}");
+            await CommitAsync(
+                lockFileFormat,
+                result: this,
+                log: log,
+                forceWrite: forceWrite,
+                toolCommit: false,
+                token: token);
 
-                    lockFileFormat.Write(LockFilePath, LockFile);
-                }
-                else
-                {
-                    log.LogMinimal($"Lock file has not changed. Skipping lock file write. Path: {LockFilePath}");
-                }
-            }
-
-            // Always write the tool lock files
             foreach (var toolRestoreResult in ToolRestoreResults)
             {
-                if (toolRestoreResult.LockFilePath != null)
+                if (toolRestoreResult.LockFilePath != null && toolRestoreResult.LockFile != null)
                 {
-                    log.LogDebug($"Writing tool lock file to disk. Path: {toolRestoreResult.LockFilePath}");
-
-                    await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
-                        toolRestoreResult.LockFilePath,
-                        lockedToken =>
-                        {
-                            var lockFileDirectory = Path.GetDirectoryName(toolRestoreResult.LockFilePath);
-                            Directory.CreateDirectory(lockFileDirectory);
-                            lockFileFormat.Write(toolRestoreResult.LockFilePath, toolRestoreResult.LockFile);
-                            return Task.FromResult((object)null);
-                        },
-                        token);
+                    await CommitAsync(
+                        lockFileFormat,
+                        result: toolRestoreResult,
+                        log: log,
+                        forceWrite: forceWrite,
+                        toolCommit: true,
+                        token: token);
                 }
             }
 
             MSBuild.Commit(log);
+        }
+
+        private static async Task CommitAsync(
+            LockFileFormat lockFileFormat,
+            IRestoreResult result,
+            ILogger log,
+            bool forceWrite,
+            bool toolCommit,
+            CancellationToken token)
+        {
+            // Don't write the lock file if it is Locked AND we're not re-locking the file
+            if (!result.LockFile.IsLocked || result.RelockFile || toolCommit)
+            {
+                // Avoid writing out the lock file if it is the same to avoid triggering an intellisense
+                // update on a restore with no actual changes.
+                if (forceWrite
+                    || result.PreviousLockFile == null
+                    || !result.PreviousLockFile.Equals(result.LockFile))
+                {
+                    if (toolCommit)
+                    {
+                        log.LogDebug($"Writing tool lock file to disk. Path: {result.LockFilePath}");
+                        
+                        await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                            result.LockFilePath,
+                            lockedToken =>
+                            {
+                                var lockFileDirectory = Path.GetDirectoryName(result.LockFilePath);
+                                Directory.CreateDirectory(lockFileDirectory);
+                                
+                                lockFileFormat.Write(result.LockFilePath, result.LockFile);
+                                
+                                return Task.FromResult(0);
+                            },
+                            token);
+                    }
+                    else
+                    {
+                        log.LogMinimal($"Writing lock file to disk. Path: {result.LockFilePath}");
+                        
+                        lockFileFormat.Write(result.LockFilePath, result.LockFile);
+                    }
+                }
+                else
+                {
+                    if (toolCommit)
+                    {
+                        log.LogDebug($"Tool lock file has not changed. Skipping lock file write. Path: {result.LockFilePath}");
+                    }
+                    else
+                    {
+                        log.LogMinimal($"Lock file has not changed. Skipping lock file write. Path: {result.LockFilePath}");
+                    }
+                }
+            }
+        }
+        
+        private static void WriteLockFile(
+            LockFileFormat lockFileFormat,
+            IRestoreResult result,
+            bool createDirectory)
+        {
+            if (createDirectory)
+            {
+            }
+            
+            lockFileFormat.Write(result.LockFilePath, result.LockFile);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
@@ -1,23 +1,32 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using NuGet.ProjectModel;
 
 namespace NuGet.Commands
 {
     public class ToolRestoreResult
     {
-        public ToolRestoreResult(bool success, IEnumerable<RestoreTargetGraph> restoreGraphs, string lockFilePath, LockFile lockFile)
+        public ToolRestoreResult(
+            string toolName,
+            bool success,
+            LockFileTarget lockFileTarget,
+            LockFileTargetLibrary fileTargetLibrary,
+            string lockFilePath,
+            LockFile lockFile)
         {
+            ToolName = toolName;
             Success = success;
-            RestoreGraphs = restoreGraphs;
+            LockFileTarget = lockFileTarget;
+            FileTargetLibrary = fileTargetLibrary;
             LockFilePath = lockFilePath;
             LockFile = lockFile;
         }
-        
+
+        public string ToolName { get; }
         public bool Success { get; }
-        public IEnumerable<RestoreTargetGraph> RestoreGraphs { get; }
+        public LockFileTarget LockFileTarget { get; }
+        public LockFileTargetLibrary FileTargetLibrary { get; }
         public string LockFilePath { get; }
         public LockFile LockFile { get; }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ToolRestoreResult.cs
@@ -5,7 +5,7 @@ using NuGet.ProjectModel;
 
 namespace NuGet.Commands
 {
-    public class ToolRestoreResult
+    public class ToolRestoreResult : IRestoreResult
     {
         public ToolRestoreResult(
             string toolName,
@@ -13,7 +13,8 @@ namespace NuGet.Commands
             LockFileTarget lockFileTarget,
             LockFileTargetLibrary fileTargetLibrary,
             string lockFilePath,
-            LockFile lockFile)
+            LockFile lockFile,
+            LockFile previousLockFile)
         {
             ToolName = toolName;
             Success = success;
@@ -21,6 +22,10 @@ namespace NuGet.Commands
             FileTargetLibrary = fileTargetLibrary;
             LockFilePath = lockFilePath;
             LockFile = lockFile;
+            PreviousLockFile = previousLockFile;
+            
+            // "locked" property is not supported on tools
+            RelockFile = false;
         }
 
         public string ToolName { get; }
@@ -29,5 +34,7 @@ namespace NuGet.Commands
         public LockFileTargetLibrary FileTargetLibrary { get; }
         public string LockFilePath { get; }
         public LockFile LockFile { get; }
+        public LockFile PreviousLockFile { get; }
+        public bool RelockFile { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
@@ -183,8 +183,17 @@ namespace NuGet.ProjectModel
             json[TargetsProperty] = WriteObject(lockFile.Targets, WriteTarget);
             json[LibrariesProperty] = WriteObject(lockFile.Libraries, WriteLibrary);
             json[ProjectFileDependencyGroupsProperty] = WriteObject(lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup);
-            json[ToolsProperty] = WriteObject(lockFile.Tools, WriteTarget);
-            json[ProjectFileToolGroupsProperty] = WriteObject(lockFile.ProjectFileToolGroups, WriteProjectFileDependencyGroup);
+            
+            if (lockFile.Tools != null)
+            {
+                json[ToolsProperty] = WriteObject(lockFile.Tools, WriteTarget);
+            }
+            
+            if (lockFile.ProjectFileToolGroups != null)
+            {
+                json[ProjectFileToolGroupsProperty] = WriteObject(lockFile.ProjectFileToolGroups, WriteProjectFileDependencyGroup);
+            }
+
             return json;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileFormat.cs
@@ -43,6 +43,8 @@ namespace NuGet.ProjectModel
         private const string PathProperty = "path";
         private const string MSBuildProjectProperty = "msbuildProject";
         private const string FrameworkProperty = "framework";
+        private const string ToolsProperty = "tools";
+        private const string ProjectFileToolGroupsProperty = "projectFileToolGroups";
 
         // Legacy property names
         private const string RuntimeAssembliesProperty = "runtimeAssemblies";
@@ -168,6 +170,8 @@ namespace NuGet.ProjectModel
             lockFile.Libraries = ReadObject(cursor[LibrariesProperty] as JObject, ReadLibrary);
             lockFile.Targets = ReadObject(cursor[TargetsProperty] as JObject, ReadTarget);
             lockFile.ProjectFileDependencyGroups = ReadObject(cursor[ProjectFileDependencyGroupsProperty] as JObject, ReadProjectFileDependencyGroup);
+            lockFile.Tools = ReadObject(cursor[ToolsProperty] as JObject, ReadTarget);
+            lockFile.ProjectFileToolGroups = ReadObject(cursor[ProjectFileToolGroupsProperty] as JObject, ReadProjectFileDependencyGroup);
             return lockFile;
         }
 
@@ -179,6 +183,8 @@ namespace NuGet.ProjectModel
             json[TargetsProperty] = WriteObject(lockFile.Targets, WriteTarget);
             json[LibrariesProperty] = WriteObject(lockFile.Libraries, WriteLibrary);
             json[ProjectFileDependencyGroupsProperty] = WriteObject(lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup);
+            json[ToolsProperty] = WriteObject(lockFile.Tools, WriteTarget);
+            json[ProjectFileToolGroupsProperty] = WriteObject(lockFile.ProjectFileToolGroups, WriteProjectFileDependencyGroup);
             return json;
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
@@ -15379,5 +15379,7 @@
       "Microsoft.NETCore.UniversalWindowsPlatform >= 5.0.0"
     ],
     "UAP,Version=v10.0": []
-  }
+  },
+  "tools": {},
+  "projectFileToolGroups": {}
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -191,36 +191,20 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_RestoresTools()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            var project1Json = @"
-            {
-              ""frameworks"": {
-                ""net45"": { }
-              },
-              ""tools"": {
-                ""packageB"": ""*""
-              }
-            }";
-
             using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
-                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
-                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
-                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
-                packagesDir.Create();
-                packageSource.Create();
-                project1.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
-
-                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
-
-                var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-
-                var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
-
-                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                var tc = new ToolTestContext(workingDir)
+                {
+                    ProjectJson = @"
+                    {
+                        ""frameworks"": {
+                            ""net45"": { }
+                        },
+                        ""tools"": {
+                            ""packageB"": ""*""
+                        }
+                    }"
+                };
 
                 var packageA = new SimpleTestPackageContext("packageA");
                 packageA.AddFile("lib/netstandard1.3/a.dll");
@@ -229,18 +213,19 @@ namespace NuGet.Commands.Test
                 packageB.AddFile("lib/netstandard1.4/b.dll");
                 packageB.Dependencies.Add(packageA);
 
-                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA, packageB);
+                SimpleTestPackageUtility.CreatePackages(tc.PackageSource.FullName, packageA, packageB);
+
+                tc.Initialize();
 
                 // Act
-                var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
-                await result.CommitAsync(logger, CancellationToken.None);
+                var result = await tc.Command.ExecuteAsync();
+                await result.CommitAsync(tc.Logger, CancellationToken.None);
 
                 // Assert
                 Assert.True(
                     result.Success,
                     "The command did not succeed. Error messages: "
-                    + Environment.NewLine + logger.ShowErrors());
+                    + Environment.NewLine + tc.Logger.ShowErrors());
                 Assert.Equal(1, result.ToolRestoreResults.Count());
 
                 var toolResult = result.ToolRestoreResults.First();
@@ -266,48 +251,33 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_FailsCommandWhenToolRestoreFails()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            var project1Json = @"
-            {
-              ""frameworks"": {
-                ""net45"": { }
-              },
-              ""tools"": {
-                ""packageA"": ""*""
-              }
-            }";
-
             using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
-                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
-                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
-                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
-                packagesDir.Create();
-                packageSource.Create();
-                project1.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
-
-                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
-
-                var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-
-                var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
-
-                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                var tc = new ToolTestContext(workingDir)
+                {
+                    ProjectJson = @"
+                    {
+                        ""frameworks"": {
+                            ""net45"": { }
+                        },
+                        ""tools"": {
+                            ""packageA"": ""*""
+                        }
+                    }"
+                };
 
                 // The tool is not available on the source.
 
+                tc.Initialize();
+
                 // Act
-                var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
-                await result.CommitAsync(logger, CancellationToken.None);
+                var result = await tc.Command.ExecuteAsync();
+                await result.CommitAsync(tc.Logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success,
                     "The command should not have succeeded. Messages: "
-                    + Environment.NewLine + logger.ShowMessages());
+                    + Environment.NewLine + tc.Logger.ShowMessages());
                 Assert.Equal(1, result.ToolRestoreResults.Count());
 
                 var toolResult = result.ToolRestoreResults.First();
@@ -326,57 +296,39 @@ namespace NuGet.Commands.Test
         public async Task RestoreCommand_HandlesMultipleToolRestores()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            var project1Json = @"
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
-              ""frameworks"": {
-                ""net45"": { }
-              },
-              ""tools"": {
-                ""packageA"": ""*"",
-                ""packageB"": ""*"",
-                ""packageC"": ""*""
-              }
-            }";
-
-            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
-                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
-                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
-                packagesDir.Create();
-                packageSource.Create();
-                project1.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
-
-                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
-
-                var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-
-                var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
-
-                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
-
-                // packageA is not on the source
+                var tc = new ToolTestContext(testDirectory)
+                {
+                    ProjectJson = @"
+                    {
+                        ""frameworks"": {
+                        ""net45"": { }
+                        },
+                        ""tools"": {
+                        ""packageA"": ""*"",
+                        ""packageB"": ""*"",
+                        ""packageC"": ""*""
+                        }
+                    }"
+                };
 
                 var packageB = new SimpleTestPackageContext("packageB");
                 packageB.AddFile("lib/netstandard1.3/a.dll");
 
-                // packageC is not on the source
+                // packageA and packageC are not on the source
+                SimpleTestPackageUtility.CreatePackages(tc.PackageSource.FullName, packageB);
 
-                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageB);
+                tc.Initialize();
 
                 // Act
-                var command = new RestoreCommand(request);
-                var result = await command.ExecuteAsync();
-                await result.CommitAsync(logger, CancellationToken.None);
+                var result = await tc.Command.ExecuteAsync();
+                await result.CommitAsync(tc.Logger, CancellationToken.None);
 
                 // Assert
                 Assert.False(result.Success,
                     "The command should not have succeeded. Messages: "
-                    + Environment.NewLine + logger.ShowMessages());
+                    + Environment.NewLine + tc.Logger.ShowMessages());
                 Assert.Equal(3, result.ToolRestoreResults.Count());
 
                 var packageAResult = result.ToolRestoreResults.ElementAt(0);
@@ -396,6 +348,56 @@ namespace NuGet.Commands.Test
                 Assert.NotNull(packageCResult.LockFile);
                 Assert.Equal(1, packageCResult.LockFile.Targets.Count);
                 Assert.False(packageCResult.Success, "packageC tool restore should not have succeeded.");
+            }
+        }
+
+        private class ToolTestContext
+        {
+            public ToolTestContext(TestDirectory testDirectory)
+            {
+                // data
+                Sources = new List<PackageSource>();
+                ProjectJson = @"
+                {
+                  ""frameworks"": {
+                    ""net45"": { }
+                  },
+                  ""tools"": {
+                    ""packageB"": ""*""
+                  }
+                }";
+
+
+                PackagesDir = new DirectoryInfo(Path.Combine(testDirectory, "globalPackages"));
+                PackageSource = new DirectoryInfo(Path.Combine(testDirectory, "packageSource"));
+                Project = new DirectoryInfo(Path.Combine(testDirectory, "projects", "project1"));
+                PackagesDir.Create();
+                PackageSource.Create();
+                Project.Create();
+                Sources.Add(new PackageSource(PackageSource.FullName));
+                Logger = new TestLogger();
+            }
+
+            public DirectoryInfo PackageSource { get; }
+            public TestLogger Logger { get; }
+            public string ProjectJson { private get; set; }
+            public RestoreRequest Request { get; set;  }
+            public RestoreCommand Command { get; private set;  }
+
+            private DirectoryInfo Project { get; }
+            private DirectoryInfo PackagesDir { get; }
+            private List<PackageSource> Sources { get; }
+
+            public void Initialize()
+            {
+                File.WriteAllText(Path.Combine(Project.FullName, "project.json"), ProjectJson);
+
+                var specPath1 = Path.Combine(Project.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(ProjectJson, "project1", specPath1);
+                Request = new RestoreRequest(spec1, Sources, PackagesDir.FullName, Logger);
+
+                Request.LockFilePath = Path.Combine(Project.FullName, "project.lock.json");
+                Command = new RestoreCommand(Request);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Logging;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
@@ -248,6 +249,124 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public async Task RestoreCommand_DoesNotRedoRestoreToolsWithValidLockFile()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new ToolTestContext(workingDir)
+                {
+                    ProjectJson = @"
+                    {
+                        ""frameworks"": {
+                            ""net45"": { }
+                        },
+                        ""tools"": {
+                            ""packageA"": ""*""
+                        }
+                    }",
+                };
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/netstandard1.3/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(tc.PackageSource.FullName, packageA);
+
+                tc.Initialize();
+
+                // the first restore
+                await (await tc.Command.ExecuteAsync()).CommitAsync(tc.Logger, CancellationToken.None);
+
+                // reset
+                tc.Logger = new TestLogger();
+                tc.Request.Log = tc.Logger;
+                tc.Initialize();
+                tc.Request.ExistingLockFile = LockFileUtilities.GetLockFile(tc.Request.LockFilePath, tc.Logger);
+
+                // Act
+                var result = await tc.Command.ExecuteAsync();
+                await result.CommitAsync(tc.Logger, CancellationToken.None);
+
+                // Assert
+                Assert.True(
+                    result.Success,
+                    "The command did not succeed. Error messages: "
+                    + Environment.NewLine + tc.Logger.ShowErrors());
+                Assert.Equal(1, result.ToolRestoreResults.Count());
+
+                Assert.Contains(
+                    $"Lock file has not changed. Skipping lock file write. Path: {result.LockFilePath}",
+                    tc.Logger.Messages);
+
+                var toolResult = result.ToolRestoreResults.First();
+                Assert.Contains(
+                    $"Tool lock file has not changed. Skipping lock file write. Path: {toolResult.LockFilePath}",
+                    tc.Logger.Messages);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_ObservesLockedFilesOnlyInProject()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new ToolTestContext(workingDir)
+                {
+                    ProjectJson = @"
+                    {
+                        ""frameworks"": {
+                            ""net45"": { }
+                        },
+                        ""tools"": {
+                            ""packageA"": ""*""
+                        }
+                    }",
+                };
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/netstandard1.3/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(tc.PackageSource.FullName, packageA);
+
+                tc.Initialize();
+
+                // the first restore
+                var initialResult = await tc.Command.ExecuteAsync();
+                await initialResult.CommitAsync(tc.Logger, CancellationToken.None);
+                
+                tc.SetIsLocked(initialResult.LockFilePath, true, tc.Logger);
+                tc.SetIsLocked(initialResult.ToolRestoreResults.First().LockFilePath, true, tc.Logger);
+
+                // reset
+                tc.Logger = new TestLogger();
+                tc.Request.Log = tc.Logger;
+                tc.Initialize();
+                tc.Request.ExistingLockFile = LockFileUtilities.GetLockFile(tc.Request.LockFilePath, tc.Logger);
+
+                // Act
+                var result = await tc.Command.ExecuteAsync();
+                await result.CommitAsync(tc.Logger, CancellationToken.None);
+
+                // Assert
+                Assert.True(
+                    result.Success,
+                    "The command did not succeed. Error messages: "
+                    + Environment.NewLine + tc.Logger.ShowErrors());
+                Assert.Equal(1, result.ToolRestoreResults.Count());
+                
+                // Since the files are locked and valid, the commit is completely skipped.
+                Assert.DoesNotContain(result.LockFilePath, tc.Logger.ShowMessages());
+
+                // Locking a tool lock file is not supported.
+                var toolResult = result.ToolRestoreResults.First();                
+                Assert.Contains(
+                    $"Tool lock file has not changed. Skipping lock file write. Path: {toolResult.LockFilePath}",
+                    tc.Logger.Messages);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_FailsCommandWhenToolRestoreFails()
         {
             // Arrange
@@ -379,7 +498,7 @@ namespace NuGet.Commands.Test
             }
 
             public DirectoryInfo PackageSource { get; }
-            public TestLogger Logger { get; }
+            public TestLogger Logger { get; set; }
             public string ProjectJson { private get; set; }
             public RestoreRequest Request { get; set;  }
             public RestoreCommand Command { get; private set;  }
@@ -398,6 +517,13 @@ namespace NuGet.Commands.Test
 
                 Request.LockFilePath = Path.Combine(Project.FullName, "project.lock.json");
                 Command = new RestoreCommand(Request);
+            }
+
+            public void SetIsLocked(string path, bool isLocked, ILogger logger)
+            {
+                var lockFile = LockFileUtilities.GetLockFile(path, logger);
+                lockFile.IsLocked = isLocked;
+                new LockFileFormat().Write(path, lockFile);
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -12,10 +12,9 @@ namespace NuGet.ProjectModel.Test
     public class LockFileFormatTests
     {
         [Fact]
-        public void ReadBasicLockFile()
+        public void LockFileFormat_ReadsLockFileWithNoTools()
         {
-            const string lockFileContent = @"
-{
+            string lockFileContent = @"{
   ""locked"": true,
   ""version"": 1,
   ""targets"": {
@@ -90,44 +89,94 @@ namespace NuGet.ProjectModel.Test
             var netPlatDepGroup = lockFile.ProjectFileDependencyGroups.Last();
             Assert.Equal(NuGetFramework.Parse("dotnet").DotNetFrameworkName, netPlatDepGroup.FrameworkName);
             Assert.Empty(netPlatDepGroup.Dependencies);
+
+            Assert.Equal(0, lockFile.ProjectFileToolGroups.Count);
+            Assert.Equal(0, lockFile.Tools.Count);
         }
 
         [Fact]
-        public void WriteBasicLockFile()
+        public void LockFileFormat_ReadsLockFileWithTools()
+        {
+            string lockFileContent = @"{
+  ""tools"": {
+    "".NETStandard,Version=v1.2"": {
+      ""System.Runtime/4.0.20-beta-22927"": {
+        ""dependencies"": {
+          ""Frob"": ""[4.0.20, )""
+        },
+        ""compile"": {
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
+  ""projectFileToolGroups"": {
+    "".NETFramework,Version=v4.5.1"": [],
+    "".NETStandard,Version=v1.5"": [
+      ""System.Runtime [4.0.10-beta-*, )""
+    ]
+  }
+}";
+            var lockFileFormat = new LockFileFormat();
+            var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
+
+            var tool = lockFile.Tools.Single();
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard12, tool.TargetFramework);
+
+            var runtimeTargetLibrary = tool.Libraries.Single();
+            Assert.Equal("System.Runtime", runtimeTargetLibrary.Name);
+            Assert.Equal(NuGetVersion.Parse("4.0.20-beta-22927"), runtimeTargetLibrary.Version);
+            Assert.Equal(0, runtimeTargetLibrary.NativeLibraries.Count);
+            Assert.Equal(0, runtimeTargetLibrary.ResourceAssemblies.Count);
+            Assert.Equal(0, runtimeTargetLibrary.FrameworkAssemblies.Count);
+            Assert.Equal(0, runtimeTargetLibrary.RuntimeAssemblies.Count);
+            Assert.Equal("ref/dotnet/System.Runtime.dll", runtimeTargetLibrary.CompileTimeAssemblies.Single().Path);
+
+            var net451Group = lockFile.ProjectFileToolGroups.First();
+            Assert.Equal(FrameworkConstants.CommonFrameworks.Net451, NuGetFramework.Parse(net451Group.FrameworkName));
+
+            var netStandardGroup = lockFile.ProjectFileToolGroups.Last();
+            Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard15, NuGetFramework.Parse(netStandardGroup.FrameworkName));
+            Assert.Equal("System.Runtime [4.0.10-beta-*, )", netStandardGroup.Dependencies.Single());
+        }
+
+        [Fact]
+        public void LockFileFormat_WritesLockFileWithNoTools()
         {
             // Arrange
-            const string lockFileContent = @"{
+            string lockFileContent = @"{
   ""locked"": true,
   ""version"": 2,
   ""targets"": {
-                "".NETPlatform,Version=v5.0"": {
-                    ""System.Runtime/4.0.20-beta-22927"": {
-                        ""type"": ""package"",
-                        ""dependencies"": {
-                            ""Frob"": ""4.0.20""
-                        },
+    "".NETPlatform,Version=v5.0"": {
+      ""System.Runtime/4.0.20-beta-22927"": {
+        ""type"": ""package"",
+        ""dependencies"": {
+          ""Frob"": ""4.0.20""
+        },
         ""compile"": {
-                            ""ref/dotnet/System.Runtime.dll"": {
-                            }
-                        }
-                    }
-                }
-            },
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
   ""libraries"": {
-                ""System.Runtime/4.0.20-beta-22927"": {
-                    ""sha512"": ""sup3rs3cur3"",
+    ""System.Runtime/4.0.20-beta-22927"": {
+      ""sha512"": ""sup3rs3cur3"",
       ""type"": ""package"",
       ""files"": [
         ""System.Runtime.nuspec""
       ]
     }
-},
+  },
   ""projectFileDependencyGroups"": {
     """": [
       ""System.Runtime [4.0.10-beta-*, )""
     ],
     "".NETPlatform,Version=v5.0"": []
-  }
+  },
+  ""tools"": {},
+  ""projectFileToolGroups"": {}
 }";
             var lockFile = new LockFile();
             lockFile.IsLocked = true;
@@ -162,6 +211,70 @@ namespace NuGet.ProjectModel.Test
             lockFile.ProjectFileDependencyGroups.Add(
                 new ProjectFileDependencyGroup("", new string[] { "System.Runtime [4.0.10-beta-*, )" }));
             lockFile.ProjectFileDependencyGroups.Add(
+                new ProjectFileDependencyGroup(FrameworkConstants.CommonFrameworks.DotNet.DotNetFrameworkName, new string[0]));
+
+            // Act
+            var lockFileFormat = new LockFileFormat();
+            var output = JObject.Parse(lockFileFormat.Render(lockFile));
+            var expected = JObject.Parse(lockFileContent);
+
+            // Assert
+            Assert.Equal(expected.ToString(), output.ToString());
+        }
+
+        [Fact]
+        public void LockFileFormat_WritesLockFileWithTools()
+        {
+            // Arrange
+            string lockFileContent = @"{
+  ""locked"": true,
+  ""version"": 2,
+  ""targets"": {},
+  ""libraries"": {},
+  ""projectFileDependencyGroups"": {},
+  ""tools"": {
+    "".NETPlatform,Version=v5.0"": {
+      ""System.Runtime/4.0.20-beta-22927"": {
+        ""type"": ""package"",
+        ""dependencies"": {
+          ""Frob"": ""4.0.20""
+        },
+        ""compile"": {
+          ""ref/dotnet/System.Runtime.dll"": {}
+        }
+      }
+    }
+  },
+  ""projectFileToolGroups"": {
+    """": [
+      ""System.Runtime [4.0.10-beta-*, )""
+    ],
+    "".NETPlatform,Version=v5.0"": []
+  }
+}";
+            var lockFile = new LockFile();
+            lockFile.IsLocked = true;
+            lockFile.Version = 2;
+
+            var target = new LockFileTarget()
+            {
+                TargetFramework = FrameworkConstants.CommonFrameworks.DotNet
+            };
+            var targetLib = new LockFileTargetLibrary()
+            {
+                Name = "System.Runtime",
+                Version = NuGetVersion.Parse("4.0.20-beta-22927"),
+                Type = LibraryTypes.Package
+            };
+            targetLib.Dependencies.Add(new NuGet.Packaging.Core.PackageDependency("Frob",
+                new VersionRange(NuGetVersion.Parse("4.0.20"))));
+            targetLib.CompileTimeAssemblies.Add(new LockFileItem("ref/dotnet/System.Runtime.dll"));
+            target.Libraries.Add(targetLib);
+            lockFile.Tools.Add(target);
+            
+            lockFile.ProjectFileToolGroups.Add(
+                new ProjectFileDependencyGroup("", new string[] { "System.Runtime [4.0.10-beta-*, )" }));
+            lockFile.ProjectFileToolGroups.Add(
                 new ProjectFileDependencyGroup(FrameworkConstants.CommonFrameworks.DotNet.DotNetFrameworkName, new string[0]));
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
@@ -1,0 +1,348 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class LockFileTests
+    {
+        [Fact]
+        public void LockFile_ComparesEqualTools()
+        {
+            // Arrange
+            var lockFileA = new LockFile
+            {
+                Tools =
+                {
+                    new LockFileTarget
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.NetStandard12,
+                        Libraries = { new LockFileTargetLibrary { Name = "SomeLibrary" } }
+                    }
+                }
+            };
+
+            // same thing
+            var lockFileB = new LockFile
+            {
+                Tools =
+                {
+                    new LockFileTarget
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.NetStandard12,
+                        Libraries = { new LockFileTargetLibrary { Name = "SomeLibrary" } }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.True(lockFileA.Equals(lockFileB), "The two lock files should be equal.");
+        }
+
+        [Fact]
+        public void LockFile_ComparesDifferentTools()
+        {
+            // Arrange
+            var lockFileA = new LockFile
+            {
+                Tools =
+                {
+                    new LockFileTarget
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.NetStandard12,
+                        Libraries = { new LockFileTargetLibrary { Name = "SomeLibrary" } }
+                    }
+                }
+            };
+
+            // different thing
+            var lockFileB = new LockFile
+            {
+                Tools =
+                {
+                    new LockFileTarget
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.NetStandard12,
+                        Libraries = { new LockFileTargetLibrary { Name = "SomeLibrary" } }
+                    },
+                    new LockFileTarget
+                    {
+                        TargetFramework = FrameworkConstants.CommonFrameworks.NetStandard12,
+                        Libraries = { new LockFileTargetLibrary { Name = "OtherLibrary" } }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFileA.Equals(lockFileB), "The two lock files should not be equal.");
+        }
+
+        [Fact]
+        public void LockFile_ComparesEqualProjectFileToolGroups()
+        {
+            // Arrange
+            var lockFileA = new LockFile
+            {
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup("FrameworkA", new [] { "DependencyA" })
+                }
+            };
+
+            // same thing
+            var lockFileB = new LockFile
+            {
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup("FrameworkA", new [] { "DependencyA" })
+                }
+            };
+
+            // Act & Assert
+            Assert.True(lockFileA.Equals(lockFileB), "The two lock files should be equal.");
+        }
+
+        [Fact]
+        public void LockFile_ComparesDifferentProjectFileToolGroups()
+        {
+            // Arrange
+            var lockFileA = new LockFile
+            {
+                ProjectFileToolGroups = 
+                {
+                    new ProjectFileDependencyGroup("FrameworkA", new [] { "DependencyA" })
+                }
+            };
+
+            // different thing
+            var lockFileB = new LockFile
+            {
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup("FrameworkA", new [] { "DependencyA" }),
+                    new ProjectFileDependencyGroup("FrameworkB", new [] { "DependencyB" })
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFileA.Equals(lockFileB), "The two lock files should not be equal.");
+        }
+
+        [Fact]
+        public void LockFile_IsValidForPackageSpec_DifferentToolVersions()
+        {
+            // Arrange
+            var lockFile = new LockFile
+            {
+                ProjectFileDependencyGroups =
+                {
+                    new ProjectFileDependencyGroup("", new string[0])
+                },
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup(LockFile.ToolFramework.ToString(), new [] { "DependencyA >= 2.0.0" })
+                }
+            };
+
+            var packageSpec = new PackageSpec(new JObject())
+            {
+                Dependencies = new List<LibraryDependency>(),
+                Tools = new List<ToolDependency>
+                {
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyA",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("1.0.0")
+                        }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFile.IsValidForPackageSpec(packageSpec));
+        }
+
+        [Fact]
+        public void LockFile_IsValidForPackageSpec_MissingTools()
+        {
+            // Arrange
+            var lockFile = new LockFile
+            {
+                ProjectFileDependencyGroups =
+                {
+                    new ProjectFileDependencyGroup("", new string[0])
+                },
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup(LockFile.ToolFramework.ToString(), new [] { "DependencyA >= 2.0.0" })
+                }
+            };
+
+            var packageSpec = new PackageSpec(new JObject())
+            {
+                Dependencies = new List<LibraryDependency>(),
+                Tools = new List<ToolDependency>
+                {
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyA",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("1.0.0")
+                        }
+                    },
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyB",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("2.0.0")
+                        }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFile.IsValidForPackageSpec(packageSpec));
+        }
+
+        [Fact]
+        public void LockFile_IsValidForPackageSpec_ExtraTools()
+        {
+            // Arrange
+            var lockFile = new LockFile
+            {
+                ProjectFileDependencyGroups =
+                {
+                    new ProjectFileDependencyGroup("", new string[0])
+                },
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup(LockFile.ToolFramework.ToString(), new []
+                    {
+                        "DependencyA >= 1.0.0",
+                        "DependencyB >= 2.0.0",
+                    })
+                }
+            };
+
+            var packageSpec = new PackageSpec(new JObject())
+            {
+                Dependencies = new List<LibraryDependency>(),
+                Tools = new List<ToolDependency>
+                {
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyA",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("1.0.0")
+                        }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFile.IsValidForPackageSpec(packageSpec));
+        }
+
+        [Fact]
+        public void LockFile_IsValidForPackageSpec_InvalidToolFramework()
+        {
+            // Arrange
+            var lockFile = new LockFile
+            {
+                ProjectFileDependencyGroups =
+                {
+                    new ProjectFileDependencyGroup("", new string[0])
+                },
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup("FrameworkA", new []
+                    {
+                        "DependencyA >= 1.0.0"
+                    })
+                }
+            };
+
+            var packageSpec = new PackageSpec(new JObject())
+            {
+                Dependencies = new List<LibraryDependency>(),
+                Tools = new List<ToolDependency>
+                {
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyA",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("1.0.0")
+                        }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.False(lockFile.IsValidForPackageSpec(packageSpec));
+        }
+
+        [Fact]
+        public void LockFile_IsValidForPackageSpec_MatchingTools()
+        {
+            // Arrange
+            var lockFile = new LockFile
+            {
+                ProjectFileDependencyGroups =
+                {
+                    new ProjectFileDependencyGroup("", new string[0])
+                },
+                ProjectFileToolGroups =
+                {
+                    new ProjectFileDependencyGroup(LockFile.ToolFramework.ToString(), new []
+                    {
+                        "DependencyA >= 1.0.0",
+                        "DependencyB >= 2.0.0",
+                    })
+                }
+            };
+
+            var packageSpec = new PackageSpec(new JObject())
+            {
+                Dependencies = new List<LibraryDependency>(),
+                Tools = new List<ToolDependency>
+                {
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyB",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("2.0.0")
+                        }
+                    },
+                    new ToolDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "DependencyA",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("1.0.0")
+                        }
+                    }
+                }
+            };
+
+            // Act & Assert
+            Assert.True(lockFile.IsValidForPackageSpec(packageSpec));
+        }
+    }
+}


### PR DESCRIPTION
1. Write tool version to consuming project lock file. This allows the dotnet CLI to execute the exact version that was restored (not picking highest version in the `.tools` directory which is the current functionality). This introduce two new nodes to the project.lock.json:
   - `"tools"` - this is analogous to `"targets"` but only contains the resolve graph nodes from the tool restore.
   - `"projectFileToolGroups"` - this is analogous to `"projectFileDependencyGroups"`.
2. Read in tool version from consuming project.lock.json file so that existing tool project.lock.json can be used during the restore (to save operations just like a normal project.json restore).

@emgarten @brthor @piotrpMSFT @davidfowl 
### Example

Suppose you have a consuming project.json:

<pre>
{
    "version": "1.0.0-*",
    "compilationOptions": {
        "emitEntryPoint": true
    },

    "dependencies": {
        "NETStandard.Library": "1.0.0-rc2-23811"
    },

    "frameworks": {
        "netstandard1.5": {
            "imports": [ "dotnet5.6", "dnxcore50", "portable-net45+win8" ]
        }
    },

    <b>"tools": {
        "dotnet-hello": "2.0.0"
    }</b>
}
</pre>


The resulting project.lock.json (for this consuming project) has this at the end:

``` json
  (truncated)

  "tools": {
    ".NETStandardApp,Version=v1.5": {
      "dotnet-hello/2.0.0": {
        "type": "package",
        "dependencies": {
          "NETStandard.Library": "1.5.0-rc2-23911"
        },
        "compile": {
          "lib/netstandardapp1.5/dotnet-hello.dll": {}
        },
        "runtime": {
          "lib/netstandardapp1.5/dotnet-hello.dll": {}
        }
      }
    }
  },
  "projectFileToolGroups": {
    ".NETStandardApp,Version=v1.5": [
      "dotnet-hello >= 2.0.0"
    ]
  }
}
```

And the existing functionality places the tool's project.lock.json at: `packages\.tools\dotnet-hello\2.0.0\netstandardapp1.5\project.lock.json`:

``` json
{
  "locked": false,
  "version": 2,
  "targets": {
    ".NETStandardApp,Version=v1.5": {
      "dotnet-hello/2.0.0": {
        "type": "package",
        "dependencies": {
          "NETStandard.Library": "1.5.0-rc2-23911"
        },
        "compile": {
          "lib/netstandardapp1.5/dotnet-hello.dll": {}
        },
        "runtime": {
          "lib/netstandardapp1.5/dotnet-hello.dll": {}
        }
      },

  (truncated)
```
