### PR TITLE
#1985 Fixing pack for the case when no project or nuspec file is spec…

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -426,6 +426,7 @@ namespace NuGet.Commands
                     if (candidates.Count == 1)
                     {
                         result = candidates[0];
+                        break;
                     }
                     goto default;
                 default:


### PR DESCRIPTION
…ified on the command-line and two possible files are found.

@emgarten @spadapet @joelverhagen 

Fixes https://github.com/NuGet/Home/issues/1985
