### PR TITLE
Fixed duplicate versions in all-sources UI

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -33,7 +33,7 @@
 		-->
 		<SemanticVersionMajor>3</SemanticVersionMajor>
 		<SemanticVersionMinor>4</SemanticVersionMinor>
-		<SemanticVersionPatch>1</SemanticVersionPatch>
+		<SemanticVersionPatch>2</SemanticVersionPatch>
 		<PreReleaseVersion>0</PreReleaseVersion>
 	</PropertyGroup>
 

--- a/src/NuGet.Clients/NuGet.CommandLine/project.json
+++ b/src/NuGet.Clients/NuGet.CommandLine/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.PackageManagement": "3.4.1-*"
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.PackageManagement": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.Credentials/project.json
+++ b/src/NuGet.Clients/NuGet.Credentials/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*"
+    "NuGet.PackageManagement": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.Resolver": "3.4.1-*",
+    "NuGet.Resolver": "3.4.2-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.Resolver": "3.4.1-*"
+    "NuGet.Resolver": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.UI/project.json
+++ b/src/NuGet.Clients/PackageManagement.UI/project.json
@@ -13,11 +13,11 @@
     "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
-    "NuGet.Indexing": "3.4.1-*",
-    "NuGet.PackageManagement": "3.4.1-*",
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*",
-    "NuGet.Resolver": "3.4.1-*"
+    "NuGet.Indexing": "3.4.2-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*",
+    "NuGet.Resolver": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
-    "NuGet.Common": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
+    "NuGet.Common": "3.4.2-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/SampleCommandLineExtensions/project.json
+++ b/src/NuGet.Clients/SampleCommandLineExtensions/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.PackageManagement": "3.4.1-*"
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.PackageManagement": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/StandaloneConsole/project.json
+++ b/src/NuGet.Clients/StandaloneConsole/project.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*",
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*",
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
     "System.Management.Automation_PowerShell_3.0": "6.3.9600.17400",
-    "Test.Utility": "3.4.1-*"
+    "Test.Utility": "3.4.2-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/StandaloneUI/project.json
+++ b/src/NuGet.Clients/StandaloneUI/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.PackageManagement": "3.4.1-*",
-    "Test.Utility": "3.4.1-*"
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "Test.Utility": "3.4.2-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/VisualStudio/project.json
+++ b/src/NuGet.Clients/VisualStudio/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.Protocol.VisualStudio": "3.4.1-*"
+    "NuGet.Protocol.VisualStudio": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/Console.Types/project.json
+++ b/src/NuGet.Clients/VsConsole/Console.Types/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*"
+    "NuGet.PackageManagement": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.Resolver": "3.4.1-*"
+    "NuGet.Resolver": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*"
+    "NuGet.PackageManagement": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -65,7 +65,7 @@ namespace NuGetVSExtension
     public sealed class NuGetPackage : Package, IVsPackageExtensionProvider, IVsPersistSolutionOpts
     {
         // It is displayed in the Help - About box of Visual Studio
-        public const string ProductVersion = "3.4.1";
+        public const string ProductVersion = "3.4.2";
         private static readonly object _credentialsPromptLock = new object();
 
         private static readonly string[] _visualizerSupportedSKUs = { "Premium", "Ultimate" };

--- a/src/NuGet.Clients/VsExtension/project.json
+++ b/src/NuGet.Clients/VsExtension/project.json
@@ -19,8 +19,8 @@
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Microsoft.VSSDK.BuildTools": "14.0.23107",
     "Microsoft.WindowsAzure.ConfigurationManager": "1.7.0",
-    "NuGet.Commands": "3.4.1-*",
-    "NuGet.Indexing": "3.4.1-*",
+    "NuGet.Commands": "3.4.2-*",
+    "NuGet.Indexing": "3.4.2-*",
     "System.IdentityModel.Tokens.Jwt": "4.0.0"
   },
   "frameworks": {

--- a/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.4.1" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.4.2" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 2015</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Icon>Resources/nuget_96.png</Icon>

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -7,13 +7,13 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.1-*",
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Repositories": "3.4.1-*",
-    "NuGet.RuntimeModel": "3.4.1-*",
-    "NuGet.ContentModel": "3.4.1-*",
+    "NuGet.Versioning": "3.4.2-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Repositories": "3.4.2-*",
+    "NuGet.RuntimeModel": "3.4.2-*",
+    "NuGet.ContentModel": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -15,9 +15,9 @@
     },
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc1-final",
     "Microsoft.NETCore.Platforms": "1.0.1-beta-*",
-    "NuGet.Commands": "3.4.1-*",
+    "NuGet.Commands": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     },
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23826",

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -20,8 +20,8 @@ namespace NuGet.Commands
         private static readonly StringComparer _comparer 
             = RuntimeEnvironmentHelper.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-        private readonly ConcurrentDictionary<PackageSource, List<IRemoteDependencyProvider>> _remoteProviders
-            = new ConcurrentDictionary<PackageSource, List<IRemoteDependencyProvider>>();
+        private readonly ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider> _remoteProviders
+            = new ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider>();
 
         private readonly ConcurrentDictionary<string, IRemoteDependencyProvider> _localProvider
             = new ConcurrentDictionary<string, IRemoteDependencyProvider>(_comparer);
@@ -49,7 +49,8 @@ namespace NuGet.Commands
 
             foreach (var source in sources)
             {
-                remoteProviders.Add(new SourceRepositoryDependencyProvider(source, log, cacheContext));
+                var remoteProvider = _remoteProviders.GetOrAdd(source, (sourceRepo) => new SourceRepositoryDependencyProvider(sourceRepo, log, cacheContext));
+                remoteProviders.Add(remoteProvider);
             }
 
             return new RestoreCommandProviders(globalCache, localProviders, remoteProviders, cacheContext);

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -20,14 +20,14 @@
     "../../../tools/compiler/preprocess/Internalization.cs"
   ],
   "dependencies": {
-    "NuGet.Client": "3.4.1-*",
-    "NuGet.ContentModel": "3.4.1-*",
-    "NuGet.ProjectModel": "3.4.1-*",
-    "NuGet.Configuration": "3.4.1-*",
-    "NuGet.DependencyResolver": "3.4.1-*",
-    "NuGet.RuntimeModel": "3.4.1-*",
+    "NuGet.Client": "3.4.2-*",
+    "NuGet.ContentModel": "3.4.2-*",
+    "NuGet.ProjectModel": "3.4.2-*",
+    "NuGet.Configuration": "3.4.2-*",
+    "NuGet.DependencyResolver": "3.4.2-*",
+    "NuGet.RuntimeModel": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.Common/UriUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/UriUtility.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+
+namespace NuGet.Common
+{
+    public static class UriUtility
+    {
+        /// <summary>
+        /// Same as "new Uri" except that it can handle UNIX style paths that start with '/'
+        /// </summary>
+        public static Uri CreateSourceUri(string source, UriKind kind = UriKind.Absolute)
+        {
+            source = FixSourceUri(source);
+            return new Uri(source, kind);
+        }
+
+        /// <summary>
+        /// Same as "Uri.TryCreate" except that it can handle UNIX style paths that start with '/'
+        /// </summary>
+        public static Uri TryCreateSourceUri(string source, UriKind kind)
+        {
+            source = FixSourceUri(source);
+
+            Uri uri;
+            return Uri.TryCreate(source, kind, out uri) ? uri : null;
+        }
+
+        private static string FixSourceUri(string source)
+        {
+            // UNIX absolute paths need to start with file://
+            if (Path.DirectorySeparatorChar == '/' && !string.IsNullOrEmpty(source) && source[0] == '/')
+            {
+                source = "file://" + source;
+            }
+
+            return source;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -23,6 +23,8 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
+        public static readonly string AddV3TrackFile = "nugetorgadd.trk";
+
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -291,6 +291,20 @@ namespace NuGet.Configuration
                 else
                 {
                     appDataSettings = ReadSettings(root, defaultSettingsFilePath);
+                    bool IsEmptyConfig = !appDataSettings.GetSettingValues(ConfigurationConstants.PackageSources).Any();
+
+                    if (IsEmptyConfig)
+                    {
+                        var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
+
+                        if (!File.Exists(trackFilePath))
+                        {
+                            File.Create(trackFilePath).Dispose();
+                            var defaultPackageSource = new SettingValue(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, isMachineWide: false);
+                            defaultPackageSource.AdditionalData.Add(ConfigurationConstants.ProtocolVersionAttribute, "3");
+                            appDataSettings.UpdateSections(ConfigurationConstants.PackageSources, new List<SettingValue> { defaultPackageSource });
+                        }
+                    }
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -16,10 +16,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.1-*",
+    "NuGet.Common": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -9,7 +9,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -7,14 +7,14 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.LibraryModel": "3.4.1-*",
-    "NuGet.Frameworks": "3.4.1-*",
-    "NuGet.Protocol.Core.v3": "3.4.1-*",
-    "NuGet.Repositories": "3.4.1-*",
-    "NuGet.RuntimeModel": "3.4.1-*",
+    "NuGet.LibraryModel": "3.4.2-*",
+    "NuGet.Frameworks": "3.4.2-*",
+    "NuGet.Protocol.Core.v3": "3.4.2-*",
+    "NuGet.Repositories": "3.4.2-*",
+    "NuGet.RuntimeModel": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -7,12 +7,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Protocol.Core.v3": "3.4.1-*",
-    "NuGet.DependencyResolver.Core": "3.4.1-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Protocol.Core.v3": "3.4.2-*",
+    "NuGet.DependencyResolver.Core": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "description": "The understanding of target frameworks for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Versioning": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Indexing/SearchResultsAggregator.cs
+++ b/src/NuGet.Core/NuGet.Indexing/SearchResultsAggregator.cs
@@ -111,7 +111,12 @@ namespace NuGet.Indexing
             {
                 var newerEntry = (lhs.Identity.Version >= rhs.Identity.Version) ? lhs : rhs;
                 var versions = await Task.WhenAll(lhs.GetVersionsAsync(), rhs.GetVersionsAsync());
-                var mergedVersions = versions.SelectMany(v => v).Distinct().ToArray();
+                var mergedVersions = versions
+                    .SelectMany(v => v) // flatten a list of two lists
+                    .GroupBy(v => v.Version) // group all by version
+                    .Select(group => group.First()) // select first VersionInfo for each version
+                    .ToArray(); // force execution
+
                 return newerEntry.WithVersions(mergedVersions);
             }
         }

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -19,8 +19,8 @@
   ],
   "dependencies": {
     "Lucene.Net": "3.0.3",
-    "NuGet.Versioning": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*"
+    "NuGet.Versioning": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
-    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Versioning": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -13,7 +13,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -8,12 +8,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.Commands": "3.4.1-*",
-    "NuGet.Protocol.Core.v2": "3.4.1-*",
-    "NuGet.Resolver": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.Commands": "3.4.2-*",
+    "NuGet.Protocol.Core.v2": "3.4.2-*",
+    "NuGet.Resolver": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -1,14 +1,14 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     },
-    "NuGet.Frameworks": "3.4.1-*"
+    "NuGet.Frameworks": "3.4.2-*"
   },
   "compilationOptions": {
     "warningsAsErrors": true

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "description": "The core data structures for NuGet.Packaging",
   "authors": [
     "NuGet"
@@ -11,10 +11,10 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging.Core.Types": "3.4.1-*",
+    "NuGet.Packaging.Core.Types": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "description": "NuGet's implementation for reading nupkg package and nuspec package specification files.",
   "authors": [
     "NuGet"
@@ -15,15 +15,15 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.1-*",
-    "NuGet.Frameworks": "3.4.1-*",
+    "NuGet.Common": "3.4.2-*",
+    "NuGet.Frameworks": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     },
-    "NuGet.Packaging.Core": "3.4.1-*",
-    "NuGet.Logging": "3.4.1-*",
-    "NuGet.Versioning": "3.4.1-*"
+    "NuGet.Packaging.Core": "3.4.2-*",
+    "NuGet.Logging": "3.4.2-*",
+    "NuGet.Versioning": "3.4.2-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
-    "NuGet.ProjectModel": "3.4.1-*",
+    "NuGet.ProjectModel": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFileLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFileLibrary.cs
@@ -47,9 +47,9 @@ namespace NuGet.ProjectModel
             if (string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(Type, other.Type, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(Path, other.Path, StringComparison.Ordinal)
-                && string.Equals(Path, other.MSBuildProject, StringComparison.Ordinal)
+                && string.Equals(MSBuildProject, other.MSBuildProject, StringComparison.Ordinal)
                 && IsServiceable == other.IsServiceable
-                && Sha512 == other.Sha512
+                && string.Equals(Sha512, other.Sha512, StringComparison.Ordinal)
                 && Version == other.Version)
             {
                 return Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -1,14 +1,14 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.DependencyResolver.Core": "3.4.1-*",
+    "NuGet.DependencyResolver.Core": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.1-*",
-    "NuGet.Configuration": "3.4.1-*",
-    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Common": "3.4.2-*",
+    "NuGet.Configuration": "3.4.2-*",
+    "NuGet.Packaging": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -14,13 +14,13 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.1-*",
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*",
+    "NuGet.Configuration": "3.4.2-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*",
     "NuGet.Core": "2.11.1-rtm-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
@@ -31,6 +31,7 @@ namespace NuGet.Protocol.Core.v3
             yield return new Lazy<INuGetResourceProvider>(() => new RegistrationResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ReportAbuseResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new ServiceIndexResourceV3Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => new ODataServiceDocumentResourceV2Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpHandlerResourceV3Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpSourceResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new HttpFileSystemBasedFindPackageByIdResourceProvider());

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol
         private readonly HttpSource _httpSource;
         private readonly Uri _baseUri;
 
-        public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, Configuration.PackageSource packageSource)
+        public AutoCompleteResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource)
         {
             if (httpSourceResource == null)
             {
@@ -31,9 +31,7 @@ namespace NuGet.Protocol
 
             _httpSource = httpSourceResource.HttpSource;
 
-            var withoutTrailingSlash = packageSource.Source.TrimEnd('/');
-
-            _baseUri = new Uri($"{withoutTrailingSlash}/");
+            _baseUri = UriUtility.CreateSourceUri($"{baseAddress}/");
         }
 
         public override async Task<IEnumerable<string>> IdStartsWith(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2FeedProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
@@ -24,9 +25,11 @@ namespace NuGet.Protocol
 
             if (FeedTypeUtility.GetFeedType(source.PackageSource) == FeedType.HttpV2)
             {
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+
                 var httpSource = await source.GetResourceAsync<HttpSourceResource>(token);
 
-                resource = new AutoCompleteResourceV2Feed(httpSource, source.PackageSource);
+                resource = new AutoCompleteResourceV2Feed(httpSource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
             return new Tuple<bool, INuGetResource>(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DependencyInfoResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DependencyInfoResourceV2FeedProvider.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
@@ -12,19 +13,21 @@ namespace NuGet.Protocol
         {
         }
 
-        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             DependencyInfoResource resource = null;
 
             if ((FeedTypeUtility.GetFeedType(source.PackageSource) & FeedType.HttpV2) != FeedType.None)
             {
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+
                 var httpSource = HttpSource.Create(source);
-                var parser = new V2FeedParser(httpSource, source.PackageSource);
+                var parser = new V2FeedParser(httpSource, serviceDocument.BaseAddress, source.PackageSource);
 
                 resource = new DependencyInfoResourceV2Feed(parser, source);
             }
 
-            return Task.FromResult(new Tuple<bool, INuGetResource>(resource != null, resource));
+            return new Tuple<bool, INuGetResource>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2FeedProvider.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
@@ -12,19 +13,21 @@ namespace NuGet.Protocol
         {
         }
 
-        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
         {
             DownloadResource resource = null;
 
             if ((FeedTypeUtility.GetFeedType(source.PackageSource) & FeedType.HttpV2) != FeedType.None)
             {
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+
                 var httpSource = HttpSource.Create(source);
-                var parser = new V2FeedParser(httpSource, source.PackageSource);
+                var parser = new V2FeedParser(httpSource, serviceDocument.BaseAddress, source.PackageSource);
 
                 resource = new DownloadResourceV2Feed(parser);
             }
 
-            return Task.FromResult(new Tuple<bool, INuGetResource>(resource != null, resource));
+            return new Tuple<bool, INuGetResource>(resource != null, resource);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol.Core.v3
+{
+    public class ODataServiceDocumentResourceV2 : INuGetResource
+    {
+        private readonly string _baseAddress;
+        private readonly DateTime _requestTime;
+
+        public ODataServiceDocumentResourceV2(string baseAddress, DateTime requestTime)
+        {
+            _baseAddress = baseAddress.Trim('/');
+            _requestTime = requestTime;
+        }
+
+        public virtual DateTime RequestTime
+        {
+            get { return _requestTime; }
+        }
+
+        public string BaseAddress
+        {
+            get { return _baseAddress; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Logging;
+using NuGet.Protocol.Core.Types;
+using System.Collections.Concurrent;
+
+namespace NuGet.Protocol.Core.v3
+{
+    public class ODataServiceDocumentResourceV2Provider : ResourceProvider
+    {
+        private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromMinutes(40);
+        protected readonly ConcurrentDictionary<string, ODataServiceDocumentCacheInfo> _cache;
+        private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+
+        /// <summary>
+        /// Maximum amount of time to store index.json
+        /// </summary>
+        public TimeSpan MaxCacheDuration { get; protected set; }
+
+        public ODataServiceDocumentResourceV2Provider()
+            : base(typeof(ODataServiceDocumentResourceV2),
+                  nameof(ODataServiceDocumentResourceV2Provider),
+                  NuGetResourceProviderPositions.Last)
+        {
+            MaxCacheDuration = _defaultCacheDuration;
+            _cache = new ConcurrentDictionary<string, ODataServiceDocumentCacheInfo>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            ODataServiceDocumentResourceV2 serviceDocument = null;
+            ODataServiceDocumentCacheInfo cacheInfo = null;
+            var url = source.PackageSource.Source;
+
+            var utcNow = DateTime.UtcNow;
+            var entryValidCutoff = utcNow.Subtract(MaxCacheDuration);
+
+            // check the cache before downloading the file
+            if (!_cache.TryGetValue(url, out cacheInfo) || entryValidCutoff > cacheInfo.CachedTime)
+            {
+                // Track if the semaphore needs to be released
+                var release = false;
+                try
+                {
+                    await _semaphore.WaitAsync(token);
+                    release = true;
+
+                    token.ThrowIfCancellationRequested();
+
+                    // check the cache again, another thread may have finished this one waited for the lock
+                    if (!_cache.TryGetValue(url, out cacheInfo) || entryValidCutoff > cacheInfo.CachedTime)
+                    {
+                        serviceDocument = await CreateODataServiceDocumentResourceV2(source, utcNow, NullLogger.Instance, token);
+
+                        // cache the value even if it is null to avoid checking it again later
+                        var cacheEntry = new ODataServiceDocumentCacheInfo
+                        {
+                            CachedTime = utcNow,
+                            ServiceDocument = serviceDocument
+                        };
+
+                        // If the cache entry has expired it will already exist
+                        _cache.AddOrUpdate(url, cacheEntry, (key, value) => cacheEntry);
+                    }
+                }
+                finally
+                {
+                    if (release)
+                    {
+                        _semaphore.Release();
+                    }
+                }
+            }
+
+            if (serviceDocument == null && cacheInfo != null)
+            {
+                serviceDocument = cacheInfo.ServiceDocument;
+            }
+
+            return new Tuple<bool, INuGetResource>(serviceDocument != null, serviceDocument);
+        }
+
+        private static async Task<ODataServiceDocumentResourceV2> CreateODataServiceDocumentResourceV2(
+            SourceRepository source,
+            DateTime utcNow,
+            ILogger log,
+            CancellationToken token)
+        {
+            var url = source.PackageSource.Source;
+            var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
+            var client = httpSourceResource.HttpSource;
+
+            var cacheContext = HttpSourceCacheContext.CreateCacheContext(new SourceCacheContext(), 0);
+
+            HttpSourceResult response = await client.GetAsync(
+                url,
+                "odata_service_document",
+                cacheContext,
+                log,
+                ignoreNotFounds: true,
+                ensureValidContents: null,
+                cancellationToken: token);
+
+            string serviceDocumentBaseAddress = null;
+            if (response.Status != HttpSourceResultStatus.NotFound)
+            {
+                serviceDocumentBaseAddress = V2FeedParser.GetBaseAddress(response.Stream);
+            }
+
+            var baseAddress = serviceDocumentBaseAddress ?? url.Trim('/');
+
+            var serviceDocument = new ODataServiceDocumentResourceV2(baseAddress, DateTime.UtcNow);
+
+            return serviceDocument;
+        }
+
+        protected class ODataServiceDocumentCacheInfo
+        {
+            public ODataServiceDocumentResourceV2 ServiceDocument { get; set; }
+
+            public DateTime CachedTime { get; set; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Logging;
 using NuGet.Protocol.Core.Types;
-using System.Collections.Concurrent;
 
 namespace NuGet.Protocol.Core.v3
 {
@@ -96,14 +98,26 @@ namespace NuGet.Protocol.Core.v3
 
             var cacheContext = HttpSourceCacheContext.CreateCacheContext(new SourceCacheContext(), 0);
 
-            HttpSourceResult response = await client.GetAsync(
-                url,
-                "odata_service_document",
-                cacheContext,
-                log,
-                ignoreNotFounds: true,
-                ensureValidContents: null,
-                cancellationToken: token);
+
+            HttpSourceResult response;
+            try
+            {
+                response = await client.GetAsync(
+                    url,
+                    "odata_service_document",
+                    cacheContext,
+                    log,
+                    ignoreNotFounds: true,
+                    ensureValidContents: null,
+                    cancellationToken: token);
+            }
+            catch (Exception ex) when (!(ex is FatalProtocolException) && (!(ex is OperationCanceledException)))
+            {
+                string message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToReadServiceIndex, source.PackageSource.Source);
+                log.LogError(message + Environment.NewLine + ExceptionUtilities.DisplayMessage(ex));
+
+                throw new FatalProtocolException(message, ex);
+            }
 
             string serviceDocumentBaseAddress = null;
             if (response.Stream != null)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -106,7 +106,7 @@ namespace NuGet.Protocol.Core.v3
                 cancellationToken: token);
 
             string serviceDocumentBaseAddress = null;
-            if (response.Status != HttpSourceResultStatus.NotFound)
+            if (response.Stream != null)
             {
                 serviceDocumentBaseAddress = V2FeedParser.GetBaseAddress(response.Stream);
             }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageMetadataResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageMetadataResourceV2Feed.cs
@@ -19,6 +19,7 @@ namespace NuGet.Protocol
 
         public PackageMetadataResourceV2Feed(
             HttpSourceResource httpSourceResource,
+            string baseAddress,
             Configuration.PackageSource packageSource)
         {
             if (httpSourceResource == null)
@@ -33,7 +34,7 @@ namespace NuGet.Protocol
 
             _httpSource = httpSourceResource.HttpSource;
             _packageSource = packageSource;
-            _feedParser = new V2FeedParser(_httpSource, packageSource);
+            _feedParser = new V2FeedParser(_httpSource, baseAddress, packageSource);
         }
 
         public override async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageMetadataResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageMetadataResourceV2FeedProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
@@ -25,7 +26,9 @@ namespace NuGet.Protocol
             {
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 
-                resource = new PackageMetadataResourceV2Feed(httpSourceResource, source.PackageSource);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+
+                resource = new PackageMetadataResourceV2Feed(httpSourceResource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
             return new Tuple<bool, INuGetResource>(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2Feed.cs
@@ -18,7 +18,7 @@ namespace NuGet.Protocol
         private readonly Configuration.PackageSource _packageSource;
         private readonly V2FeedParser _feedParser;
 
-        public PackageSearchResourceV2Feed(HttpSourceResource httpSourceResource, Configuration.PackageSource packageSource)
+        public PackageSearchResourceV2Feed(HttpSourceResource httpSourceResource, string baseAddress, Configuration.PackageSource packageSource)
         {
             if (httpSourceResource == null)
             {
@@ -32,7 +32,7 @@ namespace NuGet.Protocol
 
             _httpSource = httpSourceResource.HttpSource;
             _packageSource = packageSource;
-            _feedParser = new V2FeedParser(_httpSource, packageSource);
+            _feedParser = new V2FeedParser(_httpSource, baseAddress, packageSource);
         }
 
         public async override Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2FeedProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2FeedProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
@@ -24,7 +25,9 @@ namespace NuGet.Protocol
             {
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 
-                resource = new PackageSearchResourceV2Feed(httpSourceResource, source.PackageSource);
+                var serviceDocument = await source.GetResourceAsync<ODataServiceDocumentResourceV2>(token);
+
+                resource = new PackageSearchResourceV2Feed(httpSourceResource, serviceDocument.BaseAddress, source.PackageSource);
             }
 
             return new Tuple<bool, INuGetResource>(resource != null, resource);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol
         private const string W3Atom = "http://www.w3.org/2005/Atom";
         private const string MetadataNS = "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata";
         private const string DataServicesNS = "http://schemas.microsoft.com/ado/2007/08/dataservices";
-        private const string FindPackagesByIdFormat = "/FindPackagesById()?Id='{0}'";
+        private const string FindPackagesByIdFormat = "/FindPackagesById()?id='{0}'";
         private const string SearchEndPointFormat = "/Search()?$filter={0}&searchTerm='{1}'&targetFramework='{2}'&includePrerelease={3}&$skip={4}&$top={5}";
         private const string GetPackagesFormat = "/Packages(Id='{0}',Version='{1}')";
         private const string IsLatestVersionFilterFlag = "IsLatestVersion";

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -16,11 +16,11 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     },
-    "NuGet.Logging": "3.4.1-*",
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*",
+    "NuGet.Logging": "3.4.2-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*",
     "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -7,7 +7,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.1-*"
+    "NuGet.Protocol.Core.v3": "3.4.2-*"
   },
   "frameworks": {
     "dnx451": {

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -14,12 +14,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Configuration": "3.4.1-*",
-    "NuGet.Protocol.Core.v2": "3.4.1-*",
-    "NuGet.Protocol.Core.v3": "3.4.1-*",
+    "NuGet.Configuration": "3.4.2-*",
+    "NuGet.Protocol.Core.v2": "3.4.2-*",
+    "NuGet.Protocol.Core.v3": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -1,13 +1,13 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "dependencies": {
-    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Packaging": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "description": "NuGet's dependency resolver within the NuGet.Packaging package",
   "authors": [
     "NuGet"
@@ -11,11 +11,11 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Protocol.Core.Types": "3.4.1-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Protocol.Core.Types": "3.4.2-*",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -10,10 +10,10 @@
     "Newtonsoft.Json": "6.0.4",
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     },
-    "NuGet.Versioning": "3.4.1-*",
-    "NuGet.Frameworks": "3.4.1-*"
+    "NuGet.Versioning": "3.4.2-*",
+    "NuGet.Frameworks": "3.4.2-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -7,7 +7,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.Common": "3.4.1-*"
+    "NuGet.Common": "3.4.2-*"
   },
   "frameworks": {
     "dnx451": {},

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "xunit": "2.1.0",
-    "NuGet.Packaging": "3.4.1-*"
+    "NuGet.Packaging": "3.4.2-*"
   },
   "frameworks": {
     "net45": {

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "authors": [
     "NuGet"
   ],
@@ -17,7 +17,7 @@
   "dependencies": {
     "NuGet.Shared": {
       "type": "build",
-      "version": "3.4.1-*"
+      "version": "3.4.2-*"
     }
   },
   "frameworks": {

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -11,9 +11,9 @@
     },
 
   "dependencies": {
-    "NuGet.Common": "3.4.1-*",
+    "NuGet.Common": "3.4.2-*",
     "NuGet.Shared": {
-      "version": "3.4.1-*",
+      "version": "3.4.2-*",
       "type": "build"
     }
   },

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
@@ -7,12 +7,12 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "NuGet.PackageManagement": "3.4.1-*",
-    "NuGet.ProjectManagement": "3.4.1-*",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
     "Microsoft.VisualStudio.ProjectSystem.Interop": "1.0.0",
     "xunit": "2.1.0",
-    "NuGet.Test.Utility": "3.4.1-*"
+    "NuGet.Test.Utility": "3.4.2-*"
   },
   "frameworks": {
     "net45": {

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -330,7 +330,7 @@ function Test-InstallPackageAPIUnreachableSource
     $p = New-ClassLibrary
 
     # Act&Assert
-    Assert-Throws {[API.Test.InternalAPITestHook]::InstallPackageApiBadSource("owin","1.0.0") } "Exception calling `"InstallPackageApiBadSource`" with `"2`" argument(s): `"An error occurred while retrieving package metadata for 'owin.1.0.0' from source 'http://packagesource'.`""
+    Assert-Throws {[API.Test.InternalAPITestHook]::InstallPackageApiBadSource("owin","1.0.0") } "Exception calling `"InstallPackageApiBadSource`" with `"2`" argument(s): `"Unable to load the service index for source http://packagesource.`""
     Assert-NoPackage $p "owin"
 }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.1-*",
+    "Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.1-*",
+    "Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.1-*",
+    "Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
@@ -16,7 +16,7 @@
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.4.1-*",
+    "Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Commands": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -83,48 +83,17 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Fact]
-        public async Task DownloadResourceFromInvalidUrl()
-        {
-            // Arrange
-            var randomName = Guid.NewGuid().ToString();
-            var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2");
-
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
-
-            var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), null, true, repo, new Uri($"https://www.{randomName}.org/api/v2/package/not-found/6.2.0"), "");
-
-            // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
-
-            // Assert
-            Assert.NotNull(ex);
-            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/package/not-found/6.2.0'.", ex.Message);
-        }
-
-        [Fact]
         public async Task DownloadResourceFromIdentityInvalidSource()
         {
             // Arrange
             var randomName = Guid.NewGuid().ToString();
             var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2/");
 
-            var downloadResource = await repo.GetResourceAsync<DownloadResource>();
-
-            var package = new PackageIdentity("not-found", new NuGetVersion("6.2.0"));
-
             // Act & Assert
-            // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await repo.GetResourceAsync<DownloadResource>());
 
-            // Assert
             Assert.NotNull(ex);
-            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
+            Assert.Equal($"Unable to load the service index for source https://www.{randomName}.org/api/v2/.", ex.Message);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/ODataServiceDocumentResourceV2Tests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Logging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.FuncTest
+{
+    public class ODataServiceDocumentResourceV2Tests
+    {
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_Valid()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v2");
+
+            // Act 
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.NotNull(resource);
+            Assert.Equal("https://www.nuget.org/api/v2", resource.BaseAddress);
+        }
+
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_NotFound()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v99///");
+
+            // Act 
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.NotNull(resource);
+            Assert.Equal("https://www.nuget.org/api/v99", resource.BaseAddress);
+        }
+
+        [Fact]
+        public async Task ODataServiceDocumentResourceV2_Invalid()
+        {
+            // Arrange
+            var randomName = Guid.NewGuid().ToString();
+            var repo = Repository.Factory.GetCoreV3($"https://www.{randomName}.org/api/v2");
+
+            // Act & Assert
+            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () =>
+                await repo.GetResourceAsync<ODataServiceDocumentResourceV2>());
+
+            Assert.Equal(
+                $"Unable to load the service index for source https://www.{randomName}.org/api/v2.",
+                ex.Message);
+            Assert.NotNull(ex.InnerException);
+            Assert.IsType<HttpRequestException>(ex.InnerException);
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Protocol.Core.v3": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Client": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Client": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.CommandLine.XPlat": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.CommandLine.XPlat": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Commands": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Commands": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Common": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Common": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2237,6 +2237,46 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void AddV3ToEmptyConfigFile()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                var nugetConfigPath = "NuGet.Config";
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, 
+                    Path.Combine(mockBaseDirectory, "TestingGlobalPath"), config);
+
+                // Act
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory, null, null, true, true);
+
+                // Assert
+                var text = File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")).Replace("\r\n", "\n");
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+  </packageSources>
+</configuration>".Replace("\r\n", "\n");
+                Assert.Equal(result, text);
+
+                // Act
+                settings.DeleteSection("packageSources");
+                settings = Settings.LoadDefaultSettings(mockBaseDirectory, null, null, true, true);
+
+                // Assert
+                text = File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath" , "NuGet.Config")).Replace("\r\n", "\n");
+                result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>".Replace("\r\n", "\n");
+                Assert.Equal(result, text);
+            }
+        }
+
+        [Fact]
         public void LoadNuGetConfig_InvalidXmlThrowException()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -1,10 +1,10 @@
 {
     "dependencies": {
-        "NuGet.Configuration": "3.4.1-*",
+        "NuGet.Configuration": "3.4.2-*",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-rc1-build204",
-        "NuGet.Test.Utility": "3.4.1-*",
-        "NuGet.Common": "3.4.1-*"
+        "NuGet.Test.Utility": "3.4.2-*",
+        "NuGet.Common": "3.4.2-*"
     },
     "commands": {
         "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver.Core": "3.4.1-*",
+    "NuGet.DependencyResolver.Core": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NuGet.DependencyResolver": "3.4.1-*",
+    "NuGet.DependencyResolver": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Frameworks": "3.4.1-*",
-    "NuGet.Packaging": "3.4.1-*",
+    "NuGet.Frameworks": "3.4.2-*",
+    "NuGet.Packaging": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/SearchResultsAggregatorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/SearchResultsAggregatorTests.cs
@@ -41,9 +41,15 @@ namespace NuGet.Indexing.Test
             var results = await aggregator.AggregateAsync(queryString, rawSearch1, rawSearch2);
 
             var mergedPackage = FindNuGetCorePackage(results);
-            var vm = await GetPackageVersionsAsync(mergedPackage);
-            Assert.Superset(v1, vm);
-            Assert.Superset(v2, vm);
+
+            var vm = (await mergedPackage.GetVersionsAsync()).Select(v => v.Version);
+
+            // validate no duplicates
+            Assert.Equal(vm, vm.Distinct());
+
+            var vmset = new HashSet<NuGetVersion>(vm);
+            Assert.Superset(v1, vmset);
+            Assert.Superset(v2, vmset);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Indexing": "3.4.1-*",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.Indexing": "3.4.2-*",
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LockFileLibraryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LockFileLibraryTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.ProjectModel;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class LockFileLibraryTests
+    {
+        public void LockFileLibrary_EqualityEmpty()
+        {
+            // Arrange
+            var library1 = new LockFileLibrary();
+            var library2 = new LockFileLibrary();
+
+            // Act & Assert
+            Assert.True(library1.Equals(library2));
+        }
+
+        public void LockFileLibrary_EqualityDiffersOnMSBuildPath()
+        {
+            // Arrange
+            var library1 = new LockFileLibrary()
+            {
+                MSBuildProject = "a"
+            };
+
+            var library2 = new LockFileLibrary()
+            {
+                MSBuildProject = "b"
+            };
+
+            // Act & Assert
+            Assert.False(library1.Equals(library2));
+        }
+
+        public void LockFileLibrary_EqualitySameMSBuildPath()
+        {
+            // Arrange
+            var library1 = new LockFileLibrary()
+            {
+                MSBuildProject = "b"
+            };
+
+            var library2 = new LockFileLibrary()
+            {
+                MSBuildProject = "b"
+            };
+
+            // Act & Assert
+            Assert.True(library1.Equals(library2));
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.1-*",
+    "NuGet.ProjectModel": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Logging.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Logging": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Logging": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
     "Moq": "4.2.1510.2205",
-    "NuGet.PackageManagement": "3.4.1-*",
-    "Test.Utility": "3.4.1-*",
+    "NuGet.PackageManagement": "3.4.2-*",
+    "Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Packaging.Core": "3.4.1-*",
+    "NuGet.Packaging.Core": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Packaging": "3.4.1-*",
-    "NuGet.Test.Utility": "3.4.1-*",
+    "NuGet.Packaging": "3.4.2-*",
+    "NuGet.Test.Utility": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -1,10 +1,10 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.ProjectManagement": "3.4.1-*",
+    "NuGet.ProjectManagement": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "Test.Utility": "3.4.1-*"
+    "Test.Utility": "3.4.2-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.ProjectModel": "3.4.1-*",
+    "NuGet.ProjectModel": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -17,11 +17,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task AutoCompleteResourceV2Feed_IdStartsWith()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/package-ids?partialId=Azure&includePrerelease=False",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureAutoComplete.json", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "package-ids?partialId=Azure&includePrerelease=False",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureAutoComplete.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
 
@@ -36,11 +39,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task AutoCompleteResourceV2Feed_VersionStartsWith()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/package-versions/xunit?includePrerelease=False",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitVersionAutoComplete.json", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "package-versions/xunit?includePrerelease=False",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitVersionAutoComplete.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
 
@@ -55,10 +61,13 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task AutoCompleteResourceV2Feed_VersionStartsWithInvalidId()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/package-versions/azure?includePrerelease=False", "[]");
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "package-versions/azure?includePrerelease=False", "[]");
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
@@ -94,7 +94,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -126,7 +126,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,
@@ -148,7 +148,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='not-found'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -19,11 +19,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfoResourceV2Feed_GetDependencyInfoById()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -41,13 +44,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfoResourceV2Feed_GetDependencyInfoByPackageIdentity()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
-            responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -67,11 +73,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfo_RetrieveExactVersion()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='2.1.0-beta1-build2945')",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.Xunit.2.1.0-beta1-build2945GetPackages.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='2.1.0-beta1-build2945')",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.Xunit.2.1.0-beta1-build2945GetPackages.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -93,11 +102,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfo_RetrieveDependencies()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -124,12 +136,15 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfo_RetrieveExactVersion_NotFound()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
@@ -147,11 +162,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfo_RetrieveDependencies_NotFound()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -166,11 +184,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DependencyInfo_GetNearestFramework()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='DotNetOpenAuth.Core',Version='4.3.2.13293')",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.DotNetOpenAuth.Core.4.3.2.13293GetPackages.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='DotNetOpenAuth.Core',Version='4.3.2.13293')",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.DotNetOpenAuth.Core.4.3.2.13293GetPackages.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -20,12 +20,15 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task DownloadResourceFromIdentityInvalidId()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
             var downloadResource = await repo.GetResourceAsync<DownloadResource>();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
@@ -19,7 +19,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -38,7 +38,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -57,7 +57,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -76,7 +76,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -95,7 +95,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -135,9 +135,9 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -162,7 +162,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
 
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='not-found'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -181,7 +181,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='not-found'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -200,7 +200,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,
@@ -222,7 +222,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='not-found'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
@@ -18,11 +18,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetLatestVersion()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -37,11 +40,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetLatestVersionStable()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -56,11 +62,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetVersionsStable()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -75,11 +84,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetVersions()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -94,11 +106,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceIdExist()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -113,11 +128,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceIdentityExist()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
+                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -134,13 +152,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetLatestVersions()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -160,12 +181,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetLatestVersionInvalidId()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -180,11 +203,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceGetVersionsInvalidId()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -198,12 +224,15 @@ namespace NuGet.Protocol.Core.v3.Tests
         [Fact]
         public async Task MetaDataResourceIdentityExistInvalidIdentity()
         {
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
@@ -221,11 +250,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task MetaDataResourceIdExistNotFoundId()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class ODataServiceDocumentV2Tests
+    {
+        [Fact]
+        public async Task DefaultBaseAddressIsServiceAddress()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Act
+            var baseAddress = oDataServiceDocumentResource.BaseAddress;
+
+            // Assert
+            Assert.Equal(serviceAddress.Trim('/'), baseAddress);
+        }
+
+        [Fact]
+        public async Task BaseAddressExtractedFromServiceDocument()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress, TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.ODataServiceDocument.xml", GetType()));
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            var oDataServiceDocumentResource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Act
+            var baseAddress = oDataServiceDocumentResource.BaseAddress;
+
+            // Assert
+            Assert.Equal("https://bringing/it/all/back/home", baseAddress);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/ODataServiceDocumentV2Tests.cs
@@ -49,5 +49,23 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Assert
             Assert.Equal("https://bringing/it/all/back/home", baseAddress);
         }
+
+        [Fact]
+        public async Task IgnoresInvalidXml()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress, "[1, 2, \"not XML\"]");
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            // Act
+            var resource = await repo.GetResourceAsync<ODataServiceDocumentResourceV2>();
+
+            // Assert
+            Assert.Equal(serviceAddress.Trim('/'), resource.BaseAddress);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -18,7 +18,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
@@ -56,7 +56,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='not-found'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -17,11 +17,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task PackageMetadataResource_Basic()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
 
@@ -55,11 +58,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task PackageMetadataResource_NotFound()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='not-found'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
@@ -16,11 +16,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task PackageSearchResourceV2Feed_Basic()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>();
 
@@ -57,11 +60,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task PackageSearchResourceV2Feed_Search100()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
-     TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var repo = StaticHttpHandler.CreateSource("http://testsource/v2/", Repository.Provider.GetCoreV3(), responses);
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
+     TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
             var packageSearchResource = await repo.GetResourceAsync<PackageSearchResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/TestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/TestUtility.cs
@@ -20,5 +20,10 @@ namespace NuGet.Protocol.Core.v3.Tests
                 return reader.ReadToEnd();
             }
         }
+
+        public static string CreateServiceAddress()
+        {
+            return string.Format("http://{0}/", Guid.NewGuid());
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -42,7 +42,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='ravendb.client'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='ravendb.client'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesById.xml", GetType()));
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','1.2.2067-Unstable'",
                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesByIdPage1.xml", GetType()));
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -131,7 +131,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
@@ -324,7 +324,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
@@ -345,7 +345,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='WindowsAzure.Storage'",
+            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
@@ -384,7 +384,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'", string.Empty);
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
@@ -400,7 +400,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?Id='xunit'' " +
+                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -434,7 +434,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'", string.Empty);
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
@@ -448,7 +448,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?Id='xunit'' " +
+                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -458,7 +458,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?Id='xunit'", null);
+            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", null);
 
             var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
@@ -472,7 +472,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?Id='xunit'' " +
+                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -19,13 +19,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_Basic()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var packages = await parser.FindPackagesByIdAsync(
@@ -41,17 +44,20 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_FollowNextLinks()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='ravendb.client'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='ravendb.client'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','1.2.2067-Unstable'",
                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesByIdPage1.xml", GetType()));
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','2.0.2183-Unstable'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesByIdPage2.xml", GetType()));
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var packages = await parser.FindPackagesByIdAsync("ravendb.client", NullLogger.Instance, CancellationToken.None);
@@ -64,13 +70,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_FindPackagesByIdAsync()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var packages = await parser.FindPackagesByIdAsync("WindowsAzure.Storage", NullLogger.Instance, CancellationToken.None);
@@ -129,14 +138,17 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_DownloadFromIdentityInvalidId()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var actual = await parser.DownloadFromIdentity(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
@@ -153,13 +165,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_Search()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var searchFilter = new SearchFilter()
             {
                 IncludePrerelease = false,
@@ -196,14 +211,17 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_SearchTop100()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
             responses.Add("https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$filter=IsLatestVersion&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearchNext100.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var searchFilter = new SearchFilter()
             {
                 IncludePrerelease = false,
@@ -221,13 +239,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_Search_NotFound()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 string.Empty);
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var searchFilter = new SearchFilter()
             {
                 IncludePrerelease = false,
@@ -244,7 +265,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -253,13 +274,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_Search_InternalServerError()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
                 null);
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var searchFilter = new SearchFilter()
             {
                 IncludePrerelease = false,
@@ -276,7 +300,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }
@@ -285,13 +309,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_GetPackage()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
+            responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var package = await parser.GetPackage(new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview")), NullLogger.Instance, CancellationToken.None);
@@ -322,15 +349,18 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnPackages()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'",
-                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
             var package = await parser.GetPackage(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")), NullLogger.Instance, CancellationToken.None);
@@ -343,14 +373,17 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnPackagesFoundOnFindPackagesById()
         {
             // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses);
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
             // Act
@@ -382,14 +415,17 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnBoth()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", string.Empty);
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", string.Empty);
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var packageIdentity = new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound"));
 
             // Act
@@ -400,7 +436,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -409,13 +445,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_GetPackage_InternalServerError()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/Packages(Id='xunit',Version='1.0.0-InternalServerError')", null);
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-InternalServerError')", null);
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var packageIdentity = new PackageIdentity("xunit", new NuGetVersion("1.0.0-InternalServerError"));
 
             // Act & Assert
@@ -424,7 +463,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 NullLogger.Instance,
                 CancellationToken.None));
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/Packages(Id='xunit',Version='1.0.0-InternalServerError')' " +
+                "The V2 feed at '" + serviceAddress + "Packages(Id='xunit',Version='1.0.0-InternalServerError')' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }
@@ -433,13 +472,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_FindPackagesById_NotFound()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", string.Empty);
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", string.Empty);
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<FatalProtocolException>(() => parser.FindPackagesByIdAsync(
@@ -448,7 +490,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -457,13 +499,16 @@ namespace NuGet.Protocol.Core.v3.Tests
         public async Task V2FeedParser_FindPackagesById_InternalServerError()
         {
             // Arrange
-            var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource/v2/FindPackagesById()?id='xunit'", null);
+            var serviceAddress = TestUtility.CreateServiceAddress();
 
-            var httpSource = new TestHttpSource(new PackageSource("http://testsource/v2/"), responses,
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", null);
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.500Error.xml", GetType()));
 
-            V2FeedParser parser = new V2FeedParser(httpSource, "http://testsource/v2/");
+            V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<FatalProtocolException>(() => parser.FindPackagesByIdAsync(
@@ -472,7 +517,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at 'http://testsource/v2/FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/ODataServiceDocument.xml
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/ODataServiceDocument.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<service xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://www.w3.org/2007/app" xml:base="https://bringing/it/all/back/home">
+  <workspace>
+  <atom:title type="text">Default</atom:title>
+  <collection href="Packages">
+    <atom:title type="text">Packages</atom:title>
+  </collection>
+  </workspace>
+</service>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "NuGet.Protocol.Core.v3": "3.4.1-*",
+    "NuGet.Protocol.Core.v3": "3.4.2-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204",
-    "NuGet.Test.Utility": "3.4.1-*",
-    "NuGet.Test.Server": "3.4.1-*"
+    "NuGet.Test.Utility": "3.4.2-*",
+    "NuGet.Test.Server": "3.4.2-*"
   },
   "commands": {
     "test": "xunit.runner.dnx"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -1,8 +1,8 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "NuGet.Protocol.VisualStudio": "3.4.1-*",
+    "NuGet.Protocol.VisualStudio": "3.4.2-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.Resolver": "3.4.1-*",
+    "NuGet.Resolver": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -1,7 +1,7 @@
 {
-  "version": "3.4.1-*",
+  "version": "3.4.2-*",
   "dependencies": {
-    "NuGet.RuntimeModel": "3.4.1-*",
+    "NuGet.RuntimeModel": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -1,12 +1,12 @@
 {
-    "version": "3.4.1-*",
+    "version": "3.4.2-*",
     "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
         "NuGet.Shared": {
-            "version": "3.4.1-*",
+            "version": "3.4.2-*",
             "type": "build"
         },
-        "NuGet.Test.Utility": "3.4.1-*",
+        "NuGet.Test.Utility": "3.4.2-*",
         "SynchronizationTestApp": "1.0.0-*",
         "xunit": "2.1.0",
         "xunit.runner.dnx": "2.1.0-rc1-build204"

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "NuGet.Versioning": "3.4.1-*",
+    "NuGet.Versioning": "3.4.2-*",
     "xunit": "2.1.0",
     "xunit.runner.dnx": "2.1.0-rc1-build204"
   },


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2373.

Original implementation used distinct to eliminate duplicate VersionInfo's. This approach didn't work as entities retrieved from different sources were having different download counts.

The right solution is to eliminate duplicates using version attribute of the VersionInfo object.

//cc @emgarten @rrelyea @yishaigalatzer 
