### PR TITLE
For running on Dev15 successfully, tweaking E2E tests a little bit.

### DIFF
--- a/scripts/e2etests/NuGetFunctionalTestUtils.ps1
+++ b/scripts/e2etests/NuGetFunctionalTestUtils.ps1
@@ -20,6 +20,12 @@ function WriteToTeamCity
     [Parameter(Mandatory=$true)]
     [string]$singleResult)
 
+    if (!$singleResult)
+    {
+        # If singleResult is null or empty, simply return $false
+        return $false
+    }
+
     $parts = $singleResult -split " "
 
     if ($parts.Length -lt 3)

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -103,12 +103,14 @@ Register-TabExpansion 'Run-Test' @{
 }
 
 function Rearrange-Tests {
-    param($tests)    
+    param($tests)
 
-    if ($VSVersion -eq "12.0" -or $VSVersion -eq "14.0")
+    if ($VSVersion -eq "12.0" -or $VSVersion -eq "14.0" -or $VSVersion -eq "15.0")
     {
-        # TODO: Running PackageRestore tests on Dev12 RTM causes hang problem,
-		# so disable those tests for now.
+        # Tracked by issue: https://github.com/NuGet/Home/issues/2387
+        # And, the commit is linked to the issue
+        # TODO: PackageRestore tests should be fixed and enabled or deleted
+        # They were only ever running on Dev10.
         $tests = $tests | ? {!($_.Name -like 'Test-PackageRestore*') }
     }
 


### PR DESCRIPTION
A tracking issue has been filed for fixing PackageRestore tests or deleting them out:
https://github.com/NuGet/Home/issues/2387

@yishaigalatzer @emgarten @alpaix 
