### PR TITLE
Adding xml docs to nuget.core projects

### DIFF
--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -6,7 +6,11 @@
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
   "compilationOptions": {
     "emitEntryPoint": true,
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -533,7 +533,7 @@ namespace NuGet.Commands
         /// Create LockFileItems from groups of library items.
         /// </summary>
         /// <param name="groups">Library items grouped by RID.</param>
-        /// <param name="groupLabel">Lock file section the items apply to.</param>
+        /// <param name="assetType">Lock file section the items apply to.</param>
         private static List<LockFileRuntimeTarget> GetRuntimeTargetItems(List<ContentItemGroup> groups, string assetType)
         {
             var results = new List<LockFileRuntimeTarget>();

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -5,7 +5,15 @@
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "Complete commands common to command-line and GUI NuGet clients",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574",
+      "CS1573",
+      "CS1584",
+      "CS1658"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs",

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -13,7 +13,7 @@ namespace NuGet.Common
 
         /// <summary>
         /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
-        /// delegating all log messages to the <see cref="innerLogger"/>.
+        /// delegating all log messages to the <param name="innerLogger" />.
         /// </summary>
         public CollectorLogger(ILogger innerLogger)
         {

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -3,6 +3,14 @@
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "compilationOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574"
+    ]
+  },
   "compile": [
     "../NuGet.Shared/*.cs"
   ],

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -13,7 +13,11 @@
     "nuget.config"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -4,7 +4,12 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -192,9 +192,9 @@ namespace NuGet.Frameworks
         /// Find all equivalent frameworks, and their equivalent frameworks.
         /// Example:
         /// Mappings:
-        /// A <-> B
-        /// B <-> C
-        /// C <-> D
+        /// A &lt;&#8210;&gt; B
+        /// B &lt;&#8210;&gt; C
+        /// C &lt;&#8210;&gt; D
         /// For A we need to find B, C, and D so we must retrieve equivalent frameworks for A, B, and C
         /// also as we discover them.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
@@ -15,7 +15,7 @@ namespace NuGet.Frameworks
         /// Creates a one way compatibility mapping.
         /// Ex: net -supports-> native
         /// </summary>
-        /// <param name="framework">Project framework</param>
+        /// <param name="targetFramework">Project framework</param>
         /// <param name="supportedFramework">Framework that is supported by the project framework</param>
         public OneWayCompatibilityMappingEntry(FrameworkRange targetFramework, FrameworkRange supportedFramework)
         {

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
@@ -14,25 +14,24 @@ namespace NuGet.Frameworks
     public interface IFrameworkMappings
     {
         /// <summary>
-        /// Synonym -> Identifier
-        /// Ex: NET Framework -> .NET Framework
+        /// Synonym &#8210;&gt; Identifier
+        /// Ex: NET Framework &#8210;&gt; .NET Framework
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> IdentifierSynonyms { get; }
 
         /// <summary>
-        /// Ex: .NET Framework -> net
+        /// Ex: .NET Framework &#8210;&gt; net
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> IdentifierShortNames { get; }
 
         /// <summary>
-        /// Ex: WindowsPhone -> wp
+        /// Ex: WindowsPhone &#8210;&gt; wp
         /// </summary>
-        /// ;
         IEnumerable<FrameworkSpecificMapping> ProfileShortNames { get; }
 
         /// <summary>
         /// Equal frameworks. Used for legacy conversions.
-        /// ex: Framework: Win8 <-> Framework: NetCore45 Platform: Win8
+        /// ex: Framework: Win8 &lt;&#8210;&gt; Framework: NetCore45 Platform: Win8
         /// </summary>
         IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> EquivalentFrameworks { get; }
 
@@ -44,14 +43,14 @@ namespace NuGet.Frameworks
 
         /// <summary>
         /// Frameworks which are subsets of others.
-        /// Ex: .NETCore -> .NET
+        /// Ex: .NETCore &#8210;&gt; .NET
         /// Everything in .NETCore maps to .NET and is one way compatible. Version numbers follow the same format.
         /// </summary>
         IEnumerable<KeyValuePair<string, string>> SubSetFrameworks { get; }
 
         /// <summary>
         /// Additional framework compatibility rules beyond name and version matching.
-        /// Ex: .NETFramework -supports-> Native
+        /// Ex: .NETFramework supports &#8210;&gt; Native
         /// </summary>
         IEnumerable<OneWayCompatibilityMappingEntry> CompatibilityMappings { get; }
 
@@ -59,7 +58,7 @@ namespace NuGet.Frameworks
         /// Ordered list of framework identifiers. The first framework in the list will be preferred over other 
         /// framework identifiers. This is enable better tie breaking in scenarios where legacy frameworks are 
         /// equivalently compatible to a new framework.
-        /// Example: UAP10.0 -> win81, wpa81
+        /// Example: UAP10.0 &#8210;&gt; win81, wpa81
         /// </summary>
         IEnumerable<string> NonPackageBasedFrameworkPrecedence { get; }
 
@@ -77,13 +76,13 @@ namespace NuGet.Frameworks
 
         /// <summary>
         /// Rewrite folder short names to the given value.
-        /// Ex: dotnet50 -> dotnet
+        /// Ex: dotnet50 &#8210;&gt; dotnet
         /// </summary>
         IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> ShortNameReplacements { get; }
 
         /// <summary>
         /// Rewrite full framework names to the given value.
-        /// Ex: .NETPlatform,Version=v0.0 -> .NETPlatform,Version=v5.0
+        /// Ex: .NETPlatform,Version=v0.0 &#8210;&gt; .NETPlatform,Version=v5.0
         /// </summary>
         IEnumerable<KeyValuePair<NuGetFramework, NuGetFramework>> FullNameReplacements { get; }
     }

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -8,7 +8,13 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -4,6 +4,13 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet.Indexing Class Library",
+  "compilationOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
+  },
   "compile": [
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
     "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/IdentifierKeywordAnalyzer.cs",
@@ -28,6 +35,6 @@
     }
   },
   "frameworks": {
-    "net45": {}
+    "net45": { }
   }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -15,7 +15,11 @@
     }
   },
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "frameworks": {
     "net45": {},

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -5,7 +5,14 @@
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Package Management",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1580",
+      "CS1574",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageIdentity.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageIdentity.cs
@@ -117,7 +117,7 @@ namespace NuGet.Packaging.Core
         }
 
         /// <summary>
-        /// PackageIdentity.ToString returns "<packageId>.<packageVersion>"
+        /// PackageIdentity.ToString returns packageId.packageVersion"
         /// </summary>
         public override string ToString()
         {

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -9,7 +9,11 @@
     }
   },
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -8,7 +8,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
@@ -136,12 +136,6 @@ namespace NuGet.Packaging
         /// <summary>
         /// This returns all the installed package files (does not include satellite files)
         /// </summary>
-        /// <param name="packageIdentity"></param>
-        /// <param name="packagePathResolver"></param>
-        /// <param name="packageDirectory"></param>
-        /// <param name="packageSaveMode"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
         public static IEnumerable<ZipFilePair> GetInstalledPackageFiles(
             PackageArchiveReader packageReader,
             PackageIdentity packageIdentity,

--- a/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
@@ -207,7 +207,6 @@ namespace NuGet.Packaging
         /// <summary>
         /// Update a package entry to the file
         /// </summary>
-        /// <param name="entry">Package reference entry</param>
         public void UpdatePackageEntry(PackageReference oldEntry, PackageReference newEntry)
         {
             if (oldEntry == null)

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -12,7 +12,13 @@
     "semantic versioning"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
@@ -62,7 +62,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         /// <param name="fileName">the file name</param>
         /// <returns>The list of full paths.</returns>
-        /// <remarks>We should combine GetFiles & GetFullPaths into one method.</remarks>
+        /// <remarks>We should combine GetFiles &amp; GetFullPaths into one method.</remarks>
         IEnumerable<string> GetFullPaths(string fileName);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectManagement/SourceControl/SourceControlManager.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/SourceControl/SourceControlManager.cs
@@ -45,8 +45,6 @@ namespace NuGet.ProjectManagement
         /// Marks the files for deletion
         /// It will perform necessary operations such as undoing pending changes and so on as appropriate
         /// </summary>
-        /// <param name="packageFiles"></param>
-        /// <param name="nuGetProjectContext"></param>
         public abstract void PendDeleteFiles(IEnumerable<string> fullPaths, string root, INuGetProjectContext nuGetProjectContext);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -5,7 +5,13 @@
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "description": "NuGet Project Management",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -13,7 +13,12 @@
     }
   },
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573"
+    ]
   },
   "frameworks": {
     "net45": {},

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -11,7 +11,12 @@
     "nuget protocol"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DependencyInfoResourceV2.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/Resources/DependencyInfoResourceV2.cs
@@ -91,7 +91,7 @@ namespace NuGet.Protocol.Core.v2
         /// <summary>
         /// Retrieve dependency info for a single package.
         /// </summary>
-        /// <param name="package">package id and version</param>
+        /// <param name="packageId">package id</param>
         /// <param name="projectFramework">project target framework. This is used for finding the dependency group</param>
         /// <param name="token">cancellation token</param>
         /// <returns>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -11,7 +11,13 @@
     "nuget protocol"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1574",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/FindPackageByIdDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/FindPackageByIdDependencyInfo.cs
@@ -13,7 +13,6 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// DependencyInfo
         /// </summary>
-        /// <param name="identity">package identity</param>
         /// <param name="dependencyGroups">package dependency groups</param>
         /// <param name="frameworkReferenceGroups">Sequence of <see cref="FrameworkSpecificGroup" />s.</param>
         public FindPackageByIdDependencyInfo(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -67,7 +67,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Creates a V2 parser
         /// </summary>
-        /// <param name="httpHandler">Message handler containing auth/proxy support</param>
+        /// <param name="httpSource">HttpSource and message handler containing auth/proxy support</param>
         /// <param name="baseAddress">base address for all services from this OData service</param>
         public V2FeedParser(HttpSource httpSource, string baseAddress)
             : this(httpSource, baseAddress, new PackageSource(baseAddress))
@@ -77,7 +77,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Creates a V2 parser
         /// </summary>
-        /// <param name="httpHandler">Message handler containing auth/proxy support</param>
+        /// <param name="httpSource">HttpSource and message handler containing auth/proxy support</param>
         /// <param name="baseAddress">base address for all services from this OData service</param>
         /// <param name="source">PackageSource useful for reporting meaningful errors that relate back to the configuration</param>
         public V2FeedParser(HttpSource httpSource, string baseAddress, PackageSource source)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DependencyInfoResourceV3.cs
@@ -139,7 +139,6 @@ namespace NuGet.Protocol.Core.v3
         /// </summary>
         /// <remarks>Includes prerelease packages</remarks>
         /// <param name="packageId">package Id to search</param>
-        /// <param name="projectFramework">project target framework. This is used for finding the dependency group</param>
         /// <param name="token">cancellation token</param>
         /// <returns>available packages and their dependencies</returns>
         public override Task<IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId, Common.ILogger log, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -11,7 +11,12 @@
     "nuget protocol"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -11,7 +11,11 @@
     "nuget protocol"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -12,7 +12,11 @@
     }
   },
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "frameworks": {
     "net45": {},

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -8,7 +8,12 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -4,7 +4,13 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573",
+      "CS1572"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
+++ b/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
@@ -18,8 +18,8 @@ namespace NuGet.Shared
         /// <param name="self">This list</param>
         /// <param name="other">The other list</param>
         /// <param name="keySelector">The function to extract the key from each item in the list</param>
-        /// <param name="comparer">An optional comparer for comparing keys</param>
-        /// <returns></returns>
+        /// <param name="orderComparer">An optional comparer for comparing keys</param>
+        /// <param name="sequenceComparer">An optional comparer for sequences</param>
         internal static bool OrderedEquals<TSource, TKey>(this IEnumerable<TSource> self, IEnumerable<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey> orderComparer = null, IEqualityComparer<TSource> sequenceComparer = null)
         {
             Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + nameof(orderComparer) + " must be provided if " + nameof(TKey) + " is a string.");

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -31,7 +31,7 @@ namespace NuGet.Versioning
         /// </summary>
         /// <param name="floatBehavior">Section to float</param>
         /// <param name="minVersion">Min version of the range</param>
-        /// <param name="originalReleasePrefix">The original release label. Invalid labels are allowed here.</param>
+        /// <param name="releasePrefix">The original release label. Invalid labels are allowed here.</param>
         public FloatRange(NuGetVersionFloatBehavior floatBehavior, NuGetVersion minVersion, string releasePrefix)
         {
             _floatBehavior = floatBehavior;

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersionBase.cs
@@ -108,7 +108,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        /// ==
+        /// Equals
         /// </summary>
         public static bool operator ==(SemanticVersion version1, SemanticVersion version2)
         {
@@ -116,7 +116,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        /// !=
+        /// Not equal
         /// </summary>
         public static bool operator !=(SemanticVersion version1, SemanticVersion version2)
         {
@@ -124,7 +124,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        ///     <
+        /// Less than
         /// </summary>
         public static bool operator <(SemanticVersion version1, SemanticVersion version2)
         {
@@ -132,7 +132,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        ///     <=
+        /// Less than or equal
         /// </summary>
         public static bool operator <=(SemanticVersion version1, SemanticVersion version2)
         {
@@ -140,7 +140,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        /// >
+        /// Greater than
         /// </summary>
         public static bool operator >(SemanticVersion version1, SemanticVersion version2)
         {
@@ -148,7 +148,7 @@ namespace NuGet.Versioning
         }
 
         /// <summary>
-        /// >=
+        /// Greater than or equal
         /// </summary>
         public static bool operator >=(SemanticVersion version1, SemanticVersion version2)
         {

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
@@ -24,7 +24,6 @@ namespace NuGet.Versioning
         /// <param name="maxVersion">Upper bound of the version range.</param>
         /// <param name="includeMaxVersion">True if maxVersion satisfies the condition.</param>
         /// <param name="includePrerelease">True if prerelease versions should satisfy the condition.</param>
-        /// <param name="exclude">Subsets that are excluded from the range.</param>
         public VersionRangeBase(NuGetVersion minVersion = null, bool includeMinVersion = true, NuGetVersion maxVersion = null,
             bool includeMaxVersion = false, bool? includePrerelease = null)
         {

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -12,7 +12,12 @@
     "semantic versioning"
   ],
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591",
+      "CS1573"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -11,7 +11,12 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "emitEntryPoint": true
+    "emitEntryPoint": true,
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"
@@ -39,6 +44,6 @@
         "portable-net45+win8"
       ]
     },
-    "net46": {}
+    "net46": { }
   }
 }

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -4,7 +4,11 @@
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
   "compilationOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ]
   },
   "compile": [
     "../NuGet.Shared/*.cs"


### PR DESCRIPTION
This change adds intellisense xml to the nupkgs produced for nuget.core.sln. I've fixed a few projects which did not have warnings as errors turned on, and also added exceptions for warnings due to XML docs. Where the docs were incorrect and had the wrong parameter names I've made changes, but overall I've tried to avoid updating the comments as part of this PR.

//cc @joelverhagen @zhili1208 @spadapet @alpaix 
