### PR TITLE
Fix inverted return value for VSSettings.CanChangeSettings

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSSettings.cs
@@ -155,7 +155,7 @@ namespace NuGet.PackageManagement.VisualStudio
             get
             {
                 // The value for SolutionSettings can't possibly be null, but it could be a read-only instance
-                return object.ReferenceEquals(SolutionSettings, Configuration.NullSettings.Instance);
+                return !object.ReferenceEquals(SolutionSettings, Configuration.NullSettings.Instance);
             }
         }
     }


### PR DESCRIPTION
Fix regression from: https://github.com/NuGet/Home/issues/2539
Pull request: https://github.com/NuGet/NuGet.Client/pull/499

Changing and saving the nuget.config file from VS tools|options didn't work anymore because that pull request used an inverted value for VSSettings.CanChangeSettings

@zhili1208 @rrelyea 
