### PR TITLE
fixed NuGet.config missing issue

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -24,7 +24,7 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        public static readonly string AddV3TrackFile = "AddV3Track.config";
+        public static readonly string AddV3TrackFile = "NuGetOrgAdd.trk";
 
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -24,7 +24,7 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
-        public static readonly string AddV3TrackFile = "NuGetOrgAdd.trk";
+        public static readonly string AddV3TrackFile = "nugetorgadd.trk";
 
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -24,6 +24,8 @@ namespace NuGet.Configuration
 
         public static readonly string FeedName = "nuget.org";
 
+        public static readonly string AddV3TrackFile = "AddV3Track.config";
+
         public static readonly string DefaultConfigContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -302,8 +302,9 @@ namespace NuGet.Configuration
                     {
                         var trackFilePath = Path.Combine(Path.GetDirectoryName(defaultSettingsFilePath), NuGetConstants.AddV3TrackFile);
 
-                        if (appDataSettings.GetorCreateAddV3TrackFileValue(trackFilePath))
+                        if (!File.Exists(trackFilePath))
                         {
+                            File.Create(trackFilePath).Dispose();
                             var defaultPackageSource = new SettingValue(NuGetConstants.FeedName, NuGetConstants.V3FeedUrl, isMachineWide: false);
                             defaultPackageSource.AdditionalData.Add(ConfigurationConstants.ProtocolVersionAttribute, "3");
                             appDataSettings.UpdateSections(ConfigurationConstants.PackageSources, new List<SettingValue> { defaultPackageSource });
@@ -1203,39 +1204,6 @@ namespace NuGet.Configuration
             {
                 throw new NuGetConfigurationException(
                          string.Format(Resources.ShowError_ConfigRootInvalid, ConfigFilePath));
-            }
-        }
-
-        private bool GetorCreateAddV3TrackFileValue(string path)
-        {
-            bool FileNotExist = false;
-            if (!File.Exists(path))
-            {
-                FileNotExist = true;
-            }
-            var content = new XDocument(new XElement(ConfigurationConstants.AddV3Track, "false"));
-            XDocument doc = null;
-            ExecuteSynchronized(() => doc = XmlUtility.GetOrCreateDocument(content, path));
-
-            if (FileNotExist)
-            {
-                return true;
-            }
-            else
-            {
-                if (doc != null)
-                {
-                   try
-                    {
-                        return Convert.ToBoolean(doc.Elements(ConfigurationConstants.AddV3Track).FirstOrDefault().Value);
-                    }
-                    catch (FormatException)
-                    {
-                        return false;
-                    }
-                }
-
-                return false;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -47,7 +47,5 @@ namespace NuGet.Configuration
 
         public static readonly string BeginIgnoreMarker = "NUGET: BEGIN LICENSE TEXT";
         public static readonly string EndIgnoreMarker = "NUGET: END LICENSE TEXT";
-
-        public static string AddV3Track = "AddV3Track";
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -47,5 +47,7 @@ namespace NuGet.Configuration
 
         public static readonly string BeginIgnoreMarker = "NUGET: BEGIN LICENSE TEXT";
         public static readonly string EndIgnoreMarker = "NUGET: END LICENSE TEXT";
+
+        public static string AddV3Track = "AddV3Track";
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -2236,6 +2236,46 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
+        public void AddV3ToEmptyConfigFile()
+        {
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var config = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>";
+
+                var nugetConfigPath = "NuGet.Config";
+                ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, 
+                    Path.Combine(mockBaseDirectory, "TestingGlobalPath"), config);
+
+                // Act
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory, null, null, true, true);
+
+                // Assert
+                var text = File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath", "NuGet.Config")).Replace("\r\n", "\n");
+                var result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" protocolVersion=""3"" />
+  </packageSources>
+</configuration>".Replace("\r\n", "\n");
+                Assert.Equal(result, text);
+
+                // Act
+                settings.DeleteSection("packageSources");
+                settings = Settings.LoadDefaultSettings(mockBaseDirectory, null, null, true, true);
+
+                // Assert
+                text = File.ReadAllText(Path.Combine(mockBaseDirectory, "TestingGlobalPath" , "NuGet.Config")).Replace("\r\n", "\n");
+                result = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+</configuration>".Replace("\r\n", "\n");
+                Assert.Equal(result, text);
+            }
+        }
+
+        [Fact]
         public void LoadNuGetConfig_InvalidXmlThrowException()
         {
             // Arrange


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2445

the fix here is to check nuget.config in appdata, if there is no source, add nuget.org to it and create a track file. If the track file exist, nuget will not add nuget.org again.

And this fix is only for global nuget.config.

tested upgrading from 3.3 to 3.4 scenario, it works well
