### PR TITLE
Issue 1496: Update outputs nothing when no packages.config.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -238,6 +238,11 @@ namespace NuGet.CommandLine
             var sourceRepositoryProvider = GetSourceRepositoryProvider();
             var packageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, packagesDirectory);
             var nugetProject = new MSBuildNuGetProject(project, packagesDirectory, project.ProjectFullPath);
+            if (!nugetProject.PackagesConfigNuGetProject.PackagesConfigExists())
+            {
+                throw new CommandLineException(LocalizedResourceManager.GetString("NoPackagesConfig"));
+            }
+
             var versionConstraints = Safe ?
                 VersionConstraints.ExactMajor | VersionConstraints.ExactMinor :
                 VersionConstraints.None;

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -6253,6 +6253,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to update. The project does not contain a packages.config file..
+        /// </summary>
+        public static string NoPackagesConfig {
+            get {
+                return ResourceManager.GetString("NoPackagesConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No projects found with packages.config..
         /// </summary>
         public static string NoProjectsFound {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -252,6 +252,9 @@
   <data name="InvalidFile" xml:space="preserve">
     <value>No packages.config, project or solution file specified. Use the -self switch to update NuGet.exe.</value>
   </data>
+  <data name="NoPackagesConfig" xml:space="preserve">
+    <value>Unable to update. The project does not contain a packages.config file.</value>
+  </data>
   <data name="PackageDoesNotExist" xml:space="preserve">
     <value>Unable to locate '{0} {1}'. Make sure all packages exist in the packages folder before running update.</value>
   </data>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -689,9 +689,11 @@ namespace NuGet.PackageManagement
                 packageTargetIdsForResolver.Add(packageIdToInstall);
             }
 
+            var projectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
             var nuGetProjectActions = new List<NuGetProjectAction>();
             if (!packageTargetIdsForResolver.Any())
             {
+                nuGetProjectContext.Log(NuGet.ProjectManagement.MessageLevel.Info, Strings.NoPackagesInProject, projectName);
                 return nuGetProjectActions;
             }
 
@@ -702,7 +704,6 @@ namespace NuGet.PackageManagement
                 var contextForGather = new ResolutionContext(resolutionContext.DependencyBehavior, includePrereleaseInGather, resolutionContext.IncludeUnlisted, VersionConstraints.None);
 
                 // Step-1 : Get metadata resources using gatherer
-                var projectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
                 var targetFramework = nuGetProject.GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
                 nuGetProjectContext.Log(NuGet.ProjectManagement.MessageLevel.Info, Strings.AttemptingToGatherDependencyInfoForMultiplePackages, projectName, targetFramework);
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -222,6 +222,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to No packages were found in packages.config for project &apos;{0}&apos;..
+        /// </summary>
+        internal static string NoPackagesInProject {
+            get {
+                return ResourceManager.GetString("NoPackagesInProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to There are no new updates available..
         /// </summary>
         internal static string NoUpdatesAvailable {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -201,6 +201,9 @@
   <data name="AttemptingToGatherDependencyInfoForMultiplePackages" xml:space="preserve">
     <value>Attempting to gather dependency information for multiple packages with respect to project '{0}', targeting '{1}'</value>
   </data>
+  <data name="NoPackagesInProject" xml:space="preserve">
+    <value>No packages were found in packages.config for project '{0}'.</value>
+  </data>
   <data name="AttemptingToResolveDependenciesForMultiplePackages" xml:space="preserve">
     <value>Attempting to resolve dependencies for multiple packages.</value>
   </data>

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/PackagesConfigNuGetProject.cs
@@ -217,6 +217,16 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
+        /// Checks if there is a packages.config or packages.'projectName'.config file in the current project.
+        /// </summary>
+        /// <returns></returns>
+        public bool PackagesConfigExists()
+        {
+            UpdateFullPath();
+            return File.Exists(FullPath);
+        }
+
+        /// <summary>
         /// Retrieve the packages.config XML.
         /// This will return null if the file does not exist.
         /// </summary>


### PR DESCRIPTION
Throw an exception when try to call `update` on a `csproj` when there is no `packages.config`.

Also, output a message when there _is_ a `packages.config`, but it lists no packages.
