### PR TITLE
Fix V2 OData service document tests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -83,48 +83,17 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Fact]
-        public async Task DownloadResourceFromInvalidUrl()
-        {
-            // Arrange
-            var randomName = Guid.NewGuid().ToString();
-            var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2");
-
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
-
-            var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), null, true, repo, new Uri($"https://www.{randomName}.org/api/v2/package/not-found/6.2.0"), "");
-
-            // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
-
-            // Assert
-            Assert.NotNull(ex);
-            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/package/not-found/6.2.0'.", ex.Message);
-        }
-
-        [Fact]
         public async Task DownloadResourceFromIdentityInvalidSource()
         {
             // Arrange
             var randomName = Guid.NewGuid().ToString();
             var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2/");
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
-
-            var package = new PackageIdentity("not-found", new NuGetVersion("6.2.0"));
-
             // Act & Assert
-            // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>());
 
-            // Assert
             Assert.NotNull(ex);
-            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
+            Assert.Equal($"Unable to load the service index for source https://www.{randomName}.org/api/v2/.", ex.Message);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Logging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.FuncTest
+{
+    public class ODataServiceDocumentResourceV2Tests
+    {
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_Valid()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v2");
+
+            // Act 
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.NotNull(resource);
+            Assert.Equal("https://www.nuget.org/api/v2", resource.BaseAddress);
+        }
+
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_NotFound()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v99///");
+
+            // Act 
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.NotNull(resource);
+            Assert.Equal("https://www.nuget.org/api/v99", resource.BaseAddress);
+        }
+
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_Invalid()
+        {
+            // Arrange
+            var randomName = Guid.NewGuid().ToString();
+            var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2");
+
+            // Act & Assert
+            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () =>
+                await repo.GetResourceAsync<ODataServiceDocumentResourceV2>());
+
+            Assert.Equal(
+                $"Unable to load the service index for source https://www.{randomName}.org/api/v2.",
+                ex.Message);
+            Assert.NotNull(ex.InnerException);
+            Assert.IsType<HttpRequestException>(ex.InnerException);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
@@ -49,5 +49,23 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Assert
             Assert.Equal("https://bringing/it/all/back/home", baseAddress);
         }
+
+        [Fact]
+        public async Task IgnoresInvalidXml()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress, "[1, 2, \"not XML\"]");
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            // Act
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.Equal(serviceAddress.Trim('/'), resource.BaseAddress);
+        }
     }
 }


### PR DESCRIPTION
1. Fix V2 OData service document tests
2. Add more tests
3. ~~Validate XML when getting the V2 OData service document~~ We want to ignore broken XML.

@emgarten @johnataylor @alpaix @zhili1208 @deepakaravindr 
