### PR TITLE
3.4.1 Branch and fixes. PR against release-3.4.1 branch

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -33,7 +33,7 @@
 		-->
 		<SemanticVersionMajor>3</SemanticVersionMajor>
 		<SemanticVersionMinor>4</SemanticVersionMinor>
-		<SemanticVersionPatch>0</SemanticVersionPatch>
+		<SemanticVersionPatch>1</SemanticVersionPatch>
 		<PreReleaseVersion>0</PreReleaseVersion>
 	</PropertyGroup>
 

--- a/src/NuGet.Clients/NuGet.CommandLine/project.json
+++ b/src/NuGet.Clients/NuGet.CommandLine/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.PackageManagement": "3.4.0-*"
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.Credentials/project.json
+++ b/src/NuGet.Clients/NuGet.Credentials/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*"
+    "NuGet.PackageManagement": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-*",
+    "NuGet.Resolver": "3.4.1-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-*"
+    "NuGet.Resolver": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSourceMoniker.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSourceMoniker.cs
@@ -13,6 +13,14 @@ namespace NuGet.PackageManagement.UI
 
         public string SourceName { get; private set; }
 
+        public bool IsAggregateSource
+        {
+            get
+            {
+                return SourceRepositories.Length > 1;
+            }
+        }
+
         public PackageSourceMoniker(string sourceName, IEnumerable<SourceRepository> sourceRepositories)
         {
             SourceName = sourceName;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -485,13 +485,13 @@ namespace NuGet.PackageManagement.UI
                     // if the old active source still exists. Keep it as the active source.
                     .FirstOrDefault(i => StringComparer.CurrentCultureIgnoreCase.Equals(i.SourceName, selectedSourceName))
                     // If the old active source does not exist any more. In this case,
-                    // use the first eneabled source as the active source.
-                    ?? PackageSources.FirstOrDefault();
+                    // use the first (non-aggregate) enabled source as the active source.
+                    ?? PackageSources.FirstOrDefault(psm => !psm.IsAggregateSource);
             }
             else
             {
-                // use the first enabled source as the active source by default
-                SelectedSource = PackageSources.FirstOrDefault();
+                // use the first enabled source as the active source by default, but do not choose "All sources"!
+                SelectedSource = PackageSources.FirstOrDefault(psm => !psm.IsAggregateSource);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.UI/project.json
+++ b/src/NuGet.Clients/PackageManagement.UI/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
@@ -13,11 +13,11 @@
     "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
-    "NuGet.Indexing": "3.4.0-*",
-    "NuGet.PackageManagement": "3.4.0-*",
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*",
-    "NuGet.Resolver": "3.4.0-*"
+    "NuGet.Indexing": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*",
+    "NuGet.Resolver": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
-    "NuGet.Common": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.Common": "3.4.1-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/SampleCommandLineExtensions/project.json
+++ b/src/NuGet.Clients/SampleCommandLineExtensions/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.PackageManagement": "3.4.0-*"
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/StandaloneConsole/project.json
+++ b/src/NuGet.Clients/StandaloneConsole/project.json
@@ -1,11 +1,11 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*",
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*",
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
     "System.Management.Automation_PowerShell_3.0": "6.3.9600.17400",
-    "Test.Utility": "3.4.0-*"
+    "Test.Utility": "3.4.1-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/StandaloneUI/project.json
+++ b/src/NuGet.Clients/StandaloneUI/project.json
@@ -1,11 +1,11 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.PackageManagement": "3.4.0-*",
-    "Test.Utility": "3.4.0-*"
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "Test.Utility": "3.4.1-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/VisualStudio/project.json
+++ b/src/NuGet.Clients/VisualStudio/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Protocol.VisualStudio": "3.4.0-*"
+    "NuGet.Protocol.VisualStudio": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/Console.Types/project.json
+++ b/src/NuGet.Clients/VsConsole/Console.Types/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*"
+    "NuGet.PackageManagement": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-*"
+    "NuGet.Resolver": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*"
+    "NuGet.PackageManagement": "3.4.1-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsExtension/project.json
+++ b/src/NuGet.Clients/VsExtension/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "dependencies": {
     "Lucene.Net": "3.0.3",
     "Microsoft.IdentityModel.Clients.ActiveDirectory": "2.16.204221202",
@@ -19,8 +19,8 @@
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Microsoft.VSSDK.BuildTools": "14.0.23107",
     "Microsoft.WindowsAzure.ConfigurationManager": "1.7.0",
-    "NuGet.Commands": "3.4.0-*",
-    "NuGet.Indexing": "3.4.0-*",
+    "NuGet.Commands": "3.4.1-*",
+    "NuGet.Indexing": "3.4.1-*",
     "System.IdentityModel.Tokens.Jwt": "4.0.0"
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -15,9 +18,11 @@
     }
   },
   "frameworks": {
-    "net45": { },
+    "net45": {},
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ]
+      "imports": [
+        "portable-net45+win8"
+      ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,16 +1,16 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-*",
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Repositories": "3.4.0-*",
-    "NuGet.RuntimeModel": "3.4.0-*",
-    "NuGet.ContentModel": "3.4.0-*",
+    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Repositories": "3.4.1-*",
+    "NuGet.RuntimeModel": "3.4.1-*",
+    "NuGet.ContentModel": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "compilationOptions": {
     "emitEntryPoint": true,
@@ -32,7 +35,9 @@
       }
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Threading.Tasks": "4.0.11-beta-23516",
         "System.Console": "4.0.0-beta-23409"

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "compilationOptions": {
     "emitEntryPoint": true,
@@ -12,9 +12,9 @@
     },
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
     "Microsoft.NETCore.Platforms": "1.0.1-beta-*",
-    "NuGet.Commands": "3.4.0-*",
+    "NuGet.Commands": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     },
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23826",

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "compilationOptions": {
     "warningsAsErrors": true
@@ -56,7 +59,9 @@
       }
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Collections": "4.0.10-beta-23109",
         "System.Linq.Parallel": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "compilationOptions": {
     "warningsAsErrors": true
@@ -17,14 +17,14 @@
     "../../../tools/compiler/preprocess/Internalization.cs"
   ],
   "dependencies": {
-    "NuGet.Client": "3.4.0-*",
-    "NuGet.ContentModel": "3.4.0-*",
-    "NuGet.ProjectModel": "3.4.0-*",
-    "NuGet.Configuration": "3.4.0-*",
-    "NuGet.DependencyResolver": "3.4.0-*",
-    "NuGet.RuntimeModel": "3.4.0-*",
+    "NuGet.Client": "3.4.1-*",
+    "NuGet.ContentModel": "3.4.1-*",
+    "NuGet.ProjectModel": "3.4.1-*",
+    "NuGet.Configuration": "3.4.1-*",
+    "NuGet.DependencyResolver": "3.4.1-*",
+    "NuGet.RuntimeModel": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet's client configuration settings implementation.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Configuration/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Configuration/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget",
     "configuration",

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -16,10 +16,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-*",
+    "NuGet.Common": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,12 +1,12 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,17 +1,17 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.LibraryModel": "3.4.0-*",
-    "NuGet.Frameworks": "3.4.0-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-*",
-    "NuGet.Repositories": "3.4.0-*",
-    "NuGet.RuntimeModel": "3.4.0-*",
+    "NuGet.LibraryModel": "3.4.1-*",
+    "NuGet.Frameworks": "3.4.1-*",
+    "NuGet.Protocol.Core.v3": "3.4.1-*",
+    "NuGet.Repositories": "3.4.1-*",
+    "NuGet.RuntimeModel": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -17,7 +20,9 @@
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ]
+      "imports": [
+        "portable-net45+win8"
+      ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,15 +1,15 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-*",
-    "NuGet.DependencyResolver.Core": "3.4.0-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Protocol.Core.v3": "3.4.1-*",
+    "NuGet.DependencyResolver.Core": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -15,7 +18,9 @@
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ]
+      "imports": [
+        "portable-net45+win8"
+      ]
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -5,8 +5,8 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "The understanding of target frameworks for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Versioning": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet.Indexing Class Library",
   "compile": [
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
@@ -20,6 +23,6 @@
     "NuGet.Protocol.Core.Types": "3.4.1-*"
   },
   "frameworks": {
-    "net45": { }
+    "net45": {}
   }
 }

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet.Indexing Class Library",
   "compile": [
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
@@ -16,8 +16,8 @@
   ],
   "dependencies": {
     "Lucene.Net": "3.0.3",
-    "NuGet.Versioning": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*"
+    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*"
   },
   "frameworks": {
     "net45": { }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "NuGet.Versioning": "3.4.1-*",
     "NuGet.Shared": {

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,10 +1,10 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Versioning": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "Logger abstractions for NuGet",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Home/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Home/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -13,7 +13,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,16 +1,16 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet Package Management",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.Commands": "3.4.0-*",
-    "NuGet.Protocol.Core.v2": "3.4.0-*",
-    "NuGet.Resolver": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.Commands": "3.4.1-*",
+    "NuGet.Protocol.Core.v2": "3.4.1-*",
+    "NuGet.Resolver": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Package Management",
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,11 +1,11 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     },
-    "NuGet.Frameworks": "3.4.0-*"
+    "NuGet.Frameworks": "3.4.1-*"
   },
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -5,8 +5,8 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "The core data structures for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging.Core.Types": "3.4.0-*",
+    "NuGet.Packaging.Core.Types": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet's implementation for reading nupkg package and nuspec package specification files.",
   "authors": [
     "NuGet"
@@ -15,15 +15,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-*",
-    "NuGet.Frameworks": "3.4.0-*",
+    "NuGet.Common": "3.4.1-*",
+    "NuGet.Frameworks": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     },
-    "NuGet.Packaging.Core": "3.4.0-*",
-    "NuGet.Logging": "3.4.0-*",
-    "NuGet.Versioning": "3.4.0-*"
+    "NuGet.Packaging.Core": "3.4.1-*",
+    "NuGet.Logging": "3.4.1-*",
+    "NuGet.Versioning": "3.4.1-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -5,8 +5,8 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "semver",
     "semantic versioning"

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,14 +1,14 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet Project Management",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
-    "NuGet.ProjectModel": "3.4.0-*",
+    "NuGet.ProjectModel": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Project Management",
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
     "NuGet.DependencyResolver.Core": "3.4.1-*",
@@ -14,7 +17,9 @@
   "frameworks": {
     "net45": {},
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Dynamic.Runtime": "4.0.10-*"
       }

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,11 +1,11 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.DependencyResolver.Core": "3.4.0-*",
+    "NuGet.DependencyResolver.Core": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet's protocol-level base types used for connecting to API v2 and API v3 repositories.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-*",
-    "NuGet.Configuration": "3.4.0-*",
-    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Common": "3.4.1-*",
+    "NuGet.Configuration": "3.4.1-*",
+    "NuGet.Packaging": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet Protocol v2",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -14,13 +14,13 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.0-*",
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*",
+    "NuGet.Configuration": "3.4.1-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*",
     "NuGet.Core": "2.11.0",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -16,11 +16,11 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     },
-    "NuGet.Logging": "3.4.0-*",
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*",
+    "NuGet.Logging": "3.4.1-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*",
     "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet Protocol for 3.1.0 servers",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],
@@ -34,7 +34,9 @@
       }
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Dynamic.Runtime": "4.0.10-beta-23109",
         "System.Net.Http.WinHttpHandler": "4.0.0-beta-23409",

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "version": "1.0.0-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-*"
+    "NuGet.Protocol.Core.v3": "3.4.1-*"
   },
   "frameworks": {
     "dnx451": {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -1,5 +1,8 @@
 {
   "version": "1.0.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -11,7 +14,9 @@
       "dependencies": {}
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.Runtime": "4.0.20-beta-23109",
         "System.Net.Http": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet Protocol for Visual Studio",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Protocol/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Protocol/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "nuget protocol"
   ],

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.0-*",
-    "NuGet.Protocol.Core.v2": "3.4.0-*",
-    "NuGet.Protocol.Core.v3": "3.4.0-*",
+    "NuGet.Configuration": "3.4.1-*",
+    "NuGet.Protocol.Core.v2": "3.4.1-*",
+    "NuGet.Protocol.Core.v3": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "NuGet.Packaging": "3.4.1-*",
     "NuGet.Shared": {

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,10 +1,10 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Packaging": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -5,8 +5,8 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Packaging/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Packaging/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "description": "NuGet's dependency resolver within the NuGet.Packaging package",
   "authors": [
     "NuGet"
@@ -11,11 +11,11 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Protocol.Core.Types": "3.4.0-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Protocol.Core.Types": "3.4.1-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -7,10 +7,10 @@
     "Newtonsoft.Json": "6.0.4",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     },
-    "NuGet.Versioning": "3.4.0-*",
-    "NuGet.Frameworks": "3.4.0-*"
+    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Frameworks": "3.4.1-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -19,7 +22,9 @@
       }
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.IO.FileSystem": "4.0.0-beta-23109",
         "System.Collections": "4.0.10-beta-23109",

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
     "shared": "*.cs",
     "frameworks": {
         "net45": {

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
     "shared": "*.cs",
     "frameworks": {
         "net45": {

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,10 +1,10 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.0-*"
+    "NuGet.Common": "3.4.1-*"
   },
   "frameworks": {
     "dnx451": { },

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -7,7 +10,7 @@
     "NuGet.Common": "3.4.1-*"
   },
   "frameworks": {
-    "dnx451": { },
+    "dnx451": {},
     "dnxcore50": {
       "dependencies": {
         "System.Net.NetworkInformation": "4.0.10-beta-23019",

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,11 +1,11 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
     "xunit": "2.1.0",
-    "NuGet.Packaging": "3.4.0-*"
+    "NuGet.Packaging": "3.4.1-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },
@@ -14,7 +17,9 @@
       }
     },
     "dnxcore50": {
-      "imports": [ "portable-net45+win8" ],
+      "imports": [
+        "portable-net45+win8"
+      ],
       "dependencies": {
         "System.IO.Compression.ZipFile": "4.0.0-beta-23109",
         "System.IO.FileSystem": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -5,8 +5,8 @@
   ],
   "description": "NuGet's implementation of Semantic Versioning.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Versioning/",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Versioning/master/LICENSE",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "tags": [
     "semver",
     "semantic versioning"

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -1,5 +1,5 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "authors": [
     "NuGet"
   ],
@@ -17,7 +17,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.0-*"
+      "version": "3.4.1-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "version": "1.0.0-*",
     "description": "SynchronizationTestApp Console Application",
     "authors": [ "yigalatz" ],
@@ -11,9 +11,9 @@
     },
 
   "dependencies": {
-    "NuGet.Common": "3.4.0-*",
+    "NuGet.Common": "3.4.1-*",
     "NuGet.Shared": {
-      "version": "3.4.0-*",
+      "version": "3.4.1-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -1,11 +1,11 @@
 {
     "version": "1.0.0-*",
+    "copyright": "Copyright .NET Foundation. All rights reserved.",
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
     "description": "SynchronizationTestApp Console Application",
     "authors": [ "yigalatz" ],
     "tags": [ "" ],
-    "projectUrl": "",
-    "licenseUrl": "",
-
     "compilationOptions": {
         "emitEntryPoint": true
     },

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,15 +1,15 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.0-*",
-    "NuGet.ProjectManagement": "3.4.0-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
     "Microsoft.VisualStudio.ProjectSystem.Interop": "1.0.0",
     "xunit": "2.1.0",
-    "NuGet.Test.Utility": "3.4.0-*"
+    "NuGet.Test.Utility": "3.4.1-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,5 +1,8 @@
 {
   "version": "3.4.1-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "projectUrl": "https://github.com/NuGet/NuGet.Client",
+  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
     "warningsAsErrors": true
   },

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-*",
+    "Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-*",
+    "Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-*",
+    "Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.VisualStudio.OLE.Interop": "7.10.6070",
     "Microsoft.VisualStudio.Services.Client": "14.83.2",
@@ -16,7 +16,7 @@
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.0-*",
+    "Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Commands": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Protocol.Core.v3": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Client": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Client": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.CommandLine.XPlat": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.CommandLine.XPlat": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Commands": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.0-*",
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Common": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Common": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -1,10 +1,10 @@
 {
     "dependencies": {
-        "NuGet.Configuration": "3.4.0-*",
+        "NuGet.Configuration": "3.4.1-*",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-rc1-build204",
-        "NuGet.Test.Utility": "3.4.0-*",
-        "NuGet.Common": "3.4.0-*"
+        "NuGet.Test.Utility": "3.4.1-*",
+        "NuGet.Common": "3.4.1-*"
     },
     "commands": {
         "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver.Core": "3.4.0-*",
+    "NuGet.DependencyResolver.Core": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -1,7 +1,7 @@
-﻿{
+{
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver": "3.4.0-*",
+    "NuGet.DependencyResolver": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.0-*",
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Frameworks": "3.4.0-*",
-    "NuGet.Packaging": "3.4.0-*",
+    "NuGet.Frameworks": "3.4.1-*",
+    "NuGet.Packaging": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
@@ -1,9 +1,9 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Indexing": "3.4.0-*",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.Indexing": "3.4.1-*",
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -1,7 +1,7 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.0-*",
+    "NuGet.ProjectModel": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Logging": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Logging": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.4.0-*",
+  "version": "3.4.1-*",
   "dependencies": {
     "Moq": "4.2.1510.2205",
-    "NuGet.PackageManagement": "3.4.0-*",
-    "Test.Utility": "3.4.0-*",
+    "NuGet.PackageManagement": "3.4.1-*",
+    "Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Packaging.Core": "3.4.0-*",
+    "NuGet.Packaging.Core": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Packaging": "3.4.0-*",
-    "NuGet.Test.Utility": "3.4.0-*",
+    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Test.Utility": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -1,10 +1,10 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.0-*",
+    "NuGet.ProjectManagement": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "Test.Utility": "3.4.0-*"
+    "Test.Utility": "3.4.1-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.0-*",
+    "NuGet.ProjectModel": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.0-*",
+    "NuGet.Protocol.Core.v3": "3.4.1-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "NuGet.Test.Utility": "3.4.0-*",
-    "NuGet.Test.Server": "3.4.0-*"
+    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Test.Server": "3.4.1-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -1,8 +1,8 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Protocol.VisualStudio": "3.4.0-*",
+    "NuGet.Protocol.VisualStudio": "3.4.1-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.Resolver": "3.4.0-*",
+    "NuGet.Resolver": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -1,7 +1,7 @@
-﻿{
-  "version": "3.4.0-*",
+{
+  "version": "3.4.1-*",
   "dependencies": {
-    "NuGet.RuntimeModel": "3.4.0-*",
+    "NuGet.RuntimeModel": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -1,12 +1,12 @@
-﻿{
-    "version": "3.4.0-*",
+{
+    "version": "3.4.1-*",
     "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
         "NuGet.Shared": {
-            "version": "3.4.0-*",
+            "version": "3.4.1-*",
             "type": "build"
         },
-        "NuGet.Test.Utility": "3.4.0-*",
+        "NuGet.Test.Utility": "3.4.1-*",
         "SynchronizationTestApp": "1.0.0-*",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-rc1-build204"

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -1,6 +1,6 @@
-﻿{
+{
   "dependencies": {
-    "NuGet.Versioning": "3.4.0-*",
+    "NuGet.Versioning": "3.4.1-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },


### PR DESCRIPTION
There are 3 commits in the PR.
1. First commit changes version from 3.4.0 to 3.4.1 on project.json and build\common.props file for updating version on NuGet.Core projects and NuGet.Clients respectively.
2. Second commit has the fix for "All" not being the default. Issue: https://github.com/NuGet/Home/issues/2370 
3. Third commit contains the Project Url and License Url changes.

NOTE: Built all the binaries locally and verified the Product Version, File Version and Copyright on the dlls. Also, verified that the versions of the nupkgs generated is 3.4.1-*.

For some reason, copyright on many NuGet dlls change to "Microsoft Corporation" from ".NET Foundation". Not sure if this is intended. Need to look into this

@yishaigalatzer @rrelyea @emgarten 
