### PR TITLE
Fixes source password's multiple re-encryption

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SourcesCommand.cs
@@ -155,7 +155,8 @@ namespace NuGet.CommandLine
                 throw new CommandLineException(LocalizedResourceManager.GetString("SourcesCommandUniqueSource"));
             }
 
-            var newPackageSource = new Configuration.PackageSource(Source, Name) { UserName = UserName, PasswordText = Password, IsPasswordClearText = StorePasswordInClearText };
+            var credentials = Configuration.PackageSourceCredential.FromUserInput(Source, UserName, Password, StorePasswordInClearText);
+            var newPackageSource = new Configuration.PackageSource(Source, Name) { Credentials = credentials };
             sourceList.Add(newPackageSource);
             SourceProvider.SavePackageSources(sourceList);
             Console.WriteLine(LocalizedResourceManager.GetString("SourcesCommandSourceAddedSuccessfully"), Name);
@@ -195,9 +196,13 @@ namespace NuGet.CommandLine
             ValidateCredentials();
 
             sourceList.RemoveAt(existingSourceIndex);
-            existingSource.UserName = UserName;
-            existingSource.PasswordText = Password;
-            existingSource.IsPasswordClearText = StorePasswordInClearText;
+
+            if (!string.IsNullOrEmpty(UserName))
+            {
+                var credentials = Configuration.PackageSourceCredential.FromUserInput(Name, UserName, Password,
+                    storePasswordInClearText: StorePasswordInClearText);
+                existingSource.Credentials = credentials;
+            }
 
             sourceList.Insert(existingSourceIndex, existingSource);
             SourceProvider.SavePackageSources(sourceList);

--- a/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/SettingsCredentialProvider.cs
@@ -47,8 +47,8 @@ namespace NuGet.CommandLine
             var source = _packageSourceProvider.LoadPackageSources().FirstOrDefault(p =>
             {
                 Uri sourceUri;
-                return !String.IsNullOrEmpty(p.UserName)
-                    && !String.IsNullOrEmpty(p.Password)
+                return p.Credentials != null
+                    && p.Credentials.IsValid()
                     && Uri.TryCreate(p.Source, UriKind.Absolute, out sourceUri)
                     && UriEquals(sourceUri, uri);
             });
@@ -58,7 +58,7 @@ namespace NuGet.CommandLine
                 configurationCredentials = null;
                 return false;
             }
-            configurationCredentials = new NetworkCredential(source.UserName, source.Password);
+            configurationCredentials = new NetworkCredential(source.Credentials.Username, source.Credentials.Password);
             return true;
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -31,34 +31,7 @@ namespace NuGet.Configuration
 
         public bool IsEnabled { get; set; }
 
-        public string UserName { get; set; }
-
-        public string Password
-        {
-            get
-            {
-                if (PasswordText != null && !IsPasswordClearText)
-                {
-                    try
-                    {
-                        return EncryptionUtility.DecryptString(PasswordText);
-                    }
-                    catch (NotSupportedException e)
-                    {
-                        throw new NuGetConfigurationException(
-                            string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedDecryptPassword, Source), e);
-                    }
-                }
-                else
-                {
-                    return PasswordText;
-                }
-            }
-        }
-
-        public string PasswordText { get; set; }
-
-        public bool IsPasswordClearText { get; set; }
+        public PackageSourceCredential Credentials { get; set; }
 
         public string Description { get; set; }
 
@@ -188,14 +161,12 @@ namespace NuGet.Configuration
         public PackageSource Clone()
         {
             return new PackageSource(Source, Name, IsEnabled, IsOfficial, IsPersistable)
-                {
-                    Description = Description,
-                    UserName = UserName,
-                    PasswordText = PasswordText,
-                    IsPasswordClearText = IsPasswordClearText,
-                    IsMachineWide = IsMachineWide,
-                    ProtocolVersion = ProtocolVersion
-                };
+            {
+                Description = Description,
+                Credentials = Credentials,
+                IsMachineWide = IsMachineWide,
+                ProtocolVersion = ProtocolVersion
+            };
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace NuGet.Configuration
+{
+    /// <summary>
+    /// Represents credentials required to authenticate user within package source web requests.
+    /// </summary>
+    public class PackageSourceCredential
+    {
+        /// <summary>
+        /// User name
+        /// </summary>
+        public string Username { get; }
+
+        /// <summary>
+        /// Password text as stored in config file. May be encrypted.
+        /// </summary>
+        public string PasswordText { get; }
+
+        /// <summary>
+        /// Indicates if password is stored in clear text.
+        /// </summary>
+        public bool IsPasswordClearText { get; }
+
+        /// <summary>
+        /// Retrieves password in clear text. Decrypts on-demand.
+        /// </summary>
+        public string Password
+        {
+            get
+            {
+                if (PasswordText != null && !IsPasswordClearText)
+                {
+                    try
+                    {
+                        return EncryptionUtility.DecryptString(PasswordText);
+                    }
+                    catch (NotSupportedException e)
+                    {
+                        throw new NuGetConfigurationException(
+                            string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedDecryptPassword, Source), e);
+                    }
+                }
+                else
+                {
+                    return PasswordText;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Associated source ID
+        /// </summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// Verifies if object contains valid data, e.g. not empty user name and password.
+        /// </summary>
+        /// <returns>True if credentials object is valid</returns>
+        public bool IsValid() => !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(PasswordText);
+
+        /// <summary>
+        /// Instantiates the credential instance out of raw values read from a config file.
+        /// </summary>
+        /// <param name="source">Associated source ID (needed for reporting errors)</param>
+        /// <param name="username">User name</param>
+        /// <param name="passwordText">Password as stored in config file</param>
+        /// <param name="isPasswordClearText">Hints if password provided in clear text</param>
+        public PackageSourceCredential(string source, string username, string passwordText, bool isPasswordClearText)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (username == null)
+            {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            Source = source;
+            Username = username;
+            PasswordText = passwordText;
+            IsPasswordClearText = isPasswordClearText;
+        }
+
+        /// <summary>
+        /// Creates new instance of credential object out values provided by user.
+        /// </summary>
+        /// <param name="source">Source ID needed for reporting errors if any</param>
+        /// <param name="username">User name</param>
+        /// <param name="password">Password text in clear</param>
+        /// <param name="shouldEncrypt">Hints if the password should be encrypted when stored on disk.</param>
+        /// <returns>New instance of <see cref="PackageSourceCredential"/></returns>
+        public static PackageSourceCredential FromUserInput(string source, string username, string password, bool storePasswordInClearText)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (username == null)
+            {
+                throw new ArgumentNullException(nameof(username));
+            }
+
+            if (password == null)
+            {
+                throw new ArgumentNullException(nameof(password));
+            }
+
+            try
+            {
+                var passwordText = storePasswordInClearText ? password: EncryptionUtility.EncryptString(password);
+                return new PackageSourceCredential(source, username, passwordText, isPasswordClearText: storePasswordInClearText);
+            }
+            catch (NotSupportedException e)
+            {
+                throw new NuGetConfigurationException(
+                    string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedEncryptPassword, source), e);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -423,10 +423,10 @@ namespace NuGet.Protocol
             var credentials = CredentialStore.Instance.GetCredentials(_baseUri);
 
             if (credentials == null
-                && !String.IsNullOrEmpty(_packageSource.UserName)
-                && !String.IsNullOrEmpty(_packageSource.Password))
+                && _packageSource.Credentials != null
+                && _packageSource.Credentials.IsValid())
             {
-                credentials = new NetworkCredential(_packageSource.UserName, _packageSource.Password);
+                credentials = new NetworkCredential(_packageSource.Credentials.Username, _packageSource.Credentials.Password);
             }
 
             if (credentials != null)

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.Configuration
+{
+    public class PackageSourceCredentialTests
+    {
+        [Fact]
+        public void Constructor_WithClearTextPassword_DoesNotEncryptPassword()
+        {
+            var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: true);
+
+            Assert.Equal("password", credentials.PasswordText);
+            Assert.Equal("password", credentials.Password);
+        }
+
+        [Fact]
+        public void Constructor_WithEncryptedPassword_DoesNotEncryptPassword()
+        {
+            var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+
+            // Password string should be stored as-is with no modification OR validation
+            Assert.Equal("password", credentials.PasswordText);
+        }
+
+        [Fact]
+        public void FromUserInput_WithStorePasswordInClearText_DoesNotEncryptsPassword()
+        {
+            var credentials = PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: true);
+
+            Assert.Equal("password", credentials.PasswordText);
+            Assert.Equal("password", credentials.Password);
+        }
+
+#if !DNXCORE50
+        [Fact]
+        public void FromUserInput_WithStorePasswordEncrypted_EncryptsPassword()
+        {
+            var credentials = PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: false);
+
+            Assert.NotEqual("password", credentials.PasswordText);
+            Assert.Equal("password", credentials.Password);
+        }
+#else
+        [Fact]
+        public void FromUserInput_WithStorePasswordEncrypted_Throws()
+        {
+            Assert.Throws<NuGetConfigurationException>(() => PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: false));
+        }
+
+        [Fact]
+        public void Password_WithEncryptedPassword_Throws()
+        {
+            var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+
+            Assert.Throws<NuGetConfigurationException>(() => credentials.Password);
+        }
+#endif
+
+        [Fact]
+        public void IsValid_WithNonEmptyValues_ReturnsTrue()
+        {
+            var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+
+            Assert.True(credentials.IsValid());
+        }
+
+        [Theory]
+        [InlineData("", "password")]
+        [InlineData("username", "")]
+        [InlineData("", "")]
+        public void IsValid_WithEmptyPassword_ReturnsFalse(string username, string password)
+        {
+            var credentials = new PackageSourceCredential("source", username, password, isPasswordClearText: false);
+
+            Assert.False(credentials.IsValid());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceProviderTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.PlatformAbstractions;
@@ -89,7 +88,7 @@ namespace NuGet.Configuration.Test
         }
 
         [Fact]
-        public async Task LoadPackageSourcesWithCredentials()
+        public async Task LoadPackageSources_LoadsCredentials()
         {
             // Arrange
             //Create nuget.config that has active package source defined
@@ -153,16 +152,14 @@ namespace NuGet.Configuration.Test
                     await stream.WriteAsync(bytes, 0, configContent.Length);
                 }
 
-                Settings settings = new Settings(nugetConfigFileFolder, "nuget.Config");
-                PackageSourceProvider psp = new PackageSourceProvider(settings);
+                var settings = new Settings(nugetConfigFileFolder, "nuget.Config");
+                var psp = new PackageSourceProvider(settings);
 
                 var sources = psp.LoadPackageSources().ToList();
 
                 Assert.Equal(6, sources.Count);
-                Assert.NotNull(sources[1].Password);
-                Assert.True(String.Equals(sources[1].Password, "removed", StringComparison.OrdinalIgnoreCase));
-                Assert.NotNull(sources[5].Password);
-                Assert.True(String.Equals(sources[5].Password, "removed", StringComparison.OrdinalIgnoreCase));
+                AssertCredentials(sources[1].Credentials, "CompanyFeedUnstable", "myusername", "removed");
+                AssertCredentials(sources[5].Credentials, "CompanyFeed", "myusername", "removed");
             }
         }
 
@@ -922,22 +919,26 @@ namespace NuGet.Configuration.Test
                     new SettingValue("Source4", "//Source4", false)
                 };
 
-            settings.Setup(s => s.GetSettingValues("packageSources", true))
+            settings
+                .Setup(s => s.GetSettingValues("packageSources", true))
                 .Returns(sourcesSettings);
 
-            settings.Setup(s => s.GetNestedValues("packageSourceCredentials", "Source3"))
+            settings
+                .Setup(s => s.GetNestedValues("packageSourceCredentials", "Source3"))
                 .Returns(new[]
                     {
                         new KeyValuePair<string, string>("Username", "source3-user"),
                         new KeyValuePair<string, string>("ClearTextPassword", "source3-password"),
                     });
-            settings.Setup(s => s.GetSettingValues("disabledPackageSources", false))
+            settings
+                .Setup(s => s.GetSettingValues("disabledPackageSources", false))
                 .Returns(new[]
                     {
                         new SettingValue("Source4", "true", isMachineWide: false)
                     });
 
-            var provider = CreatePackageSourceProvider(settings.Object,
+            var provider = CreatePackageSourceProvider(
+                settings.Object,
                 migratePackageSources: null);
 
             // Act
@@ -949,8 +950,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source1", source.Name);
                         Assert.Equal("https://some-source.org", source.Source);
-                        Assert.Null(source.UserName);
-                        Assert.Null(source.Password);
+                        Assert.Null(source.Credentials);
                         Assert.Equal(2, source.ProtocolVersion);
                         Assert.True(source.IsEnabled);
                     },
@@ -958,8 +958,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source2", source.Name);
                         Assert.Equal("https://source-with-newer-protocol", source.Source);
-                        Assert.Null(source.UserName);
-                        Assert.Null(source.Password);
+                        Assert.Null(source.Credentials);
                         Assert.Equal(3, source.ProtocolVersion);
                         Assert.True(source.IsEnabled);
                     },
@@ -967,8 +966,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source3", source.Name);
                         Assert.Equal("Source3", source.Source);
-                        Assert.Equal("source3-user", source.UserName);
-                        Assert.Equal("source3-password", source.Password);
+                        AssertCredentials(source.Credentials, "Source3", "source3-user", "source3-password");
                         Assert.Equal(3, source.ProtocolVersion);
                         Assert.True(source.IsEnabled);
                     },
@@ -976,8 +974,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source4", source.Name);
                         Assert.Equal("//Source4", source.Source);
-                        Assert.Null(source.UserName);
-                        Assert.Null(source.Password);
+                        Assert.Null(source.Credentials);
                         Assert.Equal(2, source.ProtocolVersion);
                         Assert.False(source.IsEnabled);
                     });
@@ -1050,8 +1047,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source1", source.Name);
                         Assert.Equal("https://some-source.org", source.Source);
-                        Assert.Null(source.UserName);
-                        Assert.Null(source.Password);
+                        Assert.Null(source.Credentials);
                         Assert.Equal(2, source.ProtocolVersion);
                         Assert.True(source.IsEnabled);
                     },
@@ -1059,8 +1055,7 @@ namespace NuGet.Configuration.Test
                     {
                         Assert.Equal("Source2", source.Name);
                         Assert.Equal("https://api.source-with-newer-protocol/v3/", source.Source);
-                        Assert.Null(source.UserName);
-                        Assert.Null(source.Password);
+                        Assert.Null(source.Credentials);
                         Assert.Equal(3, source.ProtocolVersion);
                         Assert.True(source.IsEnabled);
                     });
@@ -1186,19 +1181,18 @@ namespace NuGet.Configuration.Test
             // Assert
             Assert.Equal(3, values.Count);
             AssertPackageSource(values[1], "two", "twosource", true);
-            Assert.Null(values[1].UserName);
-            Assert.Null(values[1].Password);
+            Assert.Null(values[1].Credentials);
         }
 
-#if !DNXCORE50
         [Fact]
-        public void LoadPackageSourcesReadsCredentialPairsFromSettings()
+        public void LoadPackageSources_ReadsCredentialPairsFromSettings()
         {
             // Arrange
-            string encryptedPassword = EncryptionUtility.EncryptString("topsecret");
+            var encryptedPassword = Guid.NewGuid().ToString();
 
             var settings = new Mock<ISettings>();
-            settings.Setup(s => s.GetSettingValues("packageSources", true))
+            settings
+                .Setup(s => s.GetSettingValues("packageSources", true))
                 .Returns(new[]
                     {
                         new SettingValue("one", "onesource", false),
@@ -1206,8 +1200,13 @@ namespace NuGet.Configuration.Test
                         new SettingValue("three", "threesource", false)
                     });
 
-            settings.Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
-                .Returns(new[] { new KeyValuePair<string, string>("Username", "user1"), new KeyValuePair<string, string>("Password", encryptedPassword) });
+            settings
+                .Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
+                .Returns(new[]
+                    {
+                        new KeyValuePair<string, string>("Username", "user1"),
+                        new KeyValuePair<string, string>("Password", encryptedPassword)
+                    });
 
             var provider = CreatePackageSourceProvider(settings.Object);
 
@@ -1217,20 +1216,18 @@ namespace NuGet.Configuration.Test
             // Assert
             Assert.Equal(3, values.Count);
             AssertPackageSource(values[1], "two", "twosource", true);
-            Assert.Equal("user1", values[1].UserName);
-            Assert.Equal("topsecret", values[1].Password);
-            Assert.False(values[1].IsPasswordClearText);
+            AssertCredentials(values[1].Credentials, "two", "user1", encryptedPassword, isPasswordClearText: false);
         }
-#endif
 
         [Fact]
-        public void LoadPackageSourcesReadsClearTextCredentialPairsFromSettings()
+        public void LoadPackageSources_ReadsClearTextCredentialPairsFromSettings()
         {
             // Arrange
             const string clearTextPassword = "topsecret";
 
             var settings = new Mock<ISettings>();
-            settings.Setup(s => s.GetSettingValues("packageSources", true))
+            settings
+                .Setup(s => s.GetSettingValues("packageSources", true))
                 .Returns(new[]
                     {
                         new SettingValue("one", "onesource", false),
@@ -1238,8 +1235,13 @@ namespace NuGet.Configuration.Test
                         new SettingValue("three", "threesource", false)
                     });
 
-            settings.Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
-                .Returns(new[] { new KeyValuePair<string, string>("Username", "user1"), new KeyValuePair<string, string>("ClearTextPassword", clearTextPassword) });
+            settings
+                .Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
+                .Returns(new[]
+                    {
+                        new KeyValuePair<string, string>("Username", "user1"),
+                        new KeyValuePair<string, string>("ClearTextPassword", clearTextPassword)
+                    });
 
             var provider = CreatePackageSourceProvider(settings.Object);
 
@@ -1249,25 +1251,29 @@ namespace NuGet.Configuration.Test
             // Assert
             Assert.Equal(3, values.Count);
             AssertPackageSource(values[1], "two", "twosource", true);
-            Assert.Equal("user1", values[1].UserName);
-            Assert.True(values[1].IsPasswordClearText);
-            Assert.Equal("topsecret", values[1].Password);
+            AssertCredentials(values[1].Credentials, "two", "user1", clearTextPassword);
         }
 
         [Fact]
-        public void LoadPackageSourcesWhenEnvironmentCredentialsAreMalformedFallsbackToSettingsCredentials()
+        public void LoadPackageSources_WhenEnvironmentCredentialsAreMalformed_FallsbackToSettingsCredentials()
         {
             // Arrange
             var settings = new Mock<ISettings>();
-            settings.Setup(s => s.GetSettingValues("packageSources", true))
+            settings
+                .Setup(s => s.GetSettingValues("packageSources", true))
                 .Returns(new[]
                     {
                         new SettingValue("one", "onesource", false),
                         new SettingValue("two", "twosource", false),
                         new SettingValue("three", "threesource", false)
                     });
-            settings.Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
-                .Returns(new[] { new KeyValuePair<string, string>("Username", "settinguser"), new KeyValuePair<string, string>("ClearTextPassword", "settingpassword") });
+            settings
+                .Setup(s => s.GetNestedValues("packageSourceCredentials", "two"))
+                .Returns(new[]
+                    {
+                        new KeyValuePair<string, string>("Username", "settinguser"),
+                        new KeyValuePair<string, string>("ClearTextPassword", "settingpassword")
+                    });
 
             var provider = CreatePackageSourceProvider(settings.Object);
 
@@ -1277,8 +1283,7 @@ namespace NuGet.Configuration.Test
             // Assert
             Assert.Equal(3, values.Count);
             AssertPackageSource(values[1], "two", "twosource", true);
-            Assert.Equal("settinguser", values[1].UserName);
-            Assert.Equal("settingpassword", values[1].Password);
+            AssertCredentials(values[1].Credentials, "two", "settinguser", "settingpassword");
         }
 
         // Test that when there are duplicate sources, i.e. sources with the same name,
@@ -1436,32 +1441,32 @@ namespace NuGet.Configuration.Test
             settings.Verify();
         }
 
-#if !DNXCORE50
         [Fact]
-        public void SavePackageSourcesSavesCredentials()
+        public void SavePackageSources_SavesEncryptedCredentials()
         {
             // Arrange
-            var entropyBytes = Encoding.UTF8.GetBytes("NuGet");
+            var encryptedPassword = Guid.NewGuid().ToString();
+            var credentials = new PackageSourceCredential("twoname", "User", encryptedPassword, isPasswordClearText: false);
             var sources = new[]
                 {
                     new PackageSource("one"),
-                    new PackageSource("twosource", "twoname") { UserName = "User", PasswordText = "password" },
+                    new PackageSource("http://twosource", "twoname") { Credentials = credentials },
                     new PackageSource("three")
                 };
             var settings = new Mock<ISettings>();
-            settings.Setup(s => s.DeleteSection("packageSourceCredentials")).Returns(true).Verifiable();
+            settings
+                .Setup(s => s.DeleteSection("packageSourceCredentials"))
+                .Returns(true)
+                .Verifiable();
 
-            settings.Setup(s => s.SetNestedValues("packageSourceCredentials", It.IsAny<string>(), It.IsAny<IList<KeyValuePair<string, string>>>()))
+            settings
+                .Setup(s => s.SetNestedValues("packageSourceCredentials", "twoname", It.IsAny<IList<KeyValuePair<string, string>>>()))
                 .Callback((string section, string key, IList<KeyValuePair<string, string>> values) =>
                     {
                         Assert.Equal("twoname", key);
                         Assert.Equal(2, values.Count);
-                        AssertKVP(new KeyValuePair<string, string>("Username", "User"), values[0]);
-                        Assert.Equal("Password", values[1].Key);
-                        var decryptedPassword = Encoding.UTF8.GetString(
-                            ProtectedData.Unprotect(Convert.FromBase64String(values[1].Value), entropyBytes, DataProtectionScope.CurrentUser));
-                        Assert.Equal("Password", values[1].Key);
-                        Assert.Equal("password", decryptedPassword);
+                        AssertKeyValuePair("Username", "User", values[0]);
+                        AssertKeyValuePair("Password", encryptedPassword, values[1]);
                     })
                 .Verifiable();
 
@@ -1473,28 +1478,32 @@ namespace NuGet.Configuration.Test
             // Assert
             settings.Verify();
         }
-#endif
 
         [Fact]
-        public void SavePackageSourcesSavesClearTextCredentials()
+        public void SavePackageSources_SavesClearTextCredentials()
         {
             // Arrange
+            var credentials = new PackageSourceCredential("twoname", "User", "password", isPasswordClearText: true);
             var sources = new[]
                 {
                     new PackageSource("one"),
-                    new PackageSource("twosource", "twoname") { UserName = "User", PasswordText = "password", IsPasswordClearText = true },
+                    new PackageSource("http://twosource", "twoname") { Credentials = credentials },
                     new PackageSource("three")
                 };
             var settings = new Mock<ISettings>();
-            settings.Setup(s => s.DeleteSection("packageSourceCredentials")).Returns(true).Verifiable();
+            settings
+                .Setup(s => s.DeleteSection("packageSourceCredentials"))
+                .Returns(true)
+                .Verifiable();
 
-            settings.Setup(s => s.SetNestedValues("packageSourceCredentials", It.IsAny<string>(), It.IsAny<IList<KeyValuePair<string, string>>>()))
+            settings
+                .Setup(s => s.SetNestedValues("packageSourceCredentials", "twoname", It.IsAny<IList<KeyValuePair<string, string>>>()))
                 .Callback((string section, string key, IList<KeyValuePair<string, string>> values) =>
                     {
                         Assert.Equal("twoname", key);
                         Assert.Equal(2, values.Count);
-                        AssertKVP(new KeyValuePair<string, string>("Username", "User"), values[0]);
-                        AssertKVP(new KeyValuePair<string, string>("ClearTextPassword", "password"), values[1]);
+                        AssertKeyValuePair("Username", "User", values[0]);
+                        AssertKeyValuePair("ClearTextPassword", "password", values[1]);
                     })
                 .Verifiable();
 
@@ -2320,15 +2329,13 @@ namespace NuGet.Configuration.Test
             }
         }
 
-#if DNXCORE50
         [Fact]
-        public void LoadPackageSource_NotDecryptPassword() 
+        public void LoadPackageSources_DoesNotDecryptPassword()
         {
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
-                var configContents =
-                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+                var configContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
       <clear />
@@ -2337,11 +2344,11 @@ namespace NuGet.Configuration.Test
 <packageSourceCredentials>
     <test>
       <add key='Username' value='myusername' />
-      <add key='Password' value='removed' />
+      <add key='Password' value='random-encrypted-password' />
     </test>
   </packageSourceCredentials>
-</configuration>
-";
+</configuration>";
+
                 File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents);
                 var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
                                   configFileName: null,
@@ -2357,19 +2364,17 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(1, sources.Count);
                 Assert.Equal("test", sources[0].Name);
                 Assert.Equal("https://nuget/test", sources[0].Source);
-                Assert.Equal("removed", sources[0].PasswordText);
-                Assert.Throws<NuGetConfigurationException>(()=> sources[0].Password);
+                AssertCredentials(sources[0].Credentials, "test", "myusername", "random-encrypted-password", isPasswordClearText: false);
             }
         }
 
         [Fact]
-        public void LoadPackageSource_NotLoadClearedSource()
+        public void LoadPackageSources_DoesNotLoadClearedSource()
         {
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
-                var configContents =
-                     @"<?xml version=""1.0"" encoding=""utf-8""?>
+                var configContents = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
       <add key=""test"" value=""https://nuget/test"" />
@@ -2382,8 +2387,7 @@ namespace NuGet.Configuration.Test
   </packageSourceCredentials>
 </configuration>
 ";
-                var configContents1 =
-                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                var configContents1 = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
     <packageSources>
       <clear />
@@ -2391,13 +2395,17 @@ namespace NuGet.Configuration.Test
     </packageSources>
 </configuration>
 ";
-                ConfigurationFileTestUtility.CreateConfigurationFile("nuget.config", Path.Combine(mockBaseDirectory, "TestingGlobalPath"), configContents);
+                ConfigurationFileTestUtility.CreateConfigurationFile(
+                    "nuget.config",
+                    Path.Combine(mockBaseDirectory, "TestingGlobalPath"),
+                    configContents);
                 File.WriteAllText(Path.Combine(mockBaseDirectory.Path, "NuGet.Config"), configContents1);
-                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
-                                  configFileName: null,
-                                  machineWideSettings: null,
-                                  loadAppDataSettings: true,
-                                  useTestingGlobalPath: true);
+                var settings = Settings.LoadDefaultSettings(
+                    mockBaseDirectory.Path,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: true,
+                    useTestingGlobalPath: true);
                 var packageSourceProvider = new PackageSourceProvider(settings);
 
                 // Act
@@ -2407,37 +2415,9 @@ namespace NuGet.Configuration.Test
                 Assert.Equal(1, sources.Count);
                 Assert.Equal("test2", sources[0].Name);
                 Assert.Equal("https://nuget/test2", sources[0].Source);
-                Assert.Null(sources[0].PasswordText);
-                Assert.Null(sources[0].Password);
+                Assert.Null(sources[0].Credentials);
             }
         }
-
-        [Fact]
-        public void SavePackageSource_EncryptPasswordGetException()
-        {
-            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                // Arrange
-                var settings = Settings.LoadDefaultSettings(mockBaseDirectory.Path,
-                                  configFileName: null,
-                                  machineWideSettings: null,
-                                  loadAppDataSettings: true,
-                                  useTestingGlobalPath: true);
-                var packageSourceProvider = new PackageSourceProvider(settings);
-
-                var newSource = new PackageSource("https://test", "test")
-                {
-                    PasswordText = "password",
-                    UserName = "username"
-                };
-                var sources = packageSourceProvider.LoadPackageSources().ToList();
-                sources.Add(newSource);
-
-                // Act & Assert
-                Assert.Throws<NuGetConfigurationException>(() => packageSourceProvider.SavePackageSources(sources));
-            }
-        }
-#endif
 
         private string CreateNuGetConfigContent(string enabledReplacement = "", string disabledReplacement = "", string activeSourceReplacement = "")
         {
@@ -2501,10 +2481,20 @@ namespace NuGet.Configuration.Test
             Assert.True(ps.IsOfficial == isOfficial);
         }
 
-        private static void AssertKVP(KeyValuePair<string, string> expected, KeyValuePair<string, string> actual)
+        private static void AssertKeyValuePair(string expectedKey, string expectedValue, KeyValuePair<string, string> actual)
         {
-            Assert.Equal(expected.Key, actual.Key);
-            Assert.Equal(expected.Value, actual.Value);
+            Assert.NotNull(actual);
+            Assert.Equal(expectedKey, actual.Key);
+            Assert.Equal(expectedValue, actual.Value);
+        }
+
+        private void AssertCredentials(PackageSourceCredential actual, string source, string userName, string passwordText, bool isPasswordClearText = true)
+        {
+            Assert.NotNull(actual);
+            Assert.Equal(source, actual.Source);
+            Assert.Equal(userName, actual.Username);
+            Assert.Equal(passwordText, actual.PasswordText);
+            Assert.Equal(isPasswordClearText, actual.IsPasswordClearText);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -5,18 +5,17 @@ using Xunit;
 
 namespace NuGet.Configuration
 {
-    public class PackageSourceTest
+    public class PackageSourceTests
     {
         [Fact]
         public void Clone_CopiesAllPropertyValuesFromSource()
         {
             // Arrange
+            var credentials = new PackageSourceCredential("SourceName", "username", "password", isPasswordClearText: false);
             var source = new PackageSource("Source", "SourceName", isEnabled: false)
                 {
-                    IsPasswordClearText = true,
-                    PasswordText = "password",
-                    UserName = "username",
-                    ProtocolVersion = 43,
+                    Credentials = credentials,
+                    ProtocolVersion = 43
                 };
 
             // Act
@@ -27,8 +26,7 @@ namespace NuGet.Configuration
             Assert.Equal(source.Name, result.Name);
             Assert.Equal(source.IsEnabled, result.IsEnabled);
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
-            Assert.Equal(source.UserName, result.UserName);
-            Assert.Equal(source.Password, source.Password);
+            Assert.Same(source.Credentials, result.Credentials);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2647.

Before the fix NuGet encrypted value stored in PasswordText on every save triggered by source update. Although it used to work just fine for first-time updated password, following saves caused the encrypted value to be encrypted again.

To resolve the issue and avoid confusion in future PackageSourceCredentials class made public to encapsulate password handling logic.

//cc @emgarten @zhili1208 @joelverhagen @rrelyea @yishaigalatzer 
