### PR TITLE
Enumerate lazy list that fetches latest version for each installed package ID

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
@@ -76,7 +76,8 @@ namespace NuGet.PackageManagement.UI
             bool includePrerelease, CancellationToken cancellationToken)
         {
             var tasks = _sourceRepositories
-                .Select(r => r.GetLatestPackageMetadataAsync(identity.Id, includePrerelease, cancellationToken));
+                .Select(r => r.GetLatestPackageMetadataAsync(identity.Id, includePrerelease, cancellationToken))
+                .ToArray();
 
             var ignored = tasks
                 .Select(task => task.ContinueWith(LogError, TaskContinuationOptions.OnlyOnFaulted))


### PR DESCRIPTION
Before this change, these tasks were created twice causing double the HTTP requests.

I think we would like to get this in for 3.4.2. :runner: 

@yishaigalatzer @emgarten @alpaix @rrelyea 
