### PR TITLE
Adding 204 support to httpsource

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
@@ -6,6 +6,7 @@ namespace NuGet.Protocol
     public enum HttpSourceResultStatus
     {
         NotFound,
+        NoContent,
         OpenedFromDisk,
         OpenedFromNetwork
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -119,7 +119,7 @@ namespace NuGet.Protocol.Core.v3
             }
 
             string serviceDocumentBaseAddress = null;
-            if (response.Status != HttpSourceResultStatus.NotFound)
+            if (response.Status != HttpSourceResultStatus.NotFound && response.Status != HttpSourceResultStatus.NoContent)
             {
                 serviceDocumentBaseAddress = V2FeedParser.GetBaseAddress(response.Stream);
             }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -134,6 +134,14 @@ namespace NuGet.Protocol.Core.v3.RemoteRepositories
                             ensureValidContents: stream => HttpStreamValidation.ValidateXml(uri, stream),
                             cancellationToken: cancellationToken))
                         {
+                            if (data.Status == HttpSourceResultStatus.NoContent)
+                            {
+                                // Team city returns 204 when no versions of the package exist
+                                // This should result in an empty list and we should not try to
+                                // read the stream as xml.
+                                break;
+                            }
+
                             var doc = V2FeedParser.LoadXml(data.Stream);
 
                             var result = doc.Root

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -106,6 +106,11 @@ namespace Test.Utility
                     msg = new HttpResponseMessage(HttpStatusCode.NotFound);
                     msg.Content = new TestContent(_errorContent);
                 }
+                else if (source == "204")
+                {
+                    msg = new HttpResponseMessage(HttpStatusCode.NoContent);
+                    msg.Content = new TestContent(string.Empty);
+                }
                 else if (source == null)
                 {
                     msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v3.Tests.Utility;
 using NuGet.Test.Server;
@@ -102,6 +103,34 @@ namespace NuGet.Protocol.Core.v3.Tests
                 // Assert
                 Assert.True(prompted, "The user should have been prompted for credentials.");
                 Assert.Equal(HttpStatusCode.OK, statusCode);
+            }
+        }
+
+        [Fact]
+        public async Task HttpSource_GetNoContent()
+        {
+            // Arrange
+            using (var td = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(td);
+
+                tc.SetResponseSequence(new[]
+                {
+                    new HttpResponseMessage(HttpStatusCode.NoContent),
+                });
+
+                // Act
+                var result = await tc.HttpSource.GetAsync(
+                    tc.Url,
+                    tc.CacheKey,
+                    tc.CacheContext,
+                    tc.Logger,
+                    ignoreNotFounds: false,
+                    ensureValidContents: tc.GetStreamValidator(validCache: true, validNetwork: true),
+                    cancellationToken: CancellationToken.None);
+
+                // Assert
+                Assert.Equal(HttpSourceResultStatus.NoContent, result.Status);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Core.v3.RemoteRepositories;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class RemoteV2FindPackageByIdResourceTests
+    {
+        [Fact]
+        public async Task RemoteV2FindPackageById_VerifyNoErrorsOnNoContent()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
+
+            var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+            var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            resource.Logger = NullLogger.Instance;
+            resource.CacheContext = new SourceCacheContext();
+
+            // Act
+            var versions = await resource.GetAllVersionsAsync("a", CancellationToken.None);
+
+            // Assert
+            // Verify no items returned, and no exceptions were thrown above
+            Assert.Equal(0, versions.Count());
+        }
+    }
+}


### PR DESCRIPTION
This fix already went into 3.4.3, this is the dev branch version which is different due to HttpSourceResultStatus existing in dev.  I've added a new status for NoContent so that it can be handled appropriately by the caller. It's kind of a special case because it isn't notfound, it won't throw under ensure success, but the validate method would fail if it were cached.

https://github.com/NuGet/Home/issues/2528

//cc @joelverhagen @zhili1208 @alpaix @rrelyea 
