### PR TITLE
Updating NuGet.Core to 2.11.1 floating version

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -26,7 +26,7 @@
     "NuGet.Protocol.Core.Types": {
       "target": "project"
     },
-    "NuGet.Core": "2.11.0"
+    "NuGet.Core": "2.11.1-rtm-*"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
Reflecting NuGet.Core versioning schema change.
Updating the only project consuming NuGet.Core to 2.11.1-rtm-*

//cc @rrelyea @emgarten @deepakaravindr @yishaigalatzer 
