### PR TITLE
Introduce CredentialRequestType to allow providers to provide better messages

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -138,9 +138,13 @@ namespace NuGet.CommandLine
 
             NuGet.Protocol.Core.v3.HttpHandlerResourceV3.CredentialSerivce = credentialService;
             
-            NuGet.Protocol.Core.v3.HttpHandlerResourceV3.PromptForCredentials =
-                async (uri, cancellationToken) => await credentialService.GetCredentials(
-                    uri, proxy: null, isProxy: false, cancellationToken: cancellationToken);
+            NuGet.Protocol.Core.v3.HttpHandlerResourceV3.PromptForCredentialsAsync =
+                async (uri, type, message, cancellationToken) => await credentialService.GetCredentialsAsync(
+                    uri,
+                    proxy: null,
+                    type: type,
+                    message: message,
+                    cancellationToken: cancellationToken);
 
             NuGet.Protocol.Core.v3.HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Credentials;
 using System.Threading;
+using NuGet.Configuration;
 
 namespace NuGet
 {
@@ -23,10 +24,11 @@ namespace NuGet
 
         private IConsole Console { get; set; }
 
-        public Task<CredentialResponse> Get(
+        public Task<CredentialResponse> GetAsync(
             Uri uri,
             IWebProxy proxy,
-            bool isProxy,
+            CredentialRequestType type,
+            string message,
             bool isRetry,
             bool nonInteractive,
             CancellationToken cancellationToken)
@@ -41,11 +43,24 @@ namespace NuGet
                 return Task.FromResult(
                     new CredentialResponse(null, CredentialStatus.ProviderNotApplicable));
             }
+            
+            switch (type)
+            {
+                case CredentialRequestType.Proxy:
+                    message = LocalizedResourceManager.GetString("Credentials_ProxyCredentials");
+                    break;
 
-            string message = isProxy ?
-                    LocalizedResourceManager.GetString("Credentials_ProxyCredentials") :
-                    LocalizedResourceManager.GetString("Credentials_RequestCredentials");
+                case CredentialRequestType.Forbidden:
+                    message = LocalizedResourceManager.GetString("Credentials_ForbiddenCredentials");
+                    break;
+
+                default:
+                    message = LocalizedResourceManager.GetString("Credentials_RequestCredentials");
+                    break;
+            }
+
             Console.WriteLine(message, uri.OriginalString);
+
             Console.Write(LocalizedResourceManager.GetString("Credentials_UserName"));
             cancellationToken.ThrowIfCancellationRequested();
             string username = Console.ReadLine();

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -1096,6 +1096,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}.
+        /// </summary>
+        public static string Credentials_ForbiddenCredentials {
+            get {
+                return ResourceManager.GetString("Credentials_ForbiddenCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password: .
         /// </summary>
         public static string Credentials_Password {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6082,4 +6082,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_AssemblyInformationalVersion" xml:space="preserve">
     <value>Invalid AssemblyInformationalVersion {0} on assembly {1}.</value>
   </data>
+  <data name="Credentials_ForbiddenCredentials" xml:space="preserve">
+    <value>The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}</value>
+    <comment>{0} will be replaced with the URL that needs credentials.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialProviderAdapter.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialProviderAdapter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 
 namespace NuGet.Credentials
 {
@@ -31,10 +32,11 @@ namespace NuGet.Credentials
         /// </summary>
         public string Id { get; }
 
-        public Task<CredentialResponse> Get(
+        public Task<CredentialResponse> GetAsync(
             Uri uri,
             IWebProxy proxy,
-            bool isProxyRequest,
+            CredentialRequestType type,
+            string message,
             bool isRetry,
             bool nonInteractive,
             CancellationToken cancellationToken)
@@ -49,7 +51,7 @@ namespace NuGet.Credentials
             var cred = _provider.GetCredentials(
                 uri,
                 proxy,
-                isProxyRequest ? CredentialType.ProxyCredentials : CredentialType.RequestCredentials,
+                type == CredentialRequestType.Proxy ? CredentialType.ProxyCredentials : CredentialType.RequestCredentials,
                 isRetry);
 
             var response = cred != null

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialServiceAdapter.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialServiceAdapter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using System.Threading;
+using NuGet.Configuration;
 
 namespace NuGet.Credentials
 {
@@ -31,8 +32,16 @@ namespace NuGet.Credentials
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            var isProxy = credentialType == CredentialType.ProxyCredentials;
-            var task = _credentialService.GetCredentials(uri, proxy, isProxy, CancellationToken.None);
+            var type = credentialType == CredentialType.ProxyCredentials ?
+                CredentialRequestType.Proxy : CredentialRequestType.Unauthorized;
+
+            var task = _credentialService.GetCredentialsAsync(
+                uri,
+                proxy,
+                type,
+                message: null,
+                cancellationToken: CancellationToken.None);
+
             return task.Result;
         }
     }

--- a/src/NuGet.Clients/NuGet.Credentials/ICredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/ICredentialProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 
 namespace NuGet.Credentials
 {
@@ -12,11 +13,13 @@ namespace NuGet.Credentials
     {
         string Id { get; }
 
-        Task<CredentialResponse> Get(Uri uri, 
-                               IWebProxy proxy, 
-                               bool isProxyRequest, 
-                               bool isRetry,
-                               bool nonInteractive, 
-                               CancellationToken cancellationToken);
+        Task<CredentialResponse> GetAsync(
+            Uri uri, 
+            IWebProxy proxy, 
+            CredentialRequestType type,
+            string message,
+            bool isRetry,
+            bool nonInteractive, 
+            CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -362,16 +362,20 @@ namespace NuGetVSExtension
 
             NuGet.Protocol.Core.v3.HttpHandlerResourceV3.CredentialSerivce = credentialService;
 
-            NuGet.Protocol.Core.v3.HttpHandlerResourceV3.PromptForCredentials =
-                async (uri, cancellationToken) =>
+            NuGet.Protocol.Core.v3.HttpHandlerResourceV3.PromptForCredentialsAsync =
+                async (uri, type, message, cancellationToken) =>
                 {
                     // Get the proxy for this URI so we can pass it to the credentialService methods
                     // this lets them use the proxy if they have to hit the network.
                     var proxyCache = ProxyCache.Instance;
                     var proxy = proxyCache?.GetProxy(uri);
 
-                    return await credentialService
-                        .GetCredentials(uri, proxy: proxy, isProxy: false, cancellationToken: cancellationToken);
+                    return await credentialService.GetCredentialsAsync(
+                        uri,
+                        proxy,
+                        type,
+                        message,
+                        cancellationToken);
                 };
 
             NuGet.Protocol.Core.v3.HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>

--- a/src/NuGet.Clients/VsExtension/VisualStudioAccountProvider.cs
+++ b/src/NuGet.Clients/VsExtension/VisualStudioAccountProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Services.Client.AccountManagement;
 using System.Threading;
 using NuGet.Credentials;
+using NuGet.Configuration;
 
 namespace NuGetVSExtension
 {
@@ -54,8 +55,12 @@ namespace NuGetVSExtension
         /// <param name="uri">URI for the feed endponint to use</param>
         /// <param name="proxy">Web proxy to use when comunicating on the network.  Null if there is no proxy
         /// authentication configured</param>
-        /// <param name="isProxyRequest">Flag to indicate that this request is to get proxy authentication
-        /// credetials.  Note, if this is set to true method will return null</param>
+        /// <param name="type">
+        /// The type of credential request that is being made. Note that this implementation of
+        /// <see cref="ICredentialProvider"/> does not support providing proxy credenitials and treats
+        /// all other types the same.
+        /// </param>
+        /// <param name="message">A message provided by NuGet to show to the user when prompting.</param>
         /// <param name="isRetry">Flag to indicate if this is the first time the URI has been looked up.
         /// If this is true we check to see if the account has access to the feed.
         /// First time we assume that is true to minimize network trafic.</param>
@@ -64,7 +69,12 @@ namespace NuGetVSExtension
         /// <param name="cancellationToken">Cancelation token used to comunicate cancelation to the async tasks</param>
         /// <returns>If a credentials can be obtained a credentails object with a session token for the URI,
         /// if not NULL</returns>
-        public async Task<CredentialResponse> Get(Uri uri, IWebProxy proxy, bool isProxyRequest, bool isRetry,
+        public async Task<CredentialResponse> GetAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
+            bool isRetry,
             bool nonInteractive, CancellationToken cancellationToken)
         {
             if (uri == null)
@@ -78,7 +88,7 @@ namespace NuGetVSExtension
                 return new CredentialResponse(CredentialStatus.ProviderNotApplicable);
             }
 
-            if (isProxyRequest)
+            if (type == CredentialRequestType.Proxy)
             {
                 //  We don't handle getting proxy credentials so don't try to do anything on a isProxyRequest.
                 return new CredentialResponse(CredentialStatus.ProviderNotApplicable);

--- a/src/NuGet.Clients/VsExtension/VisualStudioCredentialProvider.cs
+++ b/src/NuGet.Clients/VsExtension/VisualStudioCredentialProvider.cs
@@ -7,7 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Configuration;
 using NuGet.Credentials;
+using WebProxy = System.Net.WebProxy;
 
 namespace NuGetVSExtension
 {
@@ -34,8 +36,14 @@ namespace NuGetVSExtension
         /// Returns an ICredentials instance that the consumer would need in order
         /// to properly authenticate to the given Uri.
         /// </summary>
-        public async Task<CredentialResponse> Get(Uri uri, IWebProxy proxy, bool isProxyRequest, bool isRetry,
-            bool nonInteractive, CancellationToken cancellationToken)
+        public async Task<CredentialResponse> GetAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
+            bool isRetry,
+            bool nonInteractive,
+            CancellationToken cancellationToken)
         {
 
             if (uri == null)
@@ -69,7 +77,7 @@ namespace NuGetVSExtension
                 // The cached credentials that we found are not valid so let's ask the user
                 // until they abort or give us valid credentials.
                 var uriToDisplay = uri;
-                if (isProxyRequest && proxy != null)
+                if (type == CredentialRequestType.Proxy && proxy != null)
                 {
                     // Display the proxy server's host name when asking for proxy credentials
                     uriToDisplay = proxy.GetProxy(uri);

--- a/src/NuGet.Clients/VsExtension/VsCredentialProviderAdapter.cs
+++ b/src/NuGet.Clients/VsExtension/VsCredentialProviderAdapter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.VisualStudio;
 
@@ -30,10 +31,11 @@ namespace NuGetVSExtension
 
         public string Id => _provider.GetType().FullName;
 
-        public async Task<CredentialResponse> Get(
-            Uri uri, 
-            IWebProxy proxy, 
-            bool isProxyRequest, 
+        public async Task<CredentialResponse> GetAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
             bool isRetry, 
             bool nonInteractive, 
             CancellationToken cancellationToken)
@@ -48,7 +50,14 @@ namespace NuGetVSExtension
                 throw new ArgumentNullException(nameof(cancellationToken));
             }
 
-            var credentials = await _provider.GetCredentialsAsync(uri, proxy, isProxyRequest, isRetry, nonInteractive, cancellationToken);
+            // TODO: Extend the IVS API surface area to pass down the credential request type.
+            var credentials = await _provider.GetCredentialsAsync(
+                uri,
+                proxy,
+                isProxyRequest: type == CredentialRequestType.Proxy,
+                isRetry: isRetry,
+                nonInteractive: nonInteractive,
+                cancellationToken: cancellationToken);
 
             return credentials == null
                 ? new CredentialResponse(CredentialStatus.ProviderNotApplicable)

--- a/src/NuGet.Core/NuGet.Configuration/Credential/CredentialRequestType.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/CredentialRequestType.cs
@@ -1,0 +1,25 @@
+﻿namespace NuGet.Configuration
+{
+    public enum CredentialRequestType
+    {
+        /// <summary>
+        /// Indicates that the request credentials are to be used to access a proxy.
+        /// </summary>
+        Proxy,
+
+        /// <summary>
+        /// Indicates that the remote server rejected the previous request as unauthorized. This 
+        /// suggests that the server does not know who the caller is (i.e. the caller is not
+        /// authenticated).
+        /// </summary>
+        Unauthorized,
+
+        /// <summary>
+        /// Indicates that the remote server rejected the previous request as forbidden. This
+        /// suggests that the server knows who the caller is (i.e. the caller is authorized) but
+        /// is not allowed to access the request resource. A different set of credentials could
+        /// solve this failure.
+        /// </summary>
+        Forbidden
+    }
+}

--- a/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
@@ -10,6 +10,11 @@ namespace NuGet.Configuration
 {
     public interface ICredentialService
     {
-        Task<ICredentials> GetCredentials(Uri uri, IWebProxy proxy, bool isProxy, CancellationToken cancellationToken);
+        Task<ICredentials> GetCredentialsAsync(
+            Uri uri,
+            IWebProxy proxy,
+            CredentialRequestType type,
+            string message,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3.cs
@@ -53,7 +53,8 @@ namespace NuGet.Protocol.Core.v3
         /// <summary>
         /// Gets or sets a delegate to be invoked to prompt user for authenticated feed credentials.
         /// </summary>
-        public static Func<Uri, CancellationToken, Task<ICredentials>> PromptForCredentials { get; set; }
+        public static Func<Uri, CredentialRequestType, string, CancellationToken, Task<ICredentials>>
+            PromptForCredentialsAsync { get; set; }
 
         /// <summary>
         /// Gets or sets a delegate that is to be invoked when authenticated feed credentials are successfully

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.Core.v3;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyCredentialHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyCredentialHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -159,8 +160,18 @@ namespace NuGet.Protocol.Core.v3
 
         private async Task<NetworkCredential> PromptForProxyCredentialsAsync(Uri proxyAddress, IWebProxy proxy, CancellationToken cancellationToken)
         {
-            var credentials = await _credentialService.GetCredentials(
-                proxyAddress, proxy, isProxy: true, cancellationToken: cancellationToken);
+            var message = string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.Http_CredentialsForProxy,
+                proxyAddress);
+
+            var credentials = await _credentialService.GetCredentialsAsync(
+                proxyAddress,
+                proxy,
+                type: CredentialRequestType.Proxy,
+                message: message,
+                cancellationToken: cancellationToken);
+
             return credentials?.GetCredential(proxyAddress, BasicAuthenticationType);
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Core.v3 {
     // with the /str option, or rebuild your VS project.
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
+    public class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -35,7 +35,7 @@ namespace NuGet.Protocol.Core.v3 {
         ///    Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Protocol.Core.v3.Strings", typeof(Strings).GetTypeInfo().Assembly);
@@ -50,7 +50,7 @@ namespace NuGet.Protocol.Core.v3 {
         ///    resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -62,7 +62,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Install failed. Rolling back....
         /// </summary>
-        internal static string ActionExecutor_RollingBack {
+        public static string ActionExecutor_RollingBack {
             get {
                 return ResourceManager.GetString("ActionExecutor_RollingBack", resourceCulture);
             }
@@ -71,7 +71,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unrecognized Package Action &apos;{0}&apos;..
         /// </summary>
-        internal static string ActionResolver_UnsupportedAction {
+        public static string ActionResolver_UnsupportedAction {
             get {
                 return ResourceManager.GetString("ActionResolver_UnsupportedAction", resourceCulture);
             }
@@ -80,7 +80,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unsupported Dependency Behavior &apos;{0}&apos;..
         /// </summary>
-        internal static string ActionResolver_UnsupportedDependencyBehavior {
+        public static string ActionResolver_UnsupportedDependencyBehavior {
             get {
                 return ResourceManager.GetString("ActionResolver_UnsupportedDependencyBehavior", resourceCulture);
             }
@@ -89,7 +89,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Package &apos;{0}&apos; already exists at feed &apos;{1}&apos; and is invalid..
         /// </summary>
-        internal static string AddPackage_ExistingPackageInvalid {
+        public static string AddPackage_ExistingPackageInvalid {
             get {
                 return ResourceManager.GetString("AddPackage_ExistingPackageInvalid", resourceCulture);
             }
@@ -98,7 +98,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Package &apos;{0}&apos; already exists at feed &apos;{1}&apos;..
         /// </summary>
-        internal static string AddPackage_PackageAlreadyExists {
+        public static string AddPackage_PackageAlreadyExists {
             get {
                 return ResourceManager.GetString("AddPackage_PackageAlreadyExists", resourceCulture);
             }
@@ -107,7 +107,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Successfully added package &apos;{0}&apos; to feed &apos;{1}&apos;..
         /// </summary>
-        internal static string AddPackage_SuccessfullyAdded {
+        public static string AddPackage_SuccessfullyAdded {
             get {
                 return ResourceManager.GetString("AddPackage_SuccessfullyAdded", resourceCulture);
             }
@@ -116,7 +116,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Argument can not be null or empty..
         /// </summary>
-        internal static string Argument_Cannot_Be_Null_Or_Empty {
+        public static string Argument_Cannot_Be_Null_Or_Empty {
             get {
                 return ResourceManager.GetString("Argument_Cannot_Be_Null_Or_Empty", resourceCulture);
             }
@@ -125,7 +125,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Argument cannot be null or empty..
         /// </summary>
-        internal static string ArgumentCannotBeNullOrEmpty {
+        public static string ArgumentCannotBeNullOrEmpty {
             get {
                 return ResourceManager.GetString("ArgumentCannotBeNullOrEmpty", resourceCulture);
             }
@@ -134,7 +134,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to the symbol server.
         /// </summary>
-        internal static string DefaultSymbolServer {
+        public static string DefaultSymbolServer {
             get {
                 return ResourceManager.GetString("DefaultSymbolServer", resourceCulture);
             }
@@ -143,7 +143,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Delete canceled.
         /// </summary>
-        internal static string DeleteCommandCanceled {
+        public static string DeleteCommandCanceled {
             get {
                 return ResourceManager.GetString("DeleteCommandCanceled", resourceCulture);
             }
@@ -152,7 +152,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to {0} {1} will be deleted from the {2}. Would you like to continue?.
         /// </summary>
-        internal static string DeleteCommandConfirm {
+        public static string DeleteCommandConfirm {
             get {
                 return ResourceManager.GetString("DeleteCommandConfirm", resourceCulture);
             }
@@ -161,7 +161,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to {0} {1} was deleted successfully..
         /// </summary>
-        internal static string DeleteCommandDeletedPackage {
+        public static string DeleteCommandDeletedPackage {
             get {
                 return ResourceManager.GetString("DeleteCommandDeletedPackage", resourceCulture);
             }
@@ -170,7 +170,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Deleting {0} {1} from the {2}..
         /// </summary>
-        internal static string DeleteCommandDeletingPackage {
+        public static string DeleteCommandDeletingPackage {
             get {
                 return ResourceManager.GetString("DeleteCommandDeletingPackage", resourceCulture);
             }
@@ -179,7 +179,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Not Found..
         /// </summary>
-        internal static string DeletePackage_NotFound {
+        public static string DeletePackage_NotFound {
             get {
                 return ResourceManager.GetString("DeletePackage_NotFound", resourceCulture);
             }
@@ -188,7 +188,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The download URL for {0} &apos;{1}&apos; is invalid..
         /// </summary>
-        internal static string DownloadActionHandler_InvalidDownloadUrl {
+        public static string DownloadActionHandler_InvalidDownloadUrl {
             get {
                 return ResourceManager.GetString("DownloadActionHandler_InvalidDownloadUrl", resourceCulture);
             }
@@ -197,7 +197,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to No download URL could be found for {0}..
         /// </summary>
-        internal static string DownloadActionHandler_NoDownloadUrl {
+        public static string DownloadActionHandler_NoDownloadUrl {
             get {
                 return ResourceManager.GetString("DownloadActionHandler_NoDownloadUrl", resourceCulture);
             }
@@ -206,16 +206,43 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The download of &apos;{0}&apos; timed out because no data was received for {1}ms..
         /// </summary>
-        internal static string Error_DownloadTimeout {
+        public static string Error_DownloadTimeout {
             get {
                 return ResourceManager.GetString("Error_DownloadTimeout", resourceCulture);
             }
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The server responded with HTTP &apos;403 Forbidden&apos; when accessing the source &apos;{0}&apos;. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource..
+        /// </summary>
+        public static string Http_CredentialsForForbidden {
+            get {
+                return ResourceManager.GetString("Http_CredentialsForForbidden", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to The server responded with HTTP &apos;407 Proxy Authentication Required&apos; when accessing the proxy &apos;{0}&apos;. This suggests that the server needs credentials to authenticate your identity to use a proxy. Provide credentials to access this resource..
+        /// </summary>
+        public static string Http_CredentialsForProxy {
+            get {
+                return ResourceManager.GetString("Http_CredentialsForProxy", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to The server responded with HTTP &apos;401 Unauthorized&apos; when accessing the source &apos;{0}&apos;. This suggests that the server needs credentials to authenticate your identity. Provide credentials to access this resource..
+        /// </summary>
+        public static string Http_CredentialsForUnauthorized {
+            get {
+                return ResourceManager.GetString("Http_CredentialsForUnauthorized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to {0} {1}.
         /// </summary>
-        internal static string Http_RequestLog {
+        public static string Http_RequestLog {
             get {
                 return ResourceManager.GetString("Http_RequestLog", resourceCulture);
             }
@@ -224,7 +251,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to {0} {1} {2}ms.
         /// </summary>
-        internal static string Http_ResponseLog {
+        public static string Http_ResponseLog {
             get {
                 return ResourceManager.GetString("Http_ResponseLog", resourceCulture);
             }
@@ -233,7 +260,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The HTTP request to &apos;{0} {1}&apos; has timed out after {2}ms..
         /// </summary>
-        internal static string Http_Timeout {
+        public static string Http_Timeout {
             get {
                 return ResourceManager.GetString("Http_Timeout", resourceCulture);
             }
@@ -242,7 +269,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The folder &apos;{0}&apos; contains an invalid version..
         /// </summary>
-        internal static string InvalidVersionFolder {
+        public static string InvalidVersionFolder {
             get {
                 return ResourceManager.GetString("InvalidVersionFolder", resourceCulture);
             }
@@ -251,7 +278,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to the NuGet gallery.
         /// </summary>
-        internal static string LiveFeed {
+        public static string LiveFeed {
             get {
                 return ResourceManager.GetString("LiveFeed", resourceCulture);
             }
@@ -260,7 +287,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Downloading a package from &apos;{0}&apos; was canceled..
         /// </summary>
-        internal static string Log_CanceledNupkgDownload {
+        public static string Log_CanceledNupkgDownload {
             get {
                 return ResourceManager.GetString("Log_CanceledNupkgDownload", resourceCulture);
             }
@@ -269,7 +296,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Error downloading &apos;{0}&apos; from &apos;{1}&apos;..
         /// </summary>
-        internal static string Log_ErrorDownloading {
+        public static string Log_ErrorDownloading {
             get {
                 return ResourceManager.GetString("Log_ErrorDownloading", resourceCulture);
             }
@@ -278,7 +305,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Failed to download package from &apos;{0}&apos;..
         /// </summary>
-        internal static string Log_FailedToDownloadPackage {
+        public static string Log_FailedToDownloadPackage {
             get {
                 return ResourceManager.GetString("Log_FailedToDownloadPackage", resourceCulture);
             }
@@ -287,7 +314,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The V2 feed at &apos;{0}&apos; returned an unexpected status code &apos;{1} {2}&apos;..
         /// </summary>
-        internal static string Log_FailedToFetchV2Feed {
+        public static string Log_FailedToFetchV2Feed {
             get {
                 return ResourceManager.GetString("Log_FailedToFetchV2Feed", resourceCulture);
             }
@@ -296,7 +323,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unable to load package &apos;{0}&apos;..
         /// </summary>
-        internal static string Log_FailedToGetNupkgStream {
+        public static string Log_FailedToGetNupkgStream {
             get {
                 return ResourceManager.GetString("Log_FailedToGetNupkgStream", resourceCulture);
             }
@@ -305,7 +332,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unable to load nuspec from package &apos;{0}&apos;..
         /// </summary>
-        internal static string Log_FailedToGetNuspecStream {
+        public static string Log_FailedToGetNuspecStream {
             get {
                 return ResourceManager.GetString("Log_FailedToGetNuspecStream", resourceCulture);
             }
@@ -314,7 +341,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unable to load the service index for source {0}..
         /// </summary>
-        internal static string Log_FailedToReadServiceIndex {
+        public static string Log_FailedToReadServiceIndex {
             get {
                 return ResourceManager.GetString("Log_FailedToReadServiceIndex", resourceCulture);
             }
@@ -323,7 +350,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Failed to retrieve information from remote source &apos;{0}&apos;..
         /// </summary>
-        internal static string Log_FailedToRetrievePackage {
+        public static string Log_FailedToRetrievePackage {
             get {
                 return ResourceManager.GetString("Log_FailedToRetrievePackage", resourceCulture);
             }
@@ -332,7 +359,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The file &apos;{0}&apos; is corrupt..
         /// </summary>
-        internal static string Log_FileIsCorrupt {
+        public static string Log_FileIsCorrupt {
             get {
                 return ResourceManager.GetString("Log_FileIsCorrupt", resourceCulture);
             }
@@ -341,7 +368,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to An invalid cache entry was found for URL &apos;{0}&apos; and will be replaced..
         /// </summary>
-        internal static string Log_InvalidCacheEntry {
+        public static string Log_InvalidCacheEntry {
             get {
                 return ResourceManager.GetString("Log_InvalidCacheEntry", resourceCulture);
             }
@@ -350,7 +377,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The nupkg at &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string Log_InvalidNupkgFromUrl {
+        public static string Log_InvalidNupkgFromUrl {
             get {
                 return ResourceManager.GetString("Log_InvalidNupkgFromUrl", resourceCulture);
             }
@@ -359,7 +386,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Retrying &apos;{0}&apos; for source &apos;{1}&apos;..
         /// </summary>
-        internal static string Log_RetryingFindPackagesById {
+        public static string Log_RetryingFindPackagesById {
             get {
                 return ResourceManager.GetString("Log_RetryingFindPackagesById", resourceCulture);
             }
@@ -368,7 +395,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to An error was encountered when fetching &apos;{0} {1}&apos;. The request will now be retried..
         /// </summary>
-        internal static string Log_RetryingHttp {
+        public static string Log_RetryingHttp {
             get {
                 return ResourceManager.GetString("Log_RetryingHttp", resourceCulture);
             }
@@ -377,7 +404,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Retrying service index request for source &apos;{0}&apos;..
         /// </summary>
-        internal static string Log_RetryingServiceIndex {
+        public static string Log_RetryingServiceIndex {
             get {
                 return ResourceManager.GetString("Log_RetryingServiceIndex", resourceCulture);
             }
@@ -386,7 +413,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to No API Key was provided and no API Key could be found for {0}. To save an API Key for a source use the &apos;setApiKey&apos; command..
         /// </summary>
-        internal static string NoApiKeyFound {
+        public static string NoApiKeyFound {
             get {
                 return ResourceManager.GetString("NoApiKeyFound", resourceCulture);
             }
@@ -395,7 +422,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Cannot create a NuGet Repository from the Aggregate Source.
         /// </summary>
-        internal static string NuGetRepository_CannotCreateAggregateRepo {
+        public static string NuGetRepository_CannotCreateAggregateRepo {
             get {
                 return ResourceManager.GetString("NuGetRepository_CannotCreateAggregateRepo", resourceCulture);
             }
@@ -404,7 +431,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The {0} service is not supported by this object..
         /// </summary>
-        internal static string NuGetServiceProvider_ServiceNotSupported {
+        public static string NuGetServiceProvider_ServiceNotSupported {
             get {
                 return ResourceManager.GetString("NuGetServiceProvider_ServiceNotSupported", resourceCulture);
             }
@@ -413,7 +440,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to &apos;{0}&apos; is not a valid nupkg file..
         /// </summary>
-        internal static string NupkgPath_Invalid {
+        public static string NupkgPath_Invalid {
             get {
                 return ResourceManager.GetString("NupkgPath_Invalid", resourceCulture);
             }
@@ -422,7 +449,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to One or more URIs must be specified..
         /// </summary>
-        internal static string OneOrMoreUrisMustBeSpecified {
+        public static string OneOrMoreUrisMustBeSpecified {
             get {
                 return ResourceManager.GetString("OneOrMoreUrisMustBeSpecified", resourceCulture);
             }
@@ -431,7 +458,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Unrecognized Package Action &apos;{0}&apos;..
         /// </summary>
-        internal static string PackageActionDescriptionWrapper_UnrecognizedAction {
+        public static string PackageActionDescriptionWrapper_UnrecognizedAction {
             get {
                 return ResourceManager.GetString("PackageActionDescriptionWrapper_UnrecognizedAction", resourceCulture);
             }
@@ -440,7 +467,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to ERROR: This version of nuget.exe does not support updating packages to package source &apos;{0}&apos;..
         /// </summary>
-        internal static string PackageServerEndpoint_NotSupported {
+        public static string PackageServerEndpoint_NotSupported {
             get {
                 return ResourceManager.GetString("PackageServerEndpoint_NotSupported", resourceCulture);
             }
@@ -449,7 +476,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to &apos;{0}&apos; is not a valid path..
         /// </summary>
-        internal static string Path_Invalid {
+        public static string Path_Invalid {
             get {
                 return ResourceManager.GetString("Path_Invalid", resourceCulture);
             }
@@ -458,7 +485,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to &apos;{0}&apos; should be a local path or a UNC share path..
         /// </summary>
-        internal static string Path_Invalid_NotFileNotUnc {
+        public static string Path_Invalid_NotFileNotUnc {
             get {
                 return ResourceManager.GetString("Path_Invalid_NotFileNotUnc", resourceCulture);
             }
@@ -467,7 +494,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The project &apos;{0}&apos; is not one of the projects targetted by this object..
         /// </summary>
-        internal static string ProjectInstallationTarget_ProjectIsNotTargetted {
+        public static string ProjectInstallationTarget_ProjectIsNotTargetted {
             get {
                 return ResourceManager.GetString("ProjectInstallationTarget_ProjectIsNotTargetted", resourceCulture);
             }
@@ -476,7 +503,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Failed to retrieve metadata from source &apos;{0}&apos;..
         /// </summary>
-        internal static string Protocol_BadSource {
+        public static string Protocol_BadSource {
             get {
                 return ResourceManager.GetString("Protocol_BadSource", resourceCulture);
             }
@@ -485,7 +512,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The &apos;versions&apos; property at &apos;{0}&apos; must be an array..
         /// </summary>
-        internal static string Protocol_FlatContainerIndexVersionsNotArray {
+        public static string Protocol_FlatContainerIndexVersionsNotArray {
             get {
                 return ResourceManager.GetString("Protocol_FlatContainerIndexVersionsNotArray", resourceCulture);
             }
@@ -494,7 +521,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Service index document is missing the &apos;resources&apos; property..
         /// </summary>
-        internal static string Protocol_IndexMissingResourcesNode {
+        public static string Protocol_IndexMissingResourcesNode {
             get {
                 return ResourceManager.GetString("Protocol_IndexMissingResourcesNode", resourceCulture);
             }
@@ -503,7 +530,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The content at &apos;{0}&apos; is not a valid JSON object..
         /// </summary>
-        internal static string Protocol_InvalidJsonObject {
+        public static string Protocol_InvalidJsonObject {
             get {
                 return ResourceManager.GetString("Protocol_InvalidJsonObject", resourceCulture);
             }
@@ -512,7 +539,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The source does not have the &apos;version&apos; property at &apos;{0}&apos;..
         /// </summary>
-        internal static string Protocol_InvalidServiceIndex {
+        public static string Protocol_InvalidServiceIndex {
             get {
                 return ResourceManager.GetString("Protocol_InvalidServiceIndex", resourceCulture);
             }
@@ -521,7 +548,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The content at &apos;{0}&apos; is not valid XML..
         /// </summary>
-        internal static string Protocol_InvalidXml {
+        public static string Protocol_InvalidXml {
             get {
                 return ResourceManager.GetString("Protocol_InvalidXml", resourceCulture);
             }
@@ -530,7 +557,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Metadata could not be loaded from the source &apos;{0}&apos;..
         /// </summary>
-        internal static string Protocol_MalformedMetadataError {
+        public static string Protocol_MalformedMetadataError {
             get {
                 return ResourceManager.GetString("Protocol_MalformedMetadataError", resourceCulture);
             }
@@ -539,7 +566,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The source does not have a Registration Base Url defined!.
         /// </summary>
-        internal static string Protocol_MissingRegistrationBase {
+        public static string Protocol_MissingRegistrationBase {
             get {
                 return ResourceManager.GetString("Protocol_MissingRegistrationBase", resourceCulture);
             }
@@ -548,7 +575,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The source does not have a Search service!.
         /// </summary>
-        internal static string Protocol_MissingSearchService {
+        public static string Protocol_MissingSearchService {
             get {
                 return ResourceManager.GetString("Protocol_MissingSearchService", resourceCulture);
             }
@@ -557,7 +584,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The source does not have the &apos;version&apos; property..
         /// </summary>
-        internal static string Protocol_MissingVersion {
+        public static string Protocol_MissingVersion {
             get {
                 return ResourceManager.GetString("Protocol_MissingVersion", resourceCulture);
             }
@@ -566,7 +593,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to An error occurred while retrieving package metadata for &apos;{0}&apos; from source &apos;{1}&apos;..
         /// </summary>
-        internal static string Protocol_PackageMetadataError {
+        public static string Protocol_PackageMetadataError {
             get {
                 return ResourceManager.GetString("Protocol_PackageMetadataError", resourceCulture);
             }
@@ -575,7 +602,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The source version is not supported: &apos;{0}&apos;..
         /// </summary>
-        internal static string Protocol_UnsupportedVersion {
+        public static string Protocol_UnsupportedVersion {
             get {
                 return ResourceManager.GetString("Protocol_UnsupportedVersion", resourceCulture);
             }
@@ -584,7 +611,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Your package was pushed..
         /// </summary>
-        internal static string PushCommandPackagePushed {
+        public static string PushCommandPackagePushed {
             get {
                 return ResourceManager.GetString("PushCommandPackagePushed", resourceCulture);
             }
@@ -593,7 +620,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Pushing {0} to {1}....
         /// </summary>
-        internal static string PushCommandPushingPackage {
+        public static string PushCommandPushingPackage {
             get {
                 return ResourceManager.GetString("PushCommandPushingPackage", resourceCulture);
             }
@@ -602,7 +629,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The &apos;{0}&apos; installation feature was required by a package but is not supported on the current host..
         /// </summary>
-        internal static string RequiredFeatureUnsupportedException_DefaultMessageWithFeature {
+        public static string RequiredFeatureUnsupportedException_DefaultMessageWithFeature {
             get {
                 return ResourceManager.GetString("RequiredFeatureUnsupportedException_DefaultMessageWithFeature", resourceCulture);
             }
@@ -611,7 +638,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to The installation host does not support a feature required by this package..
         /// </summary>
-        internal static string RequiredFeatureUnsupportedException_DefaultMessageWithoutFeature {
+        public static string RequiredFeatureUnsupportedException_DefaultMessageWithoutFeature {
             get {
                 return ResourceManager.GetString("RequiredFeatureUnsupportedException_DefaultMessageWithoutFeature", resourceCulture);
             }
@@ -620,7 +647,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to File does not exist ({0})..
         /// </summary>
-        internal static string UnableToFindFile {
+        public static string UnableToFindFile {
             get {
                 return ResourceManager.GetString("UnableToFindFile", resourceCulture);
             }
@@ -629,7 +656,7 @@ namespace NuGet.Protocol.Core.v3 {
         /// <summary>
         ///    Looks up a localized string similar to Found symbols package &apos;{0}&apos;, but no API key was specified for the symbol server. To save an API Key, run &apos;NuGet.exe setApiKey [your API key from http://www.NuGet.org]&apos;..
         /// </summary>
-        internal static string Warning_SymbolServerNotConfigured {
+        public static string Warning_SymbolServerNotConfigured {
             get {
                 return ResourceManager.GetString("Warning_SymbolServerNotConfigured", resourceCulture);
             }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Strings.resx
@@ -321,4 +321,16 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
     <comment>'{0}' is replaced with the resource that could not be downloaded.
 '{1}' is replaced with the integer (in milliseconds) of the timeout duration.</comment>
   </data>
+  <data name="Http_CredentialsForUnauthorized" xml:space="preserve">
+    <value>The server responded with HTTP '401 Unauthorized' when accessing the source '{0}'. This suggests that the server needs credentials to authenticate your identity. Provide credentials to access this resource.</value>
+    <comment>{0} is the source that needs credentials to be accessed.</comment>
+  </data>
+  <data name="Http_CredentialsForForbidden" xml:space="preserve">
+    <value>The server responded with HTTP '403 Forbidden' when accessing the source '{0}'. This suggests that the server has authenticated your identity but has not permitted you to access the requested resource. Provide credentials that have permissions to view this resource.</value>
+    <comment>{0} is the source that needs credentials to be accessed.</comment>
+  </data>
+  <data name="Http_CredentialsForProxy" xml:space="preserve">
+    <value>The server responded with HTTP '407 Proxy Authentication Required' when accessing the proxy '{0}'. This suggests that the server needs credentials to authenticate your identity to use a proxy. Provide credentials to access this resource.</value>
+    <comment>{0} is the proxy URL that needs credentials to be accessed.</comment>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleCredentialProviderTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ConsoleCredentialProviderTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 using Xunit;
 using Console = NuGet.Common.Console;
 
@@ -18,12 +19,18 @@ namespace NuGet.CommandLine.Test
             var provider = new ConsoleCredentialProvider(console);
 
             // Act
-            var actual = await provider.Get(Uri, null, true, false, true, CancellationToken.None);
+            var actual = await provider.GetAsync(
+                Uri,
+                proxy: null,
+                type: CredentialRequestType.Proxy,
+                message: null,
+                isRetry: false,
+                nonInteractive: true,
+                cancellationToken: CancellationToken.None);
 
             // Assert
             Assert.Equal(Credentials.CredentialStatus.ProviderNotApplicable, actual.Status);
             Assert.Null(actual.Credentials);
         }
-
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
@@ -3,13 +3,13 @@
 
 using Moq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using NuGet.Configuration;
+using WebProxy = System.Net.WebProxy;
 
 namespace NuGet.Credentials.Test
 {
@@ -23,10 +23,16 @@ namespace NuGet.Credentials.Test
         public CredentialServiceTests()
         {
             _mockProvider = new Mock<ICredentialProvider>();
-            _mockProvider.Setup(x => x
-                .Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<CredentialResponse>(new CredentialResponse (CredentialStatus.ProviderNotApplicable)));
+            _mockProvider
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new CredentialResponse (CredentialStatus.ProviderNotApplicable)));
             _mockProvider.Setup(x => x.Id).Returns("1");
         }
 
@@ -38,6 +44,7 @@ namespace NuGet.Credentials.Test
         [Fact]
         public async Task GetCredentials_PassesAllParametersToProviders()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
@@ -45,58 +52,132 @@ namespace NuGet.Credentials.Test
             var webProxy = new WebProxy();
             var uri = new Uri("http://uri");
 
-            await service.GetCredentials(uri, webProxy, isProxy: true, cancellationToken: CancellationToken.None);
+            // Act
+            await service.GetCredentialsAsync(
+                uri,
+                webProxy,
+                CredentialRequestType.Proxy,
+                message: "A",
+                cancellationToken: CancellationToken.None);
 
-            _mockProvider.Verify(x => x.Get(uri, webProxy, /*isProxy*/ true, /*isRetry*/ It.IsAny<bool>(),
-                /*nonInteractive*/ true, CancellationToken.None));
+            // Assert
+            _mockProvider.Verify(x => x.GetAsync(
+                uri,
+                webProxy,
+                /*type*/ CredentialRequestType.Proxy,
+                /*message*/ "A",
+                /*isRetry*/ It.IsAny<bool>(),
+                /*nonInteractive*/ true,
+                CancellationToken.None));
         }
 
         [Fact]
         public async Task GetCredentials_FirstCallHasRetryFalse()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
-            _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<CredentialResponse>(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+            _mockProvider.Setup(
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
             var uri1 = new Uri("http://uri1");
             var uri2 = new Uri("http://uri2");
 
-            var result1 = await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            var result1 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: "A",
                 cancellationToken: CancellationToken.None);
-            var result2 = await service.GetCredentials(uri2, null, isProxy: false,
+            var result2 = await service.GetCredentialsAsync(
+                uri2,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: "B",
                 cancellationToken: CancellationToken.None);
 
-            _mockProvider.Verify(x => x.Get(uri1, null, /*isProxy*/ false, /*isRetry*/ false,
-                /*nonInteractive*/ false, CancellationToken.None));
-            _mockProvider.Verify(x => x.Get(uri2, null, /*isProxy*/ false, /*isRetry*/ false,
-                /*nonInteractive*/ false, CancellationToken.None));
+            // Assert
+            _mockProvider.Verify(x => x.GetAsync(
+                uri1,
+                /*webProxy*/ null,
+                /*type*/ CredentialRequestType.Unauthorized,
+                /*message*/ "A",
+                /*isRetry*/ false,
+                /*nonInteractive*/ false,
+                CancellationToken.None));
+
+            _mockProvider.Verify(x => x.GetAsync(
+                uri2,
+                /*webProxy*/ null,
+                /*type*/ CredentialRequestType.Unauthorized,
+                /*message*/ "B",
+                /*isRetry*/ false,
+                /*nonInteractive*/ false,
+                CancellationToken.None));
         }
 
         [Fact]
         public async Task GetCredentials_SecondCallHasRetryTrue()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
-            _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<CredentialResponse>(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+            _mockProvider.Setup(
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
             var uri1 = new Uri("http://uri1");
             var webProxy = new WebProxy();
 
-            await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
-            await service.GetCredentials(uri1, webProxy, isProxy: false,
+            await service.GetCredentialsAsync(
+                uri1,
+                webProxy,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
 
-            _mockProvider.Verify(x => x.Get(uri1, null, /*isProxy*/ false, /*isRetry*/ false,
-                /*nonInteractive*/ false, CancellationToken.None));
-            _mockProvider.Verify(x => x.Get(uri1, webProxy, /*isProxy*/ false, /*isRetry*/ true,
-                /*nonInteractive*/ false, CancellationToken.None));
+            // Assert
+            _mockProvider.Verify(x => x.GetAsync(
+                uri1,
+                null,
+                /*type*/ CredentialRequestType.Unauthorized,
+                /*message*/ null,
+                /*isRetry*/ false,
+                /*nonInteractive*/ false,
+                CancellationToken.None));
+            _mockProvider.Verify(x => x.GetAsync(
+                uri1,
+                webProxy,
+                /*type*/ CredentialRequestType.Unauthorized,
+                /*message*/ null,
+                /*isRetry*/ true,
+                /*nonInteractive*/ false,
+                CancellationToken.None));
         }
 
         private static int _lockTestConcurrencyCount = 0;
@@ -111,21 +192,31 @@ namespace NuGet.Credentials.Test
             var webProxy = new WebProxy();
             var uri = new Uri("http://uri");
             _mockProvider
-                .Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(() =>
                 {
                     _lockTestConcurrencyCount++;
                     Assert.Equal(1, _lockTestConcurrencyCount);
                     _lockTestConcurrencyCount--;
-                    return Task.FromResult<CredentialResponse>(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success));
+                    return Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success));
                 });
             var tasks = new Task[10];
 
             // Act
             for (var x = 0; x < 10; x++)
             {
-                tasks[x]=service.GetCredentials(uri, webProxy, isProxy: false,
+                tasks[x] = service.GetCredentialsAsync(
+                    uri,
+                    webProxy,
+                    type: CredentialRequestType.Unauthorized,
+                    message: null,
                     cancellationToken: CancellationToken.None);
             }
             Task.WaitAll(tasks);
@@ -137,73 +228,128 @@ namespace NuGet.Credentials.Test
         [Fact]
         public async Task GetCredentials_WhenUriHasSameAuthority_ThenReturnsCachedCredential()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
-            _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult<CredentialResponse>(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+            _mockProvider
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
             var uri1 = new Uri("http://host/some/path");
             var uri2 = new Uri("http://host/some2/path2");
 
-
-            var result1 = await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            var result1 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
-            var result2 = await service.GetCredentials(uri2, null, isProxy: false,
+            var result2 = await service.GetCredentialsAsync(
+                uri2,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.Same(result1, result2);
             _mockProvider.Verify(
-                x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Fact]
         public async Task GetCredentials_NullResponsesAreCached()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
-            _mockProvider.Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult<CredentialResponse>(new CredentialResponse (CredentialStatus.ProviderNotApplicable)));
+            _mockProvider
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new CredentialResponse (CredentialStatus.ProviderNotApplicable)));
             var uri1 = new Uri("http://host/some/path");
             var uri2 = new Uri("http://host/some2/path2");
 
-
-            var result1 = await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            var result1 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
-            var result2 = await service.GetCredentials(uri2, null, isProxy: false,
+            var result2 = await service.GetCredentialsAsync(
+                uri2,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.Null(result1);
             Assert.Null(result2);
             _mockProvider.Verify(
-                x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
-
 
         [Fact]
         public async Task GetCredentials_TriesAllProviders_EvenWhenSameType()
         {
+            // Arrange
             var mockProvider1 = new Mock<ICredentialProvider>();
-            mockProvider1.Setup(x => x
-                .Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult<CredentialResponse>(new CredentialResponse(CredentialStatus.ProviderNotApplicable)));
+            mockProvider1
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new CredentialResponse(CredentialStatus.ProviderNotApplicable)));
             mockProvider1.Setup(x => x.Id).Returns("1");
             var mockProvider2 = new Mock<ICredentialProvider>();
-            mockProvider2.Setup(x => x
-                .Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            mockProvider2
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(
-                    Task.FromResult<CredentialResponse>(new CredentialResponse(CredentialStatus.ProviderNotApplicable)));
+                    Task.FromResult(new CredentialResponse(CredentialStatus.ProviderNotApplicable)));
             mockProvider2.Setup(x => x.Id).Returns("2");
             var service = new CredentialService(
                 new[] {mockProvider1.Object, mockProvider2.Object},
@@ -211,43 +357,83 @@ namespace NuGet.Credentials.Test
                 nonInteractive: false);
             var uri1 = new Uri("http://host/some/path");
 
-
-            var result1 = await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            var result1 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.Null(result1);
             mockProvider1.Verify(
-                x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
             mockProvider2.Verify(
-                x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(), It.IsAny<bool>(),
-                    It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Fact]
         public async Task GetCredentials_WhenRetry_ThenDoesNotReturnCachedCredential()
         {
+            // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
                 TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider
-                .Setup(x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult<CredentialResponse>(new CredentialResponse(new NetworkCredential(), CredentialStatus.Success)));
+                .Setup(x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(new CredentialResponse(new NetworkCredential(), CredentialStatus.Success)));
             var uri1 = new Uri("http://uri1");
 
-            var result1 = await service.GetCredentials(uri1, null, isProxy: false,
+            // Act
+            var result1 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
-            var result2 = await service.GetCredentials(uri1, null, isProxy: false,
+            var result2 = await service.GetCredentialsAsync(
+                uri1,
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
                 cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.NotSame(result1, result2);
             _mockProvider.Verify(
-                x => x.Get(It.IsAny<Uri>(), It.IsAny<IWebProxy>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                x => x.GetAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<IWebProxy>(),
+                    It.IsAny<CredentialRequestType>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Exactly(2));
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VisualStudioAccountProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VisualStudioAccountProviderTests.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Credentials;
 using Xunit;
+using NuGet.Configuration;
 
 namespace NuGet.VsExtension.Test
 {
@@ -78,12 +79,19 @@ namespace NuGet.VsExtension.Test
             // Arange
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = true;
+            var type = CredentialRequestType.Proxy;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -97,13 +105,20 @@ namespace NuGet.VsExtension.Test
             // Arange
             var uri = null as Uri;
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
-            // Act - Assert
+            // Act & Assert
             await Assert.ThrowsAsync<ArgumentNullException>(
-                async () => await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+                async () => await _provider.GetAsync(
+                    uri,
+                    webProxy,
+                    type,
+                    message,
+                    isRetry,
+                    nonInteractive,
                     CancellationToken.None));
         }
 
@@ -113,12 +128,19 @@ namespace NuGet.VsExtension.Test
             // Arange
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -138,12 +160,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -160,12 +189,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("http://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -179,17 +215,19 @@ namespace NuGet.VsExtension.Test
             // Arange
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = true;
 
             // Act
             var exception =
                 await Assert.ThrowsAsync<InvalidOperationException>(
-                        async () => await _provider.Get(
+                        async () => await _provider.GetAsync(
                             uri, 
                             webProxy, 
-                            isProxyRequest, 
+                            type,
+                            message,
                             isRetry, 
                             nonInteractive,
                             CancellationToken.None));
@@ -208,12 +246,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -243,12 +288,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -281,12 +333,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -332,12 +391,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = false;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert
@@ -364,12 +430,19 @@ namespace NuGet.VsExtension.Test
 
             var uri = new Uri("https://uri1");
             var webProxy = null as IWebProxy;
-            var isProxyRequest = false;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
             var isRetry = true;
             var nonInteractive = false;
 
             // Act
-            var cred = await _provider.Get(uri, webProxy, isProxyRequest, isRetry, nonInteractive,
+            var cred = await _provider.GetAsync(
+                uri,
+                webProxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
                 CancellationToken.None);
 
             // Assert

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderAdapterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderAdapterTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Configuration;
 using NuGet.Credentials;
 using NuGet.VisualStudio;
 using NuGetVSExtension;
@@ -33,11 +34,21 @@ namespace NuGet.VsExtension.Test
         [Fact]
         public async Task WhenCredsNull_ThenReturnProviderNotApplicable()
         {
+            // Arrange
             var provider = new TestVsCredentialProvider(null);
             var adapter = new VsCredentialProviderAdapter(provider);
 
-            var result = await adapter.Get(new Uri("http://host"), null, false, false, false, CancellationToken.None);
+            // Act
+            var result = await adapter.GetAsync(
+                new Uri("http://host"),
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
+                isRetry: false,
+                nonInteractive: false,
+                cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.Null(result.Credentials);
             Assert.Equal(CredentialStatus.ProviderNotApplicable, result.Status);
         }
@@ -45,12 +56,22 @@ namespace NuGet.VsExtension.Test
         [Fact]
         public async Task WhenAnyValidVsCredentialResponse_Ok()
         {
+            // Arrange
             var expected = new NetworkCredential("foo", "bar");
             var provider = new TestVsCredentialProvider(expected);
             var adapter = new VsCredentialProviderAdapter(provider);
 
-            var result = await adapter.Get(new Uri("http://host"), null, false, false, false, CancellationToken.None);
+            // Act
+            var result = await adapter.GetAsync(
+                new Uri("http://host"),
+                proxy: null,
+                type: CredentialRequestType.Unauthorized,
+                message: null,
+                isRetry: false,
+                nonInteractive: false,
+                cancellationToken: CancellationToken.None);
 
+            // Assert
             Assert.Same(expected, result.Credentials);
             Assert.Equal(CredentialStatus.Success, result.Status);
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceTests.cs
@@ -46,7 +46,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 });
 
                 var prompted = false;
-                HttpHandlerResourceV3.PromptForCredentials = (uri, token) =>
+                HttpHandlerResourceV3.PromptForCredentialsAsync = (uri, type, message, token) =>
                 {
                     prompted = true;
                     return Task.FromResult(tc.Credentials);
@@ -84,7 +84,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 });
 
                 var prompted = false;
-                HttpHandlerResourceV3.PromptForCredentials = (uri, token) =>
+                HttpHandlerResourceV3.PromptForCredentialsAsync = (uri, type, message, token) =>
                 {
                     prompted = true;
                     return Task.FromResult(tc.Credentials);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/ProxyCredentialHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/ProxyCredentialHandlerTests.cs
@@ -47,8 +47,14 @@ namespace NuGet.Protocol.Core.v3.Tests
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.ProxyAuthenticationRequired, response.StatusCode);
 
-            Mock.Get(service)
-                .Verify(x => x.GetCredentials(ProxyAddress, It.IsAny<IWebProxy>(), true, It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(service).Verify(
+                x => x.GetCredentialsAsync(
+                    ProxyAddress,
+                    It.IsAny<IWebProxy>(),
+                    CredentialRequestType.Proxy,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                 Times.Once());
         }
 
         [Fact]
@@ -58,7 +64,12 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             var service = Mock.Of<ICredentialService>();
             Mock.Get(service)
-                .Setup(x => x.GetCredentials(ProxyAddress, It.IsAny<IWebProxy>(), true, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetCredentialsAsync(
+                    ProxyAddress,
+                    It.IsAny<IWebProxy>(),
+                    CredentialRequestType.Proxy,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(() => Task.FromResult<ICredentials>(new NetworkCredential()));
 
             var handler = new ProxyCredentialHandler(defaultClientHandler, service, ProxyCache.Instance);
@@ -74,8 +85,14 @@ namespace NuGet.Protocol.Core.v3.Tests
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            Mock.Get(service)
-                .Verify(x => x.GetCredentials(ProxyAddress, It.IsAny<IWebProxy>(), true, It.IsAny<CancellationToken>()), Times.Once());
+            Mock.Get(service).Verify(
+                x => x.GetCredentialsAsync(
+                    ProxyAddress,
+                    It.IsAny<IWebProxy>(),
+                    CredentialRequestType.Proxy,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
         }
 
         [Fact]
@@ -85,7 +102,12 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             var service = Mock.Of<ICredentialService>();
             Mock.Get(service)
-                .Setup(x => x.GetCredentials(ProxyAddress, It.IsAny<IWebProxy>(), true, It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetCredentialsAsync(
+                    ProxyAddress,
+                    It.IsAny<IWebProxy>(),
+                    CredentialRequestType.Proxy,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
                 .Returns(() => Task.FromResult<ICredentials>(new NetworkCredential()));
 
             var handler = new ProxyCredentialHandler(defaultClientHandler, service, ProxyCache.Instance);
@@ -102,8 +124,14 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             Assert.Equal(ProxyCredentialHandler.MaxAuthRetries, retryCount);
 
-            Mock.Get(service)
-                .Verify(x => x.GetCredentials(ProxyAddress, It.IsAny<IWebProxy>(), true, It.IsAny<CancellationToken>()), Times.Exactly(2));
+            Mock.Get(service).Verify(
+                x => x.GetCredentialsAsync(
+                    ProxyAddress,
+                    It.IsAny<IWebProxy>(),
+                    CredentialRequestType.Proxy,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Exactly(2));
         }
 
         private static HttpClientHandler GetDefaultClientHandler()


### PR DESCRIPTION
When a server challenges with `401 Unauthorized`, `403 Forbidden` or `407 Proxy Authentication Required`, we prompt the user for credentials.

Previously, we only prompted for 401 and 407. We previously used a `isProxy` flag passed to the prompt to allow the credential provider to act differently based on 401 vs. 407. Since there are now three cases, I added an enum to cover all three cases instead of a bool. This enum allows the credential provider to build a helpful message for the user so they know why they are being prompted.

This change adds the enum and makes the needed changes all the way up into the providers. Unfortunately, some providers (e.g. external credential provider EXEs) do not support this flag yet. A separate work item would be to make all credential providers support this new protocol. For now, the 401 and 403 case are mapped to `isProxy = false` and the 407 case is mapped to `isProxy = true`, so that we don't break old credential providers.

Take a look at the `ConsoleCredentialProvider` to get a feel for how a credential provider could act differently based on this prompt.

This PR (in addition to https://github.com/NuGet/NuGet.Client/pull/487) addresses the action items here: https://github.com/NuGet/Home/issues/2034#issuecomment-183084635

@emgarten @yishaigalatzer @zarenner @alpaix 
