### PR TITLE
Avoid null exceptions when SelectedVersion is null in VS UI

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -343,7 +343,7 @@ namespace NuGet.PackageManagement.UI
         {
             CanUninstall = Projects.Any(project => project.IsSelected && project.InstalledVersion != null);
 
-            CanInstall = Projects.Any(
+            CanInstall = SelectedVersion != null && Projects.Any(
                 project => project.IsSelected &&
                     VersionComparer.Default.Compare(SelectedVersion.Version, project.InstalledVersion) != 0);
         }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -84,7 +84,7 @@ namespace NuGet.PackageManagement.UI
         private void ProjectUninstallButtonClicked(object sender, EventArgs e)
         {
             var model = (PackageDetailControlModel)DataContext;
-            var userAction = UserAction.CreateUnInstallAction(model.Id);            
+            var userAction = UserAction.CreateUnInstallAction(model.Id);
             ExecuteUserAction(userAction, NuGetActionType.Uninstall);
         }
 
@@ -92,6 +92,12 @@ namespace NuGet.PackageManagement.UI
         private void SolutionInstallButtonClicked(object sender, EventArgs e)
         {
             var model = (PackageSolutionDetailControlModel)DataContext;
+
+            if (model.SelectedVersion == null)
+            {
+                return;
+            }
+
             var userAction = UserAction.CreateInstallAction(
                 model.Id,
                 model.SelectedVersion.Version);


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/2540

Users are always hitting null exceptions when the SelectedVersion property is null. Most of the uses of SelectedVersion have null checks, the two that didn't have null checks happen to have a lot of Watson crashes.

I can't repro the crash, but there must be some way in the UI to have a null version selected in the dropdown.

There must be some way to have no item in the circled Version dropdown below:

![image](https://cloud.githubusercontent.com/assets/2523431/14543720/5cb0dc00-024a-11e6-9734-5a4603480973.png)
