### PR TITLE
Imports fallback fixes for FindBestItemGroup

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -204,6 +204,12 @@ namespace NuGet.Client
 
             public SelectionCriteria ForFrameworkAndRuntime(NuGetFramework framework, string runtimeIdentifier)
             {
+                if (framework is FallbackFramework)
+                {
+                    // Fallback frameworks are not handled by content model
+                    throw new NotSupportedException("FallbackFramework is not supported.");
+                }
+
                 // Both criteria must specify a RID
 
                 var builder = new SelectionCriteriaBuilder(_conventions.Properties);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -143,30 +143,43 @@ namespace NuGet.Commands
                 }
             }
 
-            var managedCriteria = targetGraph.Conventions.Criteria.ForFrameworkAndRuntime(framework, targetGraph.RuntimeIdentifier);
+            // Create an ordered list of selection criteria. Each will be applied, if the result is empty
+            // fallback frameworks from "imports" will be tried.
+            // These are only used for framework/RID combinations where content model handles everything.
+            var orderedCriteria = CreateCriteria(targetGraph, framework);
 
-            var compileGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.CompileAssemblies, targetGraph.Conventions.Patterns.RuntimeAssemblies);
+            // Compile
+            var compileGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
+                new PatternSet[] { targetGraph.Conventions.Patterns.CompileAssemblies,
+                        targetGraph.Conventions.Patterns.RuntimeAssemblies});
 
-            if (compileGroup != null)
-            {
-                lockFileLib.CompileTimeAssemblies = compileGroup.Items.Select(t => new LockFileItem(t.Path)).ToList();
-            }
+            lockFileLib.CompileTimeAssemblies.AddRange(compileGroup);
 
-            var runtimeGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.RuntimeAssemblies);
-            if (runtimeGroup != null)
-            {
-                lockFileLib.RuntimeAssemblies = runtimeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
-            }
+            // Runtime
+            var runtimeGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
+                new PatternSet[] { targetGraph.Conventions.Patterns.RuntimeAssemblies });
 
-            var resourceGroup = contentItems.FindBestItemGroup(managedCriteria, targetGraph.Conventions.Patterns.ResourceAssemblies);
-            if (resourceGroup != null)
-            {
-                lockFileLib.ResourceAssemblies = resourceGroup.Items.Select(ToResourceLockFileItem).ToList();
-            }
+            lockFileLib.RuntimeAssemblies.AddRange(runtimeGroup);
 
+            // Resources
+            var resourceGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
+                new PatternSet[] { targetGraph.Conventions.Patterns.ResourceAssemblies });
+
+            lockFileLib.ResourceAssemblies.AddRange(resourceGroup);
+
+            // Native
             var nativeCriteria = targetGraph.Conventions.Criteria.ForRuntime(targetGraph.RuntimeIdentifier);
 
-            var nativeGroup = contentItems.FindBestItemGroup(nativeCriteria, targetGraph.Conventions.Patterns.NativeLibraries);
+            var nativeGroup = contentItems.FindBestItemGroup(
+                nativeCriteria,
+                targetGraph.Conventions.Patterns.NativeLibraries);
+
             if (nativeGroup != null)
             {
                 lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
@@ -282,6 +295,80 @@ namespace NuGet.Commands
             }
 
             return lockFileLib;
+        }
+
+        /// <summary>
+        /// Create lock file items for the best matching group.
+        /// </summary>
+        /// <remarks>Enumerate this once after calling.</remarks>
+        private static IEnumerable<LockFileItem> GetLockFileItems(
+            IReadOnlyList<SelectionCriteria> criteria,
+            ContentItemCollection items,
+            PatternSet[] patterns)
+        {
+            // Loop through each criteria taking the first one that matches one or more items.
+            foreach (var managedCriteria in criteria)
+            {
+                var group = items.FindBestItemGroup(
+                    managedCriteria,
+                    patterns);
+
+                if (group != null)
+                {
+                    foreach (var item in group.Items)
+                    {
+                        yield return new LockFileItem(item.Path);
+                    }
+
+                    // Take only the first group that has items
+                    break;
+                }
+            }
+
+            yield break;
+        }
+
+        /// <summary>
+        /// Creates an ordered list of selection criteria to use. This supports fallback frameworks.
+        /// </summary>
+        private static IReadOnlyList<SelectionCriteria> CreateCriteria(
+            RestoreTargetGraph targetGraph,
+            NuGetFramework framework)
+        {
+            var managedCriteria = new List<SelectionCriteria>(1);
+
+            var fallbackFramework = framework as FallbackFramework;
+
+            if (fallbackFramework == null)
+            {
+                var standardCriteria = targetGraph.Conventions.Criteria.ForFrameworkAndRuntime(
+                    framework,
+                    targetGraph.RuntimeIdentifier);
+
+                managedCriteria.Add(standardCriteria);
+            }
+            else
+            {
+                // Add the project framework
+                var primaryFramework = NuGetFramework.Parse(fallbackFramework.DotNetFrameworkName);
+                var primaryCriteria = targetGraph.Conventions.Criteria.ForFrameworkAndRuntime(
+                    primaryFramework,
+                    targetGraph.RuntimeIdentifier);
+
+                managedCriteria.Add(primaryCriteria);
+
+                // Add each fallback framework in order
+                foreach (var fallback in fallbackFramework.Fallback)
+                {
+                    var fallbackCriteria = targetGraph.Conventions.Criteria.ForFrameworkAndRuntime(
+                        fallback,
+                        targetGraph.RuntimeIdentifier);
+
+                    managedCriteria.Add(fallbackCriteria);
+                }
+            }
+
+            return managedCriteria;
         }
 
         private static bool HasItems(ContentItemGroup compileGroup)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -15,6 +15,282 @@ namespace NuGet.Commands.Test
     public class RestoreCommandTests
     {
         [Fact]
+        public async Task RestoreCommand_ImportsWithHigherVersion_NoFallback()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""imports"": [ ""netstandard1.5"" ],
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("lib/netstandard1.0/a.dll");
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+                packageAContext.AddFile("lib/net46/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.3"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.0/a.dll", compile.Path);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_ImportsWithHigherVersion_Fallback()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""imports"": [ ""netstandard1.5"" ],
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+                packageAContext.AddFile("lib/netstandard1.6/a.dll");
+                packageAContext.AddFile("lib/net46/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.3"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_ImportsWithHigherVersion_MultiFallback()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.0"": {
+                    ""imports"": [ ""netstandard1.1"", ""netstandard1.2"", ""dnxcore50""  ],
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("lib/netstandard1.2/a.dll");
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+                packageAContext.AddFile("lib/net46/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.0"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.2/a.dll", compile.Path);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_ImportsNoMatch()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.0"": {
+                    ""imports"": [ ""netstandard1.1"", ""netstandard1.2""  ],
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+                packageAContext.AddFile("lib/netstandard1.6/a.dll");
+                packageAContext.AddFile("lib/net46/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.0"), null)
+                                    .Libraries
+                                    .Single(library => library.Name == "packageA");
+
+                var compileItems = targetLib.CompileTimeAssemblies;
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, compileItems.Count);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_PackageWithSameName()
         {
             // Arrange


### PR DESCRIPTION
FindBestItemGroup works by checking the compatibility of package assets against the project framework, then compares the assets to each other to find the best match. This results in some scenarios where an imports framework wins over the project framework.

The fix for this is to run through the selection criteria for each framework in order so that only a single framework is evaluated at a time.

https://github.com/NuGet/Home/issues/2377

//cc @joelverhagen @alpaix @zhili1208 @TimBarham 
