### PR TITLE
Multi-project gather cache

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -362,7 +362,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             get
             {
-                _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, VersionConstraints.None);
+                // ResolutionContext contains a cache, this should only be created once per command
+                if (_context == null)
+                {
+                    _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, VersionConstraints.None);
+                }
+
                 return _context;
             }
         }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/SyncPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/SyncPackageCommand.cs
@@ -122,7 +122,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             get
             {
-                _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, VersionConstraints.None);
+                // ResolutionContext contains a cache, this should only be created once per command
+                if (_context == null)
+                {
+                    _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, VersionConstraints.None);
+                }
+
                 return _context;
             }
         }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -289,7 +289,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             get
             {
-                _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, DetermineVersionConstraints());
+                // ResolutionContext contains a cache, this should only be created once per command
+                if (_context == null)
+                {
+                    _context = new ResolutionContext(GetDependencyBehavior(), _allowPrerelease, false, DetermineVersionConstraints());
+                }
+
                 return _context;
             }
         }

--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -126,6 +126,9 @@ namespace NuGet.PackageManagement.UI
         {
             var resolvedActions = new List<ResolvedAction>();
 
+            // Keep a single gather cache across projects
+            var gatherCache = new GatherCache();
+
             foreach (var project in uiService.Projects)
             {
                 var installedPackages = await project.GetInstalledPackagesAsync(token);
@@ -150,7 +153,9 @@ namespace NuGet.PackageManagement.UI
                         uiService.DependencyBehavior,
                         includePrelease: includePrerelease,
                         includeUnlisted: true,
-                        versionConstraints: VersionConstraints.None);
+                        versionConstraints: VersionConstraints.None,
+                        gatherCache: gatherCache);
+
                     var actions = await _packageManager.PreviewUpdatePackagesAsync(
                         packagesToUpdateInProject,
                         project,

--- a/src/NuGet.Core/NuGet.PackageManagement/Context/ResolutionContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Context/ResolutionContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Resolver;
 
 namespace NuGet.PackageManagement
@@ -14,12 +15,12 @@ namespace NuGet.PackageManagement
         /// Public constructor to create the resolution context
         /// </summary>
         public ResolutionContext()
+            : this(DependencyBehavior.Lowest,
+                  includePrelease: false,
+                  includeUnlisted: true,
+                  versionConstraints: VersionConstraints.None,
+                  gatherCache: new GatherCache())
         {
-            DependencyBehavior = DependencyBehavior.Lowest;
-            IncludePrerelease = false;
-            IncludeUnlisted = true;
-            VersionConstraints = VersionConstraints.None;
-            GatherCache = new GatherCache();
         }
 
         /// <summary>
@@ -30,12 +31,34 @@ namespace NuGet.PackageManagement
             bool includePrelease,
             bool includeUnlisted,
             VersionConstraints versionConstraints)
+            : this(dependencyBehavior,
+                  includePrelease,
+                  includeUnlisted,
+                  versionConstraints,
+                  new GatherCache())
         {
+        }
+
+        /// <summary>
+        /// Public constructor to create the resolution context
+        /// </summary>
+        public ResolutionContext(
+            DependencyBehavior dependencyBehavior,
+            bool includePrelease,
+            bool includeUnlisted,
+            VersionConstraints versionConstraints,
+            GatherCache gatherCache)
+        {
+            if (gatherCache == null)
+            {
+                throw new ArgumentNullException(nameof(gatherCache));
+            }
+
             DependencyBehavior = dependencyBehavior;
             IncludePrerelease = includePrelease;
             IncludeUnlisted = includeUnlisted;
             VersionConstraints = versionConstraints;
-            GatherCache = new GatherCache();
+            GatherCache = gatherCache;
         }
 
         /// <summary>
@@ -62,7 +85,6 @@ namespace NuGet.PackageManagement
         /// Gathe cache containing cached packages that can be used across operations.
         /// Ex: Update-Package updates all packages across all projects, GatherCache stores
         /// the gathered packages and re-uses them across all sub operations.
-        /// This property is for internal use or testing only.
         /// </summary>
         public GatherCache GatherCache { get; }
     }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -701,7 +701,15 @@ namespace NuGet.PackageManagement
             {
                 // If any targets are prerelease we should gather with prerelease on and filter afterwards
                 var includePrereleaseInGather = resolutionContext.IncludePrerelease || (projectInstalledPackageReferences.Any(p => (p.PackageIdentity.HasVersion && p.PackageIdentity.Version.IsPrerelease)));
-                var contextForGather = new ResolutionContext(resolutionContext.DependencyBehavior, includePrereleaseInGather, resolutionContext.IncludeUnlisted, VersionConstraints.None);
+
+                // Create a modified resolution cache. This should include the same gather cache for multi-project
+                // operations.
+                var contextForGather = new ResolutionContext(
+                    resolutionContext.DependencyBehavior,
+                    includePrereleaseInGather,
+                    resolutionContext.IncludeUnlisted,
+                    VersionConstraints.None,
+                    resolutionContext.GatherCache);
 
                 // Step-1 : Get metadata resources using gatherer
                 var targetFramework = nuGetProject.GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);


### PR DESCRIPTION
This change allows the GatherCache to be passed into a ResolutionContext to make this feature more flexible. It also hooks it up everywhere that it wasn't being used to allow dependency information to be shared between projects during multi-project operations such as `update-package`.

This cache is already used within a single project operation, and across projects for some UI scenarios. This change adds it everywhere else that was missing it.

https://github.com/NuGet/Home/issues/2619

//cc @alpaix @joelverhagen @zhili1208 @jainaashish 
