### PR TITLE
Fix for nexus feeds that add the null string into feed responses

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedPackageInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedPackageInfo.cs
@@ -33,6 +33,7 @@ namespace NuGet.Protocol
         private readonly string _packageHash;
         private readonly string _packageHashAlgorithm;
         private readonly NuGetVersion _minClientVersion;
+        private const string NullString = "null";
 
         public V2FeedPackageInfo(PackageIdentity identity, string title, string summary, string description, IEnumerable<string> authors, IEnumerable<string> owners,
             string iconUrl, string licenseUrl, string projectUrl, string reportAbuseUrl,
@@ -230,8 +231,10 @@ namespace NuGet.Protocol
                             {
                                 var versionRangeString = parts[1];
 
+                                // Nexus will write "null" when there is no depenency version range.
                                 // Parse the optional version range
-                                if (!string.IsNullOrEmpty(versionRangeString))
+                                if (!string.IsNullOrWhiteSpace(versionRangeString) 
+                                    && !string.Equals(NullString, versionRangeString, StringComparison.Ordinal))
                                 {
                                     // Attempt to parse the version
                                     versionRange = VersionRange.Parse(versionRangeString);
@@ -242,7 +245,8 @@ namespace NuGet.Protocol
                                 {
                                     var frameworkString = parts[2];
 
-                                    if (!string.IsNullOrEmpty(frameworkString))
+                                    if (!string.IsNullOrWhiteSpace(frameworkString)
+                                        && !string.Equals(NullString, versionRangeString, StringComparison.Ordinal))
                                     {
                                         framework = NuGetFramework.Parse(frameworkString);
                                     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -425,7 +425,7 @@ namespace NuGet.Protocol
 
             return results;
         }
-        
+
         internal async Task<XDocument> LoadXmlAsync(
             string uri,
             bool ignoreNotFounds,
@@ -433,11 +433,11 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             return await _httpSource.ProcessResponseAsync(
-                () => 
+                () =>
                 {
                     var request = new HttpRequestMessage(HttpMethod.Get, uri);
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
-                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));                    
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
                     return request;
                 },
                 async response =>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/NexusFindPackagesById.xml
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/NexusFindPackagesById.xml
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<feed xml:base="http://nexus:8080/nexus/service/local/nuget/nuget-public/" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">FindPackagesById</title>
+  <id>http://nexus:8080/nexus/service/local/nuget/nuget-public/FindPackagesById</id>
+  <updated>2016-04-06T15:10:08.792Z</updated>
+  <link rel="self" title="FindPackagesById" href="FindPackagesById"/>
+  <entry>
+    <id>http://nexus:8080/nexus/service/local/nuget/nuget-public/Packages(Id='PackageA',Version='1.0.0.99')</id>
+    <title type="text">PackageA</title>
+    <summary type="text">Some description</summary>
+    <updated>2016-04-06T12:46:30.942Z</updated>
+    <author>
+      <name>My Name</name>
+    </author>
+    <link rel="edit-media" title="V2FeedPackage" href="Packages(Id='PackageA',Version='1.0.0.99')/$value" />
+    <link rel="edit" title="V2FeedPackage" href="Packages(Id='PackageA',Version='1.0.0.99')" />
+    <category term="NuGetGallery.V2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <content type="application/zip" src="http://nexus:8080/nexus/service/local/nuget/nuget-public/PackageA/1.0.0.99" />
+    <m:properties>
+      <d:Version>1.0.0.99</d:Version>
+      <d:Copyright>Copyright 2016</d:Copyright>
+      <d:Created m:type="Edm.DateTime">2016-04-06T12:46:30.942Z</d:Created>
+      <d:Dependencies>PackageB:null|EntityFramework:6.1.3|PackageC:3.7.0.15</d:Dependencies>
+      <d:Description>Some description</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:GalleryDetailsUrl m:null="true"></d:GalleryDetailsUrl>
+      <d:IconUrl m:null="true"></d:IconUrl>
+      <d:IsLatestVersion m:type="Edm.Boolean">false</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">false</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Published m:type="Edm.DateTime">2016-04-06T12:46:30.942Z</d:Published>
+      <d:Language m:null="true"></d:Language>
+      <d:LicenseUrl m:null="true"></d:LicenseUrl>
+      <d:PackageHash>aqIW4mRwo2ZXuknkKVM09X2on6INMwWd7ImzzZkenjUYNrEM+0XjL2uZlUg7tQpnUU2AzK0J3SNPWWiGuw4wgw==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type="Edm.Int64">8670</d:PackageSize>
+      <d:ProjectUrl m:null="true"></d:ProjectUrl>
+      <d:ReportAbuseUrl m:null="true"></d:ReportAbuseUrl>
+      <d:ReleaseNotes></d:ReleaseNotes>
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Tags m:null="true"></d:Tags>
+      <d:Title>PackageA Helpers</d:Title>
+      <d:VersionDownloadCount m:type="Edm.Int32">0</d:VersionDownloadCount>
+    </m:properties>
+  </entry>
+</feed>


### PR DESCRIPTION
Nexus feeds return the string "null" as part of the feed response for version ranges. This change will explicitly ignore those strings and treat them as All/Any.

https://github.com/NuGet/Home/issues/2426

//cc @alpaix @joelverhagen @yishaigalatzer 
