### PR TITLE
Issue2486: Hiding classic dependency options for project.json and xproj scenarios

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -42,7 +42,7 @@ namespace NuGet.PackageManagement.UI
             _options = new Options();
 
             // Show dependency behavior and file conflict options if any of the projects are non-build integrated
-            _options.ShowClassicOptions = nugetProjects.Any(project => !(project is BuildIntegratedNuGetProject));
+            _options.ShowClassicOptions = nugetProjects.Any(project => !(project is INuGetIntegratedProject));
         }
 
         /// <summary>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/OptionsControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/OptionsControl.xaml
@@ -43,7 +43,7 @@
         Content="{x:Static nuget:Resources.Checkbox_ShowPreviewWindow}" />
 
       <!-- install options -->
-      <Grid
+      <Grid Visibility="{Binding Options.ShowClassicOptions, Converter={StaticResource BooleanToVisibilityConverter}}"
           Grid.Row="2"
           Margin="16,16,0,0">
         <Grid.RowDefinitions>
@@ -108,7 +108,7 @@
       </Grid>
 
       <!-- uninstall options -->
-      <Grid
+      <Grid Visibility="{Binding Options.ShowClassicOptions, Converter={StaticResource BooleanToVisibilityConverter}}"
           Grid.Row="3"
           Margin="16,16,0,0">
         <Grid.RowDefinitions>


### PR DESCRIPTION
Fix for https://github.com/NuGet/Home/issues/2486

This is a pretty simple fix. It binds the visibility of the Grids which display Install & Uninstall options to an existing DataContext variable called ShowClassicOptions.

It also fixes a bug in the way ShowClassicOptions was initialized. Instead of checking for any BuildIntegratedNugetProject, the right thing to do is to check for INugetIntegratedProject, since that is the interface shared by both BuildIntegratedNugetProject & ProjectKNugetProject.

@joelverhagen @alpaix @zhili1208 @jainaashish @emgarten  @rrelyea 
