### PR TITLE
Packages.config thread safety

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Common
+{
+    /// <summary>
+    /// File operation helpers.
+    /// </summary>
+    public static class FileUtility
+    {
+        private const int MaxTries = 3;
+
+        /// <summary>
+        /// Move a file with retries.
+        /// </summary>
+        public static void Move(string sourceFileName, string destFileName)
+        {
+            if (sourceFileName == null)
+            {
+                throw new ArgumentNullException(nameof(sourceFileName));
+            }
+
+            if (destFileName == null)
+            {
+                throw new ArgumentNullException(nameof(destFileName));
+            }
+
+            // Run at least and continue until the move succeeds or this times out
+            for (int i=0; i < MaxTries; i++)
+            {
+                // Ignore exceptions for the first attempts
+                try
+                {
+                    File.Move(sourceFileName, destFileName);
+
+                    break;
+                }
+                catch (Exception ex) when ((i < (MaxTries - 1)) && (ex is UnauthorizedAccessException || ex is IOException))
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Delete a file with retries.
+        /// </summary>
+        public static void Delete(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            // Run at least and continue until the move succeeds or this times out
+            for (int i = 0; i < MaxTries; i++)
+            {
+                // Ignore exceptions for the first attempts
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+
+                    break;
+                }
+                catch (Exception ex) when ((i < (MaxTries - 1)) && (ex is UnauthorizedAccessException || ex is IOException))
+                {
+                    Thread.Sleep(100);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace NuGet.Common
 {
@@ -26,7 +26,7 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(destFileName));
             }
 
-            // Run at least and continue until the move succeeds or this times out
+            // Run up to 3 times
             for (int i = 0; i < MaxTries; i++)
             {
                 // Ignore exceptions for the first attempts
@@ -53,7 +53,7 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(path));
             }
 
-            // Run at least and continue until the move succeeds or this times out
+            // Run up to 3 times
             for (int i = 0; i < MaxTries; i++)
             {
                 // Ignore exceptions for the first attempts
@@ -76,7 +76,7 @@ namespace NuGet.Common
         private static void Sleep(int ms)
         {
             // Sleep sync
-            Task.Delay(ms).ConfigureAwait(false).GetAwaiter().GetResult();
+            SpinWait.SpinUntil(() => true, ms);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -42,7 +42,7 @@ namespace NuGet.Common
                 }
                 catch (Exception ex) when ((i < (MaxTries - 1)) && (ex is UnauthorizedAccessException || ex is IOException))
                 {
-                    Thread.Sleep(100);
+                    Sleep(100);
                 }
             }
         }
@@ -72,9 +72,15 @@ namespace NuGet.Common
                 }
                 catch (Exception ex) when ((i < (MaxTries - 1)) && (ex is UnauthorizedAccessException || ex is IOException))
                 {
-                    Thread.Sleep(100);
+                    Sleep(100);
                 }
             }
+        }
+
+        private static void Sleep(int ms)
+        {
+            // Sleep sync
+            Task.Delay(ms).ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace NuGet.Common
@@ -13,7 +9,7 @@ namespace NuGet.Common
     /// </summary>
     public static class FileUtility
     {
-        private const int MaxTries = 3;
+        public static readonly int MaxTries = 3;
 
         /// <summary>
         /// Move a file with retries.
@@ -31,7 +27,7 @@ namespace NuGet.Common
             }
 
             // Run at least and continue until the move succeeds or this times out
-            for (int i=0; i < MaxTries; i++)
+            for (int i = 0; i < MaxTries; i++)
             {
                 // Ignore exceptions for the first attempts
                 try

--- a/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -524,10 +525,7 @@ namespace NuGet.Packaging
                     @"packages.config.old." + DateTime.Now.ToString("yyyyMMddHHmmss"));
 
                 // Delete configFileCopyPath if it already exists
-                if (File.Exists(configFileCopyPath))
-                {
-                    File.Delete(configFileCopyPath);
-                }
+                FileUtility.Delete(configFileCopyPath);
 
                 // Rename existing packages.config to packages.config.old.{datetime}
                 if (File.Exists(fullPath))
@@ -541,7 +539,7 @@ namespace NuGet.Packaging
                         File.SetAttributes(fullPath, attributes & ~FileAttributes.ReadOnly);
                     }
 
-                    File.Move(fullPath, configFileCopyPath);
+                    FileUtility.Move(fullPath, configFileCopyPath);
                 }
 
                 try
@@ -561,20 +559,17 @@ namespace NuGet.Packaging
                     }
 
                     // Rename the temporary file to packages.config file
-                    File.Move(configFileNewPath, fullPath);
+                    FileUtility.Move(configFileNewPath, fullPath);
                 }
                 catch
                 {
                     // Roll back to original packages.config file
-                    File.Move(configFileCopyPath, fullPath);
+                    FileUtility.Move(configFileCopyPath, fullPath);
                     throw;
                 }
 
                 // Delete the packages.config.old.{datetime} file
-                if (File.Exists(configFileCopyPath))
-                {
-                    File.Delete(configFileCopyPath);
-                }
+                FileUtility.Delete(configFileCopyPath);
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/PackagesConfigNuGetProject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -246,7 +247,7 @@ namespace NuGet.ProjectManagement
                 var share = FileShare.ReadWrite | FileShare.Delete;
 
                 // Try to read the config file up to 3 times
-                for (int i = 0; i < 3; i++)
+                for (int i = 0; i < FileUtility.MaxTries; i++)
                 {
                     try
                     {
@@ -267,7 +268,8 @@ namespace NuGet.ProjectManagement
                             }
                         }
                     }
-                    catch (Exception ex) when ((i < 2) && (ex is IOException || ex is UnauthorizedAccessException))
+                    catch (Exception ex) when ((i < (FileUtility.MaxTries - 1))
+                        && (ex is IOException || ex is UnauthorizedAccessException))
                     {
                         // Retry incase the file temporarily does not exist due to an install or update
                         Thread.Sleep(100);

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class FileUtilityTests
+    {
+        [Fact]
+        public void FileUtility_MoveBasicSuccess()
+        {
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var orig = Path.Combine(testDirectory, "a");
+                var dest = Path.Combine(testDirectory, "b");
+
+                File.WriteAllText(orig, "a");
+
+                // Act
+                FileUtility.Move(orig, dest);
+
+                // Assert
+                Assert.True(File.Exist(dest));
+                Assert.False(File.Exist(orig));
+            }
+        }
+
+        [Fact]
+        public void FileUtility_DeleteBasicSuccess()
+        {
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var path = Path.Combine(testDirectory, "a");
+
+                File.WriteAllText(orig, "a");
+
+                // Act
+                FileUtility.Delete(path);
+
+                // Assert
+                Assert.False(File.Exist(path));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Common;
 using Xunit;
+using NuGet.Test.Utility;
+using System.IO;
 
 namespace NuGet.Common.Test
 {
@@ -24,8 +26,29 @@ namespace NuGet.Common.Test
                 FileUtility.Move(orig, dest);
 
                 // Assert
-                Assert.True(File.Exist(dest));
-                Assert.False(File.Exist(orig));
+                Assert.True(File.Exists(dest));
+                Assert.False(File.Exists(orig));
+            }
+        }
+
+        [Fact]
+        public void FileUtility_MoveBasicFail()
+        {
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var orig = Path.Combine(testDirectory, "a");
+                var dest = Path.Combine(testDirectory, "b");
+
+                File.WriteAllText(orig, "a");
+                File.WriteAllText(dest, "a");
+
+                using (var stream = File.OpenWrite(dest))
+                {
+                    // Act & Assert
+                    Assert.Throws(typeof(IOException), () =>
+                        FileUtility.Move(orig, dest));
+                }
             }
         }
 
@@ -37,13 +60,32 @@ namespace NuGet.Common.Test
                 // Arrange
                 var path = Path.Combine(testDirectory, "a");
 
-                File.WriteAllText(orig, "a");
+                File.WriteAllText(path, "a");
 
                 // Act
                 FileUtility.Delete(path);
 
                 // Assert
-                Assert.False(File.Exist(path));
+                Assert.False(File.Exists(path));
+            }
+        }
+
+        [Fact]
+        public void FileUtility_DeleteBasicFail()
+        {
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var path = Path.Combine(testDirectory, "a");
+
+                File.WriteAllText(path, "a");
+
+                using (var stream = File.OpenWrite(path))
+                {
+                    // Act & Assert
+                    Assert.Throws(typeof(IOException), () =>
+                        FileUtility.Delete(path));
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -1,11 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using NuGet.Common;
-using Xunit;
-using NuGet.Test.Utility;
+﻿using NuGet.Test.Utility;
 using System.IO;
+using Xunit;
 
 namespace NuGet.Common.Test
 {
@@ -83,8 +78,17 @@ namespace NuGet.Common.Test
                 using (var stream = File.OpenWrite(path))
                 {
                     // Act & Assert
-                    Assert.Throws(typeof(IOException), () =>
-                        FileUtility.Delete(path));
+                    if (RuntimeEnvironmentHelper.IsWindows)
+                    {
+                        Assert.Throws(typeof(IOException), () =>
+                            FileUtility.Delete(path));
+                    }
+                    else
+                    {
+                        // Linux and OSX will delete the file without an error
+                        FileUtility.Delete(path);
+                        Assert.False(File.Exists(path));
+                    }
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -1,6 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Moq;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -9,16 +18,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
-using Moq;
-using NuGet.Frameworks;
-using NuGet.PackageManagement;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.ProjectManagement;
-using NuGet.Protocol.Core.Types;
-using NuGet.Resolver;
-using NuGet.Test.Utility;
-using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using Strings = NuGet.ProjectManagement.Strings;
@@ -70,6 +69,91 @@ namespace NuGet.Test
                 new PackageIdentity("Microsoft.AspNet.Mvc.Razor", new NuGetVersion("6.0.0-beta3")),
                 new PackageIdentity("Microsoft.AspNet.Mvc.Core", new NuGetVersion("6.0.0-beta3"))
             };
+
+        // Install and uninstall a package while calling get installed on another thread
+        [Fact]
+        public async Task TestPacManInstallAndRequestInstalledPackages()
+        {
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var resolutionContext = new ResolutionContext();
+                    var testNuGetProjectContext = new TestNuGetProjectContext();
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
+                    var packagePathResolver = new PackagePathResolver(packagesFolderPath);
+                    var projectA = testSolutionManager.AddNewMSBuildProject();
+
+                    var builder = new Packaging.PackageBuilder()
+                    {
+                        Id = "packageA",
+                        Version = NuGetVersion.Parse("1.0.0"),
+                        Description = "Descriptions",
+                    };
+
+                    builder.Authors.Add("testAuthor");
+                    builder.Files.Add(CreatePackageFile(@"lib" + Path.DirectorySeparatorChar + "net45" + Path.DirectorySeparatorChar + "_._"));
+
+                    using (var stream = File.OpenWrite(Path.Combine(packageSource, "packagea.1.0.0.nupkg")))
+                    {
+                        builder.Save(stream);
+                    }
+
+                    var run = true;
+
+                    var getInstalledTask = Task.Run(async () =>
+                    {
+                        // Get the list of installed packages
+                        while (run)
+                        {
+                            var projectAInstalled = (await projectA.GetInstalledPackagesAsync(token)).ToList();
+                        }
+                    });
+
+                    // Act
+                    // Install and Uninstall 50 times while polling for installed packages
+                    for (int i = 0; i < 50; i++)
+                    {
+                        // Install
+                        await nuGetPackageManager.InstallPackageAsync(projectA, "packageA",
+                            resolutionContext, testNuGetProjectContext, sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                        // Uninstall
+                        await nuGetPackageManager.UninstallPackageAsync(
+                            projectA,
+                            "packageA",
+                            new UninstallationContext(removeDependencies: false, forceRemove: true),
+                            testNuGetProjectContext,
+                            token);
+                    }
+
+                    // Check for exceptions thrown by the get installed task
+                    run = false;
+                    await getInstalledTask;
+
+                    var installed = (await projectA.GetInstalledPackagesAsync(token)).ToList();
+
+                    // Assert
+                    // Verify no exceptions and that the final package was removed
+                    Assert.Equal(0, installed.Count);
+                }
+            }
+        }
 
         [Fact]
         public async Task TestPacManInstallPackage()
@@ -4527,6 +4611,20 @@ namespace NuGet.Test
             {
                 return obj.GetHashCode();
             }
+        }
+
+        private static Packaging.IPackageFile CreatePackageFile(string name)
+        {
+            var file = new Mock<Packaging.IPackageFile>();
+            file.SetupGet(f => f.Path).Returns(name);
+            file.Setup(f => f.GetStream()).Returns(new MemoryStream());
+
+            string effectivePath;
+            var fx = FrameworkNameUtility.ParseFrameworkNameFromFilePath(name, out effectivePath);
+            file.SetupGet(f => f.EffectivePath).Returns(effectivePath);
+            file.SetupGet(f => f.TargetFramework).Returns(fx);
+
+            return file.Object;
         }
     }
 }


### PR DESCRIPTION
This change adds locking and retries around packages.config operations. The threaded install/uninstall test was able to repro the original issue where an API call for get installed packages causes an exception while trying to update or remove packages.config.

Thread.Sleep doesn't exist in netstandard 1.3 from what I could find and we aren't using it anywhere else in netstandard. I've added a helper method to use Task.Delay in a hopefully safe sync way. Let me know if there is a better way.

https://github.com/NuGet/Home/issues/2559

//cc @joelverhagen @alpaix @zhili1208 @rrelyea @toddm 
