### PR TITLE
Lowering netstandard from 1.5 to 1.3

### DIFF
--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -31,8 +31,14 @@
     }
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -40,6 +46,11 @@
       ],
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Net;
-#if NETCOREAPP1_0
+#if IS_CORECLR
 using System.Runtime.InteropServices;
 #endif
 using Microsoft.Dnx.Runtime.Common.CommandLine;
@@ -37,7 +37,7 @@ namespace NuGet.CommandLine.XPlat
 
         public static void SetUserAgent()
         {
-#if NETCOREAPP1_0
+#if IS_CORECLR
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat")
                 .WithOSDescription(RuntimeInformation.OSDescription));
 #else
@@ -47,7 +47,7 @@ namespace NuGet.CommandLine.XPlat
 
         public static void SetConnectionLimit()
         {
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // Increase the maximum number of connections per server.
             if (!RuntimeEnvironmentHelper.IsMono)
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -33,6 +33,11 @@
     "net46": {
       "frameworkAssemblies": {
         "System.Collections": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
     "netcoreapp1.0": {
@@ -47,6 +52,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -50,6 +50,11 @@
       "frameworkAssemblies": {
         "System.Xml": "",
         "System.Xml.Linq": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
     "net46": {
@@ -70,9 +75,14 @@
           "version": "1.0.0-rc1-final",
           "type": "build"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -81,6 +91,11 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Xml.XDocument": "4.0.11-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Common/CryptoHashProvider.cs
+++ b/src/NuGet.Core/NuGet.Common/CryptoHashProvider.cs
@@ -101,7 +101,7 @@ namespace NuGet.Common
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We want to return the object.")]
         private HashAlgorithm GetHashAlgorithm()
         {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             if (_hashAlgorithm.Equals(SHA256HashAlgorithm, StringComparison.OrdinalIgnoreCase))
             {
                 return AllowOnlyFipsAlgorithms ? (HashAlgorithm)new SHA256CryptoServiceProvider() : (HashAlgorithm)new SHA256Managed();
@@ -121,7 +121,7 @@ namespace NuGet.Common
 
         private static bool ReadFipsConfigValue()
         {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             // Mono does not currently support this method. Have this in a separate method to avoid JITing exceptions.
             var cryptoConfig = typeof(CryptoConfig);
 

--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -14,7 +14,7 @@ namespace NuGet.Common
         /// </summary>
         public static void ConfigureSupportedSslProtocols()
         {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             ServicePointManager.SecurityProtocol =
                 SecurityProtocolType.Tls |
                 SecurityProtocolType.Tls11 |

--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -55,7 +55,7 @@ namespace NuGet.Common
             }
         }
 
-#if NETSTANDARD1_5
+#if IS_CORECLR
         private static string GetFolderPath(SpecialFolder folder)
         {
             switch (folder)

--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -10,7 +10,7 @@ namespace NuGet.Common
         {
             get
             {
-#if NETSTANDARD1_5
+#if IS_CORECLR
                 // This API does work on full framework but it requires a newer nuget client (RID aware)
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 {
@@ -34,7 +34,7 @@ namespace NuGet.Common
         {
             get
             {
-#if NETSTANDARD1_5
+#if IS_CORECLR
                 // This API does work on full framework but it requires a newer nuget client (RID aware)
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
                 {
@@ -53,7 +53,7 @@ namespace NuGet.Common
         {
             get
             {
-#if NETSTANDARD1_5
+#if IS_CORECLR
                 // This API does work on full framework but it requires a newer nuget client (RID aware)
                 if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
                 {

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -22,19 +22,24 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.IO.Compression": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24008",
         "System.Diagnostics.Process": "4.1.0-rc2-24008"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -51,7 +51,7 @@ namespace NuGet.Configuration
 
         private IEnumerable<PackageSource> LoadConfigurationDefaultSources(IEnumerable<PackageSource> configurationDefaultSources)
         {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             // Global default NuGet source doesn't make sense on Mono
             if (RuntimeEnvironmentHelper.IsMono)
             {

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -9,7 +9,7 @@ namespace NuGet.Configuration
 {
     public class ProxyCache : IProxyCache, IProxyCredentialCache
     {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         /// <summary>
         /// Capture the default System Proxy so that it can be re-used by the IProxyFinder
         /// because we can't rely on WebRequest.DefaultWebProxy since someone can modify the DefaultWebProxy
@@ -59,7 +59,7 @@ namespace NuGet.Configuration
                 return configuredProxy;
             }
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             if (IsSystemProxySet(sourceUri))
             {
                 var systemProxy = GetSystemProxy(sourceUri);
@@ -88,7 +88,7 @@ namespace NuGet.Configuration
                 // The host is the minimal value we need to assume a user configured proxy.
                 var webProxy = new WebProxy(host);
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
                 var userName = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationConstants.UserKey);
                 var password = SettingsUtility.GetDecryptedValue(_settings, SettingsUtility.ConfigSection, ConfigurationConstants.PasswordKey);
 
@@ -173,7 +173,7 @@ namespace NuGet.Configuration
             }
         }
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         private static WebProxy GetSystemProxy(Uri uri)
         {
             // WebRequest.DefaultWebProxy seems to be more capable in terms of getting the default

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -1037,7 +1037,7 @@ namespace NuGet.Configuration
             ExecuteSynchronized(() => FileSystemUtility.AddFile(ConfigFilePath, ConfigXDocument.Save));
         }
 
-#if NETSTANDARD1_5
+#if IS_CORECLR
         private static Mutex _globalMutex = new Mutex(initiallyOwned: false);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/EncryptionUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/EncryptionUtility.cs
@@ -14,7 +14,7 @@ namespace NuGet.Configuration
 
         public static string EncryptString(string value)
         {
-#if NETSTANDARD1_5
+#if IS_CORECLR
             throw new NotSupportedException();
 #else
             var decryptedByteArray = Encoding.UTF8.GetBytes(value);
@@ -26,7 +26,7 @@ namespace NuGet.Configuration
 
         public static string DecryptString(string encryptedString)
         {
-#if NETSTANDARD1_5
+#if IS_CORECLR
             throw new NotSupportedException();
 #else
             var encryptedByteArray = Convert.FromBase64String(encryptedString);

--- a/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/XmlUtility.cs
@@ -53,7 +53,7 @@ namespace NuGet.Configuration
         {
             var safeSettings = new XmlReaderSettings
                 {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
                     XmlResolver = null,
 #endif
                     DtdProcessing = DtdProcessing.Prohibit,

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -34,18 +34,23 @@
         "System.Security": "",
         "System.Xml": "",
         "System.Xml.Linq": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Xml.XDocument": "4.0.11-rc2-24008"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -14,8 +14,14 @@
     "../NuGet.Shared/*.cs"
   ],
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.ObjectModel": "4.0.12-rc2-24008"
@@ -24,7 +30,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -32,8 +32,14 @@
     }
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -41,6 +47,11 @@
       ],
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -25,8 +25,14 @@
     }
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -34,6 +40,11 @@
       ],
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -25,16 +25,22 @@
     }
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
@@ -35,6 +35,12 @@
     }
   },
   "frameworks": {
-    "net45": { }
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    }
   }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -22,8 +22,14 @@
     ]
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -31,7 +37,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
@@ -35,6 +35,11 @@
     "net45": {
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -19,8 +19,14 @@
     "../NuGet.Shared/*.cs"
   ],
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -28,7 +34,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -28,9 +28,14 @@
         "System.Xml": "",
         "System.Xml.Linq": "",
         "System.IO.Compression": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Xml.XDocument": "4.0.11-rc2-24008"
@@ -39,7 +44,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -150,7 +150,7 @@ namespace NuGet.Packaging
 
         private static void ValidateManifestSchema(XDocument document, string schemaNamespace)
         {
-#if !NETSTANDARD1_5 // CORECLR_TODO: XmlSchema
+#if !IS_CORECLR // CORECLR_TODO: XmlSchema
             var schemaSet = ManifestSchemaUtility.GetManifestSchemaSet(schemaNamespace);
 
             document.Validate(schemaSet, (sender, e) =>
@@ -166,7 +166,7 @@ namespace NuGet.Packaging
 
         private static void CheckSchemaVersion(XDocument document)
         {
-#if !NETSTANDARD1_5 // CORECLR_TODO: XmlSchema
+#if !IS_CORECLR // CORECLR_TODO: XmlSchema
             // Get the metadata node and look for the schemaVersion attribute
             XElement metadata = GetMetadataElement(document);
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 using System.Linq;
 using NuGet.Packaging.PackageCreation.Resources;
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
 using System.Collections.Concurrent;
 using System.IO;
 using System.Xml;
@@ -58,7 +58,7 @@ namespace NuGet.Packaging
             SchemaVersionV6
         };
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         private static ConcurrentDictionary<string, XmlSchemaSet> _manifestSchemaSetCache = new ConcurrentDictionary<string, XmlSchemaSet>(StringComparer.OrdinalIgnoreCase);
 #endif
 
@@ -80,7 +80,7 @@ namespace NuGet.Packaging
             return VersionToSchemaMappings[version - 1];
         }
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         public static XmlSchemaSet GetManifestSchemaSet(string schemaNamespace)
         {
             return _manifestSchemaSetCache.GetOrAdd(schemaNamespace, schema =>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -297,7 +297,7 @@ namespace NuGet.Packaging
             List<string> creatorInfo = new List<string>();
             var assembly = typeof(PackageBuilder).GetTypeInfo().Assembly;
             creatorInfo.Add(assembly.FullName);
-#if !NETSTANDARD1_5 // CORECLR_TODO: Environment.OSVersion
+#if !IS_CORECLR // CORECLR_TODO: Environment.OSVersion
             creatorInfo.Add(Environment.OSVersion.ToString());
 #endif
 

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -38,9 +38,14 @@
         "System.Xml": "",
         "System.Xml.Linq": "",
         "System.IO.Compression": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.IO.Compression": "4.1.0-rc2-24008"
@@ -49,7 +54,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
@@ -26,6 +26,11 @@
     "net45": {
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -21,8 +21,14 @@
     ]
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -32,6 +38,11 @@
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Dynamic.Runtime": "4.0.11-rc2-24008",
         "System.Threading.Thread": "4.0.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/UserAgentStringBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/UserAgentStringBuilder.cs
@@ -90,7 +90,7 @@ namespace NuGet.Protocol.Core.Types
         {
             var nugetVersion = string.Empty;
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             var attr = typeof(Repository).Assembly.GetName().Version;
 
             NuGetVersion version;
@@ -125,7 +125,7 @@ namespace NuGet.Protocol.Core.Types
         {
             if (_osInfo == null)
             {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
                 // When not on CoreClr and no OSDescription was provided,
                 // we will set it ourselves.
                 _osInfo = Environment.OSVersion.ToString();

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -36,9 +36,14 @@
     "net45": {
       "frameworkAssemblies": {
         "System.Net.Http": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Net.Http": "4.0.1-rc2-24008"
@@ -47,7 +52,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
@@ -40,6 +40,11 @@
         "System.Collections.Concurrent": "",
         "System.Runtime.Serialization": "",
         "WindowsBase": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyCredentialHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyCredentialHandler.cs
@@ -93,7 +93,7 @@ namespace NuGet.Protocol.Core.v3
             }
         }
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         // Returns true if the cause of the exception is proxy authentication failure
         private static bool ProxyAuthenticationRequired(Exception ex)
         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/STSAuthHelper.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/STSAuthHelper.cs
@@ -3,14 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
 using System.IdentityModel.Protocols.WSTrust;
 using System.IdentityModel.Tokens;
 using System.Linq;
 #endif
 using System.Net;
 using System.Net.Http;
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
 using System.ServiceModel;
 using System.ServiceModel.Security;
 #endif
@@ -44,7 +44,7 @@ namespace NuGet.Protocol
             CredentialStore credentialStore,
             HttpRequestMessage request)
         {
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             var credentials = credentialStore.GetCredentials(feedUri) as STSCredentials;
 
             if (credentials != null)
@@ -62,7 +62,7 @@ namespace NuGet.Protocol
             CredentialStore credentialStore,
             HttpResponseMessage response)
         {
-#if NETSTANDARD1_5
+#if IS_CORECLR
             return false;
 #else
             if (response.StatusCode != HttpStatusCode.Unauthorized)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
@@ -49,7 +49,7 @@ namespace NuGet.Protocol
             }
         }
         
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
         public override IAsyncResult BeginRead(
             byte[] buffer,
             int offset,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -41,9 +41,14 @@
         "System.Net.Http": "",
         "System.Net.Http.WebRequest": "",
         "System.ServiceModel": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -52,6 +57,11 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.Dynamic.Runtime": "4.0.11-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -20,9 +20,14 @@
   },
   "frameworks": {
     "net46": {
-      "dependencies": {}
+      "dependencies": {},
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -30,6 +35,11 @@
       ],
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "authors": [
     "NuGet"
@@ -36,6 +36,11 @@
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": "",
         "System.Runtime.Serialization": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -19,8 +19,14 @@
     ]
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -28,7 +34,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -27,8 +27,14 @@
     }
   },
   "frameworks": {
-    "net45": {},
-    "netstandard1.5": {
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -36,7 +42,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -28,9 +28,14 @@
     "net45": {
       "frameworkAssemblies": {
         "System.Collections": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -40,6 +45,11 @@
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.ObjectModel": "4.0.12-rc2-24008",
         "System.Dynamic.Runtime": "4.0.11-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -8,9 +8,14 @@
     "net45": {
       "frameworkAssemblies": {
         "System.IO.Compression": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -18,7 +23,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -19,8 +19,14 @@
     }
   },
   "frameworks": {
-    "net46": {},
-    "netstandard1.5": {
+    "net46": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
@@ -28,7 +34,12 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
@@ -27,7 +27,7 @@ namespace NuGet.Test.Utility
                 RedirectStandardInput = inputAction != null
             };
 
-#if !NETSTANDARD1_5
+#if !IS_CORECLR
             psi.EnvironmentVariables["NuGetTestModeEnabled"] = "True";
 #else
             psi.Environment["NuGetTestModeEnabled"] = "True";

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -23,9 +23,14 @@
     "net45": {
       "frameworkAssemblies": {
         "System.IO.Compression": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.3": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",
@@ -35,6 +40,11 @@
         "NETStandard.Library": "1.5.0-rc2-24008",
         "System.IO.Compression.ZipFile": "4.0.1-rc2-24008",
         "System.Diagnostics.Process": "4.1.0-rc2-24008"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -24,19 +24,21 @@
   ],
   "frameworks": {
     "net45": {
-      "frameworkAssemblies": {
-        "System.IO.Compression": ""
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     },
-    "netstandard1.5": {
+    "netstandard1.0": {
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24008"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     }
   }
 }

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -42,8 +42,19 @@
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
     },
-    "net46": { }
+    "net46": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    }
   }
 }

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
@@ -32,6 +32,11 @@
         "System.Threading.Tasks": "",
         "System.Runtime": "",
         "System.Runtime.Serialization": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -22,6 +22,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -22,6 +22,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -22,6 +22,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/project.json
@@ -17,6 +17,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -22,6 +22,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
@@ -32,7 +32,7 @@ namespace NuGet.Common.Test
 
             if (!supported.HasValue)
             {
-#if NETCOREAPP1_0
+#if IS_CORECLR
                 // .NET Core bug: https://github.com/dotnet/corefx/issues/6668
                 if (name == Ssl30Name)
                 {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -26,6 +26,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -40,6 +45,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -275,7 +275,7 @@ namespace NuGet.Configuration.Test
             // - source b is persisted in <packageSources> and <disabledPackageSources>
             // - source c is not spersisted at all since its IsPersistable is false and it's enabled.
             // - source d is persisted in <disabledPackageSources> only since its IsPersistable is false and it's disabled.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 #else
             string appDataPath = Environment.GetEnvironmentVariable("AppData");
@@ -1190,7 +1190,7 @@ namespace NuGet.Configuration.Test
             Assert.Null(values[1].Password);
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         [Fact]
         public void LoadPackageSourcesReadsCredentialPairsFromSettings()
         {
@@ -1436,7 +1436,7 @@ namespace NuGet.Configuration.Test
             settings.Verify();
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         [Fact]
         public void SavePackageSourcesSavesCredentials()
         {
@@ -2366,7 +2366,7 @@ namespace NuGet.Configuration.Test
             }
         }
 
-#if NETCOREAPP1_0
+#if IS_CORECLR
         [Fact]
         public void LoadPackageSource_NotDecryptPassword() 
         {

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ProxyCacheTest.cs
@@ -10,7 +10,7 @@ namespace NuGet.Configuration.Test
 {
     public class ProxyCacheTest
     {
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         private static readonly string _password = EncryptionUtility.EncryptString("password");
 #else
         private static readonly string _password = null;
@@ -68,7 +68,7 @@ namespace NuGet.Configuration.Test
             var proxy = proxyCache.GetUserConfiguredProxy() as WebProxy;
 
             // Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             AssertProxy(host, user, "password", proxy);
 #else
             AssertProxy(host, null, null, proxy);

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.Configuration.Test
                 var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
                 var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
 
-#if NETCOREAPP1_0
+#if IS_CORECLR
                 var commonApplicationData = Environment.GetEnvironmentVariable("PROGRAMDATA") ??
                     Environment.GetEnvironmentVariable("ALLUSERSPROFILE") ?? null;
                 var userSetting = Environment.GetEnvironmentVariable("APPDATA");
@@ -67,7 +67,7 @@ namespace NuGet.Configuration.Test
                 var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
                 var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
 
-#if NETCOREAPP1_0
+#if IS_CORECLR
                 var commonApplicationData = @"/etc/opt";
                 var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
 #else
@@ -88,7 +88,7 @@ namespace NuGet.Configuration.Test
                 var machineWidePathTuple = Settings.GetFileNameAndItsRoot("test root", machineWidePath);
                 var globalConfigTuple = Settings.GetFileNameAndItsRoot("test root", globalConfigPath);
 
-#if NETCOREAPP1_0
+#if IS_CORECLR
                 var commonApplicationData = @"/Library/Application Support";
                 var userSetting = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".nuget");
 #else
@@ -1063,7 +1063,7 @@ namespace NuGet.Configuration.Test
             }
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         [Fact]
         public void SettingsUtility_SetEncryptedValue()
         {
@@ -2193,7 +2193,7 @@ namespace NuGet.Configuration.Test
         public void GetGlobalPackagesFolder_Default()
         {
             // Arrange
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 #else
             string userProfile = null;

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -27,6 +27,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -41,6 +46,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -24,6 +24,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -36,6 +41,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
@@ -18,6 +18,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -28,6 +33,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -18,6 +18,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -28,6 +33,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
@@ -350,13 +350,13 @@ namespace NuGet.Packaging.Test
         public void ReadFromThrowIfValidateSchemaIsTrue()
         {
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
 #endif
 
             // Act && Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // Arrange
             string content = @"<?xml version=""1.0""?>
 <package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
@@ -399,13 +399,13 @@ namespace NuGet.Packaging.Test
 </package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
 #endif
 
             // Act && Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(
                 () => Manifest.ReadFrom(content.AsStream(), validateSchema: true),
                 "The element 'group' in namespace 'http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd' has incomplete content. List of possible elements expected: 'reference' in namespace 'http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd'.");
@@ -437,7 +437,7 @@ namespace NuGet.Packaging.Test
 </package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
 #endif

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -1225,7 +1225,7 @@ Description is required.");
             string spec4 = @"<?xml version=""1.0"" encoding=""utf-8""?><package><metadata></metadata></package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
@@ -1233,7 +1233,7 @@ Description is required.");
             // Act and Assert
             ExceptionAssert.Throws<XmlException>(() => new PackageBuilder(spec1.AsStream(), null), "Data at the root level is invalid. Line 1, position 1.");
             ExceptionAssert.Throws<XmlException>(() => new PackageBuilder(spec2.AsStream(), null), "Root element is missing.");
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec3.AsStream(), null));
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec4.AsStream(), null));
 #else
@@ -1255,13 +1255,13 @@ Description is required.");
   </metadata></package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec.AsStream(), null), "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. List of possible elements expected: 'id' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.");
 #else
             ExceptionAssert.Throws<InvalidDataException>(() => new PackageBuilder(spec.AsStream(), null), "The required element 'id' is missing from the manifest.");
@@ -1323,13 +1323,13 @@ Description is required.");
   </metadata></package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec.AsStream(), null), "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. List of possible elements expected: 'version' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.");
 #else
             ExceptionAssert.Throws<InvalidDataException>(() => new PackageBuilder(spec.AsStream(), null), "The required element 'version' is missing from the manifest.");
@@ -1349,13 +1349,13 @@ Description is required.");
   </metadata></package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec.AsStream(), null), "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. List of possible elements expected: 'authors' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.");
 #else
             ExceptionAssert.Throws<InvalidDataException>(() => new PackageBuilder(spec.AsStream(), null), "The required element 'authors' is missing from the manifest.");
@@ -1375,13 +1375,13 @@ Description is required.");
   </metadata></package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec.AsStream(), null), "The element 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. List of possible elements expected: 'description' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.");
 #else
             ExceptionAssert.Throws<InvalidDataException>(() => new PackageBuilder(spec.AsStream(), null), "The required element 'description' is missing from the manifest.");
@@ -1392,13 +1392,13 @@ Description is required.");
         public void MalformedDependenciesThrows()
         {
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // Arrange
             string spec = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <package><metadata>
@@ -1446,13 +1446,13 @@ Description is required.");
         {
             // Act
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             string spec = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <package><metadata>
     <id>Artem.XmlProviders</id>
@@ -1480,7 +1480,7 @@ Description is required.");
         {
             // Arrange
             // Act & Assert
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             string spec = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <package><metadata>
     <id>Artem.XmlProviders</id>
@@ -1987,7 +1987,7 @@ Enabling license acceptance requires a license url.");
 </package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
@@ -2067,7 +2067,7 @@ Enabling license acceptance requires a license url.");
             ExceptionAssert.ThrowsArgumentException(() => builder.Save(new MemoryStream()), "The package ID 'brainf%2ack' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'.");
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         [Fact]
         public void ReadingPackageWithUnknownSchemaThrows()
         {
@@ -2254,13 +2254,13 @@ Enabling license acceptance requires a license url.");
 </package>";
 
             // Switch to invariant culture to ensure the error message is in english.
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             // REVIEW: Unsupported on CoreCLR
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 #endif
 
             // Act
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
             ExceptionAssert.Throws<InvalidOperationException>(() => new PackageBuilder(spec.AsStream(), null), "The element 'package' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd' has incomplete content. List of possible elements expected: 'metadata' in namespace 'http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd'.");
 #else
             ExceptionAssert.Throws<InvalidDataException>(() => new PackageBuilder(spec.AsStream(), null), "The required element 'metadata' is missing from the manifest.");

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -24,6 +24,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -37,6 +42,11 @@
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -17,6 +17,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -22,6 +22,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -31,6 +36,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -30,7 +30,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             // Act & Assert
             var exception = await ThrowsException<HttpRequestException>(server);
-#if NETCOREAPP1_0
+#if IS_CORECLR
             Assert.NotNull(exception.InnerException);
             if (!RuntimeEnvironmentHelper.IsWindows)
             {
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             // Act & Assert
             var exception = await ThrowsException<HttpRequestException>(server);
-#if NETCOREAPP1_0
+#if IS_CORECLR
             if (!RuntimeEnvironmentHelper.IsWindows)
             {
                 Assert.Null(exception.InnerException);
@@ -79,7 +79,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
             // Act & Assert
             var exception = await ThrowsException<HttpRequestException>(server);
-#if NETCOREAPP1_0
+#if IS_CORECLR
             Assert.NotNull(exception.InnerException);
             if (!RuntimeEnvironmentHelper.IsWindows)
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/OffineFeedUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/OffineFeedUtilityTests.cs
@@ -7,7 +7,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 //Negative tests here won't run well on *nix because bad test data used will trigger new exceptions
 //TODO: we can revisit to catch them if there is value.
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
     public class OffineFeedUtilityTests
     {
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             await VerifyFailureOnReadAsync(ReadStreamAsync);
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         [Fact]
         public async Task DownloadTimeoutStream_ApmNotSupported()
         {
@@ -152,7 +152,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             return Encoding.ASCII.GetString(destination.ToArray());
         }
 
-#if !NETCOREAPP1_0
+#if !IS_CORECLR
         private async Task<string> ReadStreamApm(Stream stream)
         {
             var destination = new MemoryStream();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -30,6 +30,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -42,6 +47,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -18,6 +18,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -28,6 +33,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -19,6 +19,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -28,6 +33,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/SynchronizationTest.cs
@@ -316,7 +316,7 @@ namespace NuGet.Commands.Test
             var result = new SyncdRunResult();
             result.Start();
 
-#if NETCOREAPP1_0
+#if IS_CORECLR
             var testDir = new DirectoryInfo(dir);
 
             // Find the root test directory

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -26,6 +26,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -35,6 +40,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -18,6 +18,11 @@
           "type": "platform",
           "version": "1.0.0-rc2-3002339"
         }
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
       }
     },
     "net46": {
@@ -27,6 +32,11 @@
         "System.Core": "",
         "System.Runtime": "",
         "System.Threading.Tasks": ""
+      },
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
       }
     }
   },


### PR DESCRIPTION
This changes the nuget.core projects from netstandard1.5 (net462) to netstandard1.3 (net46). It doesn't look like any of the netstandard1.4-1.5 APIs were used, so there are no code changes involved here.

NuGet.Versioning is the only library capable of going to netstandard1.0. The rest all need System.IO or Concurrency classes which are only in 1.3 and up.

As part of this I've added compiler defines so that if defs are not depending on the exact framework name used. NETCOREAPP1_0, NETSTANDARD1_5, NETSTANDARD1_3, can now all be checked using IS_CORECLR. I've also added IS_DESKTOP for the desktop frameworks, but right now it isn't used.

https://github.com/NuGet/Home/issues/2538

//cc @joelverhagen @zhili1208 @alpaix @spadapet @rrelyea @jainaashish 
