### PR TITLE
Support for ARM architecture

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/RequestRuntimeUtility.cs
@@ -43,6 +43,10 @@ namespace NuGet.Commands
                 yield return "win7-x86";
                 yield return "win7-x64";
             }
+            else if(string.Equals(os, "ubuntu", StringComparison.Ordinal)){
+                yield return runtimeOsName + "-x64";
+                yield return runtimeOsName + "-arm";
+            }
             else
             {
                 // Core CLR only supports x64 on non-windows OSes.


### PR DESCRIPTION
Add the runtime identifier for ARM in the generated lock.json file
so that .NET CLI can be cross-built for ARM.

It is based on the issue in DOTNET-CLI: https://github.com/dotnet/cli/pull/1747

Signed-off-by: Dongyun Jin dongyun.jin@samsung.com
