### PR TITLE
Adding support for 204 no content with project.json

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -80,6 +80,7 @@ namespace NuGet.Protocol
             HttpSourceCacheContext cacheContext,
             ILogger log,
             bool ignoreNotFounds,
+            bool allowNoContent,
             Action<Stream> ensureValidContents,
             CancellationToken cancellationToken)
         {
@@ -90,6 +91,7 @@ namespace NuGet.Protocol
                 cacheContext,
                 log,
                 ignoreNotFounds,
+                allowNoContent,
                 ensureValidContents,
                 cancellationToken);
         }
@@ -104,6 +106,7 @@ namespace NuGet.Protocol
             HttpSourceCacheContext cacheContext,
             ILogger log,
             bool ignoreNotFounds,
+            bool allowNoContent,
             Action<Stream> ensureValidContents,
             CancellationToken cancellationToken)
         {
@@ -153,6 +156,11 @@ namespace NuGet.Protocol
             using (var response = await GetThrottled(throttleRequest))
             {
                 if (ignoreNotFounds && response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return new HttpSourceResult();
+                }
+
+                if (allowNoContent && response.StatusCode == HttpStatusCode.NoContent)
                 {
                     return new HttpSourceResult();
                 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -108,6 +108,7 @@ namespace NuGet.Protocol.Core.v3
                     cacheContext,
                     log,
                     ignoreNotFounds: true,
+                    allowNoContent: false,
                     ensureValidContents: null,
                     cancellationToken: token);
             }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ServiceIndexResourceV3Provider.cs
@@ -126,6 +126,7 @@ namespace NuGet.Protocol.Core.v3
                         cacheContext,
                         log,
                         ignoreNotFounds: false,
+                        allowNoContent: false,
                         ensureValidContents: stream => HttpStreamValidation.ValidateJObject(url, stream),
                         cancellationToken: token))
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -126,6 +126,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         CreateCacheContext(retry),
                         Logger,
                         ignoreNotFounds: true,
+                        allowNoContent: false,
                         ensureValidContents: stream => HttpStreamValidation.ValidateJObject(uri, stream),
                         cancellationToken: cancellationToken))
                     {
@@ -252,6 +253,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         CreateCacheContext(retry),
                         Logger,
                         ignoreNotFounds: false,
+                        allowNoContent: false,
                         ensureValidContents: stream => HttpStreamValidation.ValidateNupkg(package.ContentUri, stream),
                         cancellationToken: cancellationToken))
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -132,9 +132,17 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                             CreateCacheContext(retry),
                             Logger,
                             ignoreNotFounds: false,
+                            allowNoContent: true,
                             ensureValidContents: stream => HttpStreamValidation.ValidateXml(uri, stream),
                             cancellationToken: cancellationToken))
                         {
+                            if (data.Stream == null)
+                            {
+                                // The stream is null when a 204 is returned.
+                                // This can happen with team city feeds and means that there are 0 versions for this id.
+                                break;
+                            }
+
                             var doc = V2FeedParser.LoadXml(data.Stream);
 
                             var result = doc.Root
@@ -235,6 +243,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         CreateCacheContext(retry),
                         Logger,
                         ignoreNotFounds: false,
+                        allowNoContent: false,
                         ensureValidContents: stream => HttpStreamValidation.ValidateNupkg(package.ContentUri, stream),
                         cancellationToken: cancellationToken))
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -165,6 +165,7 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                         CreateCacheContext(retry),
                         Logger,
                         ignoreNotFounds: false,
+                        allowNoContent: false,
                         ensureValidContents: stream => HttpStreamValidation.ValidateNupkg(package.ContentUri, stream),
                         cancellationToken: cancellationToken))
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -106,6 +106,11 @@ namespace Test.Utility
                     msg = new HttpResponseMessage(HttpStatusCode.NotFound);
                     msg.Content = new TestContent(_errorContent);
                 }
+                else if (source == "204")
+                {
+                    msg = new HttpResponseMessage(HttpStatusCode.NoContent);
+                    msg.Content = new TestContent(string.Empty);
+                }
                 else if (source == null)
                 {
                     msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
@@ -30,6 +30,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                     tc.CacheContext,
                     tc.Logger,
                     ignoreNotFounds: false,
+                    allowNoContent: false,
                     ensureValidContents: tc.GetStreamValidator(validCache: true, validNetwork: true),
                     cancellationToken: CancellationToken.None);
 
@@ -55,6 +56,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                     tc.CacheContext,
                     tc.Logger,
                     ignoreNotFounds: false,
+                    allowNoContent: false,
                     ensureValidContents: tc.GetStreamValidator(validCache: true, validNetwork: false),
                     cancellationToken: CancellationToken.None));
 
@@ -81,6 +83,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                     tc.CacheContext,
                     tc.Logger,
                     ignoreNotFounds: false,
+                    allowNoContent: false,
                     ensureValidContents: tc.GetStreamValidator(validCache: true, validNetwork: true),
                     cancellationToken: CancellationToken.None);
 
@@ -107,6 +110,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                     tc.CacheContext,
                     tc.Logger,
                     ignoreNotFounds: false,
+                    allowNoContent: false,
                     ensureValidContents: tc.GetStreamValidator(validCache: false, validNetwork: true),
                     cancellationToken: CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Logging;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3.RemoteRepositories;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class RemoteV2FindPackageByIdResourceTests
+    {
+        [Fact]
+        public async Task RemoteV2FindPackageById_VerifyNoErrorsOnNoContent()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            resource.Logger = NullLogger.Instance;
+            resource.CacheContext = new SourceCacheContext();
+
+            // Act
+            var versions = await resource.GetAllVersionsAsync("a", CancellationToken.None);
+
+            // Assert
+            // Verify no items returned, and no exceptions were thrown above
+            Assert.Equal(0, versions.Count());
+        }
+    }
+}


### PR DESCRIPTION
This is a simple change for 3.4.3 to ignore 204 NoContent responses for project.json restore. Packages.config already handles this.

For 3.5.0 this should use the v2 feed parser code path, @zhili1208 has these changes.

//cc @joelverhagen @zhili1208 @yishaigalatzer @alpaix 

https://github.com/NuGet/Home/issues/2528
