### PR TITLE
Project target framework compatibility

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -190,8 +190,11 @@ namespace NuGet.Commands
                             KnownLibraryProperties.TargetFrameworkInformation,
                             out frameworkInfoObject))
                         {
+                            // Retrieve the resolved framework name, if this is null it means that the
+                            // project is incompatible. This is marked as Unsupported.
                             var targetFrameworkInformation = (TargetFrameworkInformation)frameworkInfoObject;
-                            projectFramework = targetFrameworkInformation.FrameworkName?.DotNetFrameworkName;
+                            projectFramework = targetFrameworkInformation.FrameworkName?.DotNetFrameworkName
+                                ?? NuGetFramework.UnsupportedFramework.DotNetFrameworkName;
                         }
 
                         // Create the target entry
@@ -223,6 +226,15 @@ namespace NuGet.Commands
                             var item = new LockFileItem((string)compileAssetObject);
                             lib.CompileTimeAssemblies.Add(item);
                             lib.RuntimeAssemblies.Add(item);
+                        }
+
+                        // Add frameworkAssemblies for projects
+                        object frameworkAssembliesObject;
+                        if (localMatch.LocalLibrary.Items.TryGetValue(
+                            KnownLibraryProperties.FrameworkAssemblies,
+                            out frameworkAssembliesObject))
+                        {
+                            lib.FrameworkAssemblies.AddRange((List<string>)frameworkAssembliesObject);
                         }
 
                         target.Libraries.Add(lib);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -252,9 +252,25 @@ namespace NuGet.Commands
                     success = false;
                     foreach (var unresolved in graph.Unresolved)
                     {
-                        _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_UnresolvedDependency, unresolved.Name,
-                            unresolved.VersionRange.ToNonSnapshotRange().PrettyPrint(),
-                            graph.Name));
+                        string packageDisplayName = null;
+                        var displayVersionRange = unresolved.VersionRange.ToNonSnapshotRange().PrettyPrint();
+
+                        // Projects may not have a version range
+                        if (string.IsNullOrEmpty(displayVersionRange))
+                        {
+                            packageDisplayName = unresolved.Name;
+                        }
+                        else
+                        {
+                            packageDisplayName = $"{unresolved.Name} {displayVersionRange}";
+                        }
+
+                        var message = string.Format(CultureInfo.CurrentCulture,
+                            Strings.Log_UnresolvedDependency,
+                            packageDisplayName,
+                            graph.Name);
+
+                        _logger.LogError(message);
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -276,6 +276,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to {0} ({1}).
+        /// </summary>
+        public static string Log_FrameworkDisplay {
+            get {
+                return ResourceManager.GetString("Log_FrameworkDisplay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to {0} ({1}) / {2}.
+        /// </summary>
+        public static string Log_FrameworkRIDDisplay {
+            get {
+                return ResourceManager.GetString("Log_FrameworkRIDDisplay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Generating MSBuild file {0}..
         /// </summary>
         public static string Log_GeneratingMsBuildFile {
@@ -402,7 +420,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to {0} {1} is not compatible with {2}..
+        ///    Looks up a localized string similar to Package {0} {1} is not compatible with {2}..
         /// </summary>
         public static string Log_PackageNotCompatibleWithFx {
             get {
@@ -411,16 +429,34 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to All packages are compatible with {0}..
+        ///    Looks up a localized string similar to Package {0} {1} does not support any target frameworks..
         /// </summary>
-        public static string Log_PackagesAreCompatible {
+        public static string Log_PackageNotCompatibleWithFx_NoSupports {
             get {
-                return ResourceManager.GetString("Log_PackagesAreCompatible", resourceCulture);
+                return ResourceManager.GetString("Log_PackageNotCompatibleWithFx_NoSupports", resourceCulture);
             }
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Some packages are not compatible with {0}..
+        ///    Looks up a localized string similar to Package {0} {1} supports:.
+        /// </summary>
+        public static string Log_PackageNotCompatibleWithFx_Supports {
+            get {
+                return ResourceManager.GetString("Log_PackageNotCompatibleWithFx_Supports", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to All packages and projects are compatible with {0}..
+        /// </summary>
+        public static string Log_PackagesAndProjectsAreCompatible {
+            get {
+                return ResourceManager.GetString("Log_PackagesAndProjectsAreCompatible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to One or more packages are incompatible with {0}..
         /// </summary>
         public static string Log_PackagesIncompatible {
             get {
@@ -429,11 +465,47 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to The project &apos;{0}&apos; does not specify any target frameworks in &apos;{1}&apos;..
+        ///    Looks up a localized string similar to The project {0} does not specify any target frameworks in {1}..
         /// </summary>
         public static string Log_ProjectDoesNotSpecifyTargetFrameworks {
             get {
                 return ResourceManager.GetString("Log_ProjectDoesNotSpecifyTargetFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Project {0} is not compatible with {1}..
+        /// </summary>
+        public static string Log_ProjectNotCompatibleWithFx {
+            get {
+                return ResourceManager.GetString("Log_ProjectNotCompatibleWithFx", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Project {0} does not support any target frameworks..
+        /// </summary>
+        public static string Log_ProjectNotCompatibleWithFx_NoSupports {
+            get {
+                return ResourceManager.GetString("Log_ProjectNotCompatibleWithFx_NoSupports", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Project {0} supports:.
+        /// </summary>
+        public static string Log_ProjectNotCompatibleWithFx_Supports {
+            get {
+                return ResourceManager.GetString("Log_ProjectNotCompatibleWithFx_Supports", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to One or more projects are incompatible with {0}..
+        /// </summary>
+        public static string Log_ProjectsIncompatible {
+            get {
+                return ResourceManager.GetString("Log_ProjectsIncompatible", resourceCulture);
             }
         }
         
@@ -555,7 +627,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unable to resolve {0} {1} for {2}..
+        ///    Looks up a localized string similar to Unable to resolve &apos;{0}&apos; for &apos;{1}&apos;..
         /// </summary>
         public static string Log_UnresolvedDependency {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -142,16 +142,17 @@
     <value>{0} {1} provides a compile-time reference assembly for {2} on {3}, but there is no run-time assembly compatible with {4}.</value>
   </data>
   <data name="Log_PackageNotCompatibleWithFx" xml:space="preserve">
-    <value>{0} {1} is not compatible with {2}.</value>
+    <value>Package {0} {1} is not compatible with {2}.</value>
+    <comment>0 - package id, 1 - version, 2 - target framework</comment>
   </data>
-  <data name="Log_PackagesAreCompatible" xml:space="preserve">
-    <value>All packages are compatible with {0}.</value>
+  <data name="Log_PackagesAndProjectsAreCompatible" xml:space="preserve">
+    <value>All packages and projects are compatible with {0}.</value>
   </data>
   <data name="Log_PackagesIncompatible" xml:space="preserve">
-    <value>Some packages are not compatible with {0}.</value>
+    <value>One or more packages are incompatible with {0}.</value>
   </data>
   <data name="Log_ProjectDoesNotSpecifyTargetFrameworks" xml:space="preserve">
-    <value>The project '{0}' does not specify any target frameworks in '{1}'.</value>
+    <value>The project {0} does not specify any target frameworks in {1}.</value>
   </data>
   <data name="Log_ResolvingConflicts" xml:space="preserve">
     <value>Resolving conflicts for {0}...</value>
@@ -169,7 +170,7 @@
     <value>Skipping runtime dependency walk, no runtimes defined in project.json.</value>
   </data>
   <data name="Log_UnresolvedDependency" xml:space="preserve">
-    <value>Unable to resolve {0} {1} for {2}.</value>
+    <value>Unable to resolve '{0}' for '{1}'.</value>
   </data>
   <data name="Log_UnknownCompatibilityProfile" xml:space="preserve">
     <value>Unknown Compatibility Profile: {0}</value>
@@ -362,5 +363,32 @@
   </data>
   <data name="Warning_UnspecifiedField" xml:space="preserve">
     <value>{0} was not specified. Using '{1}'.</value>
+  </data>
+  <data name="Log_ProjectNotCompatibleWithFx" xml:space="preserve">
+    <value>Project {0} is not compatible with {1}.</value>
+  </data>
+  <data name="Log_PackageNotCompatibleWithFx_Supports" xml:space="preserve">
+    <value>Package {0} {1} supports:</value>
+    <comment>0 - package id, 1 - version</comment>
+  </data>
+  <data name="Log_ProjectNotCompatibleWithFx_Supports" xml:space="preserve">
+    <value>Project {0} supports:</value>
+  </data>
+  <data name="Log_FrameworkDisplay" xml:space="preserve">
+    <value>{0} ({1})</value>
+    <comment>0 - framwork short name, 1 - System.FrameworkName</comment>
+  </data>
+  <data name="Log_FrameworkRIDDisplay" xml:space="preserve">
+    <value>{0} ({1}) / {2}</value>
+    <comment>0 - framwork short name, 1 - System.FrameworkName, 2 - Runtime ID</comment>
+  </data>
+  <data name="Log_PackageNotCompatibleWithFx_NoSupports" xml:space="preserve">
+    <value>Package {0} {1} does not support any target frameworks.</value>
+  </data>
+  <data name="Log_ProjectNotCompatibleWithFx_NoSupports" xml:space="preserve">
+    <value>Project {0} does not support any target frameworks.</value>
+  </data>
+  <data name="Log_ProjectsIncompatible" xml:space="preserve">
+    <value>One or more projects are incompatible with {0}.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
@@ -13,5 +13,7 @@ namespace NuGet.LibraryModel
         public static readonly string MSBuildProjectPath = "NuGet.ProjectModel.MSBuildProjectPath";
         public static readonly string CompileAsset = "NuGet.ProjectModel.CompileAsset";
         public static readonly string RuntimeAsset = "NuGet.ProjectModel.RuntimeAsset";
+        public static readonly string FrameworkAssemblies = "NuGet.ProjectModel.FrameworkAssemblies";
+        public static readonly string ProjectFrameworks = "NuGet.ProjectModel.ProjectFrameworks";
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -14,6 +14,147 @@ namespace NuGet.Commands.Test
     public class CompatilibityCheckerTests
     {
         [Fact]
+        public async Task CompatilibityChecker_PackageCompatibility_VerifyAvailableFrameworks()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.0"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/netstandard1.1/a.dll");
+                packageA.AddFile("contentFiles/any/win81/a.dll");
+                packageA.AddFile("ref/netstandard1.2/a.dll");
+                packageA.AddFile("runtimes/win7-x86/lib/netstandard1.3/a.dll");
+                packageA.AddFile("runtimes/win7-x86/native/a.dll");
+                packageA.AddFile("runtimes/win8/lib/netstandard1.4/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                var issue = result.CompatibilityCheckResults.SelectMany(check => check.Issues).Single();
+
+                Assert.Equal("Package packageA 1.0.0 is not compatible with netstandard1.0 (.NETStandard,Version=v1.0). Package packageA 1.0.0 supports:\n  - netstandard1.1 (.NETStandard,Version=v1.1)\n  - netstandard1.2 (.NETStandard,Version=v1.2)\n  - win81 (Windows,Version=v8.1)".Replace("\n", Environment.NewLine), issue.Format());
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_PackageCompatibility_VerifyNoAvailableFrameworks()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.0"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                request.RequestedRuntimes.Add("win7-x86");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("ref/a.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                var issue = result.CompatibilityCheckResults.SelectMany(check => check.Issues).Single();
+
+                Assert.Equal(@"Package packageA 1.0.0 is not compatible with netstandard1.0 (.NETStandard,Version=v1.0). Package packageA 1.0.0 does not support any target frameworks.".Replace("\n", Environment.NewLine), issue.Format());
+            }
+        }
+
+        [Fact]
         public async Task CompatilibityChecker_PackageExcludeCompileRuntime_Success()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -15,6 +16,557 @@ namespace NuGet.Commands.Test
 {
     public class ProjectResolutionTests
     {
+        [Fact]
+        public async Task ProjectResolution_ProjectFrameworkAssemblyReferences()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net45"": {
+                   ""frameworkAssemblies"": {
+                     ""ReferenceA"": """",
+                     ""ReferenceB"": """",
+                   },
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var target = result.LockFile.GetTarget(NuGetFramework.Parse("net45"), null);
+                var project2Lib = target.Libraries.Where(lib => lib.Name == "project2").Single();
+                var frameworkReferences = project2Lib.FrameworkAssemblies;
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(2, frameworkReferences.Count);
+                Assert.Equal("ReferenceA", frameworkReferences[0]);
+                Assert.Equal("ReferenceB", frameworkReferences[1]);
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_RootProjectWithNoFrameworks()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""2.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, result.GetAllUnresolved().Count);
+                Assert.True(logger.ErrorMessages.Any(s => s.Contains("The project project1 does not specify any target frameworks in")));
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_ProjectReferenceWithNoTFM()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""2.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var issue = result.CompatibilityCheckResults.SelectMany(ccr => ccr.Issues).Single();
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, result.GetAllUnresolved().Count);
+                Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 does not support any target frameworks.", issue.Format());
+                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_ProjectReferenceWithInCompatibleTFM()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""2.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net46"": {
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetGraph = lockFile.GetTarget(NuGetFramework.Parse("net45"), null);
+                var project2Lib = targetGraph.Libraries.Where(lib => lib.Name == "project2").FirstOrDefault();
+
+                var issue = result.CompatibilityCheckResults.SelectMany(ccr => ccr.Issues).Single();
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, result.GetAllUnresolved().Count);
+                Assert.NotNull(project2Lib);
+                Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
+                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+
+                // Incompatible projects are marked as Unsupported
+                Assert.Equal(NuGetFramework.UnsupportedFramework.DotNetFrameworkName, project2Lib.Framework);
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_ProjectReferenceWithInCompatibleTFM_Multiple()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""2.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net46"": { },
+                ""win81"": { }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var project2Lib = lockFile.Libraries.Where(lib => lib.Name == "project2").FirstOrDefault();
+
+                var issue = result.CompatibilityCheckResults.SelectMany(ccr => ccr.Issues).Single();
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, result.GetAllUnresolved().Count);
+                Assert.NotNull(project2Lib);
+                Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports:\n  - net46 (.NETFramework,Version=v4.6)\n  - win81 (Windows,Version=v8.1)".Replace("\n", Environment.NewLine), issue.Format());
+                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_ProjectReferenceWithInCompatibleTFMNoRange()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""target"": ""project"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            var project2Json = @"
+            {
+              ""version"": ""2.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net46"": {
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project2Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var specPath2 = Path.Combine(project2.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var issue = result.CompatibilityCheckResults.SelectMany(ccr => ccr.Issues).Single();
+
+                // Assert
+                Assert.False(result.Success);
+                Assert.Equal(0, result.GetAllUnresolved().Count);
+                Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
+                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+            }
+        }
+
+        [Fact]
+        public async Task ProjectResolution_ExternalReferenceWithNoProjectJson()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0-*"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""dependencies"": {
+                ""project2"": { ""version"": ""1.0.0"" }
+              },
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                project2.Create();
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var msbuidPath1 = Path.Combine(project2.FullName, "project1.xproj");
+                var msbuidPath2 = Path.Combine(project2.FullName, "project2.csproj");
+
+                File.WriteAllText(msbuidPath1, string.Empty);
+                File.WriteAllText(msbuidPath2, string.Empty);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                request.ExternalProjects.Add(new ExternalProjectReference(
+                    "project1",
+                    spec1,
+                    msbuidPath1,
+                    new string[] { "project2" }));
+
+                request.ExternalProjects.Add(new ExternalProjectReference(
+                    "project2",
+                    null,
+                    msbuidPath2,
+                    new string[] { }));
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.Targets.Single().Libraries.Single();
+
+                // Assert
+                Assert.True(result.Success);
+
+                // External projects that did not provide a framework should leave the framework property out
+                Assert.Null(targetLib.Framework);
+            }
+        }
+
         [Fact]
         public async Task ProjectResolution_MissingProjectReference()
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -344,7 +344,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(result.Success);
                 Assert.Equal(1, result.GetAllUnresolved().Count);
-                Assert.True(logger.ErrorMessages.Contains("Unable to resolve project1 (>= 1.0.0) for .NETFramework,Version=v4.5."));
+                Assert.True(logger.ErrorMessages.Contains("Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -169,7 +169,7 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var logger = new TestLogger();
-            var framework = "net46";
+            var framework = "dotnet";
 
             using (var workingDir = CreateTestFolders())
             {
@@ -211,7 +211,7 @@ namespace NuGet.Commands.Test
                 await result.CommitAsync(logger, CancellationToken.None);
 
                 // Assert
-                Assert.True(result.Success);
+                Assert.True(result.Success, logger.ShowMessages());
             }
         }
 


### PR DESCRIPTION
This adds project to project compatibility checks to support xproj -> csproj scenarios. 
- Adds TFM checks on project references. Projects without a compatible framework will now cause restore to fail.
- Improved TFM compatibility error messages. Both projects and packages will list alternative frameworks that are supported.
- Projects now contain a FrameworkAssemblies section in the lock file

Example error messages (same format for packages and projects):

```
Project MyProj is not compatible with net45 (.NETFramework,Version=v4.5). Project MyProj supports:
 - net46 (.NETFramework,Version=v4.6)
 - win8 (Windows,Version=v8.1)

Project MyProj is not compatible with net45 (.NETFramework,Version=v4.5). Project MyProj supports: win8 (Windows,Version=v8.1)

Project MyProj is not compatible with net45 (.NETFramework,Version=v4.5). Project MyProj does not support any target frameworks.
```

Target entry `framework` property behavior
- Compatible projects will list the nearest framework
- Incompatible projects will list: Unsupported
- Unknown projects such as non-project.json based msbuild projects will not have the framework property and will always pass for compatibility.

https://github.com/NuGet/Home/issues/2104
https://github.com/NuGet/Home/issues/2349
https://github.com/dotnet/cli/issues/1657

//cc @davidfowl @alpaix @joelverhagen @zhili1208 @yishaigalatzer 
