### PR TITLE
Issue 2452: Fix exception restoring with V1 lock files.

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/SettingValue.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Shared;
 
 namespace NuGet.Configuration
 {
@@ -108,9 +109,7 @@ namespace NuGet.Configuration
                 &&
                 rhs.AdditionalData.Count == AdditionalData.Count)
             {
-                return Enumerable.SequenceEqual(
-                    AdditionalData.OrderBy(data => data.Key, StringComparer.OrdinalIgnoreCase),
-                    rhs.AdditionalData.OrderBy(data => data.Key, StringComparer.OrdinalIgnoreCase));
+                return AdditionalData.OrderedEquals(rhs.AdditionalData, data => data.Key, StringComparer.OrdinalIgnoreCase);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/comparers/PackageDependencyComparer.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/comparers/PackageDependencyComparer.cs
@@ -56,14 +56,12 @@ namespace NuGet.Packaging.Core
 
             if (result)
             {
-                result = x.Include.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(y.Include.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+                result = x.Include.OrderedEquals(y.Include, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
             }
 
             if (result)
             {
-                result = x.Exclude.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(y.Exclude.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+                result = x.Exclude.OrderedEquals(y.Exclude, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Frameworks;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -166,16 +167,11 @@ namespace NuGet.ProjectModel
 
             return IsLocked == other.IsLocked
                 && Version == other.Version
-                && ProjectFileDependencyGroups.OrderBy(group => group.FrameworkName, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.ProjectFileDependencyGroups.OrderBy(
-                        group => group.FrameworkName, StringComparer.OrdinalIgnoreCase))
-                && Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase))
-                && Targets.OrderBy(target => target.Name).SequenceEqual(other.Targets.OrderBy(target => target.Name))
-                && ProjectFileToolGroups.OrderBy(group => group.FrameworkName, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.ProjectFileToolGroups.OrderBy(
-                        group => group.FrameworkName, StringComparer.OrdinalIgnoreCase))
-                && Tools.OrderBy(target => target.Name).SequenceEqual(other.Tools.OrderBy(target => target.Name));
+                && ProjectFileDependencyGroups.OrderedEquals(other.ProjectFileDependencyGroups, group => group.FrameworkName, StringComparer.OrdinalIgnoreCase)
+                && Libraries.OrderedEquals(other.Libraries, library => library.Name, StringComparer.OrdinalIgnoreCase)
+                && Targets.OrderedEquals(other.Targets, target => target.Name, StringComparer.Ordinal)
+                && ProjectFileToolGroups.OrderedEquals(other.ProjectFileToolGroups, group => group.FrameworkName, StringComparer.OrdinalIgnoreCase)
+                && Tools.OrderedEquals(other.Tools, target => target.Name, StringComparer.Ordinal);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileItem.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
+using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
@@ -35,8 +35,7 @@ namespace NuGet.ProjectModel
 
             if (string.Equals(Path, other.Path, StringComparison.OrdinalIgnoreCase))
             {
-                return Properties.OrderBy(pair => pair.Key, StringComparer.Ordinal)
-                    .SequenceEqual(other.Properties.OrderBy(pair => pair.Key, StringComparer.Ordinal));
+                return Properties.OrderedEquals(other.Properties, pair => pair.Key, StringComparer.Ordinal);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -52,8 +53,7 @@ namespace NuGet.ProjectModel
                 && string.Equals(Sha512, other.Sha512, StringComparison.Ordinal)
                 && Version == other.Version)
             {
-                return Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+                return Files.OrderedEquals(other.Files, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTarget.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTarget.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Frameworks;
+using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
@@ -34,8 +35,7 @@ namespace NuGet.ProjectModel
                 && string.Equals(RuntimeIdentifier, other.RuntimeIdentifier)
                 && string.Equals(Name, other.Name))
             {
-                return Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.Libraries.OrderBy(library => library.Name, StringComparer.OrdinalIgnoreCase));
+                return Libraries.OrderedEquals(other.Libraries, library => library.Name, StringComparer.OrdinalIgnoreCase);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileTargetLibrary.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.Frameworks;
 using NuGet.Packaging.Core;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -52,22 +52,14 @@ namespace NuGet.ProjectModel
                 && VersionComparer.Default.Equals(Version, other.Version)
                 && string.Equals(Type, other.Type, StringComparison.Ordinal)
                 && string.Equals(Framework, other.Framework, StringComparison.Ordinal)
-                && Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.Dependencies.OrderBy(dependency => dependency.Id, StringComparer.OrdinalIgnoreCase))
-                && FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.FrameworkAssemblies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
-                && RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.RuntimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-                && ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.ResourceAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-                && CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.CompileTimeAssemblies.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-                && NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.NativeLibraries.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-                && ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.ContentFiles.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase))
-                && RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(other.RuntimeTargets.OrderBy(item => item.Path, StringComparer.OrdinalIgnoreCase));
+                && Dependencies.OrderedEquals(other.Dependencies, dependency => dependency.Id, StringComparer.OrdinalIgnoreCase)
+                && FrameworkAssemblies.OrderedEquals(other.FrameworkAssemblies, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase)
+                && RuntimeAssemblies.OrderedEquals(other.RuntimeAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && ResourceAssemblies.OrderedEquals(other.ResourceAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && CompileTimeAssemblies.OrderedEquals(other.CompileTimeAssemblies, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && NativeLibraries.OrderedEquals(other.NativeLibraries, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && ContentFiles.OrderedEquals(other.ContentFiles, item => item.Path, StringComparer.OrdinalIgnoreCase)
+                && RuntimeTargets.OrderedEquals(other.RuntimeTargets, item => item.Path, StringComparer.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectFileDependencyGroup.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NuGet.LibraryModel;
+using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
@@ -39,10 +39,7 @@ namespace NuGet.ProjectModel
                     return Dependencies == other.Dependencies;
                 }
 
-                return Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-                    .SequenceEqual(
-                        other.Dependencies.OrderBy(s => s, StringComparer.OrdinalIgnoreCase),
-                        StringComparer.OrdinalIgnoreCase);
+                return Dependencies.OrderedEquals(other.Dependencies, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
             }
 
             return false;

--- a/src/NuGet.Core/NuGet.RuntimeModel/CompatibilityProfile.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/CompatibilityProfile.cs
@@ -40,7 +40,7 @@ namespace NuGet.RuntimeModel
         {
             return other != null &&
                 string.Equals(Name, other.Name, StringComparison.Ordinal) &&
-                RestoreContexts.OrderBy(r => r).SequenceEqual(other.RestoreContexts.OrderBy(r => r));
+                RestoreContexts.OrderedEquals(other.RestoreContexts, r => r);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.RuntimeModel/RuntimeDependencySet.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/RuntimeDependencySet.cs
@@ -33,12 +33,9 @@ namespace NuGet.RuntimeModel
                 return false;
             }
 
-            var dependenciesEqual = Dependencies
-                .OrderBy(p => p.Key, StringComparer.Ordinal)
-                .SequenceEqual(other.Dependencies.OrderBy(p => p.Key, StringComparer.Ordinal));
 
-            return string.Equals(other.Id, Id, StringComparison.Ordinal) &&
-                   dependenciesEqual;
+            return string.Equals(other.Id, Id, StringComparison.Ordinal)
+                && Dependencies.OrderedEquals(other.Dependencies, p => p.Key, StringComparer.Ordinal);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.RuntimeModel/RuntimeDescription.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/RuntimeDescription.cs
@@ -44,17 +44,9 @@ namespace NuGet.RuntimeModel
                 return false;
             }
 
-            var inheritedRuntimesEqual = InheritedRuntimes
-                .OrderBy(s => s, StringComparer.Ordinal)
-                .SequenceEqual(other.InheritedRuntimes.OrderBy(s => s, StringComparer.Ordinal));
-            var dependencySetsEqual = RuntimeDependencySets
-                .OrderBy(p => p.Key, StringComparer.Ordinal)
-                .SequenceEqual(other.RuntimeDependencySets.OrderBy(p => p.Key, StringComparer.Ordinal));
-
-            return
-                string.Equals(other.RuntimeIdentifier, RuntimeIdentifier, StringComparison.Ordinal) &&
-                inheritedRuntimesEqual &&
-                dependencySetsEqual;
+            return string.Equals(other.RuntimeIdentifier, RuntimeIdentifier, StringComparison.Ordinal)
+                && InheritedRuntimes.OrderedEquals(other.InheritedRuntimes, s => s, StringComparer.Ordinal, StringComparer.Ordinal)
+                && RuntimeDependencySets.OrderedEquals(other.RuntimeDependencySets, p => p.Key, StringComparer.Ordinal);
         }
 
         public RuntimeDescription Clone()

--- a/src/NuGet.Core/NuGet.RuntimeModel/RuntimeGraph.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/RuntimeGraph.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using NuGet.Shared;
 
 namespace NuGet.RuntimeModel
 {
@@ -167,13 +168,8 @@ namespace NuGet.RuntimeModel
                 return false;
             }
 
-            var runtimesEqual = Runtimes
-               .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-               .SequenceEqual(other.Runtimes.OrderBy(pair => pair.Key, StringComparer.Ordinal));
-            var supportsEqual = Supports
-               .OrderBy(pair => pair.Key, StringComparer.Ordinal)
-               .SequenceEqual(other.Supports.OrderBy(pair => pair.Key, StringComparer.Ordinal));
-            return runtimesEqual && supportsEqual;
+            return Runtimes.OrderedEquals(other.Runtimes, pair => pair.Key, StringComparer.Ordinal)
+                && Supports.OrderedEquals(other.Supports, pair => pair.Key, StringComparer.Ordinal);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
+++ b/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace NuGet.Shared
+{
+    internal static class Extensions
+    {
+        /// <summary>
+        /// Compares two enumberables for equality, ordered according to the specified key and optional comparer. Handles null values gracefully.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the list</typeparam>
+        /// <typeparam name="TKey">The type of the sorting key</typeparam>
+        /// <param name="self">This list</param>
+        /// <param name="other">The other list</param>
+        /// <param name="keySelector">The function to extract the key from each item in the list</param>
+        /// <param name="comparer">An optional comparer for comparing keys</param>
+        /// <returns></returns>
+        internal static bool OrderedEquals<TSource, TKey>(this IEnumerable<TSource> self, IEnumerable<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey> orderComparer = null, IEqualityComparer<TSource> sequenceComparer = null)
+        {
+            Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + nameof(orderComparer) + " must be provided if " + nameof(TKey) + " is a string.");
+            Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + nameof(sequenceComparer) + " must be provided if " + nameof(TSource) + " is a string.");
+
+            if (ReferenceEquals(self, other))
+            {
+                return true;
+            }
+
+            if (self == null || other == null)
+            {
+                return false;
+            }
+
+            return self.OrderBy(keySelector, orderComparer).SequenceEqual(other.OrderBy(keySelector, orderComparer), sequenceComparer);
+        }
+    }
+}


### PR DESCRIPTION
When working with V1 lock files, we set `ProjectFileToolGroups` to `null`. `LockFile.Equals()` expects it to be non-null, so we get an NRE restoring a project with a V1 lock file.

This change adds an extension method `OrderedEquals` which can replace the following commonly used pattern:

``` cs
this.enumerable.OrderBy(x => f(x), comparer)
    .SequenceEqual(other.enumerable.OrderBy(x => f(x), comparer))
```

With the following:

``` cs
this.enumerable.OrderedEquals(other.enumerable, x => f(x), comparer)
```

Since this has benefits everywhere we use this pattern (handles null refs, easier to read, reduced code duplication), I applied the change everywhere.
