### PR TITLE
All-sources infinite retry fix

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -60,7 +60,7 @@ namespace NuGet.PackageManagement.UI
                     if (_results == null)
                     {
                         // initial status when no load called before
-                        return LoadingStatus.Ready;
+                        return LoadingStatus.Unknown;
                     }
 
                     return AggregateLoadingStatus(SourceLoadingStatus?.Values);

--- a/src/NuGet.Core/NuGet.Indexing/SearchResultsAggregator.cs
+++ b/src/NuGet.Core/NuGet.Indexing/SearchResultsAggregator.cs
@@ -67,11 +67,17 @@ namespace NuGet.Indexing
                 }
             }
 
-            // process the last single queue
-            foreach(var entry in queues.FirstOrDefault()?.Where(e => !enqueued.Contains(e)))
+            // append tail elements from the last queue (should be one or none)
+            // in most cases input queues are unbalanced, i.e. contain different amount of search results.
+            // in that scenario merging algorithm ends leaving a "tail" in a longer queue.
+            // although in certain rare edge cases it might empty all queues at once.
+            if (queues.Any())
             {
-                // don't have to update enqueued as this is the last queue
-                outputQueue.Enqueue(mergedIndex[entry]);
+                foreach (var entry in queues.Single().Where(e => !enqueued.Contains(e)))
+                {
+                    // don't have to update enqueued as this is the last queue
+                    outputQueue.Enqueue(mergedIndex[entry]);
+                }
             }
 
             return outputQueue;


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2363.
- Null-ref fix in merge algorithm
- Change default loader state to Unknown
