### PR TITLE
Cache remote dependency providers when restoring.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -20,8 +20,8 @@ namespace NuGet.Commands
         private static readonly StringComparer _comparer 
             = RuntimeEnvironmentHelper.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-        private readonly ConcurrentDictionary<PackageSource, List<IRemoteDependencyProvider>> _remoteProviders
-            = new ConcurrentDictionary<PackageSource, List<IRemoteDependencyProvider>>();
+        private readonly ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider> _remoteProviders
+            = new ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider>();
 
         private readonly ConcurrentDictionary<string, IRemoteDependencyProvider> _localProvider
             = new ConcurrentDictionary<string, IRemoteDependencyProvider>(_comparer);
@@ -51,7 +51,8 @@ namespace NuGet.Commands
 
             foreach (var source in sources)
             {
-                remoteProviders.Add(new SourceRepositoryDependencyProvider(source, log, cacheContext));
+                var remoteProvider = _remoteProviders.GetOrAdd(source, (sourceRepo) => new SourceRepositoryDependencyProvider(sourceRepo, log, cacheContext));
+                remoteProviders.Add(remoteProvider);
             }
 
             return new RestoreCommandProviders(globalCache, localProviders, remoteProviders, cacheContext);


### PR DESCRIPTION
Otherwise, we continually generate new (but duplicate) `SourceRepositoryDependencyProvider`'s and call `EnsureResource()` on them, which results in a bunch of duplicate GETs to servers.
