### PR TITLE
limit findLibrary concurrency to 4

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -19,6 +19,7 @@ namespace NuGet.DependencyResolver
     public class RemoteDependencyWalker
     {
         private readonly RemoteWalkContext _context;
+        private static readonly int maxTasks = 4;
 
         public RemoteDependencyWalker(RemoteWalkContext context)
         {
@@ -585,7 +586,9 @@ namespace NuGet.DependencyResolver
             IEnumerable<IRemoteDependencyProvider> providers,
             Func<IRemoteDependencyProvider, Task<LibraryIdentity>> action)
         {
-            var tasks = new List<Task<RemoteMatch>>();
+            var tasks = new List<Task<RemoteMatch>>(maxTasks);
+            var taskRequests = new Queue<Func<Task<RemoteMatch>>>();
+
             foreach (var provider in providers)
             {
                 Func<Task<RemoteMatch>> taskWrapper = async () =>
@@ -603,33 +606,44 @@ namespace NuGet.DependencyResolver
                     return null;
                 };
 
-                tasks.Add(taskWrapper());
+                taskRequests.Enqueue(taskWrapper);
             }
 
             RemoteMatch bestMatch = null;
 
-            while (tasks.Count > 0)
+            while (taskRequests.Count > 0 || tasks.Count > 0)
             {
-                var task = await Task.WhenAny(tasks);
-                tasks.Remove(task);
-                var match = await task;
 
-                // If we found an exact match then use it.
-                // This allows us to shortcircuit slow feeds even if there's an exact match
-                if (!libraryRange.VersionRange.IsFloating &&
-                    match?.Library?.Version != null &&
-                    libraryRange.VersionRange.IsMinInclusive &&
-                    match.Library.Version.Equals(libraryRange.VersionRange.MinVersion))
+                while (taskRequests.Count > 0 && tasks.Count < maxTasks)
                 {
-                    return match;
+                    var request = taskRequests.Dequeue();
+                    var task = Task.Run(async () => await request());
+                    tasks.Add(task);
                 }
 
-                // Otherwise just find the best out of the matches
-                if (libraryRange.VersionRange.IsBetter(
-                    current: bestMatch?.Library?.Version,
-                    considering: match?.Library?.Version))
+                if (tasks.Count > 0)
                 {
-                    bestMatch = match;
+                    var doneTask = await Task.WhenAny(tasks);
+                    tasks.Remove(doneTask);
+                    var match = await doneTask;
+                   
+                    // If we found an exact match then use it.
+                    // This allows us to shortcircuit slow feeds even if there's an exact match
+                    if (!libraryRange.VersionRange.IsFloating &&
+                        match?.Library?.Version != null &&
+                        libraryRange.VersionRange.IsMinInclusive &&
+                        match.Library.Version.Equals(libraryRange.VersionRange.MinVersion))
+                    {
+                        return match;
+                    }
+
+                    // Otherwise just find the best out of the matches
+                    if (libraryRange.VersionRange.IsBetter(
+                        current: bestMatch?.Library?.Version,
+                        considering: match?.Library?.Version))
+                    {
+                        bestMatch = match;
+                    }
                 }
             }
 


### PR DESCRIPTION
Did some investigation for "open file errors", current design is for each http source, concurrency http request limit is 16 on Mac, for each http request, it at most holds three file stream at the same time, first is network stream from http response, second is cache file steam on disk, the third is lock file stream for locking. Since we share resources between projects and resources share http source between providers, parallel restore does not increase open file number. But for each source, we have one http source, increasing source number will increase open file number.

the fix here is adding concurrency limit for source providers, nuget will try at most 4 sources at the same time.
