### PR TITLE
Allocate accept header values once statically

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -31,6 +31,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
 
         // An unlisted package's publish time must be 1900-01-01T00:00:00.
         private static readonly DateTime _unlistedPublishedTime = new DateTime(1900, 1, 1, 0, 0, 0);
+        private static readonly MediaTypeWithQualityHeaderValue[] _acceptHeaderValues = new[] { new MediaTypeWithQualityHeaderValue("application/atom+xml"), new MediaTypeWithQualityHeaderValue("application/xml") };
 
         private readonly string _baseUri;
         private readonly HttpSource _httpSource;
@@ -127,7 +128,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         // So we decide to leave current logic and observe.
                         using (var data = await _httpSource.GetAsync(
                             uri,
-                            new[] { new MediaTypeWithQualityHeaderValue("application/atom+xml"), new MediaTypeWithQualityHeaderValue("application/xml") },
+                            _acceptHeaderValues,
                             $"list_{id}_page{page}",
                             CreateCacheContext(retry),
                             Logger,


### PR DESCRIPTION
Reduce allocations by declaring a `private static readonly` array of the media type accept headers used when fetching the package source instead of allocating a new array every package fetch.
