### PR TITLE
Adding UriUtility.UrlEncodeOdataParameter for v2 searches

### DIFF
--- a/src/NuGet.Core/NuGet.Common/UriUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/UriUtility.cs
@@ -35,5 +35,21 @@ namespace NuGet.Common
 
             return source;
         }
+
+        /// <summary>
+        /// Provides Uri encoding for V2 servers in the same way that NuGet.Core.dll encoded urls.
+        /// </summary>
+        public static string UrlEncodeOdataParameter(string value)
+        {
+            if (!String.IsNullOrEmpty(value))
+            {
+                // OData requires that a single quote MUST be escaped as 2 single quotes.
+                // In .NET 4.5, Uri.EscapeDataString() escapes single quote as %27. Thus we must replace %27 with 2 single quotes.
+                // In .NET 4.0, Uri.EscapeDataString() doesn't escape single quote. Thus we must replace it with 2 single quotes.
+                return Uri.EscapeDataString(value).Replace("'", "''").Replace("%27", "''");
+            }
+
+            return value;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Logging;
@@ -219,8 +220,8 @@ namespace NuGet.Protocol
             // The search term comes in already encoded from VS
             var uri = string.Format(CultureInfo.InvariantCulture, SearchEndPointFormat,
                                     filters.IncludePrerelease ? IsAbsoluteLatestVersionFilterFlag : IsLatestVersionFilterFlag,
-                                    WebUtility.UrlEncode(searchTerm),
-                                    WebUtility.UrlEncode(shortFormTargetFramework),
+                                    UriUtility.UrlEncodeOdataParameter(searchTerm),
+                                    UriUtility.UrlEncodeOdataParameter(shortFormTargetFramework),
                                     filters.IncludePrerelease.ToString().ToLowerInvariant(),
                                     skip,
                                     take);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
@@ -46,7 +46,7 @@ namespace NuGet.Protocol.Core.v3
                 // The search term comes in already encoded from VS
                 var queryUrl = new UriBuilder(endpoint.AbsoluteUri);
                 var queryString =
-                    "q=" + WebUtility.UrlEncode(searchTerm) +
+                    "q=" + searchTerm +
                     "&skip=" + skip.ToString() +
                     "&take=" + take.ToString() +
                     "&prerelease=" + filters.IncludePrerelease.ToString().ToLowerInvariant();
@@ -61,7 +61,7 @@ namespace NuGet.Protocol.Core.v3
                     var frameworks =
                         string.Join("&",
                             filters.SupportedFrameworks.Select(
-                                fx => "supportedFramework=" + WebUtility.UrlEncode(fx.ToString())));
+                                fx => "supportedFramework=" + fx.ToString()));
                     queryString += "&" + frameworks;
                 }
 
@@ -70,7 +70,7 @@ namespace NuGet.Protocol.Core.v3
                 {
                     var types = string.Join("&",
                         filters.PackageTypes.Select(
-                            s => "packageTypeFilter=" + WebUtility.UrlEncode(s)));
+                            s => "packageTypeFilter=" + s));
                     queryString += "&" + types;
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "?q=azure%2Bb&skip=0&take=1&prerelease=false&supportedFramework=portable-net45%2Bwin8",
+            responses.Add(serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false&supportedFramework=.NETFramework,Version=v4.5",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.V3Search.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -35,11 +35,11 @@ namespace NuGet.Protocol.Core.v3.Tests
             var searchFilter = new SearchFilter()
             {
                 IncludePrerelease = false,
-                SupportedFrameworks = new string[] { "portable-net45+win8" }
+                SupportedFrameworks = new string[] { ".NETFramework,Version=v4.5" }
             };
 
             // Act
-            var packages = await searchResource.Search("azure+b", searchFilter, 0, 1, NullLogger.Instance, CancellationToken.None);
+            var packages = await searchResource.Search("azure b", searchFilter, 0, 1, NullLogger.Instance, CancellationToken.None);
             var packagesArray = packages.ToArray();
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -214,7 +214,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%2Bb'&targetFramework='portable-net45%2Bwin8'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'&targetFramework='portable-net45%2Bwin8'&includePrerelease=false&$skip=0&$top=1",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -228,7 +228,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             };
 
             // Act
-            var packages = await parser.Search("azure+b", searchFilter, 0, 1, NullLogger.Instance, CancellationToken.None);
+            var packages = await parser.Search("azure +' b ", searchFilter, 0, 1, NullLogger.Instance, CancellationToken.None);
             var package = packages.FirstOrDefault();
 
             // Assert


### PR DESCRIPTION
This change copies the UrlEncodeOdataParameter method from nuget.core.dll, and applies it to the v2 search url building code for both search and target framework (same as nuget.core.dll).

Encoding for v3 has been removed.

//cc @yishaigalatzer @joelverhagen @rrelyea @maartenba @xavierdecoster 
