### PR TITLE
Fixing up dependency handling in project.json files by adding logic a…

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -172,10 +172,22 @@ namespace NuGet.Commands
             {
                 builder.Id = id;
             }
-            builder.Version = spec.Version;
-            builder.Title = spec.Title;
-            builder.Description = spec.Description;
-            builder.Copyright = spec.Copyright;
+            if (!spec.IsDefaultVersion)
+            {
+                builder.Version = spec.Version;
+            }
+            if (spec.Title != null)
+            {
+                builder.Title = spec.Title;
+            }
+            if (spec.Description != null)
+            {
+                builder.Description = spec.Description;
+            }
+            if (spec.Copyright != null)
+            {
+                builder.Copyright = spec.Copyright;
+            }
             if (spec.Authors.Any())
             {
                 builder.Authors.AddRange(spec.Authors);
@@ -198,9 +210,18 @@ namespace NuGet.Commands
                 builder.IconUrl = tempUri;
             }
             builder.RequireLicenseAcceptance = spec.RequireLicenseAcceptance;
-            builder.Summary = spec.Summary;
-            builder.ReleaseNotes = spec.ReleaseNotes;
-            builder.Language = spec.Language;
+            if (spec.Summary != null)
+            {
+                builder.Summary = spec.Summary;
+            }
+            if (spec.ReleaseNotes != null)
+            {
+                builder.ReleaseNotes = spec.ReleaseNotes;
+            }
+            if (spec.Language != null)
+            {
+                builder.Language = spec.Language;
+            }
 
             foreach (var include in spec.PackInclude)
             {
@@ -211,7 +232,7 @@ namespace NuGet.Commands
             // Also, id is null only when we want to skip the AddFiles
             if (basePath != null && id != null && !builder.Files.Any())
             {
-                builder.AddFiles(basePath, @"**\*", null);
+                builder.AddFiles(basePath, @"**\*.dll", null);
             }
 
             if (spec.Tags.Any())

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -137,6 +137,11 @@ namespace NuGet.Commands
                 LoadProjectJsonFile(builder, path, _packArgs.BasePath, Path.GetFileName(Path.GetDirectoryName(path)), stream, propertyProvider);
             }
 
+            if (!builder.Files.Any())
+            {
+                builder.AddFiles(_packArgs.BasePath, @"**/*", null);
+            }
+
             return builder;
         }
 
@@ -226,13 +231,6 @@ namespace NuGet.Commands
             foreach (var include in spec.PackInclude)
             {
                 builder.AddFiles(basePath, include.Value, include.Key);
-            }
-
-            // If there's no base path then ignore the files node
-            // Also, id is null only when we want to skip the AddFiles
-            if (basePath != null && id != null && !builder.Files.Any())
-            {
-                builder.AddFiles(basePath, @"**\*.dll", null);
             }
 
             if (spec.Tags.Any())

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -239,19 +239,19 @@ namespace NuGet.Commands
             }
             if (spec.Dependencies.Any())
             {
-                AddDependencyGroups(spec.Dependencies, NuGetFramework.AnyFramework, builder, isTargetFrameworks: false);
+                AddDependencyGroups(spec.Dependencies, NuGetFramework.AnyFramework, builder);
             }
 
             if (spec.TargetFrameworks.Any())
             {
                 foreach (var framework in spec.TargetFrameworks)
                 {
-                    AddDependencyGroups(framework.Dependencies, framework.FrameworkName, builder, isTargetFrameworks: true);
+                    AddDependencyGroups(framework.Dependencies, framework.FrameworkName, builder);
                 }
             }
         }
 
-        private static void AddDependencyGroups(IList<LibraryDependency> dependencies, NuGetFramework framework, PackageBuilder builder, bool isTargetFrameworks)
+        private static void AddDependencyGroups(IList<LibraryDependency> dependencies, NuGetFramework framework, PackageBuilder builder)
         {
             List<PackageDependency> packageDependencies = new List<PackageDependency>();
             bool addedFrameworkReference = false;

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTarget.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTarget.cs
@@ -17,7 +17,7 @@ namespace NuGet.LibraryModel
         Assembly = 1 << 3,
         Reference = 1 << 4,
         WinMD = 1 << 5,
-        All = 0xFFFF,
+        All = Package | Project | ExternalProject | Assembly | Reference | WinMD,
 
         /// <summary>
         /// A package, project, or external project

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -68,6 +68,7 @@ namespace NuGet.ProjectModel
             if (version == null)
             {
                 packageSpec.Version = new NuGetVersion("1.0.0");
+                packageSpec.IsDefaultVersion = true;
             }
             else
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -217,7 +217,7 @@ namespace NuGet.ProjectModel
                     // Dependencies should allow everything but framework references.
                     var targetFlagsValue = isGacOrFrameworkReference
                                                     ? LibraryDependencyTarget.Reference
-                                                    : ~LibraryDependencyTarget.Reference;
+                                                    : LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
 
                     string dependencyVersionValue = null;
                     var dependencyVersionToken = dependencyValue;

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -37,7 +37,20 @@ namespace NuGet.ProjectModel
 
         public string Title { get; set; }
 
-        public NuGetVersion Version { get; set; }
+        private NuGetVersion _version;
+        public NuGetVersion Version
+        {
+            get
+            {
+                return _version;
+            }
+            set
+            {
+                _version = value;
+                this.IsDefaultVersion = false;
+            }
+        }
+        public bool IsDefaultVersion { get; set; }
 
         public string Description { get; set; }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -2441,7 +2441,7 @@ namespace " + projectName + @"
                     var actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
+                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <group targetFramework="".NETFramework4.6"" />
 </dependencies>".Replace("\r\n", "\n"), actual);
 
@@ -2449,7 +2449,7 @@ namespace " + projectName + @"
                     actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
+                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
   <frameworkAssembly assemblyName=""System.Xml"" targetFramework="".NETFramework4.6"" />
   <frameworkAssembly assemblyName=""System.Xml.Linq"" targetFramework="".NETFramework4.6"" />
 </frameworkAssemblies>".Replace("\r\n", "\n"), actual);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -2441,7 +2441,7 @@ namespace " + projectName + @"
                     var actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <group targetFramework="".NETFramework4.6"" />
 </dependencies>".Replace("\r\n", "\n"), actual);
 
@@ -2449,7 +2449,7 @@ namespace " + projectName + @"
                     actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <frameworkAssembly assemblyName=""System.Xml"" targetFramework="".NETFramework4.6"" />
   <frameworkAssembly assemblyName=""System.Xml.Linq"" targetFramework="".NETFramework4.6"" />
 </frameworkAssemblies>".Replace("\r\n", "\n"), actual);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -120,7 +120,7 @@ namespace NuGet.ProjectModel.Test
             var dependency = spec.Dependencies.Single();
 
             // Assert
-            var expected = ~LibraryDependencyTarget.Reference;
+            var expected = LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference;
             Assert.Equal(expected, dependency.LibraryRange.TypeConstraint);
         }
 


### PR DESCRIPTION
…round the TypeConstraint.

@emgarten, let me know if this logic looks right.  I didn't have logic around the TypeConstraint before.  This adds that in and makes the dependencies come out close to what the dotnet pack produces.
