### PR TITLE
Use the last request URL as the V2 base URL (like the old OData code)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/MetadataResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/MetadataResourceV2Feed.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.Core.v3;
 using NuGet.Versioning;
 using Strings = NuGet.Protocol.Core.v3.Strings;
 

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -99,9 +99,13 @@ namespace Test.Utility
             string source;
             if (_responses.TryGetValue(request.RequestUri.AbsoluteUri, out source))
             {
-                // TODO: allow s to be a status code to return
-
-                if (source == string.Empty)
+                // TODO: Make this test infrastructure not a big hack.
+                if (source == null)
+                {
+                    msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                    msg.Content = new TestContent(_errorContent);
+                }
+                else if (source == string.Empty)
                 {
                     msg = new HttpResponseMessage(HttpStatusCode.NotFound);
                     msg.Content = new TestContent(_errorContent);
@@ -111,10 +115,14 @@ namespace Test.Utility
                     msg = new HttpResponseMessage(HttpStatusCode.NoContent);
                     msg.Content = new TestContent(string.Empty);
                 }
-                else if (source == null)
+                else if (source.StartsWith("301 "))
                 {
-                    msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-                    msg.Content = new TestContent(_errorContent);
+                    var url = source.Substring(4);
+                    msg = new HttpResponseMessage(HttpStatusCode.MovedPermanently)
+                    {
+                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, url),
+                        Content = new TestContent(string.Empty)
+                    };
                 }
                 else
                 {


### PR DESCRIPTION
I've tested the following 2.8.6, 3.3.0, 3.4.3.843, and this change against:
1. Vanilla NuGet.Server
2. NuGet.Server with auth rewrite (https://github.com/NuGet/Home/issues/2520)
3. Klondike
4. NuGet.org

After this investigation it's clear that the old OData implementation does not observe `xml:base`. Instead it uses the final redirect URL as a base. The previous change to observe `xml:base` causes the second server configuration (mentioned above) to fail on 3.4.x code.

Address https://github.com/NuGet/Home/issues/2520.

@yishaigalatzer @emgarten @rrelyea 
