### PR TITLE
Normalize versions for lock file libraries

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -251,7 +251,7 @@ namespace NuGet.ProjectModel
 
             WritePathArray(json, FilesProperty, library.Files, WriteString);
             return new JProperty(
-                library.Name + "/" + library.Version.ToString(),
+                library.Name + "/" + library.Version.ToNormalizedString(),
                 json);
         }
 


### PR DESCRIPTION
Normalize versions written out for lock file libraries.

The version is normalized for target libraries (https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs#L379) but not the libraries section. They need to match.

https://github.com/NuGet/Home/issues/2525

//cc @jainaashish @zhili1208 @joelverhagen @alpaix 
