### PR TITLE
Don't let invalid file times in the zip file stop package installation

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -173,7 +173,14 @@ namespace NuGet.Packaging
                         var attr = File.GetAttributes(copiedFile);
                         if (!attr.HasFlag(FileAttributes.Directory))
                         {
-                            File.SetLastWriteTimeUtc(copiedFile, entry.LastWriteTime.UtcDateTime);
+                            try
+                            {
+                                File.SetLastWriteTimeUtc(copiedFile, entry.LastWriteTime.UtcDateTime);
+                            }
+                            catch (ArgumentOutOfRangeException)
+                            {
+                                // Ignore invalid file times in zip file
+                            }
                         }
 
                         filesCopied.Add(copiedFile);

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -57,7 +57,14 @@ namespace NuGet.Packaging
             var attr = File.GetAttributes(fileFullPath);
             if (!attr.HasFlag(FileAttributes.Directory))
             {
-                File.SetLastWriteTimeUtc(fileFullPath, entry.LastWriteTime.UtcDateTime);
+                try
+                {
+                    File.SetLastWriteTimeUtc(fileFullPath, entry.LastWriteTime.UtcDateTime);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Ignore invalid file times in zip file
+                }
             }
 
             return fileFullPath;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -750,5 +750,41 @@ namespace NuGet.Packaging.Test
                 }
             }
         }
+
+        [Fact]
+        public async Task PackageExtractor_PreservesZipEntryTime()
+        {
+            // Arrange
+            using (TestDirectory root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                DateTime time = DateTime.Parse("2084-09-26T01:23:00Z",
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AdjustToUniversal);
+
+                FileInfo packageFileInfo = await TestPackages.GeneratePackageAsync(root, "A", "2.0.3", time.ToLocalTime(), "lib/net45/A.dll");
+
+                using (FileStream packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext
+                    {
+                        PackageSaveMode = PackageSaveMode.Nuspec | PackageSaveMode.Files
+                    };
+
+                    // Act
+                    PackageExtractor.ExtractPackage(
+                        packageStream,
+                        new PackagePathResolver(root),
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    string outputDll = Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll");
+                    DateTime outputTime = File.GetLastWriteTimeUtc(outputDll);
+
+                    // Assert
+                    Assert.True(File.Exists(outputDll));
+                    Assert.Equal(time, outputTime);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2518

The package for ModernHttpClient won't unzip on Mono on Mac/Linux. The file times in the zip file are far in the future and can't be set on the files on disk. An argument exception is thrown trying to update the file on disk after unzipping it. I don't think that should be a fatal error, or any error at all, so I'm just ignoring the exception.
If someone feels strongly to show an error message, I can figure out how to do that.

@yishaigalatzer @alpaix @emgarten 
