### PR TITLE
fixed https://github.com/NuGet/Home/issues/2601

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
@@ -73,10 +73,18 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 // Treat projects with project.json as build integrated projects
                 // Search for projectName.project.json first, then project.json
-                var projectJsonPath = string.IsNullOrEmpty(projectNameFromMSBuildPath) ?
-                    Path.Combine(msbuildProjectFile.DirectoryName, ProjectJsonPathUtilities.ProjectConfigFileName)
-                    : ProjectJsonPathUtilities.GetProjectConfigPath(msbuildProjectFile.DirectoryName,
+                // For website project, since projectNameFromMSBuildPath is empty, only search project.json
+                string projectJsonPath = null;
+                if (string.IsNullOrEmpty(projectNameFromMSBuildPath))
+                {
+                    projectJsonPath = Path.Combine(msbuildProjectFile.DirectoryName, 
+                        ProjectJsonPathUtilities.ProjectConfigFileName);
+                }
+                else
+                {
+                    projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(msbuildProjectFile.DirectoryName,
                     projectNameFromMSBuildPath);
+                }
 
                 if (File.Exists(projectJsonPath))
                 {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
@@ -73,8 +73,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 // Treat projects with project.json as build integrated projects
                 // Search for projectName.project.json first, then project.json
-                var projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(
-                    msbuildProjectFile.DirectoryName,
+                var projectJsonPath = string.IsNullOrEmpty(projectNameFromMSBuildPath) ?
+                    Path.Combine(msbuildProjectFile.DirectoryName, ProjectJsonPathUtilities.ProjectConfigFileName)
+                    : ProjectJsonPathUtilities.GetProjectConfigPath(msbuildProjectFile.DirectoryName,
                     projectNameFromMSBuildPath);
 
                 if (File.Exists(projectJsonPath))


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2601

the issue here is for website, projectNameFromMSbuildPath will be empty string, then projectJsonPathUtilities will throw.

the fix here is if the projectNameFromMSbuildPath is empty, just return project.json
