### PR TITLE
Allow file path sources to work in XPlat (where absolute paths start with '/')

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/PackageSourceProviderExtensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/PackageSourceProviderExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Configuration;
 
 namespace NuGet.Commands
@@ -40,8 +41,8 @@ namespace NuGet.Commands
 
         private static void ValidateSource(string source)
         {
-            Uri result;
-            if (!Uri.TryCreate(source, UriKind.Absolute, out result))
+            Uri result = UriUtility.TryCreateSourceUri(source, UriKind.Absolute);
+            if (result == null)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.InvalidSource, source));
             }

--- a/src/NuGet.Core/NuGet.Common/UriUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/UriUtility.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+
+namespace NuGet.Common
+{
+    public static class UriUtility
+    {
+        /// <summary>
+        /// Same as "new Uri" except that it can handle UNIX style paths that start with '/'
+        /// </summary>
+        public static Uri CreateSourceUri(string source, UriKind kind = UriKind.Absolute)
+        {
+            source = FixSourceUri(source);
+            return new Uri(source, kind);
+        }
+
+        /// <summary>
+        /// Same as "Uri.TryCreate" except that it can handle UNIX style paths that start with '/'
+        /// </summary>
+        public static Uri TryCreateSourceUri(string source, UriKind kind)
+        {
+            source = FixSourceUri(source);
+
+            Uri uri;
+            return Uri.TryCreate(source, kind, out uri) ? uri : null;
+        }
+
+        private static string FixSourceUri(string source)
+        {
+            // UNIX absolute paths need to start with file://
+            if (Path.DirectorySeparatorChar == '/' && !string.IsNullOrEmpty(source) && source[0] == '/')
+            {
+                source = "file://" + source;
+            }
+
+            return source;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using NuGet.Common;
 
 namespace NuGet.Configuration
 {
@@ -20,6 +21,22 @@ namespace NuGet.Configuration
         public string Name { get; private set; }
 
         public string Source { get; set; }
+
+        /// <summary>
+        /// Returns null if Source is an invalid URI
+        /// </summary>
+        public Uri TrySourceAsUri
+        {
+            get { return UriUtility.TryCreateSourceUri(Source, UriKind.Absolute); }
+        }
+
+        /// <summary>
+        /// Throws if Source is an invalid URI
+        /// </summary>
+        public Uri SourceUri
+        {
+            get { return UriUtility.CreateSourceUri(Source, UriKind.Absolute); }
+        }
 
         /// <summary>
         /// This does not represent just the NuGet Official Feed alone
@@ -92,8 +109,8 @@ namespace NuGet.Configuration
             {
                 if (!_isLocal.HasValue)
                 {
-                    Uri uri;
-                    if (Uri.TryCreate(Source, UriKind.Absolute, out uri))
+                    Uri uri = TrySourceAsUri;
+                    if (uri != null)
                     {
                         _isLocal = uri.IsFile;
                     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DependencyInfoResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DependencyInfoResourceV2.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -194,7 +195,7 @@ namespace NuGet.Protocol.Core.v2
 
             if (repository != null)
             {
-                var sourceUri = new Uri(repository.Source);
+                var sourceUri = UriUtility.CreateSourceUri(repository.Source);
                 repository = new DataServicePackageRepository(sourceUri);
             }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DownloadResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DownloadResourceV2.cs
@@ -164,7 +164,7 @@ namespace NuGet.Protocol.Core.v2
             if (dataServiceRepo != null)
             {
                 // Clone the repo to allow for concurrent calls
-                var sourceUri = new Uri(dataServiceRepo.Source);
+                var sourceUri = UriUtility.CreateSourceUri(dataServiceRepo.Source);
                 dataServiceRepo = new DataServicePackageRepository(sourceUri);
 
                 var package = dataServiceRepo.FindPackage(identity.Id, version);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/V2Utilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/V2Utilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -13,7 +14,7 @@ namespace NuGet.Protocol.Core.v2
     {
         public static bool IsV2(Configuration.PackageSource source)
         {
-            var url = new Uri(source.Source);
+            var url = source.SourceUri;
 
             // If the url is a directory, then it's a V2 source
             if (url.IsFile

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v3;
@@ -66,7 +67,7 @@ namespace NuGet.Protocol
 
         public static HttpClientHandler CreateCredentialHandler(PackageSource packageSource)
         {
-            var uri = new Uri(packageSource.Source);
+            var uri = packageSource.SourceUri;
             var proxy = ProxyCache.Instance.GetProxy(uri);
 
             if (proxy != null

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -68,7 +68,7 @@ namespace NuGet.Protocol
             }
 
             _packageSource = source;
-            _baseUri = new Uri(source.Source);
+            _baseUri = source.SourceUri;
             _messageHandlerFactory = messageHandlerFactory;
             _retryHandler = new HttpRetryHandler();
         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -35,7 +36,7 @@ namespace NuGet.Protocol
 
             var withoutTrailingSlash = packageSource.Source.TrimEnd('/');
 
-            _baseUri = new Uri($"{withoutTrailingSlash}/");
+            _baseUri = UriUtility.CreateSourceUri($"{withoutTrailingSlash}/");
         }
 
         public override async Task<IEnumerable<string>> IdStartsWith(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResourceProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Protocol.Core.v3.LocalRepositories
@@ -30,8 +31,8 @@ namespace NuGet.Protocol.Core.v3.LocalRepositories
         {
             INuGetResource resource = null;
 
-            Uri uri;
-            if (!Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out uri) || uri.IsFile)
+            Uri uri = source.PackageSource.TrySourceAsUri;
+            if (uri == null || uri.IsFile)
             {
                 if (!LocalV2FindPackageByIdResource.GetNupkgFiles(source.PackageSource.Source, id: string.Empty).Any())
                 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV3FindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV3FindPackageByIdResourceProvider.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Protocol.Core.v3.LocalRepositories
@@ -24,8 +25,8 @@ namespace NuGet.Protocol.Core.v3.LocalRepositories
         {
             INuGetResource resource = null;
 
-            Uri uri;
-            if (!Uri.TryCreate(source.PackageSource.Source, UriKind.Absolute, out uri) || uri.IsFile)
+            Uri uri = source.PackageSource.TrySourceAsUri;
+            if (uri == null || uri.IsFile)
             {
                 if (Directory.Exists(source.PackageSource.Source)
                     &&

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -165,7 +165,7 @@ namespace NuGet.Protocol.Core.Types
             ILogger log,
             CancellationToken token)
         {
-            var sourceUri = new Uri(source);
+            var sourceUri = UriUtility.CreateSourceUri(source);
             var sourceName = GetSourceDisplayName(source);
 
             log.LogInformation(string.Format(CultureInfo.CurrentCulture,
@@ -369,7 +369,7 @@ namespace NuGet.Protocol.Core.Types
         // Deletes a package from a FileSystem.
         private void DeletePackageFromFileSystem(string source, string packageId, string packageVersion, ILogger logger)
         {
-            var sourceuri = new Uri(source);
+            var sourceuri = UriUtility.CreateSourceUri(source);
             var root = sourceuri.LocalPath;
             var resolver = new PackagePathResolver(sourceuri.AbsolutePath, useSideBySidePaths: true);
             resolver.GetPackageFileName(new Packaging.Core.PackageIdentity(packageId, new NuGetVersion(packageVersion)));
@@ -444,7 +444,7 @@ namespace NuGet.Protocol.Core.Types
                 value += "/";
             }
 
-            return new Uri(value);
+            return UriUtility.CreateSourceUri(value);
         }
 
         private bool IsV2LocalRepository(string root)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.PackageExtraction;
@@ -75,8 +76,8 @@ namespace NuGet.Protocol.Core.Types
 
         public static void ThrowIfInvalid(string path)
         {
-            Uri pathUri;
-            if (!Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out pathUri))
+            Uri pathUri = UriUtility.TryCreateSourceUri(path, UriKind.RelativeOrAbsolute);
+            if (pathUri == null)
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.Path_Invalid,

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/Resources/PackageSearchResourceLocal.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/Resources/PackageSearchResourceLocal.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v2;
 using NuGet.Versioning;
@@ -111,8 +112,8 @@ namespace NuGet.Protocol.VisualStudio
                 return false;
             }
 
-            Uri uri;
-            if (Uri.TryCreate(source, UriKind.Absolute, out uri))
+            Uri uri = UriUtility.TryCreateSourceUri(source, UriKind.Absolute);
+            if (uri != null)
             {
                 return (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
             }
@@ -124,8 +125,8 @@ namespace NuGet.Protocol.VisualStudio
 
         private static bool IsLocalOrUNC(string currentSource)
         {
-            Uri currentURI;
-            if (Uri.TryCreate(currentSource, UriKind.RelativeOrAbsolute, out currentURI))
+            Uri currentURI = UriUtility.TryCreateSourceUri(currentSource, UriKind.RelativeOrAbsolute);
+            if (currentURI != null)
             {
                 if (currentURI.IsFile || currentURI.IsUnc)
                 {

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -12,7 +12,7 @@ using NuGet.Versioning;
 
 namespace NuGet.Test.Utility
 {
-    public class SimpleTestPackageUtility
+    public static class SimpleTestPackageUtility
     {
         /// <summary>
         /// Creates a net45 package containing lib, build, native, tools, and contentFiles

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Logging;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class PushCommandTests
+    {
+        [Fact]
+        public async Task PushCommand_AbsolutePathSource()
+        {
+            using (TestDirectory workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange (create a test package)
+                DirectoryInfo packagePushDest = new DirectoryInfo(Path.Combine(workingDir, "packagePushDest"));
+                packagePushDest.Create();
+
+                List<PackageSource> packageSources = new List<PackageSource>();
+                packageSources.Add(new PackageSource(packagePushDest.FullName));
+
+                FileInfo packageInfo = SimpleTestPackageUtility.CreateFullPackage(workingDir, "test", "1.0.0");
+
+                // Act
+                await PushRunner.Run(
+                    Settings.LoadDefaultSettings(null, null, null),
+                    new TestPackageSourceProvider(packageSources),
+                    packageInfo.FullName,
+                    packagePushDest.FullName,
+                    null, // api key
+                    0, // timeout
+                    false, // disable buffering
+                    false, // no symbols
+                    new TestLogger());
+
+                // Assert
+                string destFile = Path.Combine(packagePushDest.FullName, packageInfo.Name);
+                Assert.Equal(true, File.Exists(destFile));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/886

Basically this is a bug in the core Uri class that they aren't going to fix any time soon. See https://github.com/dotnet/corefx/issues/1745

So we need to work around the fact that the Uri class will fail when given an absolute UNIX style path. I found all of the places in the code that converted a "source path" string into a Uri and made them use a wrapper instead. The wrapper will properly convert UNIX absolute paths to file:// Uris.

@emgarten @toddm 
