### PR TITLE
Add "imports" support to tools

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -251,6 +251,13 @@ namespace NuGet.Commands
                     Strings.Log_RestoringToolPackages,
                     tool.LibraryRange.Name,
                     _request.Project.FilePath));
+                    
+                // Build the fallback framework (which uses the "imports").
+                var framework = LockFile.ToolFramework;
+                if (tool.Imports.Any())
+                {
+                    framework = new FallbackFramework(framework, tool.Imports);
+                }
 
                 // Build a package spec in memory to execute the tool restore as if it were
                 // its own project. For now, we always restore for a null runtime and a single
@@ -262,9 +269,9 @@ namespace NuGet.Commands
                     Tools = new List<ToolDependency>(),
                     TargetFrameworks =
                     {
-                         new TargetFrameworkInformation
+                        new TargetFrameworkInformation
                         {
-                            FrameworkName = LockFile.ToolFramework,
+                            FrameworkName = framework,
                             Dependencies = new List<LibraryDependency>
                             {
                                 new LibraryDependency

--- a/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
@@ -28,7 +28,7 @@ namespace NuGet.Frameworks
 
             if (fallbackFrameworks.Count == 0)
             {
-                throw new ArgumentException("Empty fallbackFrameworks is invalid",nameof(fallbackFrameworks));
+                throw new ArgumentException("Empty fallbackFrameworks is invalid", nameof(fallbackFrameworks));
             }
 
             Fallback = fallbackFrameworks;

--- a/src/NuGet.Core/NuGet.LibraryModel/ToolDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/ToolDependency.cs
@@ -1,10 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
 namespace NuGet.LibraryModel
 {
     public class ToolDependency
     {
         public LibraryRange LibraryRange { get; set; }
+        public List<NuGetFramework> Imports { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "NuGet.Versioning": {
       "target": "project"
+    },
+    "NuGet.Frameworks": {
+      "target": "project"
     }
   },
   "compilationOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FallbackFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FallbackFrameworkTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.Test
+{
+    public class FallbackFrameworkTests
+    {
+        [Fact]
+        public void FallbackFramework_ReferenceEquals()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            
+            // Act & Assert
+            Assert.Equal(a, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_Equals()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            
+            // Act & Assert
+            Assert.Equal(a, b);
+            Assert.Equal(b, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_DifferentPrimary()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("net46"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            
+            // Act & Assert
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_SubsetFallbacks()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("dnxcore50"), NuGetFramework.Parse("netstandard1.1") });
+            
+            // Act & Assert
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_DifferentFallbackOrder()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("netstandardapp1.5"),
+                new[] { NuGetFramework.Parse("net40"), NuGetFramework.Parse("net45") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("netstandardapp1.5"),
+                new[] { NuGetFramework.Parse("net40"), NuGetFramework.Parse("net46") });
+            
+            // Act & Assert
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_DifferentFallbacks()
+        {
+            // Arrange
+            var a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("netstandard1.2") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("win8") });
+            
+            // Act & Assert
+            Assert.NotEqual(a, b);
+            Assert.NotEqual(b, a);
+        }
+        
+        [Fact]
+        public void FallbackFramework_CompareAsNuGetFramework()
+        {
+            // Arrange
+            NuGetFramework a = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("netstandard1.2") });
+            var b = new FallbackFramework(
+                NuGetFramework.Parse("net45"),
+                new[] { NuGetFramework.Parse("win8") });
+            
+            // Act & Assert
+            Assert.Equal(a, (NuGetFramework) b);
+            Assert.Equal(b, (NuGetFramework) a);
+            Assert.Equal((NuGetFramework) a, b);
+            Assert.Equal((NuGetFramework) b, a);
+        }
+    }
+}


### PR DESCRIPTION
This add support for `"imports"` for tools, to be used when a consuming project wants to pull in a tool that does not support `netstandardapp1.5`. Same semantics as adding adding `"imports"` to a framework under the `"frameworks"` node.

**Example:**

``` json
{
    "tools": {
        "dotnet-hello": {
           "version": "2.0.0",
           "imports": [ "portable-net45+win8", "dnxcore50" ]
        }
    }
}
```

@emgarten @piotrpMSFT @brthor @davidfowl @yishaigalatzer 
