### PR TITLE
Nuget.exe push needs a helpful error message for timeout

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -51,6 +51,11 @@ namespace NuGet.CommandLine
                     NoSymbols,
                     Console);
             }
+            catch (TaskCanceledException ex)
+            {
+                string timeoutMessage = LocalizedResourceManager.GetString(nameof(NuGetResources.PushCommandTimeoutError));
+                throw new AggregateException(ex, new Exception(timeoutMessage));
+            }
             catch (Exception ex)
             {
                 if (ex is HttpRequestException && ex.InnerException is WebException)

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -9178,6 +9178,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command..
+        /// </summary>
+        public static string PushCommandTimeoutError {
+            get {
+                return ResourceManager.GetString("PushCommandTimeoutError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All.
         /// </summary>
         public static string ReservedPackageNameAll {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6076,4 +6076,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_UnableToLocateRestoreTarget" xml:space="preserve">
     <value>The folder '{0}' does not contain an msbuild solution, packages.config, or project.json file to restore.</value>
   </data>
+  <data name="PushCommandTimeoutError" xml:space="preserve">
+    <value>Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Commands;
 using NuGet.Configuration;
@@ -66,16 +67,23 @@ namespace NuGet.CommandLine.XPlat
 
                     PackageSourceProvider sourceProvider = new PackageSourceProvider(XPlatUtility.CreateDefaultSettings());
 
-                    await PushRunner.Run(
-                        sourceProvider.Settings,
-                        sourceProvider,
-                        packagePath,
-                        sourcePath,
-                        apiKeyValue,
-                        timeoutSeconds,
-                        disableBufferingValue,
-                        noSymbolsValue,
-                        getLogger());
+                    try
+                    {
+                        await PushRunner.Run(
+                            sourceProvider.Settings,
+                            sourceProvider,
+                            packagePath,
+                            sourcePath,
+                            apiKeyValue,
+                            timeoutSeconds,
+                            disableBufferingValue,
+                            noSymbolsValue,
+                            getLogger());
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        throw new AggregateException(ex, new Exception(Strings.Push_Timeout_Error));
+                    }
 
                     return 0;
                 });

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -447,6 +447,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Pushing took too long. You can change the default timeout of 300 seconds by using the --timeout &lt;seconds&gt; option with the push command..
+        /// </summary>
+        public static string Push_Timeout_Error {
+            get {
+                return ResourceManager.GetString("Push_Timeout_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files..
         /// </summary>
         public static string Restore_Arg_ProjectName_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -293,4 +293,7 @@
   <data name="Exclude_Description" xml:space="preserve">
     <value>Specifies one or more wildcard patterns to exclude when creating a package.</value>
   </data>
+  <data name="Push_Timeout_Error" xml:space="preserve">
+    <value>Pushing took too long. You can change the default timeout of 300 seconds by using the --timeout &lt;seconds&gt; option with the push command.</value>
+  </data>
 </root>


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2199

In each of the command line projects, if "push" times out, then show a better error message. The TaskCanceledException message "A task was canceled." still shows, but then I appended more info about how to change the timeout.

@toddm @emgarten 
