### PR TITLE
Add verbose log for invalid zip file times

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -262,7 +262,7 @@ namespace NuGet.CommandLine
             {
                 var projectContext = new ConsoleProjectContext(Console)
                 {
-                    PackageExtractionContext = new PackageExtractionContext()
+                    PackageExtractionContext = new PackageExtractionContext(Console)
                 };
 
                 if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -304,7 +304,7 @@ namespace NuGet.CommandLine
             var collectorLogger = new CollectorLogger(Console);
             var projectContext = new ConsoleProjectContext(collectorLogger)
             {
-                PackageExtractionContext = new PackageExtractionContext()
+                PackageExtractionContext = new PackageExtractionContext(collectorLogger)
             };
 
             if (EffectivePackageSaveMode != Packaging.PackageSaveMode.None)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleProjectContext.cs
@@ -28,12 +28,17 @@ namespace NuGet.CommandLine
             switch (level)
             {
                 case ProjectManagement.MessageLevel.Debug:
+                    _logger.LogDebug(message);
+                    break;
+
                 case ProjectManagement.MessageLevel.Info:
                     _logger.LogMinimal(message);
                     break;
+
                 case ProjectManagement.MessageLevel.Warning:
                     _logger.LogWarning(message);
                     break;
+
                 case ProjectManagement.MessageLevel.Error:
                     _logger.LogError(message);
                     break;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/VSAPIProjectContext.cs
@@ -18,7 +18,7 @@ namespace NuGet.VisualStudio
 
         public VSAPIProjectContext(bool skipAssemblyReferences, bool bindingRedirectsDisabled, bool useLegacyInstallPaths = true)
         {
-            PackageExtractionContext = new PackageExtractionContext();
+            PackageExtractionContext = new PackageExtractionContext(new LoggerAdapter(this));
 
             // many templates depend on legacy paths, for the VS API and template wizard we unfortunately need to keep them
             PackageExtractionContext.UseLegacyPackageInstallPath = useLegacyInstallPaths;

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -304,7 +304,7 @@ namespace NuGet.PackageManagement
 
             if (nuGetProjectContext.PackageExtractionContext == null)
             {
-                nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext();
+                nuGetProjectContext.PackageExtractionContext = new PackageExtractionContext(new LoggerAdapter(nuGetProjectContext));
             }
             nuGetProjectContext.PackageExtractionContext.CopySatelliteFiles = false;
 

--- a/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using NuGet.Common;
 using NuGet.Versioning;
 
 namespace NuGet.Packaging.Core
@@ -58,6 +59,7 @@ namespace NuGet.Packaging.Core
             string destination,
             IEnumerable<string> packageFiles,
             ExtractPackageFileDelegate extractFile,
+            ILogger logger,
             CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -18,6 +18,9 @@
     "../NuGet.Shared/*.cs"
   ],
   "dependencies": {
+    "NuGet.Common": {
+      "target": "project"
+    },
     "NuGet.Packaging.Core.Types": {
       "target": "project"
     }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageExtractionContext.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using NuGet.Common;
 using NuGet.Packaging.PackageExtraction;
 
 namespace NuGet.Packaging
 {
     public class PackageExtractionContext
     {
+        public ILogger Logger { get; private set; }
         public bool CopySatelliteFiles { get; set; } = true;
 
         /// <summary>
@@ -18,5 +21,15 @@ namespace NuGet.Packaging
         public PackageSaveMode PackageSaveMode { get; set; } = PackageSaveMode.Defaultv2;
 
         public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; } = PackageExtractionBehavior.XmlDocFileSaveMode;
+
+        public PackageExtractionContext(ILogger logger)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            Logger = logger;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 
@@ -170,6 +171,7 @@ namespace NuGet.Packaging
             string destination,
             IEnumerable<string> packageFiles,
             ExtractPackageFileDelegate extractFile,
+            ILogger logger,
             CancellationToken token)
         {
             var filesCopied = new List<string>();

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -66,6 +67,7 @@ namespace NuGet.Packaging
             string destination,
             IEnumerable<string> packageFiles,
             ExtractPackageFileDelegate extractFile,
+            ILogger logger,
             CancellationToken token);
 
         public virtual PackageIdentity GetIdentity()

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -114,6 +114,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Failed to update file time for {0}: {1}.
+        /// </summary>
+        internal static string FailedFileTime {
+            get {
+                return ResourceManager.GetString("FailedFileTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Fail to load packages.config as XML file. Please check it. .
         /// </summary>
         internal static string FailToLoadPackagesConfig {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -174,4 +174,7 @@
   <data name="ErrorUnableToDeleteFile" xml:space="preserve">
     <value>Unable to delete temporary file '{0}'. Error: '{1}'.</value>
   </data>
+  <data name="FailedFileTime" xml:space="preserve">
+    <value>Failed to update file time for {0}: {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -88,6 +88,12 @@ namespace NuGet.ProjectManagement
             downloadResourceResult.PackageStream.Seek(0, SeekOrigin.Begin);
             var addedPackageFilesList = new List<string>();
 
+            PackageExtractionContext packageExtractionContext = nuGetProjectContext.PackageExtractionContext;
+            if (packageExtractionContext == null)
+            {
+                packageExtractionContext = new PackageExtractionContext(new LoggerAdapter(nuGetProjectContext));
+            }
+
             if (downloadResourceResult.PackageReader != null)
             {
                 addedPackageFilesList.AddRange(
@@ -95,7 +101,7 @@ namespace NuGet.ProjectManagement
                         downloadResourceResult.PackageReader,
                         downloadResourceResult.PackageStream,
                         PackagePathResolver,
-                        nuGetProjectContext.PackageExtractionContext ?? new PackageExtractionContext(),
+                        packageExtractionContext,
                         token));
             }
             else
@@ -104,7 +110,7 @@ namespace NuGet.ProjectManagement
                     PackageExtractor.ExtractPackage(
                         downloadResourceResult.PackageStream,
                         PackagePathResolver,
-                        nuGetProjectContext.PackageExtractionContext ?? new PackageExtractionContext(),
+                        packageExtractionContext,
                         token));
             }
 
@@ -143,14 +149,18 @@ namespace NuGet.ProjectManagement
             INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
-            var xmlDocFileSaveMode = nuGetProjectContext.PackageExtractionContext?.XmlDocFileSaveMode ??
-                PackageExtractionBehavior.XmlDocFileSaveMode;
+
+            PackageExtractionContext packageExtractionContext = nuGetProjectContext.PackageExtractionContext;
+            if (packageExtractionContext == null)
+            {
+                packageExtractionContext = new PackageExtractionContext(new LoggerAdapter(nuGetProjectContext));
+            }
 
             var copiedSatelliteFiles = PackageExtractor.CopySatelliteFiles(
                 packageIdentity,
                 PackagePathResolver,
                 GetPackageSaveMode(nuGetProjectContext),
-                xmlDocFileSaveMode,
+                packageExtractionContext,
                 token);
 
             FileSystemUtility.PendAddFiles(copiedSatelliteFiles, Root, nuGetProjectContext);

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestNuGetProjectContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -25,7 +26,7 @@ namespace Test.Utility
             return FileConflictAction.IgnoreAll;
         }
 
-        public PackageExtractionContext PackageExtractionContext { get; set; } = new PackageExtractionContext();
+        public PackageExtractionContext PackageExtractionContext { get; set; } = new PackageExtractionContext(NullLogger.Instance);
 
         public ISourceControlManagerProvider SourceControlManagerProvider { get; set; }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -25,10 +25,10 @@ namespace NuGet.Packaging.Test
                 // Act
                 var files = PackageExtractor.ExtractPackage(
                     packageReader,
-                                                                 packageStream,
-                                                                 new PackagePathResolver(root),
-                                                                 new PackageExtractionContext(),
-                                                                 CancellationToken.None);
+                    packageStream,
+                    new PackagePathResolver(root),
+                    new PackageExtractionContext(NullLogger.Instance),
+                    CancellationToken.None);
                 // Assert
                 Assert.DoesNotContain(Path.Combine(packagePath + "[Content_Types].xml"), files);
                 Assert.Contains(Path.Combine(packagePath, "content" + Path.DirectorySeparatorChar + "[Content_Types].xml"), files);
@@ -54,10 +54,10 @@ namespace NuGet.Packaging.Test
                     {
                         // Act
                         var files = PackageExtractor.ExtractPackage(folderReader,
-                                                                         stream,
-                                                                         new PackagePathResolver(root),
-                                                                         new PackageExtractionContext(),
-                                                                         CancellationToken.None);
+                            stream,
+                            new PackagePathResolver(root),
+                            new PackageExtractionContext(NullLogger.Instance),
+                            CancellationToken.None);
 
                         // Assert
                         Assert.Equal(1, files.Where(p => p.EndsWith(".nupkg")).Count());
@@ -81,7 +81,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.None
                     };
@@ -113,7 +113,7 @@ namespace NuGet.Packaging.Test
                 {
                     zipFile.ExtractAll(packageFolder);
 
-                    var packageExtractionContext = new PackageExtractionContext();
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance);
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nupkg;
 
                     // Act
@@ -144,7 +144,7 @@ namespace NuGet.Packaging.Test
                 {
                     zipFile.ExtractAll(packageFolder);
 
-                    var packageExtractionContext = new PackageExtractionContext();
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance);
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nuspec;
 
                     // Act
@@ -175,7 +175,7 @@ namespace NuGet.Packaging.Test
                 {
                     zipFile.ExtractAll(packageFolder);
 
-                    var packageExtractionContext = new PackageExtractionContext();
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance);
                     packageExtractionContext.PackageSaveMode = PackageSaveMode.Nuspec | PackageSaveMode.Nupkg;
 
                     // Act
@@ -204,7 +204,7 @@ namespace NuGet.Packaging.Test
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 using (var satellitePackageStream = File.OpenRead(satellitePackageInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext();
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance);
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(packageStream,
@@ -245,7 +245,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.None
                     };
@@ -282,7 +282,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Compress
                     };
@@ -331,7 +331,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Compress
                     };
@@ -371,7 +371,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Skip
                     };
@@ -411,7 +411,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Skip
                     };
@@ -462,7 +462,7 @@ namespace NuGet.Packaging.Test
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 using (var satellitePackageStream = File.OpenRead(satellitePackageInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Skip
                     };
@@ -507,7 +507,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Compress
                     };
@@ -545,7 +545,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         XmlDocFileSaveMode = XmlDocFileSaveMode.Compress
                     };
@@ -580,7 +580,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         PackageSaveMode = PackageSaveMode.Nupkg | PackageSaveMode.Nuspec
                     };
@@ -617,7 +617,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         PackageSaveMode = PackageSaveMode.Nupkg | PackageSaveMode.Files
                     };
@@ -654,7 +654,7 @@ namespace NuGet.Packaging.Test
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         PackageSaveMode = PackageSaveMode.Nuspec | PackageSaveMode.Files
                     };
@@ -798,7 +798,7 @@ namespace NuGet.Packaging.Test
 
                 using (FileStream packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
-                    var packageExtractionContext = new PackageExtractionContext
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
                     {
                         PackageSaveMode = PackageSaveMode.Nuspec | PackageSaveMode.Files
                     };


### PR DESCRIPTION
Related to: https://github.com/NuGet/Home/issues/2518

When the time can't be set on a file after unzipping it from a package, Mono would throw an argument exception. I caught that exception in a previous fix, and this change will add a verbose message.
The message is:
`Failed to update file time for {path}: {exception message}`

There isn't really a way to hit this exception in a test.
