### PR TITLE
Removed unnecessary net45 System library references

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -31,9 +31,6 @@
   },
   "frameworks": {
     "net46": {
-      "frameworkAssemblies": {
-        "System.Collections": ""
-      },
       "compilationOptions": {
         "define": [
           "IS_DESKTOP"

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -20,7 +20,6 @@
         "Microsoft.CSharp": "",
         "System": "",
         "System.Core": "",
-        "System.Runtime": "",
         "System.IO.Compression": ""
       },
       "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -30,7 +30,6 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.Globalization": "",
         "System.Security": "",
         "System.Xml": "",
         "System.Xml.Linq": ""

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -34,7 +34,6 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.Runtime": "",
         "System.Xml": "",
         "System.Xml.Linq": "",
         "System.IO.Compression": ""

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -37,7 +37,6 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.Collections.Concurrent": "",
         "System.Runtime.Serialization": "",
         "WindowsBase": ""
       },

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -36,7 +36,6 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.Collections.Concurrent": "",
         "System.IdentityModel": "",
         "System.Net.Http": "",
         "System.Net.Http.WebRequest": "",

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -26,9 +26,6 @@
   },
   "frameworks": {
     "net45": {
-      "frameworkAssemblies": {
-        "System.Collections": ""
-      },
       "compilationOptions": {
         "define": [
           "IS_DESKTOP"

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -29,8 +29,6 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.Threading.Tasks": "",
-        "System.Runtime": "",
         "System.Runtime.Serialization": ""
       },
       "compilationOptions": {


### PR DESCRIPTION
Removed unnecessary net45 system library references from project.json file to let it work with csproj and avoid design-facade issue. Installing Nuget.Common with csproj failing because of this which is blocking Entity Framework team for RC2.

Fix - https://github.com/NuGet/Home/issues/2635 

@rrelyea @emgarten @alpaix 
