### PR TITLE
project.json restore casing fixes

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -79,7 +79,7 @@ namespace NuGet.DependencyResolver
                 {
                     foreach (var sideNode in n.InnerNodes)
                     {
-                        if (sideNode != node && sideNode.Key.Name == node.Key.Name)
+                        if (sideNode != node && StringComparer.OrdinalIgnoreCase.Equals(sideNode.Key.Name, node.Key.Name))
                         {
                             // Nodes that have no version range should be ignored as potential downgrades e.g. framework reference
                             if (sideNode.Key.VersionRange != null &&
@@ -127,7 +127,8 @@ namespace NuGet.DependencyResolver
         {
             foreach (var item in path)
             {
-                var childNode = node.InnerNodes.FirstOrDefault(n => n.Key.Name == item);
+                var childNode = node.InnerNodes.FirstOrDefault(n => 
+                    StringComparer.OrdinalIgnoreCase.Equals(n.Key.Name, item));
 
                 if (childNode == null)
                 {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -58,7 +58,7 @@ namespace NuGet.DependencyResolver
                         }
                     };
 
-                    if (runtimeDependency.Id == libraryRange.Name)
+                    if (StringComparer.OrdinalIgnoreCase.Equals(runtimeDependency.Id, libraryRange.Name))
                     {
                         if (libraryRange.VersionRange != null &&
                             runtimeDependency.VersionRange != null &&
@@ -175,7 +175,7 @@ namespace NuGet.DependencyResolver
 
             return library =>
             {
-                if (item.Data.Match.Library.Name == library.Name)
+                if (StringComparer.OrdinalIgnoreCase.Equals(item.Data.Match.Library.Name, library.Name))
                 {
                     return DependencyResult.Cycle;
                 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -138,12 +138,15 @@ namespace NuGet.Protocol.Core.v3.LocalRepositories
                 yield break;
             }
 
-            var filter = id + "*.nupkg";
+            var filter = "*.nupkg";
 
             // Check top level directory
             foreach (var path in rootDirectoryInfo.EnumerateFiles(filter))
             {
-                yield return path;
+                if (path.Name.StartsWith(id, StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return path;
+                }
             }
 
             // Check sub directories
@@ -151,7 +154,10 @@ namespace NuGet.Protocol.Core.v3.LocalRepositories
             {
                 foreach (var path in dir.EnumerateFiles(filter))
                 {
-                    yield return path;
+                    if (path.Name.StartsWith(id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        yield return path;
+                    }
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -106,7 +106,7 @@ namespace NuGet.Protocol.Core.v3.LocalRepositories
                         throw new FatalProtocolException(message, ex);
                     }
 
-                    if (string.Equals(reader.GetId(), id, StringComparison.Ordinal))
+                    if (string.Equals(reader.GetId(), id, StringComparison.OrdinalIgnoreCase))
                     {
                         result.Add(new CachedPackageInfo { Path = nupkgInfo.FullName, Reader = reader });
                     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -14,6 +14,132 @@ namespace NuGet.Commands.Test
     public class RestoreCommandTests
     {
         [Fact]
+        public async Task RestoreCommand_FindInV2FolderWithDifferentCasing()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // Both TxMs reference packageA, but they are different types.
+            // Verify that the reference does not show up under libraries.
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""PACKAGEA"": ""4.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "packageA", "4.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, lockFile.Libraries.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_ReferenceWithSameNameDifferentCasing()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // Both TxMs reference packageA, but they are different types.
+            // Verify that the reference does not show up under libraries.
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""packageA"": ""4.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "PROJECT1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "PROJECT1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var aContext = new SimpleTestPackageContext()
+                {
+                    Id = "packageA",
+                    Version = "4.0.0"
+                };
+
+                aContext.Dependencies.Add(new SimpleTestPackageContext("proJect1"));
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "projeCt1", "4.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                result.Commit(logger);
+
+                // Assert
+                // Verify no stack overflows from circular dependencies
+                Assert.False(result.Success);
+            }
+        }
+
+        [Fact]
         public async Task RestoreCommand_PackageAndReferenceWithSameNameAndVersion()
         {
             // Arrange


### PR DESCRIPTION
This contains a few minor fixes for project.json restore id casing. The cycle check is case sensitive but other parts of restore are not, this caused the cycle to go undetected and overflow.

I've also fixed the v2 folder casing as part of this to get the test to work.

https://github.com/NuGet/Home/issues/2558

//cc @joelverhagen @zhili1208 @alpaix @rrelyea 
