### PR TITLE
Updated version to 3.5 everywhere and created a script to use in the future

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -31,9 +31,7 @@
 		  Semantic Version. See http://semver.org for full details.
 		  Update for every public release.
 		-->
-		<SemanticVersionMajor>3</SemanticVersionMajor>
-		<SemanticVersionMinor>5</SemanticVersionMinor>
-		<SemanticVersionPatch>0</SemanticVersionPatch>
+		<SemanticVersion>3.5.0</SemanticVersion>
 		<PreReleaseVersion>0</PreReleaseVersion>
 	</PropertyGroup>
 
@@ -60,13 +58,13 @@
 		  NuGet package version is derived from AssemblyFileVersion.
 		-->
 		<AssemblyAttributes Include="AssemblyVersion">
-		  <_Parameter1>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch).$(PreReleaseVersion)</_Parameter1>
+		  <_Parameter1>$(SemanticVersion).$(PreReleaseVersion)</_Parameter1>
 		</AssemblyAttributes>
 		<AssemblyAttributes Include="AssemblyFileVersion">
-		  <_Parameter1>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch).$(PreReleaseVersion)</_Parameter1>
+		  <_Parameter1>$(SemanticVersion).$(PreReleaseVersion)</_Parameter1>
 		</AssemblyAttributes>
 		<AssemblyAttributes Include="AssemblyInformationalVersion">
-		  <_Parameter1>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)$(PreReleaseInformationVersion)</_Parameter1>
+		  <_Parameter1>$(SemanticVersion)$(PreReleaseInformationVersion)</_Parameter1>
 		</AssemblyAttributes>
 		<AssemblyAttributes Include="AssemblyCompany">
 		  <_Parameter1>Microsoft Corporation</_Parameter1>

--- a/scripts/utils/UpdateNuGetVersion.ps1
+++ b/scripts/utils/UpdateNuGetVersion.ps1
@@ -1,0 +1,38 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$nuGetRoot,
+    [Parameter(Mandatory=$true)]
+    [string]$oldVersion,
+    [Parameter(Mandatory=$true)]
+    [string]$newVersion)
+
+function ReplaceNuGetVersion
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$file
+    )
+
+    if ((gc $file | Out-String) -match $oldVersion)
+    {
+        Write-Host "On $file, replacing version from $oldVersion to $newVersion"
+        $c = Get-Content $file
+        $d = $c | %{
+            $_.Replace($oldVersion, $newVersion)
+        }
+
+        Set-Content $file $d | Out-Null
+    }
+}
+
+ls -r project.json | ?{ ReplaceNuGetVersion($_.FullName) }
+
+$vsixManifestFile = Join-Path $nuGetRoot "src\NuGet.Clients\VsExtension\source.extension.vsixmanifest"
+ReplaceNuGetVersion($vsixManifestFile)
+
+$nugetPackageCSFile = Join-Path $nuGetRoot "src\NuGet.Clients\VsExtension\NuGetPackage.cs"
+ReplaceNuGetVersion($nugetPackageCSFile)
+
+$commonProps = Join-Path $nuGetRoot "build\common.props"
+ReplaceNuGetVersion($commonProps)

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -65,7 +65,7 @@ namespace NuGetVSExtension
     public sealed class NuGetPackage : Package, IVsPackageExtensionProvider, IVsPersistSolutionOpts
     {
         // It is displayed in the Help - About box of Visual Studio
-        public const string ProductVersion = "3.4.0";
+        public const string ProductVersion = "3.5.0";
         private static readonly object _credentialsPromptLock = new object();
 
         private static readonly string[] _visualizerSupportedSKUs = { "Premium", "Ultimate" };

--- a/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.4.0" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.5.0" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 2015</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Icon>Resources/nuget_96.png</Icon>


### PR DESCRIPTION
1. Updated version from 3.4.0 to 3.5.0 on the vsix manifest version
   and NuGetPackage.cs
2. Simplified common.props file to have the
   SemanticVersion as a single property.
3. Created an UpdateVersion script that can be used to update NuGet version 
   when creating new releases.

@yishaigalatzer @emgarten @alpaix 
