### PR TITLE
Add support for "push -NoSymbols" which will not try to auto-publish symbol packages

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -23,6 +23,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "PushCommandDisableBufferingDescription")]
         public bool DisableBuffering { get; set; }
 
+        [Option(typeof(NuGetCommand), "PushCommandNoSymbolsDescription")]
+        public bool NoSymbols { get; set; }
+
         public override async Task ExecuteCommandAsync()
         {
             string packagePath = Arguments[0];
@@ -45,6 +48,7 @@ namespace NuGet.CommandLine
                     apiKeyValue,
                     Timeout,
                     DisableBuffering,
+                    NoSymbols,
                     Console);
             }
             catch (Exception ex)

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -360,7 +360,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A list of packages sources to use as fallbacks for this command..
+        ///   Looks up a localized string similar to A list of package sources to use as fallbacks for this command..
         /// </summary>
         internal static string CommandFallbackSourceDescription {
             get {
@@ -8858,6 +8858,15 @@ namespace NuGet.CommandLine {
         internal static string PushCommandDisableBufferingDescription {
             get {
                 return ResourceManager.GetString("PushCommandDisableBufferingDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If a symbols package exists, it will not be pushed to a symbols server..
+        /// </summary>
+        internal static string PushCommandNoSymbolsDescription {
+            get {
+                return ResourceManager.GetString("PushCommandNoSymbolsDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5239,8 +5239,11 @@ nuget update -Self</value>
   <data name="PushCommandDisableBufferingDescription" xml:space="preserve">
     <value>Disable buffering when pushing to an HTTP(S) server to decrease memory usage. Note that when this option is enabled, integrated windows authentication might not work.</value>
   </data>
+  <data name="PushCommandNoSymbolsDescription" xml:space="preserve">
+    <value>If a symbols package exists, it will not be pushed to a symbols server.</value>
+  </data>
   <data name="CommandFallbackSourceDescription" xml:space="preserve">
-    <value>A list of packages sources to use as fallbacks for this command.</value>
+    <value>A list of package sources to use as fallbacks for this command.</value>
   </data>
   <data name="CommandMSBuildVersion" xml:space="preserve">
     <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Commands;
@@ -35,6 +35,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.DisableBuffering_Description,
                     CommandOptionType.SingleValue);
 
+                var noSymbols = push.Option(
+                    "-n|--no-symbols",
+                    Strings.NoSymbols_Description,
+                    CommandOptionType.SingleValue);
+
                 var arguments = push.Argument(
                     "[root]",
                     Strings.Push_Package_ApiKey_Description,
@@ -51,6 +56,7 @@ namespace NuGet.CommandLine.XPlat
                     string sourcePath = source.Value();
                     string apiKeyValue = apikey.Value();
                     bool disableBufferingValue = disableBuffering.HasValue();
+                    bool noSymbolsValue = noSymbols.HasValue();
                     int timeoutSeconds = 0;
 
                     if (timeout.HasValue() && !int.TryParse(timeout.Value(), out timeoutSeconds))
@@ -68,6 +74,7 @@ namespace NuGet.CommandLine.XPlat
                         apiKeyValue,
                         timeoutSeconds,
                         disableBufferingValue,
+                        noSymbolsValue,
                         getLogger());
 
                     return 0;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -384,6 +384,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to If a symbols package exists, it will not be pushed to a symbols server..
+        /// </summary>
+        internal static string NoSymbols_Description {
+            get {
+                return ResourceManager.GetString("NoSymbols_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Pushes a package to the server and publishes it..
         /// </summary>
         internal static string Push_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -141,6 +141,9 @@
   <data name="DisableBuffering_Description" xml:space="preserve">
     <value>Disable buffering when pushing to an HTTP(S) server to decrease memory usage.</value>
   </data>
+  <data name="NoSymbols_Description" xml:space="preserve">
+    <value>If a symbols package exists, it will not be pushed to a symbols server.</value>
+  </data>
   <data name="Log_Committing" xml:space="preserve">
     <value>Committing restore...</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PushRunner.cs
@@ -18,6 +18,7 @@ namespace NuGet.Commands
             string apiKey,
             int timeoutSeconds,
             bool disableBuffering,
+            bool noSymbols,
             ILogger logger)
         {
             source = CommandRunnerUtility.ResolveSource(sourceProvider, source);
@@ -29,8 +30,13 @@ namespace NuGet.Commands
 
             PackageUpdateResource packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
 
+            string symbolsSource = !noSymbols
+                ? NuGetConstants.DefaultSymbolServerUrl
+                : string.Empty;
+
             await packageUpdateResource.Push(
                 packagePath,
+                symbolsSource,
                 timeoutSeconds,
                 disableBuffering,
                 endpoint => CommandRunnerUtility.GetApiKey(settings, endpoint, apiKey),


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2204

The auto-push of symbols to a public server (https://nuget.smbsrc.net) isn't wanted by some people. They'll push symbols to their own server. There is now a way to turn symbol auto-push off.
