### PR TITLE
Send package payload in chunks to avoid multiple sends when auth is required

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -280,6 +280,10 @@ namespace NuGet.Protocol.Core.Types
             //not tied to actual package name.  
             content.Add(packageContent, "package", "package.nupkg");
             request.Content = content;
+
+            // Send the data in chunks so that it can be canceled if auth fails.
+            // Otherwise the whole package needs to be sent to the server before the PUT fails.
+            request.Headers.TransferEncodingChunked = true;
 
             if (!string.IsNullOrEmpty(apiKey))
             {


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/1501

When we PUT a package to the server with Content-Length in the header, we must send the whole content. If auth fails, then we need to retry and send it all again.

This change will remove the Content-Length and use Transfer-Encoding:chunked instead. That way if the server responds with 401, we can stop sending chunks. It'll probably respond before the first chunk is even sent since .NET waits 350ms before starting to send data.

For servers that know about this, they can respond with 100-continue to kill the 350ms timer and start sending right away. But I tested with visualstudio.com and it doesn't respond with 100-continue.

@yishaigalatzer @zarenner @joelverhagen @emgarten 
