### PR TITLE
Remove NuGetFramework.IsCompile

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -628,12 +628,9 @@ namespace NuGet.Commands
                 // We care about TFM only and null RID for compilation purposes
                 projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, null));
 
-                if (!framework.FrameworkName.IsCompileOnly)
+                foreach (var runtimeId in runtimeIds)
                 {
-                    foreach (var runtimeId in runtimeIds)
-                    {
-                        projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, runtimeId));
-                    }
+                    projectFrameworkRuntimePairs.Add(new FrameworkRuntimePair(framework.FrameworkName, runtimeId));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -262,22 +262,6 @@ namespace NuGet.Frameworks
         }
 
         /// <summary>
-        /// True if the framework is only used for compilation, not for execution.
-        /// Ex: dotnet, netstandard, portable-*
-        /// </summary>
-        public bool IsCompileOnly
-        {
-            get
-            {
-                return FrameworkConstants.FrameworkIdentifiers.NetPlatform
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || FrameworkConstants.FrameworkIdentifiers.NetStandard
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || IsPCL;
-            } 
-        }
-
-        /// <summary>
         /// True if the framework is packages based.
         /// Ex: dotnet, dnxcore
         /// </summary>


### PR DESCRIPTION
This removes the check for netstandard and portable frameworks when restoring for RIDs. In some scenarios users need to create RID graphs for portable frameworks.

The check was previously in place to avoid inferring rids for the wrong framework. If this is still a problem for CLI users we will need to find another way to fix this such as a per framework runtime section in project.json.

https://github.com/NuGet/Home/issues/2553

//cc @jainaashish @anurse @joelverhagen @zhili1208 @rrelyea @alpaix 
