### PR TITLE
ProjectName for build integrated projects

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -34,10 +34,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public BuildIntegratedProjectSystem(
             string jsonConfigPath,
+            string msbuildProjectFilePath,
             EnvDTEProject envDTEProject,
             IMSBuildNuGetProjectSystem msbuildProjectSystem,
             string uniqueName)
-            : base(jsonConfigPath, msbuildProjectSystem)
+            : base(jsonConfigPath, msbuildProjectFilePath, msbuildProjectSystem)
         {
             InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, uniqueName);
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
@@ -68,18 +68,20 @@ namespace NuGet.PackageManagement.VisualStudio
                     envDTEProject, 
                     nuGetProjectContext);
 
-                var projectName = msBuildNuGetProjectSystem.ProjectName;
-
-                string projectPath = EnvDTEProjectUtility.GetFullPath(envDTEProject);
+                var msbuildProjectFile = new FileInfo(EnvDTEProjectUtility.GetFullProjectPath(envDTEProject));
+                var projectNameFromMSBuildPath = Path.GetFileNameWithoutExtension(msbuildProjectFile.Name);
 
                 // Treat projects with project.json as build integrated projects
                 // Search for projectName.project.json first, then project.json
-                string jsonConfig = ProjectJsonPathUtilities.GetProjectConfigPath(projectPath, projectName);
+                var projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(
+                    msbuildProjectFile.DirectoryName,
+                    projectNameFromMSBuildPath);
 
-                if (File.Exists(jsonConfig))
+                if (File.Exists(projectJsonPath))
                 {
                     result = new BuildIntegratedProjectSystem(
-                        jsonConfig,
+                        projectJsonPath,
+                        msbuildProjectFile.FullName,
                         envDTEProject,
                         msBuildNuGetProjectSystem,
                         EnvDTEProjectUtility.GetCustomUniqueName(envDTEProject));

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -28,15 +28,36 @@ namespace NuGet.ProjectManagement.Projects
     {
         private readonly FileInfo _jsonConfig;
 
-        public BuildIntegratedNuGetProject(string jsonConfig, IMSBuildNuGetProjectSystem msbuildProjectSystem)
+        /// <summary>
+        /// MSBuild project file path.
+        /// </summary>
+        public string MSBuildProjectPath { get; }
+
+        /// <summary>
+        /// Project.json based project system.
+        /// </summary>
+        /// <param name="jsonConfig">Path to project.json.</param>
+        /// <param name="msBuildProjectPath">Path to the msbuild project file.</param>
+        /// <param name="msbuildProjectSystem">Underlying msbuild project system.</param>
+        public BuildIntegratedNuGetProject(
+            string jsonConfig,
+            string msBuildProjectPath,
+            IMSBuildNuGetProjectSystem msbuildProjectSystem)
         {
             if (jsonConfig == null)
             {
                 throw new ArgumentNullException(nameof(jsonConfig));
             }
 
+            if (msBuildProjectPath == null)
+            {
+                throw new ArgumentNullException(nameof(msBuildProjectPath));
+            }
+
             _jsonConfig = new FileInfo(jsonConfig);
             MSBuildNuGetProjectSystem = msbuildProjectSystem;
+
+            MSBuildProjectPath = msBuildProjectPath;
 
             JObject projectJson;
             IEnumerable<NuGetFramework> targetFrameworks = Enumerable.Empty<NuGetFramework>();
@@ -171,7 +192,7 @@ namespace NuGet.ProjectManagement.Projects
         {
             get
             {
-                return JsonPackageSpecReader.GetPackageSpec(File.ReadAllText(JsonConfigPath), ProjectName, JsonConfigPath);
+                return JsonPackageSpecReader.GetPackageSpec(ProjectName, JsonConfigPath);
             }
         }
 
@@ -182,7 +203,7 @@ namespace NuGet.ProjectManagement.Projects
         {
             get
             {
-                return MSBuildNuGetProjectSystem.ProjectName;
+                return Path.GetFileNameWithoutExtension(MSBuildProjectPath);
             }
         }
 

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -78,7 +78,9 @@ namespace Test.Utility
             projectTargetFramework = projectTargetFramework ?? NuGetFramework.Parse("net46");
             var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext(),
                 projectFullPath, projectName);
-            NuGetProject nuGetProject = new BuildIntegratedNuGetProject(projectJsonPath, msBuildNuGetProjectSystem);
+
+            var projectFilePath = Path.Combine(projectFullPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+            NuGetProject nuGetProject = new BuildIntegratedNuGetProject(projectJsonPath, projectFilePath, msBuildNuGetProjectSystem);
             NuGetProjects.Add(nuGetProject);
             return nuGetProject;
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -214,6 +214,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "testproj.project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -225,7 +226,7 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework,
                     new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var effectiveGlobalPackagesFolder =
                     BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -258,6 +259,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -277,7 +279,7 @@ namespace NuGet.Test
 
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var result = await BuildIntegratedRestoreUtility.RestoreAsync(
                     project,
@@ -319,6 +321,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -338,7 +341,7 @@ namespace NuGet.Test
 
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var result = await BuildIntegratedRestoreUtility.RestoreAsync(
                     project,
@@ -380,6 +383,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -399,7 +403,7 @@ namespace NuGet.Test
 
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var result = await BuildIntegratedRestoreUtility.RestoreAsync(
                     project,
@@ -437,6 +441,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -456,7 +461,7 @@ namespace NuGet.Test
 
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var effectiveGlobalPackagesFolder =
                     BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -494,6 +499,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -513,7 +519,7 @@ namespace NuGet.Test
 
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var effectiveGlobalPackagesFolder =
                     BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -866,6 +872,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 CreateConfigJson(projectConfig.FullName);
 
@@ -877,7 +884,7 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework,
                     new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var effectiveGlobalPackagesFolder =
                     BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -908,6 +915,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
                 CreateConfigJson(projectConfig.FullName);
 
                 var sources = new List<SourceRepository>
@@ -918,7 +926,7 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework,
                     new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var effectiveGlobalPackagesFolder =
                     BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -966,6 +974,7 @@ namespace NuGet.Test
                 var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
                 projectFolder.Create();
                 var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
 
                 File.WriteAllText(projectConfig.FullName, ProjectJsonWithPackage);
 
@@ -977,7 +986,7 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("uap10.0");
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework,
                     new TestNuGetProjectContext());
-                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+                var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msbuildProjectPath.FullName, msBuildNuGetProjectSystem);
 
                 var configContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -279,7 +279,8 @@ namespace NuGet.Test
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 testNuGetProjectContext.TestExecutionContext = new TestExecutionContext(packageIdentity);
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -324,7 +325,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -371,7 +373,8 @@ namespace NuGet.Test
                     testNuGetProjectContext,
                     randomProjectFolderPath);
 
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 var message = string.Empty;
 
@@ -438,7 +441,8 @@ namespace NuGet.Test
                     testNuGetProjectContext,
                     randomProjectFolderPath);
 
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 var message = string.Empty;
 
@@ -507,7 +511,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -559,7 +564,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -605,7 +611,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -667,7 +674,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("net45");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -731,7 +739,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("net45");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -803,7 +812,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -870,7 +880,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -975,7 +986,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -1035,7 +1047,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 string message = string.Empty;
 
@@ -1091,7 +1104,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 // Check that there are no packages returned by PackagesConfigProject
                 var installedPackages = (await buildIntegratedProject.GetInstalledPackagesAsync(token)).ToList();
@@ -1138,7 +1152,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), null, new TestNuGetProjectContext(), token);
                 await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), null, new TestNuGetProjectContext(), token);
@@ -1183,7 +1198,8 @@ namespace NuGet.Test
                 var projectTargetFramework = NuGetFramework.Parse("net452");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject,
                     packageIdentityA,

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -22,6 +22,74 @@ namespace ProjectManagement.Test
     public class BuildIntegratedNuGetProjectTests
     {
         [Fact]
+        public async Task TestBuildIntegratedNuGetPackageSpecNameMatchesFilePath_ProjectNameJson()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+            using (var randomTestPackageSourcePath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomProjectFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var randomConfig = Path.Combine(randomProjectFolderPath, "fileName.project.json");
+                var token = CancellationToken.None;
+
+                CreateConfigJson(randomConfig);
+
+                var projectTargetFramework = NuGetFramework.Parse("netcore50");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                    projectTargetFramework,
+                    testNuGetProjectContext,
+                    randomProjectFolderPath,
+                    "msbuildName");
+
+                var projectFilePath = Path.Combine(randomProjectFolderPath, "fileName.csproj");
+
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
+
+                // Assert
+                Assert.Equal(projectFilePath, buildIntegratedProject.MSBuildProjectPath);
+                Assert.Equal("fileName", buildIntegratedProject.ProjectName);
+                Assert.Equal("fileName", buildIntegratedProject.PackageSpec.Name);
+            }
+        }
+
+        [Fact]
+        public async Task TestBuildIntegratedNuGetPackageSpecNameMatchesFilePath()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+            using (var randomTestPackageSourcePath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomProjectFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+                var token = CancellationToken.None;
+
+                CreateConfigJson(randomConfig);
+
+                var projectTargetFramework = NuGetFramework.Parse("netcore50");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                    projectTargetFramework,
+                    testNuGetProjectContext,
+                    randomProjectFolderPath,
+                    "msbuildName");
+
+                var projectFilePath = Path.Combine(randomProjectFolderPath, "fileName.csproj");
+
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
+
+                // Assert
+                Assert.Equal(projectFilePath, buildIntegratedProject.MSBuildProjectPath);
+                Assert.Equal("fileName", buildIntegratedProject.ProjectName);
+                Assert.Equal("fileName", buildIntegratedProject.PackageSpec.Name);
+            }
+        }
+
+        [Fact]
         public async Task TestBuildIntegratedNuGetProjectInstallPackage()
         {
             // Arrange
@@ -38,7 +106,8 @@ namespace ProjectManagement.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
@@ -76,7 +145,8 @@ namespace ProjectManagement.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
@@ -119,7 +189,8 @@ namespace ProjectManagement.Test
                 var projectTargetFramework = NuGetFramework.Parse("netcore50");
                 var testNuGetProjectContext = new TestNuGetProjectContext();
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
-                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+                var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
+                var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyContentPackage(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());


### PR DESCRIPTION
This change uses the project file name to get the name used within the PackageSpec for the project being restored. This is already done everywhere else in the code so that restore works the same in nuget.exe and xplat as it does in Visual Studio. The problem was just that for the root project it was getting this property from DTE and in the issue below it was overridden by an msbuild property.

Project to project references are walked through DTE and those projects, including the root are passed into restore. As an optimization the restore command finds the already loaded project.json file from these references. The cause of the issue was that the restore command expected one string for the project name, while DTE had given another. The two just need to match up. For the actual project to project references the full path to the msbuild files are used to avoid ambiguity.

This is a relatively safe fix because the ProjectName property that is changing here is only for BuildIntegrated projects to be used for the package spec. The DTE value can still be retrieved from the underlying msbuild project that all nuget projects share.

This is targeted for 3.4.3

https://github.com/NuGet/Home/issues/2535

//cc @joelverhagen @alpaix @zhili1208 @rrelyea @jainaashish 
