### PR TITLE
Add IVS API to GetNearest with fallback frameworks

### DIFF
--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility.cs
@@ -33,8 +33,8 @@ namespace NuGet.VisualStudio
         IEnumerable<FrameworkName> GetFrameworksSupportingNetStandard(FrameworkName frameworkName);
 
         /// <summary>
-        /// Selects the framework from <see cref="frameworks"/> that is nearest
-        /// to the <see cref="targetFramework"/>, according to NuGet's framework
+        /// Selects the framework from <paramref name="frameworks"/> that is nearest
+        /// to the <paramref name="targetFramework"/>, according to NuGet's framework
         /// compatibility rules. <c>null</c> is returned of none of the frameworks
         /// are compatible.
         /// </summary>

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkCompatibility2.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// Contains methods to discover frameworks and compatibility between frameworks.
+    /// </summary>
+    [ComImport]
+    [Guid("61C038E9-0308-482B-8602-279E42A3BB1E")]
+    public interface IVsFrameworkCompatibility2 : IVsFrameworkCompatibility
+    {
+        /// <summary>
+        /// Selects the framework from <paramref name="frameworks"/> that is nearest
+        /// to the <paramref name="targetFramework"/>, according to NuGet's framework
+        /// compatibility rules. <c>null</c> is returned of none of the frameworks
+        /// are compatible.
+        /// </summary>
+        /// <param name="targetFramework">The target framework.</param>
+        /// <param name="fallbackTargetFrameworks">
+        /// Target frameworks to use if the provided <paramref name="targetFramework"/> is not compatible.
+        /// These fallback frameworks are attempted in sequence after <paramref name="targetFramework"/>.
+        /// </param>
+        /// <param name="frameworks">The list of frameworks to choose from.</param>
+        /// <exception cref="ArgumentException">If any of the arguments are <c>null</c>.</exception>
+        /// <returns>The nearest framework.</returns>
+        FrameworkName GetNearest(
+            FrameworkName targetFramework,
+            IEnumerable<FrameworkName> fallbackTargetFrameworks,
+            IEnumerable<FrameworkName> frameworks);
+    }
+}

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkParser.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsFrameworkParser.cs
@@ -7,6 +7,10 @@ using System.Runtime.Versioning;
 
 namespace NuGet.VisualStudio
 {
+    /// <summary>
+    /// An interface for dealing with the conversion between strings and <see cref="FrameworkName"/>
+    /// instances.
+    /// </summary>
     [ComImport]
     [Guid("E6335CF1-70FE-416A-BA4B-4E92D90934A1")]
     public interface IVsFrameworkParser

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsSemanticVersionComparer.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsSemanticVersionComparer.cs
@@ -6,16 +6,20 @@ using System.Runtime.InteropServices;
 
 namespace NuGet.VisualStudio
 {
+    /// <summary>
+    /// An interface for comparing two opaque version strings by treating them as NuGet semantic
+    /// versions.
+    /// </summary>
     [ComImport]
     [Guid("1AE338E2-9120-4D1A-A779-012FEBEF77FA")]
     public interface IVsSemanticVersionComparer
     {
         /// <summary>
         /// Compares two version strings as if they were NuGet semantic version
-        /// strings. Returns a number less than zero if <see cref="versionA"/>
-        /// is less than <see cref="versionB"/>. Returns zero if the two versions 
-        /// are equivalent. Returns a number greater than zero if <see cref="versionA"/>
-        /// is greater than <see cref="versionB"/>.
+        /// strings. Returns a number less than zero if <paramref name="versionA"/>
+        /// is less than <paramref name="versionB"/>. Returns zero if the two versions 
+        /// are equivalent. Returns a number greater than zero if <paramref name="versionA"/>
+        /// is greater than <paramref name="versionB"/>.
         /// </summary>
         /// <param name="versionA">The first version string.</param>
         /// <param name="versionB">The second version string.</param>

--- a/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
+++ b/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
@@ -102,6 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensibility\IVsCredentialProvider.cs" />
+    <Compile Include="Extensibility\IVsFrameworkCompatibility2.cs" />
     <Compile Include="Extensibility\IVsFrameworkParser.cs" />
     <Compile Include="Extensibility\IVsGlobalPackagesInitScriptExecutor.cs" />
     <Compile Include="Extensibility\IVsFrameworkCompatibility.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsFrameworkCompatibilityTests.cs
@@ -22,6 +22,7 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, frameworks));
         }
+
         [Fact]
         public void VsFrameworkCompatibility_GetNearestRejectsNullFrameworks()
         {
@@ -32,6 +33,23 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, frameworks));
+        }
+
+        [Fact]
+        public void VsFrameworkCompatibility_GetNearestRejectsNullFallbackFrameworks()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility();
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            FrameworkName[] fallbackTargetFrameworks = null;
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.1"),
+                new FrameworkName(".NETFramework,Version=v4.5.2"),
+            };
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks));
         }
 
         [Fact]
@@ -59,6 +77,74 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
             // Arrange
             var target = new VsFrameworkCompatibility();
             var targetFramework = new FrameworkName(".NETFramework,Version=v4.5.1");
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v3.5"),
+                new FrameworkName(".NETFramework,Version=v4.0"),
+                new FrameworkName(".NETFramework,Version=v4.5"),
+                new FrameworkName(".NETFramework,Version=v4.5.2"),
+            };
+
+            // Act
+            var actual = target.GetNearest(targetFramework, frameworks);
+
+            // Assert
+            Assert.Equal(".NETFramework,Version=v4.5", actual.ToString());
+        }
+
+        [Fact]
+        public void VsFrameworkCompatibility_GetNearestWithCompatibleFallback()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility();
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            var fallbackTargetFrameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.2")
+            };
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.1"),
+                new FrameworkName(".NETFramework,Version=v4.6.1"),
+            };
+
+            // Act
+            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
+
+            // Assert
+            Assert.Equal(".NETFramework,Version=v4.5.1", actual.ToString());
+        }
+
+        [Fact]
+        public void VsFrameworkCompatibility_GetNearestWithIncompatibleFallback()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility();
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5");
+            var fallbackTargetFrameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.5.2")
+            };
+            var frameworks = new[]
+            {
+                new FrameworkName(".NETFramework,Version=v4.6"),
+                new FrameworkName(".NETFramework,Version=v4.6.1"),
+            };
+
+            // Act
+            var actual = target.GetNearest(targetFramework, fallbackTargetFrameworks, frameworks);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void VsFrameworkCompatibility_GetNearestWithWithEmptyFallbackList()
+        {
+            // Arrange
+            var target = new VsFrameworkCompatibility();
+            var targetFramework = new FrameworkName(".NETFramework,Version=v4.5.1");
+            var fallbackTargetFrameworks = new FrameworkName[0];
             var frameworks = new[]
             {
                 new FrameworkName(".NETFramework,Version=v3.5"),


### PR DESCRIPTION
Addresses https://github.com/NuGet/Home/issues/2633.
1. Adds `IVsFrameworkCompatibility2.GetNearest` that accepts fallback frameworks.
2. Clean up some XML doc warnings.

@abpiskunov 
@emgarten @yishaigalatzer @zhili1208 @rrelyea @alpaix @rohit21agrawal
