### PR TITLE
Remove metadata from ToNormalizedString

### DIFF
--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -156,7 +156,9 @@ namespace NuGet.Versioning
                 {
                     range = new FloatRange(NuGetVersionFloatBehavior.Major, new NuGetVersion(new Version(0, 0)));
                 }
-                else if (starPos == versionString.Length - 1)
+                // * must appear as the last char in the string. 
+                // * cannot appear in the metadata section after the +
+                else if (starPos == versionString.Length - 1 && versionString.IndexOf('+') == -1)
                 {
                     var behavior = NuGetVersionFloatBehavior.None;
 
@@ -240,7 +242,7 @@ namespace NuGet.Versioning
                     result = MinVersion.ToNormalizedString();
                     break;
                 case NuGetVersionFloatBehavior.Prerelease:
-                    result = String.Format(new VersionFormatter(), "{0:V}-{1}*", MinVersion, _releasePrefix);
+                    result = String.Format(VersionFormatter.Instance, "{0:V}-{1}*", MinVersion, _releasePrefix);
                     break;
                 case NuGetVersionFloatBehavior.Revision:
                     result = String.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch);

--- a/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/NuGetVersion.cs
@@ -151,9 +151,13 @@ namespace NuGet.Versioning
         /// Returns the version string.
         /// </summary>
         /// <remarks>This method includes legacy behavior. Use ToNormalizedString() instead.</remarks>
+        /// <remarks>Versions with SemVer 2.0.0 components are automatically normalized.</remarks>
         public override string ToString()
         {
-            if (String.IsNullOrEmpty(_originalString))
+            // Versions with SemVer 2.0.0 components are automatically normalized,
+            // non-normalized strings are only allowed for backcompat with older versions
+            // of nuget, and those did not support SemVer 2.0.0.
+            if (string.IsNullOrEmpty(_originalString) || IsSemVer2)
             {
                 return ToNormalizedString();
             }

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
@@ -12,10 +12,21 @@ namespace NuGet.Versioning
     {
         /// <summary>
         /// Gives a normalized representation of the version.
+        /// This string is unique to the identity of the version and does not contain metadata.
         /// </summary>
         public virtual string ToNormalizedString()
         {
-            return ToString("N", new VersionFormatter());
+            return ToString("N", VersionFormatter.Instance);
+        }
+
+        /// <summary>
+        /// Gives a full representation of the version include metadata.
+        /// This string is not unique to the identity of the version. Other versions 
+        /// that differ on metadata will have a different full string representation.
+        /// </summary>
+        public virtual string ToFullString()
+        {
+            return ToString("F", VersionFormatter.Instance);
         }
 
         public override string ToString()

--- a/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionFormatter.cs
@@ -9,11 +9,16 @@ namespace NuGet.Versioning
 {
     public class VersionFormatter : IFormatProvider, ICustomFormatter
     {
+        /// <summary>
+        /// A static instance of the VersionFormatter class.
+        /// </summary>
+        public static readonly VersionFormatter Instance = new VersionFormatter();
+
         public string Format(string format, object arg, IFormatProvider formatProvider)
         {
             if (arg == null)
             {
-                throw new ArgumentNullException("arg");
+                throw new ArgumentNullException(nameof(arg));
             }
 
             string formatted = null;
@@ -72,25 +77,35 @@ namespace NuGet.Versioning
             return null;
         }
 
+        /// <summary>
+        /// Create a normalized version string. This string is unique for each version 'identity' 
+        /// and does not include leading zeros or metadata.
+        /// </summary>
         private static string GetNormalizedString(SemanticVersion version)
         {
-            var sb = new StringBuilder();
-
-            sb.Append(Format('V', version));
+            var normalized = Format('V', version);
 
             if (version.IsPrerelease)
             {
-                sb.Append('-');
-                sb.Append(version.Release);
+                normalized = $"{normalized}-{version.Release}";
             }
+
+            return normalized;
+        }
+
+        /// <summary>
+        /// Create the full version string including metadata. This is primarily for display purposes.
+        /// </summary>
+        private static string GetFullString(SemanticVersion version)
+        {
+            var fullString = GetNormalizedString(version);
 
             if (version.HasMetadata)
             {
-                sb.Append('+');
-                sb.Append(version.Metadata);
+                fullString = $"{fullString}+{version.Metadata}";
             }
 
-            return sb.ToString();
+            return fullString;
         }
 
         private static string Format(char c, SemanticVersion version)
@@ -111,18 +126,21 @@ namespace NuGet.Versioning
                 case 'V':
                     s = FormatVersion(version);
                     break;
+                case 'F':
+                    s = GetFullString(version);
+                    break;
                 case 'x':
-                    s = String.Format(CultureInfo.InvariantCulture, "{0}", version.Major);
+                    s = string.Format(CultureInfo.InvariantCulture, "{0}", version.Major);
                     break;
                 case 'y':
-                    s = String.Format(CultureInfo.InvariantCulture, "{0}", version.Minor);
+                    s = string.Format(CultureInfo.InvariantCulture, "{0}", version.Minor);
                     break;
                 case 'z':
-                    s = String.Format(CultureInfo.InvariantCulture, "{0}", version.Patch);
+                    s = string.Format(CultureInfo.InvariantCulture, "{0}", version.Patch);
                     break;
                 case 'r':
                     var nuGetVersion = version as NuGetVersion;
-                    s = String.Format(CultureInfo.InvariantCulture, "{0}", nuGetVersion != null && nuGetVersion.IsLegacyVersion ? nuGetVersion.Version.Revision : 0);
+                    s = string.Format(CultureInfo.InvariantCulture, "{0}", nuGetVersion != null && nuGetVersion.IsLegacyVersion ? nuGetVersion.Version.Revision : 0);
                     break;
             }
 
@@ -134,8 +152,8 @@ namespace NuGet.Versioning
             var nuGetVersion = version as NuGetVersion;
             var legacy = nuGetVersion != null && nuGetVersion.IsLegacyVersion;
 
-            return String.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}{3}", version.Major, version.Minor, version.Patch,
-                legacy ? String.Format(CultureInfo.InvariantCulture, ".{0}", nuGetVersion.Version.Revision) : null);
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}{3}", version.Major, version.Minor, version.Patch,
+                legacy ? string.Format(CultureInfo.InvariantCulture, ".{0}", nuGetVersion.Version.Revision) : null);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFormatter.cs
@@ -19,14 +19,14 @@ namespace NuGet.Versioning
 
         public VersionRangeFormatter()
         {
-            _versionFormatter = new VersionFormatter();
+            _versionFormatter = VersionFormatter.Instance;
         }
 
         public string Format(string format, object arg, IFormatProvider formatProvider)
         {
             if (arg == null)
             {
-                throw new ArgumentNullException("arg");
+                throw new ArgumentNullException(nameof(arg));
             }
 
             string formatted = null;
@@ -94,10 +94,10 @@ namespace NuGet.Versioning
                     s = PrettyPrint(range);
                     break;
                 case 'L':
-                    s = range.HasLowerBound ? String.Format(new VersionFormatter(), ZeroN, range.MinVersion) : string.Empty;
+                    s = range.HasLowerBound ? string.Format(VersionFormatter.Instance, ZeroN, range.MinVersion) : string.Empty;
                     break;
                 case 'U':
-                    s = range.HasUpperBound ? String.Format(new VersionFormatter(), ZeroN, range.MaxVersion) : string.Empty;
+                    s = range.HasUpperBound ? string.Format(VersionFormatter.Instance, ZeroN, range.MaxVersion) : string.Empty;
                     break;
                 case 'S':
                     s = GetToString(range);
@@ -161,7 +161,7 @@ namespace NuGet.Versioning
                 && range.IsMinInclusive
                 && !range.HasUpperBound)
             {
-                s = String.Format(_versionFormatter, ZeroN, range.MinVersion);
+                s = string.Format(_versionFormatter, ZeroN, range.MinVersion);
             }
             else if (range.HasLowerAndUpperBounds
                      && range.IsMinInclusive
@@ -171,7 +171,7 @@ namespace NuGet.Versioning
             {
                 // TODO: Does this need a specific version comparision? Does metadata matter?
 
-                s = String.Format(_versionFormatter, "[{0:N}]", range.MinVersion);
+                s = string.Format(_versionFormatter, "[{0:N}]", range.MinVersion);
             }
             else
             {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.Logging;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class RestoreSemVerTests
+    {
+        // Restore 1.0.0-alpha.1.2.3
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageWithMultipleReleaseLabels()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0-alpha.1.2.3""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1.2.3"
+                };
+
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0-alpha.1.2.3", targetLib.Version.ToNormalizedString());
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
@@ -15,6 +15,122 @@ namespace NuGet.Commands.Test
 {
     public class RestoreSemVerTests
     {
+        // Float on release label
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageFloatOnReleaseLabel()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0-alpha.1.*""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packages = new List<SimpleTestPackageContext>();
+
+                var package1 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1.10.1"
+                };
+                package1.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package1);
+
+                var package2 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1.11.1"
+                };
+                package2.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package2);
+
+                var package3 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1.9.2"
+                };
+                package3.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package3);
+
+                var package4 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1"
+                };
+                package4.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package4);
+
+                var package5 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-beta.1.99"
+                };
+                package5.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package5);
+
+                var package6 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.2.99"
+                };
+                package6.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package6);
+
+                var package7 = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0-alpha.1.2+skip"
+                };
+                package7.AddFile("lib/netstandard1.5/a.dll");
+                packages.Add(package7);
+
+                SimpleTestPackageUtility.CreatePackages(packages, packageSource.FullName);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0-alpha.1.11.1", targetLib.Version.ToNormalizedString());
+            }
+        }
+
         // Restore 1.0.0-alpha.1.2.3
         [Fact]
         public async Task RestoreSemVer_RestorePackageWithMultipleReleaseLabels()
@@ -84,6 +200,293 @@ namespace NuGet.Commands.Test
                 Assert.True(result.Success);
                 Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
                 Assert.Equal("1.0.0-alpha.1.2.3", targetLib.Version.ToNormalizedString());
+            }
+        }
+
+        // Restore 1.0.0+security.fix
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageWithMetadata_Identical()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0+security.fix""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0+security.fix"
+                };
+
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0", targetLib.Version.ToNormalizedString());
+            }
+        }
+
+        // Restore 1.0.0+security.fix where the package does not contain +security.fix
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageWithMetadata_MetadataOnlyInProjectJson()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0+security.fix""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0"
+                };
+
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0", targetLib.Version.ToNormalizedString());
+            }
+        }
+
+        // Restore 1.0.0+security.fix where the project does not contain +security.fix
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageWithMetadata_MetadataOnlyInPackage()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0+security.fix"
+                };
+
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0", targetLib.Version.ToNormalizedString());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreSemVer_RestorePackageWithMetadata_DifferentMetadataDoesNotMatter()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0+1""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA")
+                {
+                    Version = "1.0.0+B"
+                };
+
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), null)
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.Single();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("lib/netstandard1.5/a.dll", compile.Path);
+                Assert.Equal("1.0.0", targetLib.Version.ToNormalizedString());
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
@@ -328,13 +328,17 @@ namespace NuGet.Versioning.Test
             Assert.Equal("[1.*, )", range.ToNormalizedString());
         }
 
-        // TODO: fix this one the proper syntax is determined
-        //[Fact]
-        //public void FloatingRange_ToStringMajor()
-        //{
-        //    VersionRange range = VersionRange.Parse("*");
+        [Fact]
+        public void FloatingRange_FloatMetadata_Invalid()
+        {
+            // Arrange
+            FloatRange range;
 
-        //    Assert.Equal("[*, )", range.ToNormalizedString());
-        //}
+            // Act
+            var valid = FloatRange.TryParse("1.0.0+*", out range);
+
+            // Assert
+            Assert.False(valid);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/NuGetVersionTest.cs
@@ -53,17 +53,17 @@ namespace NuGet.Versioning.Test
             NuGetVersion.TryParseStrict(versionString, out semVer);
 
             // Assert
-            Assert.Equal<string>(versionString, semVer.ToNormalizedString());
-            Assert.Equal<string>(versionString, semVer.ToString());
+            Assert.Equal<string>(versionString, semVer.ToFullString());
+            Assert.Equal<string>(semVer.ToNormalizedString(), semVer.ToString());
         }
 
         [Theory]
-        [InlineData("1.0.0", "1.0.0.0", "")]
-        [InlineData("2.3-alpha", "2.3.0.0", "alpha")]
-        [InlineData("3.4.0.3-RC-3", "3.4.0.3", "RC-3")]
-        [InlineData("1.0.0-beta.x.y.5.79.0+aa", "1.0.0.0", "beta.x.y.5.79.0")]
-        [InlineData("1.0.0-beta.x.y.5.79.0+AA", "1.0.0.0", "beta.x.y.5.79.0")]
-        public void StringConstructorParsesValuesCorrectly(string version, string versionValueString, string specialValue)
+        [InlineData("1.0.0", "1.0.0.0", "", "")]
+        [InlineData("2.3-alpha", "2.3.0.0", "alpha", "")]
+        [InlineData("3.4.0.3-RC-3", "3.4.0.3", "RC-3", "")]
+        [InlineData("1.0.0-beta.x.y.5.79.0+aa", "1.0.0.0", "beta.x.y.5.79.0", "aa")]
+        [InlineData("1.0.0-beta.x.y.5.79.0+AA", "1.0.0.0", "beta.x.y.5.79.0", "AA")]
+        public void StringConstructorParsesValuesCorrectly(string version, string versionValueString, string specialValue, string metadata)
         {
             // Arrange
             var versionValue = new Version(versionValueString);
@@ -74,7 +74,7 @@ namespace NuGet.Versioning.Test
             // Assert
             Assert.Equal(versionValue, semanticVersion.Version);
             Assert.Equal(specialValue, semanticVersion.Release);
-            Assert.Equal(version, semanticVersion.ToString());
+            Assert.Equal(metadata, semanticVersion.Metadata);
         }
 
         [Fact]
@@ -95,6 +95,8 @@ namespace NuGet.Versioning.Test
         [InlineData("1.34.2Alpha")]
         [InlineData("1.34.2Release Candidate")]
         [InlineData("1.4.7-")]
+        [InlineData("1.4.7-*")]
+        [InlineData("1.4.7+*")]
         public void ParseThrowsIfStringIsNotAValidSemVer(string versionString)
         {
             ExceptionAssert.ThrowsArgumentException(() => NuGetVersion.Parse(versionString),
@@ -247,6 +249,22 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(version, semVer.ToString());
+        }
+
+        [Theory]
+        [InlineData("1.0+A", "1.0.0", "1.0.0+A")]
+        [InlineData("1.0-1.1", "1.0.0-1.1", "1.0.0-1.1")]
+        [InlineData("1.0-1.1+B.B", "1.0.0-1.1", "1.0.0-1.1+B.B")]
+        [InlineData("1.0.0009.01-1.1+A", "1.0.9.1-1.1", "1.0.9.1-1.1+A")]
+        public void ToStringReturnsNormalizedForSemVer2(string version, string expected, string full)
+        {
+            // Act
+            var semVer = NuGetVersion.Parse(version);
+
+            // Assert
+            Assert.Equal(expected, semVer.ToString());
+            Assert.Equal(expected, semVer.ToNormalizedString());
+            Assert.Equal(full, semVer.ToFullString());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/SemanticVersionTests.cs
@@ -25,8 +25,8 @@ namespace NuGet.Versioning.Test
             SemanticVersion.TryParse(versionString, out semVer);
 
             // Assert
-            Assert.Equal<string>(versionString, semVer.ToNormalizedString());
-            Assert.Equal<string>(versionString, semVer.ToString());
+            Assert.Equal<string>(versionString, semVer.ToFullString());
+            Assert.Equal<string>(semVer.ToNormalizedString(), semVer.ToString());
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionFormatterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionFormatterTests.cs
@@ -14,6 +14,27 @@ namespace NuGet.Versioning.Test
         [InlineData("1.2.3-Pre.2", "1.2.3-Pre.2")]
         [InlineData("1.2.3+99", "1.2.3+99")]
         [InlineData("1.2-Pre", "1.2.0-Pre")]
+        public void FullStringFormatTest(string versionString, string expected)
+        {
+            // arrange
+            var formatter = new VersionFormatter();
+            var version = NuGetVersion.Parse(versionString);
+
+            // act
+            var s = String.Format(formatter, "{0:F}", version);
+            var s2 = version.ToString("F", formatter);
+
+            // assert
+            Assert.Equal(expected, s);
+            Assert.Equal(expected, s2);
+        }
+
+        [Theory]
+        [InlineData("1.2.3.4-RC+99", "1.2.3.4-RC")]
+        [InlineData("1.2.3", "1.2.3")]
+        [InlineData("1.2.3-Pre.2", "1.2.3-Pre.2")]
+        [InlineData("1.2.3+99", "1.2.3")]
+        [InlineData("1.2-Pre", "1.2.0-Pre")]
         public void NormalizedFormatTest(string versionString, string expected)
         {
             // arrange

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionParsingTests.cs
@@ -37,7 +37,7 @@ namespace NuGet.Versioning.Test
             // Assert
             foreach (var v in versions)
             {
-                Assert.Equal(version, v.ToNormalizedString());
+                Assert.Equal(version, v.ToFullString());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -9,6 +9,77 @@ namespace NuGet.Versioning.Test
 {
     public class VersionRangeTests
     {
+        [Fact]
+        public void VersionRange_MetadataIsIgnored_Satisfy()
+        {
+            // Arrange
+            var noMetadata = VersionRange.Parse("[1.0.0, 2.0.0]");
+            var lowerMetadata = VersionRange.Parse("[1.0.0+A, 2.0.0]");
+            var upperMetadata = VersionRange.Parse("[1.0.0, 2.0.0+A]");
+            var bothMetadata = VersionRange.Parse("[1.0.0+A, 2.0.0+A]");
+
+            var versionNoMetadata = NuGetVersion.Parse("1.0.0");
+            var versionMetadata = NuGetVersion.Parse("1.0.0+B");
+
+            // Act & Assert
+            Assert.True(noMetadata.Satisfies(versionNoMetadata));
+            Assert.True(noMetadata.Satisfies(versionMetadata));
+            Assert.True(lowerMetadata.Satisfies(versionNoMetadata));
+            Assert.True(lowerMetadata.Satisfies(versionMetadata));
+            Assert.True(upperMetadata.Satisfies(versionNoMetadata));
+            Assert.True(upperMetadata.Satisfies(versionMetadata));
+            Assert.True(bothMetadata.Satisfies(versionNoMetadata));
+            Assert.True(bothMetadata.Satisfies(versionMetadata));
+        }
+
+        [Fact]
+        public void VersionRange_MetadataIsIgnored_Equality()
+        {
+            // Arrange
+            var noMetadata = VersionRange.Parse("[1.0.0, 2.0.0]");
+            var lowerMetadata = VersionRange.Parse("[1.0.0+A, 2.0.0]");
+            var upperMetadata = VersionRange.Parse("[1.0.0, 2.0.0+A]");
+            var bothMetadata = VersionRange.Parse("[1.0.0+A, 2.0.0+A]");
+
+            // Act & Assert
+            Assert.True(noMetadata.Equals(lowerMetadata));
+            Assert.True(lowerMetadata.Equals(upperMetadata));
+            Assert.True(upperMetadata.Equals(bothMetadata));
+            Assert.True(bothMetadata.Equals(noMetadata));
+        }
+
+        [Fact]
+        public void VersionRange_MetadataIsIgnored_FormatRemovesMetadata()
+        {
+            // Arrange
+            var bothMetadata = VersionRange.Parse("[1.0.0+A, 2.0.0+A]");
+
+            // Act & Assert
+            Assert.Equal("[1.0.0, 2.0.0]", bothMetadata.ToString());
+            Assert.Equal("[1.0.0, 2.0.0]", bothMetadata.ToNormalizedString());
+            Assert.Equal("[1.0.0, 2.0.0]", bothMetadata.ToLegacyString());
+        }
+
+        [Fact]
+        public void VersionRange_MetadataIsIgnored_FormatRemovesMetadata_Short()
+        {
+            // Arrange
+            var bothMetadata = VersionRange.Parse("[1.0.0+A, )");
+
+            // Act & Assert
+            Assert.Equal("1.0.0", bothMetadata.ToLegacyShortString());
+        }
+
+        [Fact]
+        public void VersionRange_MetadataIsIgnored_FormatRemovesMetadata_PrettyPrint()
+        {
+            // Arrange
+            var bothMetadata = VersionRange.Parse("[1.0.0+A, )");
+
+            // Act & Assert
+            Assert.Equal("(>= 1.0.0)", bothMetadata.PrettyPrint());
+        }
+
         [Theory]
         [InlineData("1.0.0", "1.0.0")]
         [InlineData("1.0.0-beta", "1.0.0-beta")]
@@ -224,36 +295,36 @@ namespace NuGet.Versioning.Test
         }
 
         [Theory]
-        [InlineData("1.2.0")]
-        [InlineData("1.2.3")]
-        [InlineData("1.2.3-beta")]
-        [InlineData("1.2.3-beta+900")]
-        [InlineData("1.2.3-beta.2.4.55.X+900")]
-        [InlineData("1.2.3-0+900")]
-        [InlineData("[1.2.0]")]
-        [InlineData("[1.2.3]")]
-        [InlineData("[1.2.3-beta]")]
-        [InlineData("[1.2.3-beta+900]")]
-        [InlineData("[1.2.3-beta.2.4.55.X+900]")]
-        [InlineData("[1.2.3-0+90]")]
-        [InlineData("(, 1.2.0]")]
-        [InlineData("(, 1.2.3]")]
-        [InlineData("(, 1.2.3-beta]")]
-        [InlineData("(, 1.2.3-beta+900]")]
-        [InlineData("(, 1.2.3-beta.2.4.55.X+900]")]
-        [InlineData("(, 1.2.3-0+900]")]
-        public void ParseVersionRangeToStringShortHand(string version)
+        [InlineData("1.2.0", "1.2.0")]
+        [InlineData("1.2.3", "1.2.3")]
+        [InlineData("1.2.3-beta", "1.2.3-beta")]
+        [InlineData("1.2.3-beta+900", "1.2.3-beta")]
+        [InlineData("1.2.3-beta.2.4.55.X+900", "1.2.3-beta.2.4.55.X")]
+        [InlineData("1.2.3-0+900", "1.2.3-0")]
+        [InlineData("[1.2.0]", "[1.2.0]")]
+        [InlineData("[1.2.3]", "[1.2.3]")]
+        [InlineData("[1.2.3-beta]", "[1.2.3-beta]")]
+        [InlineData("[1.2.3-beta+900]", "[1.2.3-beta]")]
+        [InlineData("[1.2.3-beta.2.4.55.X+900]", "[1.2.3-beta.2.4.55.X]")]
+        [InlineData("[1.2.3-0+90]", "[1.2.3-0]")]
+        [InlineData("(, 1.2.0]", "(, 1.2.0]")]
+        [InlineData("(, 1.2.3]", "(, 1.2.3]")]
+        [InlineData("(, 1.2.3-beta]", "(, 1.2.3-beta]")]
+        [InlineData("(, 1.2.3-beta+900]", "(, 1.2.3-beta]")]
+        [InlineData("(, 1.2.3-beta.2.4.55.X+900]", "(, 1.2.3-beta.2.4.55.X]")]
+        [InlineData("(, 1.2.3-0+900]", "(, 1.2.3-0]")]
+        public void ParseVersionRangeToStringShortHand(string version, string expected)
         {
             // Act
             var versionInfo = VersionRange.Parse(version);
 
             // Assert
-            Assert.Equal(version, versionInfo.ToString("S", new VersionRangeFormatter()));
+            Assert.Equal(expected, versionInfo.ToString("S", new VersionRangeFormatter()));
         }
 
         [Theory]
         [InlineData("1.2.0", "[1.2.0, )")]
-        [InlineData("1.2.3-beta.2.4.55.X+900", "[1.2.3-beta.2.4.55.X+900, )")]
+        [InlineData("1.2.3-beta.2.4.55.X+900", "[1.2.3-beta.2.4.55.X, )")]
         [InlineData("[1.2.0)", "[1.2.0, 1.2.0)")]
         public void ParseVersionRangeToString(string version, string expected)
         {


### PR DESCRIPTION
NuGet uses `normalized` to mean unique to the package identity. This change moves SemVer 2.0.0 metadata out of ToNormalizedString and into ToFullString. Callers expect the normalized string to be unique such as in the case of version folders and url construction for the v3 feed, however Metadata (the section after the `+` in a version) breaks this by adding a comment to the version which has no impact on the meaning of the version itself.

Callers can still get this metadata info, but will need to opt into retrieving this by calling ToFullString(), NuGetVersion.Metadata, or by using the version formatter directly. Today there are no places in NuGet which need this metadata info, but it could potentially be displayed in the UI. This change ensures that the info may be carried along with the version, but that it will be primarily ignored by the client.

Note, Metadata was already ignored for all equality and comparison checks, this change just removes it from the ToString operations also.

//cc @joelverhagen @alpaix @zhili1208 @johnataylor 
