### PR TITLE
Fixing pack for frameworkAssemblies without a targetFramework.

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -215,6 +215,8 @@ namespace NuGet.Packaging
                     let assemblyNameAttribute = element.Attribute("assemblyName")
                     where assemblyNameAttribute != null && !String.IsNullOrEmpty(assemblyNameAttribute.Value)
                     select new FrameworkAssemblyReference(assemblyNameAttribute.Value?.Trim(),
+                        string.IsNullOrEmpty(element.GetOptionalAttributeValue("targetFramework")) ?
+                        new[] { NuGetFramework.AnyFramework } :
                         new[] { NuGetFramework.Parse(element.GetOptionalAttributeValue("targetFramework")?.Trim()) })
                     ).ToList();
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -193,7 +193,7 @@ namespace NuGet.CommandLine.Test
       <frameworkAssembly assemblyName=""System.Core"" />
       <frameworkAssembly assemblyName=""System.Xml"" />
       <frameworkAssembly assemblyName=""System.Xml.Linq"" />
-      <frameworkAssembly assemblyName=""System.Net.Http"" />
+      <frameworkAssembly assemblyName=""System.Net.Http"" targetFramework="""" />
       <frameworkAssembly assemblyName=""System.Net.Http.Formatting"" targetFramework=""net45"" />
       <frameworkAssembly assemblyName=""System.ComponentModel.DataAnnotations"" targetFramework=""net35"" />
     </frameworkAssemblies>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -168,6 +168,74 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PackCommand_PackageFromNuspecWithFrameworkAssemblies()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                Util.CreateFile(
+                    workingDirectory,
+                    "packageA.nuspec",
+@"<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>packageA</id>
+    <version>1.0.0.2</version>
+    <title>packageA</title>
+    <authors>test</authors>
+    <owners>test</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <copyright>Copyright ©  2013</copyright>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName=""System"" />
+      <frameworkAssembly assemblyName=""System.Core"" />
+      <frameworkAssembly assemblyName=""System.Xml"" />
+      <frameworkAssembly assemblyName=""System.Xml.Linq"" />
+      <frameworkAssembly assemblyName=""System.Net.Http"" />
+      <frameworkAssembly assemblyName=""System.Net.Http.Formatting"" targetFramework=""net45"" />
+      <frameworkAssembly assemblyName=""System.ComponentModel.DataAnnotations"" targetFramework=""net35"" />
+    </frameworkAssemblies>
+  </metadata>
+</package>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack packageA.nuspec",
+                    waitForExit: true);
+                Assert.Equal(0, r.Item1);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, "packageA.1.0.0.2.nupkg");
+                var package = new OptimizedZipPackage(path);
+                using (var zip = new ZipArchive(File.OpenRead(path)))
+                {
+                    var manifestReader
+                        = new StreamReader(zip.Entries.Single(file => file.FullName == "packageA.nuspec").Open());
+                    var nuspecXml = XDocument.Parse(manifestReader.ReadToEnd());
+
+                    var node = nuspecXml.Descendants().Single(e => e.Name.LocalName == "frameworkAssemblies");
+
+                    var actual = node.ToString().Replace("\r\n", "\n");
+
+                    Assert.Equal(
+                        @"<frameworkAssemblies xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+  <frameworkAssembly assemblyName=""System"" targetFramework="""" />
+  <frameworkAssembly assemblyName=""System.Core"" targetFramework="""" />
+  <frameworkAssembly assemblyName=""System.Xml"" targetFramework="""" />
+  <frameworkAssembly assemblyName=""System.Xml.Linq"" targetFramework="""" />
+  <frameworkAssembly assemblyName=""System.Net.Http"" targetFramework="""" />
+  <frameworkAssembly assemblyName=""System.Net.Http.Formatting"" targetFramework="".NETFramework4.5"" />
+  <frameworkAssembly assemblyName=""System.ComponentModel.DataAnnotations"" targetFramework="".NETFramework3.5"" />
+</frameworkAssemblies>".Replace("\r\n", "\n"), actual);
+                }
+            }
+        }
+
+        [Fact]
         public void PackCommand_PackRuntimesRefNativeNoWarnings()
         {
             var nugetexe = Util.GetNuGetExePath();


### PR DESCRIPTION
The code was trying to NuGetFramework.Parse on the targetFramework value without checking to see if it was null or not.

Fixes https://github.com/NuGet/Home/issues/2648

@emgarten @joelverhagen @yishaigalatzer @rrelyea 
