### PR TITLE
Avoid writing project.lock.json when unchanged.

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -312,7 +312,7 @@ namespace NuGet.ProjectModel
                         else
                         {
                             // Projects and references with no version property allow all versions
-                            dependencyVersionRange = VersionRange.All;
+                            dependencyVersionRange = VersionRange.AllStable;
                         }
                     }
 


### PR DESCRIPTION
When we read `project.json`, we use `VersionRange.All` when version range is not specified (`VersionRange.All` means all versions, including pre-release and stable). That gets written out to `project.lock.json` as "(, )". However, When we read `project.lock.json`, we parse that version range as meaning all stable versions.

This means we always consider `project.lock.json` as having changed in this scenario, even though what we end up writing out will be unchanged. This has a performance impact, and can also cause VS to update intellisense unnecessarily.

Solution is to either:

1) Interpret "(, )" as including pre-release versions.
2) Use `VersionRange.AllStable` when reading `project.json`.

This change does the latter.
