### PR TITLE
To improve build time, upgraded CleanCache to be able to only clean NuGet.* packages.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -6,7 +6,8 @@ param (
     [string]$ReleaseLabel = 'local',
     [int]$BuildNumber,
     [switch]$SkipRestore,
-    [switch]$CleanCache,
+    [ValidateSet("none", "all", "webcache", "allpackages", "nugetpackages")]
+    [string]$CleanCache="none",
     [string]$MSPFXPath,
     [string]$NuGetPFXPath,
     [switch]$SkipXProj,
@@ -64,7 +65,7 @@ Invoke-BuildStep 'Cleaning nupkgs' { Clear-Nupkgs } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' { Clear-PackageCache } `
-    -skip:(-not $CleanCache) `
+    -skip:($CleanCache -eq "none") `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet } `

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -192,22 +192,37 @@ Function Format-BuildNumber([int]$BuildNumber) {
 Function Clear-PackageCache {
     [CmdletBinding()]
     param()
-    Trace-Log 'Removing .NUGET packages'
 
-    if (Test-Path $env:userprofile\.nuget\packages) {
-        rm -r $env:userprofile\.nuget\packages -Force
+    if (Test-Path $env:userprofile\.nuget\packages)
+    {
+        if (($CleanCache -eq "all") -or ($CleanCache -eq "allpackages"))
+        {
+            Trace-Log "Removing all packages from global packages folder at $env:userprofile\.nuget\packages"
+            rm -r $env:userprofile\.nuget\packages -Force
+        }
+        ElseIf(($CleanCache -eq "all") -or ($CleanCache -eq "nugetpackages"))
+        {
+            Trace-Log "Removing only NuGet.* packages from global packages folder at $env:userprofile\.nuget\packages"
+            rm -r $env:userprofile\.nuget\packages\NuGet.* -Force
+        }
     }
 
-    Trace-Log 'Removing NuGet web cache'
-
-    if (Test-Path $env:localappdata\NuGet\v3-cache) {
-        rm -r $env:localappdata\NuGet\v3-cache -Force
+    if (Test-Path $env:localappdata\NuGet\v3-cache)
+    {
+        if (($CleanCache -eq "all") -or ($CleanCache -eq "webcache"))
+        {
+            Trace-Log "Removing NuGet web cache at $env:localappdata\NuGet\v3-cache"
+            rm -r $env:localappdata\NuGet\v3-cache -Force
+        }
     }
 
-    Trace-Log 'Removing NuGet machine cache'
-
-    if (Test-Path $env:localappdata\NuGet\Cache) {
-        rm -r $env:localappdata\NuGet\Cache -Force
+    if (Test-Path $env:localappdata\NuGet\Cache)
+    {
+        if ($CleanCache -eq "all")
+        {
+            Trace-Log "Removing NuGet v2 machine cache at $env:localappdata\NuGet\Cache"
+            rm -r $env:localappdata\NuGet\Cache -Force
+        }
     }
 }
 

--- a/scripts/funcTests/runFuncTests.ps1
+++ b/scripts/funcTests/runFuncTests.ps1
@@ -2,7 +2,8 @@ param (
     [string]$DepBuildBranch="",
     [string]$DepCommitID="",
     [string]$DepBuildNumber="",
-    [switch]$CleanCache
+    [ValidateSet("none", "all", "webcache", "allpackages", "nugetpackages")]
+    [string]$CleanCache="none",
 )
 
 # For TeamCity - Incase any issue comes in this script fail the build. - Be default TeamCity returns exit code of 0 for all powershell even if it fails
@@ -36,7 +37,7 @@ Invoke-BuildStep 'Updating sub-modules' { Update-SubModules } `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Cleaning package cache' { Clear-PackageCache } `
-    -skip:(-not $CleanCache) `
+    -skip:($CleanCache -eq "none") `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Installing NuGet.exe' { Install-NuGet } `


### PR DESCRIPTION
Converted the switch CleanCache to be string parameter which takes one of

the following values. Made similar changes to runFuncTests.ps1

"none" - Default
"all" - Same as current CleanCache switch
"webcache" - only deletes the web cache on localappdata
"allpackages" - only deletes the packages
"nugetpackages" - only deletes NuGet.\* packages

@emgarten @alpaix
