### PR TITLE
Build of project.json files in pack

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -792,13 +792,6 @@ namespace NuGet.CommandLine
             {
                 AddProjectReferenceDependencies(dependencies);
             }
-
-            // TO FIX: when we persist the target framework into packages.config file,
-            // we need to pull that info into building the PackageDependencySet object
-            builder.DependencyGroups.Clear();
-
-            // REVIEW: IS NuGetFramework.AnyFramework correct?
-            builder.DependencyGroups.Add(new PackageDependencyGroup(NuGetFramework.AnyFramework, dependencies.Values));
         }
 
         private void AddDependencies(Dictionary<String, Tuple<IPackage, NuGet.PackageDependency>> packagesAndDependencies)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -31,6 +31,7 @@ namespace NuGet.CommandLine
 
         private Logging.ILogger _logger;
         private Configuration.ISettings _settings;
+        private bool _usingJsonFile = false;
 
         // Files we want to always exclude from the resulting package
         private static readonly HashSet<string> _excludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
@@ -241,6 +242,10 @@ namespace NuGet.CommandLine
             {
                 // If the package contains a nuspec file then use it for metadata
                 manifest = ProcessNuspec(builder, basePath);
+            }
+            else
+            {
+                _usingJsonFile = true;
             }
 
             // Remove the extra author
@@ -791,6 +796,16 @@ namespace NuGet.CommandLine
             if (IncludeReferencedProjects)
             {
                 AddProjectReferenceDependencies(dependencies);
+            }
+
+            if (!_usingJsonFile)
+            {
+                // TO FIX: when we persist the target framework into packages.config file,
+                // we need to pull that info into building the PackageDependencySet object
+                builder.DependencyGroups.Clear();
+
+                // REVIEW: IS NuGetFramework.AnyFramework correct?
+                builder.DependencyGroups.Add(new PackageDependencyGroup(NuGetFramework.AnyFramework, dependencies.Values));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -31,7 +31,7 @@ namespace NuGet.CommandLine
 
         private Logging.ILogger _logger;
         private Configuration.ISettings _settings;
-        private bool _usingJsonFile = false;
+        private bool _usingJsonFile;
 
         // Files we want to always exclude from the resulting package
         private static readonly HashSet<string> _excludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -104,6 +104,7 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.Exclude = exclude.Values;
                     packArgs.ExcludeEmptyDirectories = excludeEmpty.HasValue();
                     packArgs.LogLevel = XPlatUtility.GetLogLevel(verbosity);
+
                     if (minClientVersion.HasValue())
                     {
                         Version version;
@@ -119,17 +120,19 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.NoDefaultExcludes = noDefaultExcludes.HasValue();
                     packArgs.NoPackageAnalysis = noPackageAnalysis.HasValue();
                     packArgs.OutputDirectory = outputDirectory.Value();
+
                     if (properties.HasValue())
                     {
                         foreach (var property in properties.Value().Split(';'))
                         {
                             int index = property.IndexOf('=');
-                            if (index > 0 && index < property.Length)
+                            if (index > 0 && index < property.Length - 1)
                             {
                                 packArgs.Properties.Add(property.Substring(0, index), property.Substring(index + 1));
                             }
                         }
                     }
+
                     packArgs.Suffix = suffix.Value();
                     packArgs.Symbols = symbols.HasValue();
                     if (versionOption.HasValue())

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -126,7 +126,7 @@ namespace NuGet.CommandLine.XPlat
                             int index = property.IndexOf('=');
                             if (index > 0 && index < property.Length)
                             {
-                                packArgs.Properties.Add(property.Substring(0, index - 1), property.Substring(index));
+                                packArgs.Properties.Add(property.Substring(0, index), property.Substring(index + 1));
                             }
                         }
                     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -21,6 +21,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.BasePath_Description,
                     CommandOptionType.SingleValue);
 
+                var build = pack.Option(
+                    "--build",
+                    Strings.Build_Description,
+                    CommandOptionType.NoValue);
+
                 var exclude = pack.Option(
                     "--exclude",
                     Strings.Exclude_Description,
@@ -48,6 +53,11 @@ namespace NuGet.CommandLine.XPlat
 
                 var outputDirectory = pack.Option(
                     "-o|--output-directory <outputDirectory>",
+                    Strings.OutputDirectory_Description,
+                    CommandOptionType.SingleValue);
+
+                var properties = pack.Option(
+                    "-p|--properties <properties>",
                     Strings.OutputDirectory_Description,
                     CommandOptionType.SingleValue);
 
@@ -90,6 +100,7 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.BasePath = !basePath.HasValue() ? Path.GetDirectoryName(Path.GetFullPath(packArgs.Path)) : basePath.Value();
                     packArgs.BasePath = packArgs.BasePath.TrimEnd(Path.DirectorySeparatorChar);
 
+                    packArgs.Build = build.HasValue();
                     packArgs.Exclude = exclude.Values;
                     packArgs.ExcludeEmptyDirectories = excludeEmpty.HasValue();
                     packArgs.LogLevel = XPlatUtility.GetLogLevel(verbosity);
@@ -108,6 +119,17 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.NoDefaultExcludes = noDefaultExcludes.HasValue();
                     packArgs.NoPackageAnalysis = noPackageAnalysis.HasValue();
                     packArgs.OutputDirectory = outputDirectory.Value();
+                    if (properties.HasValue())
+                    {
+                        foreach (var property in properties.Value().Split(';'))
+                        {
+                            int index = property.IndexOf('=');
+                            if (index > 0 && index < property.Length)
+                            {
+                                packArgs.Properties.Add(property.Substring(0, index - 1), property.Substring(index));
+                            }
+                        }
+                    }
                     packArgs.Suffix = suffix.Value();
                     packArgs.Symbols = symbols.HasValue();
                     if (versionOption.HasValue())

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -154,7 +154,7 @@ namespace NuGet.Commands
 
             if (_dotnetLocation == null)
             {
-                GetDotNetLocation();
+                _dotnetLocation = NuGetEnvironment.GetDotNetLocation();
             }
 
             var processStartInfo = new ProcessStartInfo
@@ -180,62 +180,6 @@ namespace NuGet.Commands
                 // If the build fails, report the error
                 throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_BuildFailed, processStartInfo.FileName, processStartInfo.Arguments));
             }
-        }
-
-        private void GetDotNetLocation()
-        {
-            string path = Environment.GetEnvironmentVariable("PATH");
-            foreach (var dir in path.Split(':', ';'))
-            {
-                string fullPathExe = Path.Combine(dir, "dotnet.exe");
-                if (File.Exists(fullPathExe))
-                {
-                    _dotnetLocation = fullPathExe;
-                    return;
-                }
-
-                string fullPath = Path.Combine(dir, "dotnet");
-                if (File.Exists(fullPath))
-                {
-                    _dotnetLocation = fullPath;
-                    return;
-                }
-            }
-
-            string programFiles = Environment.GetEnvironmentVariable("ProgramW6432");
-            if (!string.IsNullOrEmpty(programFiles))
-            {
-                string fullPath = Path.Combine(programFiles, "dotnet", "dotnet.exe");
-                if (File.Exists(fullPath))
-                {
-                    _dotnetLocation = fullPath;
-                    return;
-                }
-            }
-
-            programFiles = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
-            if (!string.IsNullOrEmpty(programFiles))
-            {
-                string fullPath = Path.Combine(programFiles, "dotnet", "dotnet.exe");
-                if (File.Exists(fullPath))
-                {
-                    _dotnetLocation = fullPath;
-                    return;
-                }
-            }
-
-            string localBin = "/usr/local/bin";
-            if (!string.IsNullOrEmpty(localBin))
-            {
-                string fullPath = Path.Combine(localBin, "dotnet");
-                if (File.Exists(fullPath))
-                {
-                    _dotnetLocation = fullPath;
-                    return;
-                }
-            }
-
-            _dotnetLocation = "dotnet";
         }
 
         private void AddOutputFiles(PackageBuilder builder)

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -60,7 +60,6 @@ namespace NuGet.Commands
         private static readonly IReadOnlyList<string> defaultIncludeFlags = LibraryIncludeFlagUtils.NoContent.ToString().Split(new char[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
         private readonly HashSet<string> _excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        private static string _dotnetLocation = null;
 
         public IEnumerable<IPackageRule> Rules { get; set; }
 
@@ -152,15 +151,12 @@ namespace NuGet.Commands
                 properties += $" -b \"{outputDirectory}\"";
             }
 
-            if (_dotnetLocation == null)
-            {
-                _dotnetLocation = NuGetEnvironment.GetDotNetLocation();
-            }
+            string dotnetLocation = NuGetEnvironment.GetDotNetLocation();
 
             var processStartInfo = new ProcessStartInfo
             {
                 UseShellExecute = false,
-                FileName = _dotnetLocation,
+                FileName = dotnetLocation,
                 Arguments = $"build {properties}",
                 WorkingDirectory = _packArgs.BasePath,
                 RedirectStandardOutput = false,

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -146,8 +146,11 @@ namespace NuGet.Commands
                 }
             }
 
-            string outputDirectory = _packArgs.OutputDirectory ?? Path.Combine(_packArgs.CurrentDirectory, "bin");
-            properties += $" -b \"{outputDirectory}\"";
+            if (!string.IsNullOrEmpty(_packArgs.OutputDirectory))
+            {
+                string outputDirectory = _packArgs.OutputDirectory;
+                properties += $" -b \"{outputDirectory}\"";
+            }
 
             if (_dotnetLocation == null)
             {

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -23,7 +24,7 @@ namespace NuGet.Commands
         private PackArgs _packArgs;
         internal static readonly string SymbolsExtension = ".symbols" + NuGetConstants.PackageExtension;
         private CreateProjectFactory _createProjectFactory;
-
+        private const string Configuration = "configuration";
 
         private static readonly HashSet<string> _allowedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             NuGetConstants.ManifestExtension,
@@ -96,6 +97,14 @@ namespace NuGet.Commands
         {
             PackageBuilder packageBuilder = CreatePackageBuilderFromProjectJson(path, _packArgs.GetPropertyValue);
 
+            if (_packArgs.Build)
+            {
+                BuildProjectWithDotNet();
+            }
+
+            // Add output files
+            AddOutputFiles(packageBuilder);
+
             if (_packArgs.Symbols)
             {
                 // remove source related files when building the lib package
@@ -122,6 +131,121 @@ namespace NuGet.Commands
             return package;
         }
 
+        private void BuildProjectWithDotNet()
+        {
+            string properties = string.Empty;
+            if (_packArgs.Properties.Any())
+            {
+                foreach (var property in _packArgs.Properties)
+                {
+                    if (property.Key.Equals(Configuration, StringComparison.OrdinalIgnoreCase))
+                    {
+                        properties = $"-c {property.Value}";
+                    }
+                }
+            }
+
+            string outputDirectory = _packArgs.OutputDirectory ?? Path.Combine(_packArgs.CurrentDirectory, "bin");
+            properties += $" -b {outputDirectory}";
+
+            var processStartInfo = new ProcessStartInfo
+            {
+                UseShellExecute = false,
+                FileName = "dotnet.exe",
+                Arguments = $"build {properties}",
+                WorkingDirectory = _packArgs.BasePath,
+                RedirectStandardOutput = false,
+                RedirectStandardError = false
+            };
+
+            int result;
+            using (var process = Process.Start(processStartInfo))
+            {
+                process.WaitForExit();
+
+                result = process.ExitCode;
+            }
+
+            if (0 != result)
+            {
+                // If the build fails, report the error
+                throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_BuildFailed, processStartInfo.FileName, processStartInfo.Arguments));
+            }
+        }
+
+        private void AddOutputFiles(PackageBuilder builder)
+        {
+            // Get the target file path
+            string outputDirectory;
+            if (_packArgs.OutputDirectory != null)
+            {
+                outputDirectory = Path.Combine(_packArgs.OutputDirectory, builder.Id, "bin");
+            }
+            else
+            {
+                outputDirectory = _packArgs.OutputDirectory ?? Path.Combine(_packArgs.CurrentDirectory, "bin");
+            }
+
+            // Default to Debug unless the configuration was passed in as a property
+            string configuration = "Debug";
+            foreach (var property in _packArgs.Properties)
+            {
+                if (String.Equals(Configuration, property.Key, StringComparison.OrdinalIgnoreCase))
+                {
+                    configuration = property.Value;
+                }
+            }
+
+            string targetPath = Path.Combine(outputDirectory, configuration, builder.Id + ".dll");
+            NuGetFramework targetFramework = NuGetFramework.AnyFramework;
+
+            // List of extensions to allow in the output path
+            var allowedOutputExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+                ".dll",
+                ".exe",
+                ".xml",
+                ".winmd",
+                ".runtimeconfig.json",
+
+            };
+
+            if (_packArgs.Symbols)
+            {
+                // Include pdbs for symbol packages
+                allowedOutputExtensions.Add(".pdb");
+            }
+
+            string projectOutputDirectory = Path.GetDirectoryName(targetPath);
+
+            string targetFileName = Path.GetFileNameWithoutExtension(targetPath);
+
+            // By default we add all files in the project's output directory
+            foreach (var file in GetFiles(projectOutputDirectory, targetFileName, allowedOutputExtensions))
+            {
+                string targetFolder = Path.GetDirectoryName(file).Replace(projectOutputDirectory + Path.DirectorySeparatorChar, "");
+
+                var packageFile = new PhysicalPackageFile
+                {
+                    SourcePath = file,
+                    TargetPath = Path.Combine("lib", targetFolder, Path.GetFileName(file))
+                };
+                AddFileToBuilder(builder, packageFile);
+            }
+        }
+
+        private void AddFileToBuilder(PackageBuilder builder, PhysicalPackageFile packageFile)
+        {
+            if (!builder.Files.Any(p => packageFile.Path.Equals(p.Path, StringComparison.OrdinalIgnoreCase)))
+            {
+                builder.Files.Add(packageFile);
+            }
+        }
+
+        private static IEnumerable<string> GetFiles(string path, string fileNameWithoutExtension, HashSet<string> allowedExtensions)
+        {
+            return allowedExtensions.Select(extension => Directory.GetFiles(path, fileNameWithoutExtension + extension, SearchOption.AllDirectories)).SelectMany(a => a);
+        }
+
         private PackageBuilder CreatePackageBuilderFromProjectJson(string path, Func<string, string> propertyProvider)
         {
             // Set the version property if the flag is set
@@ -135,11 +259,6 @@ namespace NuGet.Commands
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             {
                 LoadProjectJsonFile(builder, path, _packArgs.BasePath, Path.GetFileName(Path.GetDirectoryName(path)), stream, propertyProvider);
-            }
-
-            if (!builder.Files.Any())
-            {
-                builder.AddFiles(_packArgs.BasePath, @"**/*", null);
             }
 
             return builder;
@@ -254,7 +373,7 @@ namespace NuGet.Commands
         private static void AddDependencyGroups(IList<LibraryDependency> dependencies, NuGetFramework framework, PackageBuilder builder)
         {
             List<PackageDependency> packageDependencies = new List<PackageDependency>();
-            bool addedFrameworkReference = false;
+
             foreach (var dependency in dependencies)
             {
                 LibraryIncludeFlags effectiveInclude = dependency.IncludeType & ~dependency.SuppressParent;
@@ -282,7 +401,6 @@ namespace NuGet.Commands
                             builder.FrameworkReferences.Insert(index, newReference);
                         }
                     }
-                    addedFrameworkReference = true;
                 }
                 else
                 {
@@ -308,10 +426,7 @@ namespace NuGet.Commands
                 }
             }
 
-            if (addedFrameworkReference || packageDependencies.Any())
-            {
-                builder.DependencyGroups.Add(new PackageDependencyGroup(framework, packageDependencies));
-            }
+            builder.DependencyGroups.Add(new PackageDependencyGroup(framework, packageDependencies));
         }
 
         private PackageArchiveReader BuildFromNuspec(string path)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -78,6 +78,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Failed to build using &apos;{0} {1}&apos;..
+        /// </summary>
+        public static string Error_BuildFailed {
+            get {
+                return ResourceManager.GetString("Error_BuildFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Cannot find version of msbuild..
         /// </summary>
         public static string Error_CannotFindMsbuild {

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -177,7 +177,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Please specify a nuspec, project.json, project file to use.
+        ///    Looks up a localized string similar to Please specify a nuspec, project.json, or project file to use.
         /// </summary>
         public static string InputFileNotSpecified {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -392,7 +392,7 @@
     <value>One or more projects are incompatible with {0}.</value>
   </data>
   <data name="InputFileNotSpecified" xml:space="preserve">
-    <value>Please specify a nuspec, project.json, project file to use</value>
+    <value>Please specify a nuspec, project.json, or project file to use</value>
   </data>
   <data name="Error_BuildFailed" xml:space="preserve">
     <value>Failed to build using '{0} {1}'.</value>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -394,4 +394,7 @@
   <data name="InputFileNotSpecified" xml:space="preserve">
     <value>Please specify a nuspec, project.json, project file to use</value>
   </data>
+  <data name="Error_BuildFailed" xml:space="preserve">
+    <value>Failed to build using '{0} {1}'.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -199,48 +199,51 @@ namespace NuGet.Common
         public static string GetDotNetLocation()
         {
             string path = Environment.GetEnvironmentVariable("PATH");
-            foreach (var dir in path.Split(':', ';'))
-            {
-                string fullPathExe = Path.Combine(dir, DotNetExe);
-                if (File.Exists(fullPathExe))
-                {
-                    return fullPathExe;
-                }
+            bool isWindows = (Path.DirectorySeparatorChar == '\\');
+            char splitChar = isWindows ? ';' : ':';
+            string executable = isWindows ? DotNetExe : DotNet;
 
-                string fullPath = Path.Combine(dir, DotNet);
+            foreach (var dir in path.Split(splitChar))
+            {
+                string fullPath = Path.Combine(dir, executable);
                 if (File.Exists(fullPath))
                 {
                     return fullPath;
                 }
             }
 
-            string programFiles = GetFolderPath(SpecialFolder.ProgramFiles);
-            if (!string.IsNullOrEmpty(programFiles))
+            if (isWindows)
             {
-                string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
-                if (File.Exists(fullPath))
+                string programFiles = GetFolderPath(SpecialFolder.ProgramFiles);
+                if (!string.IsNullOrEmpty(programFiles))
                 {
-                    return fullPath;
+                    string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
+                    if (File.Exists(fullPath))
+                    {
+                        return fullPath;
+                    }
+                }
+
+                programFiles = GetFolderPath(SpecialFolder.ProgramFilesX86);
+                if (!string.IsNullOrEmpty(programFiles))
+                {
+                    string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
+                    if (File.Exists(fullPath))
+                    {
+                        return fullPath;
+                    }
                 }
             }
-
-            programFiles = GetFolderPath(SpecialFolder.ProgramFilesX86);
-            if (!string.IsNullOrEmpty(programFiles))
+            else
             {
-                string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
-                if (File.Exists(fullPath))
+                string localBin = "/usr/local/bin";
+                if (!string.IsNullOrEmpty(localBin))
                 {
-                    return fullPath;
-                }
-            }
-
-            string localBin = "/usr/local/bin";
-            if (!string.IsNullOrEmpty(localBin))
-            {
-                string fullPath = Path.Combine(localBin, DotNet);
-                if (File.Exists(fullPath))
-                {
-                    return fullPath;
+                    string fullPath = Path.Combine(localBin, DotNet);
+                    if (File.Exists(fullPath))
+                    {
+                        return fullPath;
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -8,6 +8,9 @@ namespace NuGet.Common
 {
     public static class NuGetEnvironment
     {
+        private const string DotNet = "dotnet";
+        private const string DotNetExe = "dotnet.exe";
+
         public static string GetFolderPath(NuGetFolderPath folder)
         {
             switch (folder)
@@ -191,6 +194,57 @@ namespace NuGet.Common
             {
                 return Environment.GetEnvironmentVariable("HOME");
             }
+        }
+
+        public static string GetDotNetLocation()
+        {
+            string path = Environment.GetEnvironmentVariable("PATH");
+            foreach (var dir in path.Split(':', ';'))
+            {
+                string fullPathExe = Path.Combine(dir, DotNetExe);
+                if (File.Exists(fullPathExe))
+                {
+                    return fullPathExe;
+                }
+
+                string fullPath = Path.Combine(dir, DotNet);
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+
+            string programFiles = GetFolderPath(SpecialFolder.ProgramFiles);
+            if (!string.IsNullOrEmpty(programFiles))
+            {
+                string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+
+            programFiles = GetFolderPath(SpecialFolder.ProgramFilesX86);
+            if (!string.IsNullOrEmpty(programFiles))
+            {
+                string fullPath = Path.Combine(programFiles, DotNet, DotNetExe);
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+
+            string localBin = "/usr/local/bin";
+            if (!string.IsNullOrEmpty(localBin))
+            {
+                string fullPath = Path.Combine(localBin, DotNet);
+                if (File.Exists(fullPath))
+                {
+                    return fullPath;
+                }
+            }
+
+            return DotNet;
         }
 
 

--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -199,7 +199,7 @@ namespace NuGet.Common
         public static string GetDotNetLocation()
         {
             string path = Environment.GetEnvironmentVariable("PATH");
-            bool isWindows = (Path.DirectorySeparatorChar == '\\');
+            bool isWindows = RuntimeEnvironmentHelper.IsWindows;
             char splitChar = isWindows ? ';' : ':';
             string executable = isWindows ? DotNetExe : DotNet;
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -97,6 +97,9 @@ namespace NuGet.CommandLine.Test
                     "image.jpg",
                     "");
 
+                Directory.CreateDirectory(
+                    Path.Combine(workingDirectory, "bin/Debug"));
+
                 Util.CreateFile(
                     workingDirectory,
                     Path.GetFileName(workingDirectory) + ".project.json",
@@ -248,25 +251,16 @@ namespace NuGet.CommandLine.Test
             using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
+                string id = Path.GetFileName(workingDirectory);
 
                 Util.CreateFile(
-                    Path.Combine(workingDirectory, "ref/uap10.0"),
-                    "a.dll",
+                    Path.Combine(workingDirectory, "bin/Debug/uap10.0"),
+                    id + ".dll",
                     string.Empty);
 
                 Util.CreateFile(
-                    Path.Combine(workingDirectory, "native"),
-                    "a.dll",
-                    string.Empty);
-
-                Util.CreateFile(
-                    Path.Combine(workingDirectory, "runtimes/win-x86/lib/uap10.0"),
-                    "a.dll",
-                    string.Empty);
-
-                Util.CreateFile(
-                    Path.Combine(workingDirectory, "lib/uap10.0"),
-                    "a.dll",
+                    Path.Combine(workingDirectory, "bin/Debug/native"),
+                    id + ".dll",
                     string.Empty);
 
                 Util.CreateFile(
@@ -279,7 +273,13 @@ namespace NuGet.CommandLine.Test
   ""owners"": [ ""test"" ],
   ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
-  ""copyright"": ""Copyright ©  2013""
+  ""copyright"": ""Copyright ©  2013"",
+  ""frameworks"": {
+    ""native"": {
+    },
+    ""uap10.0"": {
+    }
+  }
 }");
 
                 // Act
@@ -300,10 +300,8 @@ namespace NuGet.CommandLine.Test
                     files,
                     new string[]
                     {
-                            @"lib\uap10.0\a.dll",
-                            @"native\a.dll",
-                            @"ref\uap10.0\a.dll",
-                            @"runtimes\win-x86\lib\uap10.0\a.dll",
+                            @"lib\native\" + id + ".dll",
+                            @"lib\uap10.0\" + id + ".dll",
                     });
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
@@ -372,10 +370,12 @@ namespace NuGet.CommandLine.Test
             using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
+                string id = Path.GetFileName(workingDirectory);
+
                 Util.CreateFile(
-                    Path.Combine(workingDirectory, "analyzers/cs/code"),
-                    "a.dll",
-                    "");
+                    Path.Combine(workingDirectory, "bin/Debug/native"),
+                    id + ".dll",
+                    string.Empty);
 
                 Util.CreateFile(
                     workingDirectory,
@@ -408,7 +408,7 @@ namespace NuGet.CommandLine.Test
                     files,
                     new string[]
                     {
-                            @"analyzers\cs\code\a.dll",
+                        @"lib\native\" + id + ".dll",
                     });
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
@@ -2396,6 +2396,9 @@ namespace " + projectName + @"
                     "image.jpg",
                     "");
 
+                Directory.CreateDirectory(
+                    Path.Combine(workingDirectory, "bin/Debug"));
+
                 Util.CreateFile(
                     workingDirectory,
                     Path.GetFileName(workingDirectory) + ".project.json",
@@ -2414,6 +2417,9 @@ namespace " + projectName + @"
         ""System.Xml.Linq"": """"
       }
     }
+  },
+  ""packInclude"": {
+    ""image"": ""contentFiles/any/any/image.jpg""
   }
 }
 ");
@@ -2441,7 +2447,7 @@ namespace " + projectName + @"
                     var actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                        @"<dependencies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <group targetFramework="".NETFramework4.6"" />
 </dependencies>".Replace("\r\n", "\n"), actual);
 
@@ -2449,7 +2455,7 @@ namespace " + projectName + @"
                     actual = node.ToString().Replace("\r\n", "\n");
 
                     Assert.Equal(
-                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
+                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <frameworkAssembly assemblyName=""System.Xml"" targetFramework="".NETFramework4.6"" />
   <frameworkAssembly assemblyName=""System.Xml.Linq"" targetFramework="".NETFramework4.6"" />
 </frameworkAssemblies>".Replace("\r\n", "\n"), actual);


### PR DESCRIPTION
Adding support for building with project.json files by calling dotnet build when the build option is passed.  It also adds the correct dlls into the lib directory of the nupkg.

This PR builds off of another branch of mine that has been approved but hasn't been checked in yet because Dev is locked down.

@emgarten @spadapet 
