### PR TITLE
Make PortReserver platform-independent and enable tests

### DIFF
--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -18,8 +18,7 @@
     "net46": {},
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23911",
-        "System.Net.NetworkInformation": "4.0.10-beta-23127"
+        "NETStandard.Library": "1.5.0-rc2-23911"
       },
       "imports": [
         "dotnet5.6",

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
@@ -42,12 +42,6 @@ namespace NuGet.Protocol.Core.v3.Tests
         [Fact]
         public async Task HttpSource_TimesOutDownload()
         {
-            // https://github.com/NuGet/Home/issues/2096
-            if (!RuntimeEnvironmentHelper.IsWindows)
-            {
-                return;
-            }
-            
             // Arrange
             using (var td = TestFileSystemUtility.CreateRandomTestFolder())
             {


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2096

@emgarten @yishaigalatzer @alpaix @deepakaravindr @zhili1208 
