### PR TITLE
LOCK the supported VS version on the VSIX manifest to 14.0.

### DIFF
--- a/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
@@ -8,12 +8,12 @@
     <PreviewImage>Resources/nuget_256.png</PreviewImage>
   </Metadata>
   <Installation InstalledByMsi="false" AllUsers="true">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.VPDExpress" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[14.0,]" />
-    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[14.0,]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[14.0,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VPDExpress" Version="[14.0,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinExpress" Version="[14.0,15.0)" />
+    <InstallationTarget Id="Microsoft.VisualStudio.VSWinDesktopExpress" Version="[14.0,15.0)" />
   </Installation>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
LOCK the supported VS version on the VSIX manifest to 14.0.

@yishaigalatzer @rrelyea
