### PR TITLE
Only DeleteOnClose when running under Windows for global lock

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -36,7 +36,19 @@ namespace NuGet.Common
                 {
                     try
                     {
-                        // This file is deleted when the stream is closed.
+                        FileOptions options;
+                        if (RuntimeEnvironmentHelper.IsWindows)
+                        {
+                            
+                            // This file is deleted when the stream is closed.
+                            options = FileOptions.DeleteOnClose;
+                        }
+                        else
+                        {
+                            // FileOptions.DeleteOnClose causes concurrency issues on Mac OS X and Linux.
+                            options = FileOptions.None;
+                        }
+
                         // Sync operations have shown much better performance than FileOptions.Asynchronous
                         fs = new FileStream(
                             lockPath,
@@ -44,7 +56,7 @@ namespace NuGet.Common
                             FileAccess.ReadWrite,
                             FileShare.None,
                             bufferSize: 32,
-                            options: FileOptions.DeleteOnClose);
+                            options: options);
                     }
                     catch (DirectoryNotFoundException)
                     {


### PR DESCRIPTION
1. Loop more in global lock stress test. This causes a global lock failure to reproduce on Mac OS X and Linux. Multiple threads get access to the same lock at the same time.
2. Only `FileOptions.DeleteOnClose` when running under Windows when opening the global lock `FileStream`. We need to come up with a cleanup story for the other platforms.

@emgarten @yishaigalatzer @stephentoub @zhili1208 @alpaix 
