### PR TITLE
When pushing to custom, non-NuGet.org feed, symbols should not be pushed to SymbolSource automatically

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PushRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PushRunner.cs
@@ -30,9 +30,18 @@ namespace NuGet.Commands
 
             PackageUpdateResource packageUpdateResource = await CommandRunnerUtility.GetPackageUpdateResource(sourceProvider, source);
 
-            string symbolsSource = !noSymbols
-                ? NuGetConstants.DefaultSymbolServerUrl
-                : string.Empty;
+            // only push to SymbolSource when the actual package is being pushed to the official NuGet.org
+            string symbolsSource = string.Empty;
+
+            Uri sourceUri;
+            if (!noSymbols && Uri.TryCreate(source, UriKind.RelativeOrAbsolute, out sourceUri))
+            {
+                if (sourceUri.Host.Equals(NuGetConstants.NuGetHostName, StringComparison.OrdinalIgnoreCase) // e.g. nuget.org
+                    || sourceUri.Host.EndsWith("." + NuGetConstants.NuGetHostName, StringComparison.OrdinalIgnoreCase)) // *.nuget.org, e.g. www.nuget.org
+                {
+                    symbolsSource = NuGetConstants.DefaultSymbolServerUrl;
+                }
+            }
 
             await packageUpdateResource.Push(
                 packagePath,

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/NuGetConstants.cs
@@ -5,6 +5,8 @@ namespace NuGet.Configuration
 {
     public static class NuGetConstants
     {
+        public static readonly string NuGetHostName = "nuget.org";
+
         public static readonly string V3FeedUrl = "https://api.nuget.org/v3/index.json";
         public static readonly string V2FeedUrl = "https://www.nuget.org/api/v2/";
         public static readonly string V2LegacyOfficialPackageSourceUrl = "https://nuget.org/api/v2/";


### PR DESCRIPTION
Check if the package source is on NuGet.org before automatically pushing to SymbolSource. Fixes https://github.com/NuGet/Home/issues/2484

Alternatively we should stop doing this auto-push and enrich docs.nuget.org on how to push their stuff to SymbolSource.org.

@yishaigalatzer @rrelyea @Emgarten @joelverhagen 
