### PR TITLE
Fix for NuGet/Home#670 : changing the project title in Package manager window when a VS Project is renamed

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -77,7 +78,6 @@ namespace NuGet.PackageManagement.UI
         {
             _uiDispatcher = Dispatcher.CurrentDispatcher;
             _uiLogger = uiLogger;
-
             Model = model;
             if (!Model.IsSolution)
             {
@@ -139,7 +139,7 @@ namespace NuGet.PackageManagement.UI
             var solutionManager = Model.Context.SolutionManager;
             solutionManager.NuGetProjectAdded += SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRemoved += SolutionManager_ProjectsChanged;
-            solutionManager.NuGetProjectRenamed += SolutionManager_ProjectsChanged;
+            solutionManager.NuGetProjectRenamed += SolutionManager_ProjectRenamed;
             solutionManager.ActionsExecuted += SolutionManager_ActionsExecuted;
 
             Model.Context.SourceProvider.PackageSourceProvider.PackageSourcesChanged += Sources_PackageSourcesChanged;
@@ -150,6 +150,25 @@ namespace NuGet.PackageManagement.UI
             }
 
             _missingPackageStatus = false;
+        }
+
+        private void SolutionManager_ProjectRenamed(object sender, NuGetProjectEventArgs e)
+        {
+            SolutionManager_ProjectsChanged(sender, e);
+            if (!Model.IsSolution)
+            {
+                var currentNugetProject = Model.Context.Projects.First();
+                var newNugetProject = e.NuGetProject;
+                string currentFullPath, newFullPath;
+                currentNugetProject.TryGetMetadata(NuGetProjectMetadataKeys.FullPath, out currentFullPath);
+                e.NuGetProject.TryGetMetadata(NuGetProjectMetadataKeys.FullPath, out newFullPath);
+                if (currentFullPath == newFullPath)
+                {
+                    Model.Context.Projects = new[] {e.NuGetProject};
+                    SetTitle();
+                }
+            }
+
         }
 
         private void SolutionManager_ProjectsChanged(object sender, NuGetProjectEventArgs e)
@@ -828,7 +847,7 @@ namespace NuGet.PackageManagement.UI
             var solutionManager = Model.Context.SolutionManager;
             solutionManager.NuGetProjectAdded -= SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRemoved -= SolutionManager_ProjectsChanged;
-            solutionManager.NuGetProjectRenamed -= SolutionManager_ProjectsChanged;
+            solutionManager.NuGetProjectRenamed -= SolutionManager_ProjectRenamed;
             solutionManager.ActionsExecuted -= SolutionManager_ActionsExecuted;
 
             Model.Context.SourceProvider.PackageSourceProvider.PackageSourcesChanged -= Sources_PackageSourcesChanged;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -69,6 +69,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
 
+        public event EventHandler<NuGetProjectEventArgs> AfterNuGetProjectRenamed;
+
         public event EventHandler SolutionClosed;
 
         public event EventHandler SolutionClosing;
@@ -424,6 +426,12 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         NuGetProjectRenamed(this, new NuGetProjectEventArgs(nuGetProject));
                     }
+
+                    // VSSolutionManager susbscribes to this Event, in order to update the caption on the DocWindow Tab.
+                    // This needs to fire after NugetProjectRenamed so that PackageManagerModel has been updated with
+                    // the right project context.
+                    AfterNuGetProjectRenamed?.Invoke(this, new NuGetProjectEventArgs(nuGetProject));
+
                 }
                 else if (EnvDTEProjectUtility.IsSolutionFolder(envDTEProject))
                 {

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -196,9 +196,27 @@ namespace NuGetVSExtension
                 if (_solutionManager == null)
                 {
                     _solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+                    _solutionManager.AfterNuGetProjectRenamed += SolutionManager_NuGetProjectRenamed;
                     Debug.Assert(_solutionManager != null);
                 }
                 return _solutionManager;
+            }
+        }
+
+        private void SolutionManager_NuGetProjectRenamed(object sender, NuGetProjectEventArgs e)
+        {
+            VSSolutionManager manager = SolutionManager as VSSolutionManager;
+            if (manager != null)
+            {
+                Project project = manager.GetDTEProject(manager.GetNuGetProjectSafeName(e.NuGetProject));
+                var windowFrame = FindExistingWindowFrame(project);
+                if (windowFrame != null)
+                {
+                    windowFrame.SetProperty((int) __VSFPROPID.VSFPROPID_OwnerCaption, String.Format(
+                        CultureInfo.CurrentCulture,
+                        Resx.Label_NuGetWindowCaption,
+                        project.Name));
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -23,6 +23,8 @@ namespace NuGet.PackageManagement
 
         event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
 
+        event EventHandler<NuGetProjectEventArgs> AfterNuGetProjectRenamed;
+
         /// <summary>
         /// Event raised after user actions are executed.
         /// </summary>

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -159,6 +159,8 @@ namespace Test.Utility
 
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
 
+        public event EventHandler<NuGetProjectEventArgs> AfterNuGetProjectRenamed;
+
         public event EventHandler SolutionClosed;
 
         public event EventHandler SolutionClosing;


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/670
VSSolutionManager listens to ProjectRenamed events, however does nothing special to change the UI to reflect the name change.
This fix changes:
1) The title of the project in the top right of the Package Manager Window
2) The title of the doc window tab.

In order to change the doc window, ISolutionManager interface was augmented with a AfterNuGetProjectRenamed event. This was necessary since we have to wait for NuGetProjectRenamed events to fire on the right PackageManagerControl to update its Project's context, and call SetTitle() so it can update the title appropriately. Once this has been done, we fire the AfterNuGetProjectRenamed, subscribed to by the NuGetPackage class, which has context of the existing open WindowFrames. This enables it to update the tab window caption.
