### PR TITLE
Load CredentialProviders on NuGet startup

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -131,7 +131,7 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider()
         {
-            var credentialService = new CredentialService(GetCredentialProviders, Console.WriteError, NonInteractive);
+            var credentialService = new CredentialService(GetCredentialProviders(), Console.WriteError, NonInteractive);
 
             HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(credentialService);
 

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
@@ -21,7 +21,6 @@ namespace NuGet.Credentials
         private readonly ConcurrentDictionary<string, CredentialResponse> _providerCredentialCache
             = new ConcurrentDictionary<string, CredentialResponse>();
         private readonly bool _nonInteractive;
-        private readonly Lazy<IEnumerable<ICredentialProvider>> _providers;
 
         /// <summary>
         /// This semaphore ensures only one provider active per process, in order
@@ -35,18 +34,18 @@ namespace NuGet.Credentials
         /// <summary>
         /// Constructor
         /// </summary>
-        /// <param name="providersDelegate">Used to enumerate available credential providers.</param>
+        /// <param name="providers">All available credential providers.</param>
         /// <param name="errorDelegate">Used to write error messages to the user</param>
         /// <param name="nonInteractive">If true, the nonInteractive flag will be passed to providers.
         /// NonInteractive requests must not promt the user for credentials.</param>
         public CredentialService(
-            Func<IEnumerable<ICredentialProvider>> providersDelegate,
+            IEnumerable<ICredentialProvider> providers,
             Action<string> errorDelegate,
             bool nonInteractive)
         {
-            if (providersDelegate == null)
+            if (providers == null)
             {
-                throw new ArgumentNullException(nameof(providersDelegate));
+                throw new ArgumentNullException(nameof(providers));
             }
 
             if (errorDelegate == null)
@@ -56,7 +55,7 @@ namespace NuGet.Credentials
 
             ErrorDelegate = errorDelegate;
             _nonInteractive = nonInteractive;
-            _providers = new Lazy<IEnumerable<ICredentialProvider>>(providersDelegate);
+            Providers = new List<ICredentialProvider>(providers);
         }
 
         /// <summary>
@@ -140,7 +139,7 @@ namespace NuGet.Credentials
         /// <summary>
         /// Gets the currently configured providers.
         /// </summary>
-        private IEnumerable<ICredentialProvider> Providers => _providers.Value;
+        private IEnumerable<ICredentialProvider> Providers { get; }
 
         private bool TryFromCredentialCache(Uri uri, bool isProxy, bool isRetry, ICredentialProvider provider,
             out CredentialResponse credentials)

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -336,7 +336,7 @@ namespace NuGetVSExtension
         private void SetDefaultCredentialProvider()
         {
             var credentialService = new CredentialService(
-                GetCredentialProviders,
+                GetCredentialProviders(),
                 this._outputConsoleLogger.OutputConsole.WriteLine,
                 nonInteractive: false);
 

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_PassesAllParametersToProviders()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: true);
             var webProxy = new WebProxy();
@@ -55,7 +55,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_FirstCallHasRetryFalse()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
@@ -79,7 +79,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_SecondCallHasRetryTrue()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
@@ -105,7 +105,7 @@ namespace NuGet.Credentials.Test
         {
             // Arrange
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: true);
             var webProxy = new WebProxy();
@@ -138,7 +138,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_WhenUriHasSameAuthority_ThenReturnsCachedCredential()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
@@ -164,7 +164,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_NullResponsesAreCached()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
@@ -206,7 +206,7 @@ namespace NuGet.Credentials.Test
                     Task.FromResult<CredentialResponse>(new CredentialResponse(CredentialStatus.ProviderNotApplicable)));
             mockProvider2.Setup(x => x.Id).Returns("2");
             var service = new CredentialService(
-                () => new[] {mockProvider1.Object, mockProvider2.Object},
+                new[] {mockProvider1.Object, mockProvider2.Object},
                 TestableErrorWriter,
                 nonInteractive: false);
             var uri1 = new Uri("http://host/some/path");
@@ -230,7 +230,7 @@ namespace NuGet.Credentials.Test
         public async Task GetCredentials_WhenRetry_ThenDoesNotReturnCachedCredential()
         {
             var service = new CredentialService(
-                () => new[] { _mockProvider.Object },
+                new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider


### PR DESCRIPTION
Move credential provider initialization to NuGet startup, in order to avoid UI deadlocks occurring when this occurs during build #2361
