### PR TITLE
Add or Updates Copyright, ProjectUrl and LicenseUrl to NuGet.Core project.json files

### DIFF
--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -24,7 +27,7 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "compilationOptions": {
     "emitEntryPoint": true,

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compile": [
     "../NuGet.Shared/*.cs"
   ],

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet's client configuration settings implementation.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Configuration/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Configuration/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget",
     "configuration",

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -7,7 +10,7 @@
     "../NuGet.Shared/*.cs"
   ],
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911",

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -24,7 +27,7 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -18,7 +21,7 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "description": "The understanding of target frameworks for NuGet.Packaging",
   "authors": [
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -19,7 +19,7 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet.Indexing Class Library",
   "compile": [
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
@@ -25,6 +28,6 @@
     }
   },
   "frameworks": {
-    "net45": { }
+    "net45": {}
   }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compile": [
     "../NuGet.Shared/*.cs"
   ],
@@ -15,7 +18,7 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "Logger abstractions for NuGet",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Home/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Home/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -14,7 +14,7 @@
     "../NuGet.Shared/*.cs"
   ],
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Package Management",
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "NuGet.Frameworks": {
       "target": "project"
@@ -12,7 +15,7 @@
     "../NuGet.Shared/*.cs"
   ],
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "description": "The core data structures for NuGet.Packaging",
   "authors": [
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "description": "NuGet's implementation for reading nupkg package and nuspec package specification files.",
   "authors": [
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "semver",
     "semantic versioning"

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Project Management",
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compile": [
     "../NuGet.Shared/*.cs"
   ],
@@ -13,7 +16,7 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet's protocol-level base types used for connecting to API v2 and API v3 repositories.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet Protocol v2",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet Protocol for 3.1.0 servers",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "1.0.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -13,7 +16,7 @@
   },
   "frameworks": {
     "net46": {
-      "dependencies": { }
+      "dependencies": {}
     },
     "netstandard1.5": {
       "imports": [

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet Protocol for Visual Studio",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compile": [
     "../NuGet.Shared/*.cs"
   ],
@@ -12,7 +15,7 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "description": "NuGet's dependency resolver within the NuGet.Packaging package",
   "authors": [
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -22,7 +22,7 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911"

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "shared": "*.cs",
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -12,7 +15,7 @@
     }
   },
   "frameworks": {
-    "net46": { },
+    "net46": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911",

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
   ],
   "description": "NuGet's implementation of Semantic Versioning.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Versioning/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Versioning/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "semver",
     "semantic versioning"

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "description": "SynchronizationTestApp Console Application",
   "authors": [
@@ -7,8 +7,9 @@
   "tags": [
     ""
   ],
-  "projectUrl": "",
-  "licenseUrl": "",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "emitEntryPoint": true
   },
@@ -35,6 +36,6 @@
         "portable-net45+win8"
       ]
     },
-    "net46": { }
+    "net46": {}
   }
 }

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,5 +1,8 @@
-﻿{
+{
   "version": "3.5.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },


### PR DESCRIPTION
Updates files with old ProjectUrl to have the new ProjectUrl.
Add files with projectUrl if not present.
Same with license urls and copyright information.

@yishaigalatzer @rrelyea @emgarten  @alpaix 
