### PR TITLE
Invalid AssemblyInformationalVersion throws instead of using default version

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
@@ -5,11 +5,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using NuGet.Runtime;
 
 namespace NuGet.CommandLine
 {
     using NuGet.Packaging;
+    using NuGet.Runtime;
     using NuGet.Versioning;
 
     public static class AssemblyMetadataExtractor
@@ -94,7 +94,7 @@ namespace NuGet.CommandLine
                         }
                         else
                         {
-                            throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, NuGetResources.Error_AssemblyInformationalVersion, assemblyInformationalVersion));
+                            throw new InvalidDataException(String.Format(CultureInfo.CurrentCulture, NuGetResources.Error_AssemblyInformationalVersion, assemblyInformationalVersion, path));
                         }
                     }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadataExtractor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -9,7 +10,8 @@ using NuGet.Runtime;
 namespace NuGet.CommandLine
 {
     using NuGet.Packaging;
-    using Versioning;
+    using NuGet.Versioning;
+
     public static class AssemblyMetadataExtractor
     {
         public static AssemblyMetadata GetMetadata(string assemblyPath)
@@ -86,7 +88,14 @@ namespace NuGet.CommandLine
                     string assemblyInformationalVersion = GetAttributeValueOrDefault<AssemblyInformationalVersionAttribute>(attributes);
                     if (!NuGetVersion.TryParse(assemblyInformationalVersion, out version))
                     {
-                        version = NuGetVersion.Parse(assemblyName.Version.ToString());
+                        if (string.IsNullOrEmpty(assemblyInformationalVersion))
+                        {
+                            version = NuGetVersion.Parse(assemblyName.Version.ToString());
+                        }
+                        else
+                        {
+                            throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, NuGetResources.Error_AssemblyInformationalVersion, assemblyInformationalVersion));
+                        }
                     }
 
                     return new AssemblyMetadata

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -218,18 +218,23 @@ namespace NuGet.CommandLine
             }
             catch (Exception ex)
             {
-                Logger.LogWarning(
+                Logger.LogError(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("UnableToExtractAssemblyMetadata"),
                         Path.GetFileName(TargetPath)));
+
                 IConsole console = Logger as IConsole;
                 if (console != null && console.Verbosity == Verbosity.Detailed)
                 {
-                    Logger.LogWarning(ex.ToString());
+                    Logger.LogError(ex.ToString());
+                }
+                else
+                {
+                    Logger.LogError(ex.Message);
                 }
 
-                ExtractMetadataFromProject(builder);
+                return null;
             }
 
             var projectAuthor = InitializeProperties(builder);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -227,7 +227,7 @@ namespace NuGet.CommandLine
                 IConsole console = Logger as IConsole;
                 if (console != null && console.Verbosity == Verbosity.Detailed)
                 {
-                    Logger.LogVerbose(ex.ToString());
+                    Logger.LogError(ex.ToString());
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -227,7 +227,7 @@ namespace NuGet.CommandLine
                 IConsole console = Logger as IConsole;
                 if (console != null && console.Verbosity == Verbosity.Detailed)
                 {
-                    Logger.LogError(ex.ToString());
+                    Logger.LogVerbose(ex.ToString());
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2320,6 +2320,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Invalid AssemblyInformationalVersion {0}..
+        /// </summary>
+        public static string Error_AssemblyInformationalVersion {
+            get {
+                return ResourceManager.GetString("Error_AssemblyInformationalVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot find the specified version of msbuild: &apos;{0}&apos;.
         /// </summary>
         public static string Error_CannotFindMsbuild {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2320,7 +2320,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid AssemblyInformationalVersion {0}..
+        ///   Looks up a localized string similar to Invalid AssemblyInformationalVersion {0} on assembly {1}..
         /// </summary>
         public static string Error_AssemblyInformationalVersion {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6080,6 +6080,6 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command.</value>
   </data>
   <data name="Error_AssemblyInformationalVersion" xml:space="preserve">
-    <value>Invalid AssemblyInformationalVersion {0}.</value>
+    <value>Invalid AssemblyInformationalVersion {0} on assembly {1}.</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6079,4 +6079,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="PushCommandTimeoutError" xml:space="preserve">
     <value>Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command.</value>
   </data>
+  <data name="Error_AssemblyInformationalVersion" xml:space="preserve">
+    <value>Invalid AssemblyInformationalVersion {0}.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -336,6 +336,11 @@ namespace NuGet.Commands
             // Create a builder for the main package as well as the sources/symbols package
             PackageBuilder mainPackageBuilder = factory.CreateBuilder(_packArgs.BasePath);
 
+            if (mainPackageBuilder == null)
+            {
+                throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_PackFailed, path));
+            }
+
             // Build the main package
             PackageArchiveReader package = BuildPackage(mainPackageBuilder);
 

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -390,6 +390,8 @@ namespace NuGet.Commands
 
             outputPath = outputPath ?? GetOutputPath(builder, false, builder.Version);
 
+            CheckForUnsupportedFrameworks(builder);
+
             ExcludeFiles(builder.Files);
 
             // Track if the package file was already present on disk
@@ -418,6 +420,20 @@ namespace NuGet.Commands
             WriteLine(String.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath));
 
             return new PackageArchiveReader(outputPath);
+        }
+
+        private void CheckForUnsupportedFrameworks(PackageBuilder builder)
+        {
+            foreach (var reference in builder.FrameworkReferences)
+            {
+                foreach (var framework in reference.SupportedFrameworks)
+                {
+                    if (framework.IsUnsupported)
+                    {
+                        throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, reference.AssemblyName));
+                    }
+                }
+            }
         }
 
         private void PrintVerbose(string outputPath, PackageBuilder builder)

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -226,6 +226,11 @@ namespace NuGet.Commands
             {
                 foreach (var framework in spec.TargetFrameworks)
                 {
+                    if (framework.FrameworkName.IsUnsupported)
+                    {
+                        throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, framework.FrameworkName));
+                    }
+
                     AddDependencyGroups(framework.Dependencies, framework.FrameworkName, builder);
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -96,7 +96,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unsupported targetFramework value on &apos;{0}&apos;.
+        ///    Looks up a localized string similar to Failed to build package because of an unsupported targetFramework value on &apos;{0}&apos;..
         /// </summary>
         public static string Error_InvalidTargetFramework {
             get {
@@ -132,7 +132,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Error packaging &apos;{0}&apos;..
+        ///    Looks up a localized string similar to Failed to build package.  The error message was &apos;{0}&apos;..
         /// </summary>
         public static string Error_PackFailed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -123,6 +123,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Error packaging &apos;{0}&apos;..
+        /// </summary>
+        public static string Error_PackFailed {
+            get {
+                return ResourceManager.GetString("Error_PackFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Error occurred when processing file &apos;{0}&apos;: {1}.
         /// </summary>
         public static string Error_ProcessingNuspecFile {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -132,7 +132,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Failed to build package.  The error message was &apos;{0}&apos;..
+        ///    Looks up a localized string similar to Failed to build package. {0}.
         /// </summary>
         public static string Error_PackFailed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -96,6 +96,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Unsupported targetFramework value on &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidTargetFramework {
+            get {
+                return ResourceManager.GetString("Error_InvalidTargetFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Source parameter was not specified..
         /// </summary>
         public static string Error_MissingSourceParameter {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -397,4 +397,7 @@
   <data name="Error_PackFailed" xml:space="preserve">
     <value>Error packaging '{0}'.</value>
   </data>
+  <data name="Error_InvalidTargetFramework" xml:space="preserve">
+    <value>Unsupported targetFramework value on '{0}'</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -395,9 +395,9 @@
     <value>Please specify a nuspec, project.json, project file to use</value>
   </data>
   <data name="Error_PackFailed" xml:space="preserve">
-    <value>Error packaging '{0}'.</value>
+    <value>Failed to build package.  The error message was '{0}'.</value>
   </data>
   <data name="Error_InvalidTargetFramework" xml:space="preserve">
-    <value>Unsupported targetFramework value on '{0}'</value>
+    <value>Failed to build package because of an unsupported targetFramework value on '{0}'.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -376,11 +376,11 @@
   </data>
   <data name="Log_FrameworkDisplay" xml:space="preserve">
     <value>{0} ({1})</value>
-    <comment>0 - framwork short name, 1 - System.FrameworkName</comment>
+    <comment>0 - framework short name, 1 - System.FrameworkName</comment>
   </data>
   <data name="Log_FrameworkRIDDisplay" xml:space="preserve">
     <value>{0} ({1}) / {2}</value>
-    <comment>0 - framwork short name, 1 - System.FrameworkName, 2 - Runtime ID</comment>
+    <comment>0 - framework short name, 1 - System.FrameworkName, 2 - Runtime ID</comment>
   </data>
   <data name="Log_PackageNotCompatibleWithFx_NoSupports" xml:space="preserve">
     <value>Package {0} {1} does not support any target frameworks.</value>
@@ -393,5 +393,8 @@
   </data>
   <data name="InputFileNotSpecified" xml:space="preserve">
     <value>Please specify a nuspec, project.json, project file to use</value>
+  </data>
+  <data name="Error_PackFailed" xml:space="preserve">
+    <value>Error packaging '{0}'.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -395,7 +395,7 @@
     <value>Please specify a nuspec, project.json, project file to use</value>
   </data>
   <data name="Error_PackFailed" xml:space="preserve">
-    <value>Failed to build package.  The error message was '{0}'.</value>
+    <value>Failed to build package. {0}</value>
   </data>
   <data name="Error_InvalidTargetFramework" xml:space="preserve">
     <value>Failed to build package because of an unsupported targetFramework value on '{0}'.</value>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -256,7 +256,7 @@ namespace NuGet.Packaging
 
                         if (targetFramework.IsUnsupported)
                         {
-                            throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, targetFrameworkName));
+                            throw new InvalidDataException(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, targetFrameworkName));
                         }
                     }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -253,6 +253,11 @@ namespace NuGet.Packaging
                     if (targetFrameworkName != null)
                     {
                         targetFramework = NuGetFramework.Parse(targetFrameworkName);
+
+                        if (targetFramework.IsUnsupported)
+                        {
+                            throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, targetFrameworkName));
+                        }
                     }
 
                     // REVIEW: Is UnsupportedFramework correct?

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging {
     // with the /str option, or rebuild your VS project.
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
+    public class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -35,7 +35,7 @@ namespace NuGet.Packaging {
         ///    Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Packaging.Strings", typeof(Strings).GetTypeInfo().Assembly);
@@ -50,7 +50,7 @@ namespace NuGet.Packaging {
         ///    resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -60,9 +60,18 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Unsupported targetFramework value &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidTargetFramework {
+            get {
+                return ResourceManager.GetString("Error_InvalidTargetFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to There are duplicate packages: {0}.
         /// </summary>
-        internal static string ErrorDuplicatePackages {
+        public static string ErrorDuplicatePackages {
             get {
                 return ResourceManager.GetString("ErrorDuplicatePackages", resourceCulture);
             }
@@ -71,7 +80,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid allowedVersions for package id &apos;{0}&apos;: &apos;{1}&apos;.
         /// </summary>
-        internal static string ErrorInvalidAllowedVersions {
+        public static string ErrorInvalidAllowedVersions {
             get {
                 return ResourceManager.GetString("ErrorInvalidAllowedVersions", resourceCulture);
             }
@@ -80,7 +89,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid minClientVersion: &apos;{0}&apos;.
         /// </summary>
-        internal static string ErrorInvalidMinClientVersion {
+        public static string ErrorInvalidMinClientVersion {
             get {
                 return ResourceManager.GetString("ErrorInvalidMinClientVersion", resourceCulture);
             }
@@ -89,7 +98,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid package version for package id &apos;{0}&apos;: &apos;{1}&apos;.
         /// </summary>
-        internal static string ErrorInvalidPackageVersion {
+        public static string ErrorInvalidPackageVersion {
             get {
                 return ResourceManager.GetString("ErrorInvalidPackageVersion", resourceCulture);
             }
@@ -98,7 +107,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Null or empty package id.
         /// </summary>
-        internal static string ErrorNullOrEmptyPackageId {
+        public static string ErrorNullOrEmptyPackageId {
             get {
                 return ResourceManager.GetString("ErrorNullOrEmptyPackageId", resourceCulture);
             }
@@ -107,7 +116,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Unable to delete temporary file &apos;{0}&apos;. Error: &apos;{1}&apos;..
         /// </summary>
-        internal static string ErrorUnableToDeleteFile {
+        public static string ErrorUnableToDeleteFile {
             get {
                 return ResourceManager.GetString("ErrorUnableToDeleteFile", resourceCulture);
             }
@@ -116,7 +125,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Fail to load packages.config as XML file. Please check it. .
         /// </summary>
-        internal static string FailToLoadPackagesConfig {
+        public static string FailToLoadPackagesConfig {
             get {
                 return ResourceManager.GetString("FailToLoadPackagesConfig", resourceCulture);
             }
@@ -125,7 +134,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Failed to write packages.config as XML file &apos;{0}&apos;. Error: &apos;{1}&apos;..
         /// </summary>
-        internal static string FailToWritePackagesConfig {
+        public static string FailToWritePackagesConfig {
             get {
                 return ResourceManager.GetString("FailToWritePackagesConfig", resourceCulture);
             }
@@ -134,7 +143,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to The nuspec contains an invalid entry &apos;{0}&apos; in package &apos;{1}&apos; ..
         /// </summary>
-        internal static string InvalidNuspecEntry {
+        public static string InvalidNuspecEntry {
             get {
                 return ResourceManager.GetString("InvalidNuspecEntry", resourceCulture);
             }
@@ -143,7 +152,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Installing {0} {1}..
         /// </summary>
-        internal static string Log_InstallingPackage {
+        public static string Log_InstallingPackage {
             get {
                 return ResourceManager.GetString("Log_InstallingPackage", resourceCulture);
             }
@@ -152,7 +161,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to MinClientVersion already exists in packages.config.
         /// </summary>
-        internal static string MinClientVersionAlreadyExist {
+        public static string MinClientVersionAlreadyExist {
             get {
                 return ResourceManager.GetString("MinClientVersionAlreadyExist", resourceCulture);
             }
@@ -161,7 +170,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Nuspec file does not exist in package..
         /// </summary>
-        internal static string MissingNuspec {
+        public static string MissingNuspec {
             get {
                 return ResourceManager.GetString("MissingNuspec", resourceCulture);
             }
@@ -170,7 +179,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package contains multiple nuspec files..
         /// </summary>
-        internal static string MultipleNuspecFiles {
+        public static string MultipleNuspecFiles {
             get {
                 return ResourceManager.GetString("MultipleNuspecFiles", resourceCulture);
             }
@@ -179,7 +188,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package entry already exists in packages.config. Id: {0}.
         /// </summary>
-        internal static string PackageEntryAlreadyExist {
+        public static string PackageEntryAlreadyExist {
             get {
                 return ResourceManager.GetString("PackageEntryAlreadyExist", resourceCulture);
             }
@@ -188,7 +197,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package entry does not exists in packages.config. Id: {0}, Version: {1}.
         /// </summary>
-        internal static string PackageEntryNotExist {
+        public static string PackageEntryNotExist {
             get {
                 return ResourceManager.GetString("PackageEntryNotExist", resourceCulture);
             }
@@ -197,7 +206,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Packages node does not exists in packages.config at {0}..
         /// </summary>
-        internal static string PackagesNodeNotExist {
+        public static string PackagesNodeNotExist {
             get {
                 return ResourceManager.GetString("PackagesNodeNotExist", resourceCulture);
             }
@@ -206,7 +215,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package stream should be seekable.
         /// </summary>
-        internal static string PackageStreamShouldBeSeekable {
+        public static string PackageStreamShouldBeSeekable {
             get {
                 return ResourceManager.GetString("PackageStreamShouldBeSeekable", resourceCulture);
             }
@@ -215,7 +224,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to String argument &apos;{0}&apos; cannot be null or empty.
         /// </summary>
-        internal static string StringCannotBeNullOrEmpty {
+        public static string StringCannotBeNullOrEmpty {
             get {
                 return ResourceManager.GetString("StringCannotBeNullOrEmpty", resourceCulture);
             }
@@ -224,7 +233,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to An error occurred while updating packages.config. The file was closed before the entry could be added..
         /// </summary>
-        internal static string UnableToAddEntry {
+        public static string UnableToAddEntry {
             get {
                 return ResourceManager.GetString("UnableToAddEntry", resourceCulture);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace NuGet.Packaging {
     // with the /str option, or rebuild your VS project.
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Strings {
+    internal class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -35,7 +35,7 @@ namespace NuGet.Packaging {
         ///    Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Packaging.Strings", typeof(Strings).GetTypeInfo().Assembly);
@@ -50,7 +50,7 @@ namespace NuGet.Packaging {
         ///    resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -60,9 +60,9 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unsupported targetFramework value &apos;{0}&apos;.
+        ///    Looks up a localized string similar to Unsupported targetFramework value &apos;{0}&apos;..
         /// </summary>
-        public static string Error_InvalidTargetFramework {
+        internal static string Error_InvalidTargetFramework {
             get {
                 return ResourceManager.GetString("Error_InvalidTargetFramework", resourceCulture);
             }
@@ -71,7 +71,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to There are duplicate packages: {0}.
         /// </summary>
-        public static string ErrorDuplicatePackages {
+        internal static string ErrorDuplicatePackages {
             get {
                 return ResourceManager.GetString("ErrorDuplicatePackages", resourceCulture);
             }
@@ -80,7 +80,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid allowedVersions for package id &apos;{0}&apos;: &apos;{1}&apos;.
         /// </summary>
-        public static string ErrorInvalidAllowedVersions {
+        internal static string ErrorInvalidAllowedVersions {
             get {
                 return ResourceManager.GetString("ErrorInvalidAllowedVersions", resourceCulture);
             }
@@ -89,7 +89,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid minClientVersion: &apos;{0}&apos;.
         /// </summary>
-        public static string ErrorInvalidMinClientVersion {
+        internal static string ErrorInvalidMinClientVersion {
             get {
                 return ResourceManager.GetString("ErrorInvalidMinClientVersion", resourceCulture);
             }
@@ -98,7 +98,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Invalid package version for package id &apos;{0}&apos;: &apos;{1}&apos;.
         /// </summary>
-        public static string ErrorInvalidPackageVersion {
+        internal static string ErrorInvalidPackageVersion {
             get {
                 return ResourceManager.GetString("ErrorInvalidPackageVersion", resourceCulture);
             }
@@ -107,7 +107,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Null or empty package id.
         /// </summary>
-        public static string ErrorNullOrEmptyPackageId {
+        internal static string ErrorNullOrEmptyPackageId {
             get {
                 return ResourceManager.GetString("ErrorNullOrEmptyPackageId", resourceCulture);
             }
@@ -116,7 +116,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Unable to delete temporary file &apos;{0}&apos;. Error: &apos;{1}&apos;..
         /// </summary>
-        public static string ErrorUnableToDeleteFile {
+        internal static string ErrorUnableToDeleteFile {
             get {
                 return ResourceManager.GetString("ErrorUnableToDeleteFile", resourceCulture);
             }
@@ -125,7 +125,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Fail to load packages.config as XML file. Please check it. .
         /// </summary>
-        public static string FailToLoadPackagesConfig {
+        internal static string FailToLoadPackagesConfig {
             get {
                 return ResourceManager.GetString("FailToLoadPackagesConfig", resourceCulture);
             }
@@ -134,7 +134,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Failed to write packages.config as XML file &apos;{0}&apos;. Error: &apos;{1}&apos;..
         /// </summary>
-        public static string FailToWritePackagesConfig {
+        internal static string FailToWritePackagesConfig {
             get {
                 return ResourceManager.GetString("FailToWritePackagesConfig", resourceCulture);
             }
@@ -143,7 +143,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to The nuspec contains an invalid entry &apos;{0}&apos; in package &apos;{1}&apos; ..
         /// </summary>
-        public static string InvalidNuspecEntry {
+        internal static string InvalidNuspecEntry {
             get {
                 return ResourceManager.GetString("InvalidNuspecEntry", resourceCulture);
             }
@@ -152,7 +152,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Installing {0} {1}..
         /// </summary>
-        public static string Log_InstallingPackage {
+        internal static string Log_InstallingPackage {
             get {
                 return ResourceManager.GetString("Log_InstallingPackage", resourceCulture);
             }
@@ -161,7 +161,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to MinClientVersion already exists in packages.config.
         /// </summary>
-        public static string MinClientVersionAlreadyExist {
+        internal static string MinClientVersionAlreadyExist {
             get {
                 return ResourceManager.GetString("MinClientVersionAlreadyExist", resourceCulture);
             }
@@ -170,7 +170,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Nuspec file does not exist in package..
         /// </summary>
-        public static string MissingNuspec {
+        internal static string MissingNuspec {
             get {
                 return ResourceManager.GetString("MissingNuspec", resourceCulture);
             }
@@ -179,7 +179,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package contains multiple nuspec files..
         /// </summary>
-        public static string MultipleNuspecFiles {
+        internal static string MultipleNuspecFiles {
             get {
                 return ResourceManager.GetString("MultipleNuspecFiles", resourceCulture);
             }
@@ -188,7 +188,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package entry already exists in packages.config. Id: {0}.
         /// </summary>
-        public static string PackageEntryAlreadyExist {
+        internal static string PackageEntryAlreadyExist {
             get {
                 return ResourceManager.GetString("PackageEntryAlreadyExist", resourceCulture);
             }
@@ -197,7 +197,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package entry does not exists in packages.config. Id: {0}, Version: {1}.
         /// </summary>
-        public static string PackageEntryNotExist {
+        internal static string PackageEntryNotExist {
             get {
                 return ResourceManager.GetString("PackageEntryNotExist", resourceCulture);
             }
@@ -206,7 +206,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Packages node does not exists in packages.config at {0}..
         /// </summary>
-        public static string PackagesNodeNotExist {
+        internal static string PackagesNodeNotExist {
             get {
                 return ResourceManager.GetString("PackagesNodeNotExist", resourceCulture);
             }
@@ -215,7 +215,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to Package stream should be seekable.
         /// </summary>
-        public static string PackageStreamShouldBeSeekable {
+        internal static string PackageStreamShouldBeSeekable {
             get {
                 return ResourceManager.GetString("PackageStreamShouldBeSeekable", resourceCulture);
             }
@@ -224,7 +224,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to String argument &apos;{0}&apos; cannot be null or empty.
         /// </summary>
-        public static string StringCannotBeNullOrEmpty {
+        internal static string StringCannotBeNullOrEmpty {
             get {
                 return ResourceManager.GetString("StringCannotBeNullOrEmpty", resourceCulture);
             }
@@ -233,7 +233,7 @@ namespace NuGet.Packaging {
         /// <summary>
         ///    Looks up a localized string similar to An error occurred while updating packages.config. The file was closed before the entry could be added..
         /// </summary>
-        public static string UnableToAddEntry {
+        internal static string UnableToAddEntry {
             get {
                 return ResourceManager.GetString("UnableToAddEntry", resourceCulture);
             }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -174,4 +174,7 @@
   <data name="ErrorUnableToDeleteFile" xml:space="preserve">
     <value>Unable to delete temporary file '{0}'. Error: '{1}'.</value>
   </data>
+  <data name="Error_InvalidTargetFramework" xml:space="preserve">
+    <value>Unsupported targetFramework value '{0}'</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -175,6 +175,6 @@
     <value>Unable to delete temporary file '{0}'. Error: '{1}'.</value>
   </data>
   <data name="Error_InvalidTargetFramework" xml:space="preserve">
-    <value>Unsupported targetFramework value '{0}'</value>
+    <value>Unsupported targetFramework value '{0}'.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -526,13 +526,6 @@ namespace NuGet.ProjectModel
         {
             var frameworkName = GetFramework(targetFramework.Key);
 
-            // If it's not unsupported then keep it
-            if (frameworkName == NuGetFramework.UnsupportedFramework)
-            {
-                // REVIEW: Should we skip unsupported target frameworks
-                return false;
-            }
-
             var properties = targetFramework.Value.Value<JObject>();
 
             var importFrameworks = GetImports(properties, packageSpec);


### PR DESCRIPTION
Changing the parsing of the assembly data to throw if the informational version is invalid, and then changing the pack command to throw if the ProjectFactory failed to create a PackageBuilder so it stops the whole command instead of continuing.

Fixes https://github.com/NuGet/Home/issues/2281

@emgarten 
