### PR TITLE
Adding UAP and netcore50 to IsPackagesBased

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -959,13 +959,17 @@ namespace NuGet.Frameworks
 
         public int CompareFrameworks(NuGetFramework x, NuGetFramework y)
         {
-            if (x.IsPackageBased != y.IsPackageBased)
+            // For the purposes of this compare do not treat netcore50 as packages based
+            var xPackagesBased = x.IsPackageBased && !NuGetFrameworkUtility.IsNetCore50AndUp(x);
+            var yPackagesBased = y.IsPackageBased && !NuGetFrameworkUtility.IsNetCore50AndUp(y);
+
+            if (xPackagesBased != yPackagesBased)
             {
                 // non-package based always come before package based
-                return x.IsPackageBased.CompareTo(y.IsPackageBased);
+                return xPackagesBased.CompareTo(yPackagesBased);
             }
 
-            var precedence = x.IsPackageBased ? _packageBasedFrameworkPrecedence : _nonPackageBasedFrameworkPrecedence;
+            var precedence = xPackagesBased ? _packageBasedFrameworkPrecedence : _nonPackageBasedFrameworkPrecedence;
 
             return CompareUsingPrecedence(x, y, precedence);
         }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
@@ -125,8 +125,9 @@ namespace NuGet.Frameworks
                     }
                 }
 
-                // Packages based framework reduce
+                // Packages based framework reduce, only if the project is not packages based
                 if (reduced.Count() > 1
+                    && !framework.IsPackageBased
                     && reduced.Any(f => f.IsPackageBased)
                     && reduced.Any(f => !f.IsPackageBased))
                 {

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -263,22 +263,21 @@ namespace NuGet.Frameworks
 
         /// <summary>
         /// True if the framework is packages based.
-        /// Ex: dotnet, dnxcore
+        /// Ex: dotnet, dnxcore, netcoreapp, netstandard, uap, netcore50
         /// </summary>
         public bool IsPackageBased
         {
             get
             {
-                return FrameworkConstants.FrameworkIdentifiers.DnxCore
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || FrameworkConstants.FrameworkIdentifiers.NetPlatform
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || FrameworkConstants.FrameworkIdentifiers.NetStandard
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || FrameworkConstants.FrameworkIdentifiers.NetStandardApp
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase)
-                    || FrameworkConstants.FrameworkIdentifiers.NetCoreApp
-                    .Equals(Framework, StringComparison.OrdinalIgnoreCase);
+                // For these frameworks all versions are packages based.
+                if (_packagesBased.Contains(Framework))
+                {
+                    return true;
+                }
+
+                // NetCore 5.0 and up are packages based.
+                // Everything else is not packages based.
+                return NuGetFrameworkUtility.IsNetCore50AndUp(this);
             }
         }
 
@@ -383,5 +382,20 @@ namespace NuGet.Frameworks
 
             return normalized;
         }
+
+        /// <summary>
+        /// Frameworks that are packages based across all versions.
+        /// </summary>
+        private static readonly SortedSet<string> _packagesBased = new SortedSet<string>(
+            new[]
+            {
+                        FrameworkConstants.FrameworkIdentifiers.DnxCore,
+                        FrameworkConstants.FrameworkIdentifiers.NetPlatform,
+                        FrameworkConstants.FrameworkIdentifiers.NetStandard,
+                        FrameworkConstants.FrameworkIdentifiers.NetStandardApp,
+                        FrameworkConstants.FrameworkIdentifiers.NetCoreApp,
+                        FrameworkConstants.FrameworkIdentifiers.UAP,
+            },
+            StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
@@ -137,5 +137,17 @@ namespace NuGet.Frameworks
 
             return compatible;
         }
+
+        /// <summary>
+        /// True if the framework is netcore50 or higher. This is where the framework
+        /// becomes packages based.
+        /// </summary>
+        public static bool IsNetCore50AndUp(NuGetFramework framework)
+        {
+            return (framework.Version.Major >= 5
+                    && StringComparer.OrdinalIgnoreCase.Equals(
+                        framework.Framework,
+                        FrameworkConstants.FrameworkIdentifiers.NetCore));
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -113,6 +113,8 @@ namespace NuGet.Frameworks
         /// For group #2 and #4, the order is the original order in the incoming list. This should later be made
         /// consistent between different input orderings by using the <see cref="NuGetFrameworkSorter"/>.
         /// </summary>
+        /// <remarks>netcore50 is a special case since netcore451 is not packages based, but netcore50 is.
+        /// This sort will treat all versions of netcore as non-packages based.</remarks>
         int CompareFrameworks(NuGetFramework x, NuGetFramework y);
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
@@ -35,6 +35,23 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public void FrameworkNameProvider_OrderNetCore50BeforePackagesBasedFrameworks()
+        {
+            // Arrange
+            var provider = DefaultFrameworkNameProvider.Instance;
+
+            // Act
+            var a = provider.CompareFrameworks(FrameworkConstants.CommonFrameworks.NetCore50, FrameworkConstants.CommonFrameworks.WPA81);
+            var b = provider.CompareFrameworks(FrameworkConstants.CommonFrameworks.NetCore50, FrameworkConstants.CommonFrameworks.NetStandard12);
+            var c = provider.CompareFrameworks(FrameworkConstants.CommonFrameworks.NetCore50, FrameworkConstants.CommonFrameworks.Win81);
+
+            // Assert
+            Assert.True(a < 0);
+            Assert.True(b < 0);
+            Assert.True(c < 0);
+        }
+
+        [Fact]
         public void FrameworkNameProvider_DuplicateFrameworksInPrecedence()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -19,6 +19,7 @@ namespace NuGet.Test
         // 4. then lib/netstandard1.2, 
         // 5. then lib/dotnet5.3, 
         // 6. then portable-win81+*, etc
+        [InlineData("uap10.0", "netcore50,win81,wpa81,dotnet5.4,portable-win81+net45", "netcore50")]
         [InlineData("uap10.0", "uap10.0,win81,wpa81,dotnet5.4,portable-win81+net45", "uap10.0")]
         [InlineData("uap10.0", "win81,wpa81,dotnet5.4,portable-win81+net45", "win81")]
         [InlineData("uap10.0", "wpa81,dotnet5.4,portable-win81+net45", "wpa81")]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -97,6 +97,17 @@ namespace NuGet.Test
         [InlineData("dotnet5.1", true)]
         [InlineData("dotnet", true)]
         [InlineData("netcoreapp1.0", true)]
+        [InlineData("netcore50", true)]
+        [InlineData("netcore51", true)]
+        [InlineData("netcore61", true)]
+        [InlineData("netcore45", false)]
+        [InlineData("netcore4.9.9", false)]
+        [InlineData("win81", false)]
+        [InlineData("win10", false)] // this framework must use netcore
+        [InlineData("aspnetcore1.0", false)] // deprecated
+        [InlineData("aspnet451", false)]
+        [InlineData("uap10.0", true)]
+        [InlineData("uap11.0", true)]
         public void NuGetFramework_IsPackageBased(string framework, bool isPackageBased)
         {
             var fw = NuGetFramework.Parse(framework);


### PR DESCRIPTION
This change adds UAP and netcore50 to the list of packages based frameworks. This property is used heavily in finding the nearest framework, so to keep the behavior the same I've added two changes:
- netcore50 is special cased during the precedence compare, without this it has a very low priority since desktop frameworks are preferred
- Packages based frameworks will not remove other packages based frameworks during the reduce

I've also added a couple tests for the new behavior, but overall these behaviors are already well covered in the unit tests. The xunit functional tests verify that restore for UAP apps produces an identical lock file, so for at least the basic scenarios there it is guaranteed that this doesn't change package assets.

//cc @davidfowl @joelverhagen @zhili1208 @jainaashish @rohit21agrawal @rrelyea 
