### PR TITLE
Fixed issue of merging versions of slow source

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
@@ -196,11 +196,16 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
+                var items = nonEmptyResults.Select(r => r.Items).ToArray();
+
                 var indexer = new RelevanceSearchResultsIndexer();
                 var aggregator = new SearchResultsAggregator(indexer);
                 var aggregatedItems = await aggregator.AggregateAsync(
-                    searchText, nonEmptyResults.Select(r => r.Items).ToArray());
+                    searchText, items);
+
                 result = SearchResult.FromItems(aggregatedItems.ToArray());
+                // set correct count of unmerged items
+                result.RawItemsCount = items.Aggregate(0, (r, next) => r + next.Count);
             }
 
             result.SourceSearchStatus = results

--- a/src/NuGet.Clients/PackageManagement.UI/Models/SearchResult.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/SearchResult.cs
@@ -40,6 +40,9 @@ namespace NuGet.PackageManagement.UI
         IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
 
         public IDictionary<string, LoadingStatus> SourceSearchStatus { get; set; }
+
+        // total number of unmerged items found
+        public int RawItemsCount { get; set; }
     }
 
     /// <summary>
@@ -47,9 +50,17 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     internal static class SearchResult
     {
-        public static SearchResult<T> FromItems<T>(params T[] items) => new SearchResult<T> { Items = items };
+        public static SearchResult<T> FromItems<T>(params T[] items) => new SearchResult<T>
+        {
+            Items = items,
+            RawItemsCount = items.Length
+        };
 
-        public static SearchResult<T> FromItems<T>(IReadOnlyList<T> items) => new SearchResult<T> { Items = items };
+        public static SearchResult<T> FromItems<T>(IReadOnlyList<T> items) => new SearchResult<T>
+        {
+            Items = items,
+            RawItemsCount = items.Count
+        };
 
         public static SearchResult<T> Empty<T>() => new SearchResult<T>
         {

--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -67,7 +67,9 @@ namespace NuGet.PackageManagement.UI
                 }
             }
 
-            public int ItemsCount => _results?.Items?.Count() ?? 0;
+            // returns the "raw" counter which is not the same as _results.Items.Count
+            // simply because it correlates to un-merged items
+            public int ItemsCount => _results?.RawItemsCount ?? 0;
 
             public IDictionary<string, LoadingStatus> SourceLoadingStatus => _results?.SourceSearchStatus;
 

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -196,7 +196,7 @@ namespace NuGet.PackageManagement.UI
             await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                _loadingStatusBar.ItemsLoaded = PackageItems.Count();
+                _loadingStatusBar.ItemsLoaded = currentLoader.State.ItemsCount;
             });
 
             token.ThrowIfCancellationRequested();
@@ -281,7 +281,7 @@ namespace NuGet.PackageManagement.UI
 
             if (loader.IsMultiSource)
             {
-                bool hasMore = PackageItems.Any() && state.ItemsCount > PackageItems.Count();
+                bool hasMore = _loadingStatusBar.ItemsLoaded != 0 && state.ItemsCount > _loadingStatusBar.ItemsLoaded;
                 if (hasMore)
                 {
                     statusBarVisibility = Visibility.Visible;
@@ -325,7 +325,7 @@ namespace NuGet.PackageManagement.UI
                 .ForEach(i => i.PropertyChanged -= Package_PropertyChanged);
             Items.Clear();
 
-            _loadingStatusBar.ItemsLoaded = PackageItems.Count();
+            _loadingStatusBar.ItemsLoaded = 0;
         }
 
         public void UpdatePackageStatus(PackageIdentity[] installedPackages)
@@ -513,7 +513,7 @@ namespace NuGet.PackageManagement.UI
         {
             var packageItems = _loader?.GetCurrent() ?? Enumerable.Empty<PackageItemListViewModel>();
             UpdatePackageList(packageItems.ToList(), refresh: true);
-            _loadingStatusBar.ItemsLoaded = PackageItems.Count();
+            _loadingStatusBar.ItemsLoaded = _loader?.State.ItemsCount ?? 0;
 
             var desiredVisibility = EvaluateStatusBarVisibility(_loader, _loader.State);
             if (_loadingStatusBar.Visibility != desiredVisibility)


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2374.

This change corrects the all-sources UI behavior when evaluating incremental search results coming from slow sources. The original issue manifested itself when slow source was returning overlapping search results.  In certain edge cases displayed items count was the same as loaded items count therefore the yellow bar didn't pop up to prompt user refreshing the list.

This fix suggests using "raw" counter of un-merged items to detect when more search results are available.

//cc @rrelyea @emgarten @yishaigalatzer 
