### PR TITLE
Prompt for credentials when the server returns HTTP 403

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
@@ -12,7 +12,7 @@ using NuGet.Protocol.Core.v3;
 
 namespace NuGet.Protocol
 {
-    public class HttpRetryHandler
+    public class HttpRetryHandler : IHttpRetryHandler
     {
         /// <summary>
         /// The <see cref="HttpRetryHandler"/> is for retrying and HTTP request if it times out, has any exception,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IHttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IHttpRetryHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+
+namespace NuGet.Protocol
+{
+    public interface IHttpRetryHandler
+    {
+        Task<HttpResponseMessage> SendAsync(
+            HttpClient client,
+            Func<HttpRequestMessage> requestFactory,
+            HttpCompletionOption completionOption,
+            ILogger log,
+            CancellationToken cancellationToken);
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
@@ -4,13 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3.Tests.Utility;
 using NuGet.Test.Server;
 using NuGet.Test.Utility;
 using Test.Utility;
@@ -20,8 +23,88 @@ namespace NuGet.Protocol.Core.v3.Tests
 {
     public class HttpSourceTests
     {
+        /// <summary>
+        /// We need a lock whenever we set static properties on <see cref="HttpHandlerResourceV3"/>.
+        /// </summary>
+        private static readonly SemaphoreSlim HttpHandlerResourceV3Lock = new SemaphoreSlim(1);
         private const string FakeSource = "https://fake.server/users.json";
-        
+
+        [Fact]
+        public async Task HttpSource_PromptsForCredentialsOn401()
+        {
+            // Arrange
+            using (await UsingSemaphore.WaitAsync(HttpHandlerResourceV3Lock))
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(td);
+
+                tc.SetResponseSequence(new[]
+                {
+                    new HttpResponseMessage(HttpStatusCode.Unauthorized),
+                    new HttpResponseMessage(HttpStatusCode.OK),
+                });
+
+                var prompted = false;
+                HttpHandlerResourceV3.PromptForCredentials = (uri, token) =>
+                {
+                    prompted = true;
+                    return Task.FromResult(tc.Credentials);
+                };
+
+                // Act
+                var statusCode = await tc.HttpSource.ProcessResponseAsync(
+                    () => new HttpRequestMessage(),
+                    response =>
+                    {
+                        return Task.FromResult(response.StatusCode);
+                    },
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.True(prompted, "The user should have been prompted for credentials.");
+                Assert.Equal(HttpStatusCode.OK, statusCode);
+            }
+        }
+
+        [Fact]
+        public async Task HttpSource_PromptsForCredentialsOn403()
+        {
+            // Arrange
+            using (await UsingSemaphore.WaitAsync(HttpHandlerResourceV3Lock))
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(td);
+
+                tc.SetResponseSequence(new[]
+                {
+                    new HttpResponseMessage(HttpStatusCode.Forbidden),
+                    new HttpResponseMessage(HttpStatusCode.OK),
+                });
+
+                var prompted = false;
+                HttpHandlerResourceV3.PromptForCredentials = (uri, token) =>
+                {
+                    prompted = true;
+                    return Task.FromResult(tc.Credentials);
+                };
+
+                // Act
+                var statusCode = await tc.HttpSource.ProcessResponseAsync(
+                    () => new HttpRequestMessage(),
+                    response =>
+                    {
+                        return Task.FromResult(response.StatusCode);
+                    },
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.True(prompted, "The user should have been prompted for credentials.");
+                Assert.Equal(HttpStatusCode.OK, statusCode);
+            }
+        }
+
         [Fact]
         public void HttpSource_DefaultDownloadTimeout()
         {
@@ -190,6 +273,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 NetworkContent = "network";
                 CacheKey = "CacheKey";
                 Url = "https://fake.server/foo/bar/something.json";
+                Credentials = new NetworkCredential("foo", "bar");
 
                 if (!RuntimeEnvironmentHelper.IsWindows)
                 {
@@ -209,6 +293,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 CacheContext = new HttpSourceCacheContext();
                 Logger = new TestLogger();
                 TestDirectory = testDirectory;
+                RetryHandlerMock = new Mock<IHttpRetryHandler>();
 
                 // target
                 HttpSource = new HttpSource(packageSource, () => Task.FromResult((HttpHandlerResource)handlerResource))
@@ -240,6 +325,8 @@ namespace NuGet.Protocol.Core.v3.Tests
             public bool ValidatedNetworkContent { get; set; }
 
             public bool ValidatedCacheContent { get; set; }
+            public Mock<IHttpRetryHandler> RetryHandlerMock { get; }
+            public ICredentials Credentials { get; }
 
             public void WriteToCache(string cacheKey, string content)
             {
@@ -253,6 +340,20 @@ namespace NuGet.Protocol.Core.v3.Tests
             public string ReadStream(Stream stream)
             {
                 return new StreamReader(stream, Encoding.UTF8).ReadToEnd();
+            }
+
+            public void SetResponseSequence(HttpResponseMessage[] responses)
+            {
+                HttpSource.RetryHandler = RetryHandlerMock.Object;
+                int index = 0;
+                RetryHandlerMock
+                    .Setup(x => x.SendAsync(
+                        It.IsAny<HttpClient>(),
+                        It.IsAny<Func<HttpRequestMessage>>(),
+                        It.IsAny<HttpCompletionOption>(),
+                        It.IsAny<ILogger>(),
+                        It.IsAny<CancellationToken>()))
+                    .Returns(() => Task.FromResult(responses[index++ % responses.Length]));
             }
 
             public Action<Stream> GetStreamValidator(bool validCache, bool validNetwork)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/UsingSemaphore.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/UsingSemaphore.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol.Core.v3.Tests.Utility
+{
+    public class UsingSemaphore : IDisposable
+    {
+        private SemaphoreSlim _semaphore;
+
+        private UsingSemaphore(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public static async Task<IDisposable> WaitAsync(SemaphoreSlim semaphore)
+        {
+            await semaphore.WaitAsync();
+            return new UsingSemaphore(semaphore);
+        }
+
+        public void Dispose()
+        {
+            _semaphore?.Release();
+            _semaphore = null;
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/NuGet/Home/issues/2520, however more information from the user is needed before we determine that this will close the issue.

Currently we only prompt for credentials on HTTP 401. This changes makes it so we also prompt on HTTP 403.

@yishaigalatzer @alpaix @emgarten
