### PR TITLE
Associate package metadata with version in VS UI

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageMetadataProvider.cs
@@ -136,8 +136,8 @@ namespace NuGet.PackageManagement.UI
                 .Concat(new[] { new VersionInfo(identity.Version) });
 
             return allVersions
-                .GroupBy(v => v.Version, v => v.DownloadCount)
-                .Select(g => new VersionInfo(g.Key, g.Max()))
+                .GroupBy(v => v.Version)
+                .Select(g => g.OrderBy(v => v.DownloadCount).First())
                 .ToArray();
         }
 

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/SourceRepositoryExtensions.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/SourceRepositoryExtensions.cs
@@ -161,7 +161,10 @@ namespace NuGet.PackageManagement.UI
             return packages?
                 .Where(v => includePrerelease || !v.Identity.Version.IsPrerelease)
                 .OrderByDescending(m => m.Identity.Version, VersionComparer.VersionRelease)
-                .Select(m => new VersionInfo(m.Identity.Version, m.DownloadCount));
+                .Select(m => new VersionInfo(m.Identity.Version, m.DownloadCount)
+                {
+                    PackageSearchMetadata = m
+                });
         }
 
         public static async Task<IEnumerable<string>> IdStartsWithAsync(

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/Model/VersionInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/Model/VersionInfo.cs
@@ -32,5 +32,13 @@ namespace NuGet.Protocol.Core.Types
         public NuGetVersion Version { get; private set; }
 
         public long? DownloadCount { get; private set; }
+
+        /// <summary>
+        /// In V2, when finding the list of versions that a package ID has, we also get all of the metadata
+        /// associated with each version. It would be wasteful to throw this away, so we store what we have
+        /// here. For V3, the metadata property is null. Callers that receive this type need to be able to
+        /// fetch this package metadata some other way if this property is null.
+        /// </summary>
+        public IPackageSearchMetadata PackageSearchMetadata { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/PackageSearchResourceV2Feed.cs
@@ -93,7 +93,12 @@ namespace NuGet.Protocol
             {
                 if (uniqueVersions.Add(versionPackage.Version))
                 {
-                    results.Add(new VersionInfo(versionPackage.Version, versionPackage.DownloadCount));
+                    var versionInfo = new VersionInfo(versionPackage.Version, versionPackage.DownloadCount)
+                    {
+                        PackageSearchMetadata = new PackageSearchMetadataV2Feed(versionPackage)
+                    };
+
+                    results.Add(versionInfo);
                 }
             }
             return results;

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/Resources/PackageSearchResourceLocal.cs
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/Resources/PackageSearchResourceLocal.cs
@@ -93,14 +93,23 @@ namespace NuGet.Protocol.VisualStudio
                 .ToArray();
 
             IEnumerable<VersionInfo> versions = packages
-                .Select(p => new VersionInfo(V2Utilities.SafeToNuGetVer(p.Version), p.DownloadCount))
+                .Select(p => new VersionInfo(V2Utilities.SafeToNuGetVer(p.Version), p.DownloadCount)
+                {
+                    PackageSearchMetadata = new PackageSearchMetadata(package)
+                })
                 .OrderByDescending(v => v.Version, VersionComparer.VersionRelease);
 
             var packageVersion = V2Utilities.SafeToNuGetVer(package.Version);
+
             if (!versions.Any(v => v.Version == packageVersion))
             {
-                versions = versions.Concat(
-                    new[] { new VersionInfo(packageVersion, package.DownloadCount) });
+                versions = versions.Concat(new[]
+                {
+                    new VersionInfo(packageVersion, package.DownloadCount)
+                    {
+                        PackageSearchMetadata = new PackageSearchMetadata(package)
+                    }
+                });
             }
 
             return versions;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    public class MultiSourcePackageMetadataProviderTests
+    {
+        [Fact]
+        public async Task GetLatestPackageMetadataAsync_Always_SendsASingleRequestPerSource()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            await tc.Target.GetLatestPackageMetadataAsync(
+                tc.PackageIdentity,
+                includePrerelease: true,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            tc.PackageMetadata.Verify(
+                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetPackageMetadataAsync_Always_SendsASingleRequestPerSource()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            await tc.Target.GetPackageMetadataAsync(
+                tc.PackageIdentity,
+                includePrerelease: true,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            tc.PackageMetadata.Verify(
+                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task GetPackageMetadataListAsync_Always_SendsASingleRequestPerSource()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            await tc.Target.GetPackageMetadataListAsync(
+                tc.PackageIdentity.Id,
+                includePrerelease: true,
+                includeUnlisted: false,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            tc.PackageMetadata.Verify(
+                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        private class TestContext
+        {
+            public TestContext()
+            {
+                // dependencies and data
+                PackageMetadata = new Mock<PackageMetadataResource>();
+
+                var provider = new Mock<INuGetResourceProvider>();
+                provider
+                    .Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => Task.FromResult(Tuple.Create(true, (INuGetResource)PackageMetadata.Object)));
+                provider
+                    .Setup(x => x.ResourceType)
+                    .Returns(typeof(PackageMetadataResource));
+
+                var logger = new TestLogger();
+                var packageSource = new Configuration.PackageSource("http://fake-source");
+                var source = new SourceRepository(packageSource, new[] { provider.Object });
+                PackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+                
+                // target
+                Target = new MultiSourcePackageMetadataProvider(
+                    new[] { source },
+                    null,
+                    null,
+                    logger);
+            }
+
+            public MultiSourcePackageMetadataProvider Target { get; }
+            public PackageIdentity PackageIdentity { get; }
+            public Mock<PackageMetadataResource> PackageMetadata { get; }
+        } 
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="Converters\IconUrlToImageCacheConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
+    <Compile Include="Feeds\MultiSourcePackageMetadataProviderTests.cs" />
     <Compile Include="PackageItemLoaderTests.cs" />
     <Compile Include="PackageManagerProviderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This allows for metadata about each version to be cached. The lifetime of the cache is as long as the `VersionInfo` instance lives, which is until the infinite scroll panel is repopulated (e.g. the refresh button is pressed).

Also, add tests for https://github.com/NuGet/NuGet.Client/pull/481 and https://github.com/NuGet/NuGet.Client/pull/476.

Addresses https://github.com/NuGet/Home/issues/2517.

@alpaix @emgarten @yishaigalatzer @rrelyea @zhili1208 
