### PR TITLE
Use solution settings for restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -117,9 +117,12 @@ namespace NuGet.CommandLine
                                         globalPackagesFolder);
 
                     // Providers
+                    // Use the settings loaded above in ReadSettings(restoreInputs)
                     restoreContext.RequestProviders.Add(new MSBuildCachedRequestProvider(
                         providerCache,
-                        restoreInputs.ProjectReferenceLookup));
+                        restoreInputs.ProjectReferenceLookup,
+                        Settings));
+
                     restoreContext.RequestProviders.Add(new MSBuildP2PRestoreRequestProvider(providerCache));
                     restoreContext.RequestProviders.Add(new ProjectJsonRestoreRequestProvider(providerCache));
 


### PR DESCRIPTION
This change passes in the solution level settings to the RestoreRequest provider. For solution restores all projects use the same settings instead of finding the settings based on their own folder root. XPlat stays the same, this is only for nuget.exe restore which allows a single solution or project file to be passed as the restore input.

The NuGet.Commands request provider already had support for a settings override to support this, it just wasn't being passed in from nuget.exe.

https://github.com/NuGet/Home/issues/2510

This PR is against dev, but it will also go into 3.4.2 nuget.exe.

//cc @rrelyea @joelverhagen @zhili1208 @TimBarham 
