### PR TITLE
Added null check for selected version

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -345,6 +345,7 @@ namespace NuGet.PackageManagement.UI
 
             CanInstall = SelectedVersion != null && Projects.Any(
                 project => project.IsSelected &&
+                    SelectedVersion != null &&
                     VersionComparer.Default.Compare(SelectedVersion.Version, project.InstalledVersion) != 0);
         }
 


### PR DESCRIPTION
In some rare cases, we get selectedVersion as null while making decision to enable/disable install/uninstall button in DetailControl ui. So to be on safe side, added a null check for SelectedVersion which will restrict throwing null ref exception. 

https://github.com/NuGet/Home/issues/2551

@emgarten @joelverhagen @alpaix 
