### PR TITLE
nuspec version range should override -IncludeReferencedProjects version

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -675,7 +675,7 @@ namespace NuGet.CommandLine
                     projectFactory.ProcessNuspec(builder, null);
                 }
 
-                VersionRange versionRange = VersionRange.Parse(builder.Version.ToString());
+                VersionRange versionRange = null;
                 if (dependencies.ContainsKey(builder.Id))
                 {
                     VersionRange nuspecVersion = dependencies[builder.Id].VersionRange;
@@ -683,6 +683,11 @@ namespace NuGet.CommandLine
                     {
                         versionRange = nuspecVersion;
                     }
+                }
+
+                if (versionRange == null)
+                {
+                    versionRange = VersionRange.Parse(builder.Version.ToString());
                 }
 
                 return new PackageDependency(


### PR DESCRIPTION
Fixing it so that the version from the nuspec file will get used in referenced projects when the dependency is created instead of always using the current version of the dependency.

Fixes https://github.com/NuGet/Home/issues/1983

@emgarten @spadapet 
