### PR TITLE
Fixed default Push source from NuGetDefault.Config

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -35,7 +35,7 @@ namespace NuGet.CommandLine
             // First argument should be the package
             var packagePath = Arguments[0];
 
-            var source = ResolveSource(packagePath, ConfigurationDefaults.Instance.DefaultPushSource);
+            var source = ResolveSource(packagePath, SourceProvider.DefaultPushSource);
             if (string.IsNullOrEmpty(source))
             {
                 throw new CommandLineException(
@@ -73,6 +73,11 @@ namespace NuGet.CommandLine
         private string ResolveSource(string packagePath, string configurationDefaultPushSource = null)
         {
             var source = Source;
+
+            if (string.IsNullOrEmpty(source))
+            {
+                source = configurationDefaultPushSource;
+            }
 
             if (!String.IsNullOrEmpty(source))
             {

--- a/src/NuGet.Clients/StandaloneUI/MainWindow.xaml.cs
+++ b/src/NuGet.Clients/StandaloneUI/MainWindow.xaml.cs
@@ -166,6 +166,11 @@ namespace StandaloneUI
         {
             throw new NotImplementedException();
         }
+
+        public string DefaultPushSource
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 
     internal class StandAloneUICommonOperations : ICommonOperations

--- a/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/NuGetEnvironment.cs
@@ -13,12 +13,13 @@ namespace NuGet.Common
             switch (folder)
             {
                 case NuGetFolderPath.MachineWideSettingsBaseDirectory:
-                    return GetFolderPath(SpecialFolder.CommonApplicationData);
+                    return Path.Combine(
+                        GetFolderPath(SpecialFolder.CommonApplicationData),
+                        "nuget");
 
                 case NuGetFolderPath.MachineWideConfigDirectory:
                     return Path.Combine(
                         GetFolderPath(NuGetFolderPath.MachineWideSettingsBaseDirectory),
-                        "nuget",
                         "Config");
 
                 case NuGetFolderPath.UserSettingsDirectory:

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/IPackageSourceProvider.cs
@@ -19,5 +19,7 @@ namespace NuGet.Configuration
         string ActivePackageSourceName { get; }
 
         void SaveActivePackageSource(PackageSource source);
+
+        string DefaultPushSource { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -122,12 +122,42 @@ namespace NuGet.Configuration
                 .Select(source => source.PackageSource)
                 .ToList();
 
+            if (_configurationDefaultSources != null && _configurationDefaultSources.Any())
+            {
+                SetDefaultPackageSources(loadedPackageSources);
+            }
+
             if (_migratePackageSources != null)
             {
                 MigrateSources(loadedPackageSources);
             }
 
             return loadedPackageSources;
+        }
+
+        private void SetDefaultPackageSources(List<PackageSource> loadedPackageSources)
+        {
+            var defaultPackageSourcesToBeAdded = new List<PackageSource>();
+
+            foreach (var packageSource in _configurationDefaultSources)
+            {
+                bool sourceMatching = loadedPackageSources.Any(p => p.Source.Equals(packageSource.Source, StringComparison.CurrentCultureIgnoreCase));
+                bool feedNameMatching = loadedPackageSources.Any(p => p.Name.Equals(packageSource.Name, StringComparison.CurrentCultureIgnoreCase));
+
+                if (!sourceMatching && !feedNameMatching)
+                {
+                    defaultPackageSourcesToBeAdded.Add(packageSource);
+                }
+            }
+
+            var defaultSourcesInsertIndex = loadedPackageSources.FindIndex(source => source.IsMachineWide);
+
+            if (defaultSourcesInsertIndex == -1)
+            {
+                defaultSourcesInsertIndex = loadedPackageSources.Count;
+            }
+
+            loadedPackageSources.InsertRange(defaultSourcesInsertIndex, defaultPackageSourcesToBeAdded);
         }
 
         private PackageSource ReadPackageSource(SettingValue setting, bool isEnabled)
@@ -488,6 +518,21 @@ namespace NuGet.Configuration
             catch (Exception)
             {
                 // we want to ignore all errors here.
+            }
+        }
+
+        public string DefaultPushSource
+        {
+            get
+            {
+                var source = Settings.GetValue(ConfigurationConstants.Config, ConfigurationConstants.DefaultPushSource);
+                
+                if (string.IsNullOrEmpty(source))
+                {
+                    source = ConfigurationDefaults.Instance.DefaultPushSource;
+                }
+
+                return source;
             }
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/ConfigurationContants.cs
@@ -5,43 +5,43 @@ namespace NuGet.Configuration
 {
     internal static class ConfigurationConstants
     {
-        internal static string DisabledPackageSources = "disabledPackageSources";
+        internal static readonly string DisabledPackageSources = "disabledPackageSources";
 
-        internal static string PackageSources = "packageSources";
+        internal static readonly string PackageSources = "packageSources";
 
-        internal static string DefaultPushSource = "DefaultPushSource";
+        internal static readonly string DefaultPushSource = "DefaultPushSource";
 
-        internal static string PackageRestore = "packageRestore";
+        internal static readonly string PackageRestore = "packageRestore";
 
-        internal static string Config = "config";
+        internal static readonly string Config = "config";
 
-        internal static string enabled = "enabled";
+        internal static readonly string enabled = "enabled";
 
-        internal static string ConfigurationDefaultsFile = "NuGetDefaults.config";
+        internal static readonly string ConfigurationDefaultsFile = "NuGetDefaults.config";
 
-        internal static string CredentialsSectionName = "packageSourceCredentials";
+        internal static readonly string CredentialsSectionName = "packageSourceCredentials";
 
-        internal static string UsernameToken = "Username";
+        internal static readonly string UsernameToken = "Username";
 
-        internal static string PasswordToken = "Password";
+        internal static readonly string PasswordToken = "Password";
 
-        internal static string ClearTextPasswordToken = "ClearTextPassword";
+        internal static readonly string ClearTextPasswordToken = "ClearTextPassword";
 
-        internal static string ActivePackageSourceSectionName = "activePackageSource";
+        internal static readonly string ActivePackageSourceSectionName = "activePackageSource";
 
-        internal static string HostKey = "http_proxy";
+        internal static readonly string HostKey = "http_proxy";
 
-        internal static string UserKey = "http_proxy.user";
+        internal static readonly string UserKey = "http_proxy.user";
 
-        internal static string PasswordKey = "http_proxy.password";
+        internal static readonly string PasswordKey = "http_proxy.password";
         
-        internal static string NoProxy     = "no_proxy";
+        internal static readonly string NoProxy = "no_proxy";
 
-        internal static string KeyAttribute = "key";
+        internal static readonly string KeyAttribute = "key";
 
-        internal static string ValueAttribute = "value";
+        internal static readonly string ValueAttribute = "value";
 
-        internal static string ProtocolVersionAttribute = "protocolVersion";
+        internal static readonly string ProtocolVersionAttribute = "protocolVersion";
 
     }
 }

--- a/src/NuGet.Core/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
+++ b/src/NuGet.Core/Test.Utility/SourceRepository/TestSourceRepositoryUtility.cs
@@ -109,6 +109,11 @@ namespace Test.Utility
         {
             throw new NotImplementedException();
         }
+
+        public string DefaultPushSource
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 
     public static class TestPackageSourceSettings

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1313,6 +1313,43 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void PushCommand_PushToV2FileSystemDefaultPushSource()
+        {
+            string nugetexe = Util.GetNuGetExePath();
+
+            using (TestDirectory packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (TestDirectory source = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                string packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+                string config = string.Format(
+$@"<?xml version='1.0' encoding='utf-8'?>
+<configuration>
+  <config>
+    <add key='DefaultPushSource' value='{source}' />
+  </config>
+</configuration>");
+
+                string configFileName = Path.Combine(packageDirectory, "nuget.config");
+                File.WriteAllText(configFileName, config);
+
+                // Act
+                string[] args = new string[] { "push", packageFileName };
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    packageDirectory,
+                    string.Join(" ", args),
+                    true);
+
+                // Assert
+                Assert.Equal(0, result.Item1);
+                Assert.True(File.Exists(Path.Combine(source, "testPackage1.1.1.0.nupkg")));
+                var output = result.Item2;
+                Assert.DoesNotContain("WARNING: No API Key was provided", output);
+            }
+        }
+
+        [Fact]
         public void PushCommand_PushToServerV3_ApiKeyFromConfig()
         {
             Util.ClearWebCache();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/TestPackageSourceProvider.cs
@@ -51,5 +51,10 @@ namespace NuGet.Commands.Test
         {
             throw new NotImplementedException();
         }
+
+        public string DefaultPushSource
+        {
+            get { throw new NotImplementedException(); }
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -17,10 +17,13 @@ namespace NuGet.Configuration
         public void CreateConfigurationDefaultsReturnsNonNullConfigurationDefaults()
         {
             // Arrange
-            ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(@"<configuration></configuration>");
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(@"<configuration></configuration>", mockBaseDirectory);
 
-            // Act & Assert
-            Assert.NotNull(ConfigurationDefaults);
+                // Act & Assert
+                Assert.NotNull(ConfigurationDefaults);
+            }
         }
 
         [Fact]
@@ -106,24 +109,29 @@ namespace NuGet.Configuration
         public void GetDefaultPushSourceReadsTheCorrectValue()
         {
             // Arrange
-            var configurationDefaultsContent = @"
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configurationDefaultsContent = @"
 <configuration>
      <config>
         <add key='DefaultPushSource' value='http://contoso.com/packages/' />
     </config>
 </configuration>";
 
-            // Act & Assert
-            ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent);
+                // Act & Assert
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
 
-            Assert.Equal(ConfigurationDefaults.DefaultPushSource, "http://contoso.com/packages/");
+                Assert.Equal(ConfigurationDefaults.DefaultPushSource, "http://contoso.com/packages/");
+            }
         }
 
         [Fact]
         public void GetDefaultPackageSourcesReturnsValidPackageSources()
         {
             // Arrange
-            var configurationDefaultsContent = @"
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configurationDefaultsContent = @"
 <configuration>
     <packageSources>
         <add key='Contoso Package Source' value='http://contoso.com/packages/' />
@@ -133,22 +141,23 @@ namespace NuGet.Configuration
         <add key='NuGet Official Feed' value='true' />
     </disabledPackageSources>
 </configuration>";
-            // Act & Assert
-            ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent);
+                // Act & Assert
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
 
-            Assert.NotNull(ConfigurationDefaults.DefaultPackageSources);
+                Assert.NotNull(ConfigurationDefaults.DefaultPackageSources);
 
-            List<PackageSource> defaultPackageSources = ConfigurationDefaults.DefaultPackageSources.ToList();
+                List<PackageSource> defaultPackageSources = ConfigurationDefaults.DefaultPackageSources.ToList();
 
-            Assert.Equal(defaultPackageSources.Count, 2);
+                Assert.Equal(defaultPackageSources.Count, 2);
 
-            Assert.Equal(defaultPackageSources[0].Name, "Contoso Package Source");
-            Assert.True(defaultPackageSources[0].IsEnabled);
-            Assert.True(defaultPackageSources[0].IsOfficial);
+                Assert.Equal(defaultPackageSources[0].Name, "Contoso Package Source");
+                Assert.True(defaultPackageSources[0].IsEnabled);
+                Assert.True(defaultPackageSources[0].IsOfficial);
 
-            Assert.Equal(defaultPackageSources[1].Name, "NuGet Official Feed");
-            Assert.False(defaultPackageSources[1].IsEnabled);
-            Assert.True(defaultPackageSources[1].IsOfficial);
+                Assert.Equal(defaultPackageSources[1].Name, "NuGet Official Feed");
+                Assert.False(defaultPackageSources[1].IsEnabled);
+                Assert.True(defaultPackageSources[1].IsOfficial);
+            }
         }
 
         [Fact]
@@ -165,6 +174,125 @@ namespace NuGet.Configuration
 
                 ConfigurationDefaults configDefaults = new ConfigurationDefaults(nugetConfigFileFolder, nugetConfigFile);
                 Assert.True(configDefaults.DefaultPackageSources.ToList().Count == 0);
+            }
+        }
+
+        [Fact]
+        public void GetDefaultPackageSourcesFromSourceProvider()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configurationDefaultsContent = @"
+<configuration>
+    <packageSources>
+        <add key='Contoso Package Source' value='http://contoso.com/packages/' />
+    </packageSources>
+      <config>
+        <add key='DefaultPushSource' value='http://contoso.com/packages/' />
+    </config>
+</configuration>";
+                var config = @"
+<configuration>
+    <packageSources>
+        <add key='v2' value='http://www.nuget.org/api/v2/' />
+    </packageSources>
+</configuration>";
+
+                File.WriteAllText(Path.Combine(mockBaseDirectory, "NuGet.Config"), config);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                var packageSourceProvider = new PackageSourceProvider(settings, null, ConfigurationDefaults.DefaultPackageSources);
+
+                // Act
+                List<PackageSource> packageSources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(ConfigurationDefaults.DefaultPushSource, "http://contoso.com/packages/");
+                Assert.Equal(2, packageSources.Count());
+                Assert.Equal("v2", packageSources[0].Name);
+                Assert.Equal("Contoso Package Source", packageSources[1].Name);
+            }
+        }
+
+        public void GetDefaultSameNamePackageSourcesFromSourceProvider()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configurationDefaultsContent = @"
+<configuration>
+    <packageSources>
+        <add key='Contoso Package Source' value='http://contoso.com/packages/' />
+    </packageSources>
+</configuration>";
+                var config = @"
+<configuration>
+    <packageSources>
+        <add key='Contoso Package Source' value='http://www.nuget.org/api/v2/' />
+    </packageSources>
+</configuration>";
+
+                File.WriteAllText(Path.Combine(mockBaseDirectory, "NuGet.Config"), config);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                var packageSourceProvider = new PackageSourceProvider(settings, null, ConfigurationDefaults.DefaultPackageSources);
+
+                // Act
+                List<PackageSource> packageSources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(1, packageSources.Count());
+                Assert.Equal("Contoso Package Source", packageSources[0].Name);
+                Assert.Equal("http://www.nuget.org/api/v2/", packageSources[0].Source);
+            }
+        }
+
+        public void GetDefaultSameSourcePackageSourcesFromSourceProvider()
+        {
+            // Arrange
+            using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configurationDefaultsContent = @"
+<configuration>
+    <packageSources>
+        <add key='Contoso Package Source' value='http://www.nuget.org/api/v2/' />
+    </packageSources>
+</configuration>";
+                var config = @"
+<configuration>
+    <packageSources>
+        <add key='v2' value='http://www.nuget.org/api/v2/' />
+    </packageSources>
+</configuration>";
+
+                File.WriteAllText(Path.Combine(mockBaseDirectory, "NuGet.Config"), config);
+                var settings = Settings.LoadDefaultSettings(mockBaseDirectory,
+                    configFileName: null,
+                    machineWideSettings: null,
+                    loadAppDataSettings: false,
+                    useTestingGlobalPath: false);
+                ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
+
+                var packageSourceProvider = new PackageSourceProvider(settings, null, ConfigurationDefaults.DefaultPackageSources);
+
+                // Act
+                List<PackageSource> packageSources = packageSourceProvider.LoadPackageSources().ToList();
+
+                // Assert
+                Assert.Equal(1, packageSources.Count());
+                Assert.Equal("v2", packageSources[0].Name);
+                Assert.Equal("http://www.nuget.org/api/v2/", packageSources[0].Source);
             }
         }
 
@@ -213,17 +341,11 @@ namespace NuGet.Configuration
             }
         }
 
-        private ConfigurationDefaults GetConfigurationDefaults(string configurationDefaultsContent)
+        private ConfigurationDefaults GetConfigurationDefaults(string configurationDefaultsContent, TestDirectory mockBaseDirectory)
         {
             var configurationDefaultsPath = "NuGetDefaults.config";
-            var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder();
-            Directory.CreateDirectory(mockBaseDirectory);
-
-            using (var file = File.Create(Path.Combine(mockBaseDirectory, configurationDefaultsPath)))
-            {
-                var info = new UTF8Encoding(true).GetBytes(configurationDefaultsContent);
-                file.Write(info, 0, info.Count());
-            }
+      
+            File.WriteAllText(Path.Combine(mockBaseDirectory, configurationDefaultsPath), configurationDefaultsContent);
             return new ConfigurationDefaults(mockBaseDirectory, configurationDefaultsPath);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/SettingsTests.cs
@@ -56,7 +56,7 @@ namespace NuGet.Configuration.Test
                 var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 #endif
                 // Assert 
-                Assert.Equal(commonApplicationData, machineWidePathTuple.Item2);
+                Assert.Equal(Path.Combine(commonApplicationData,"nuget"), machineWidePathTuple.Item2);
                 Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
                 Assert.Equal(Path.Combine(userSetting,"NuGet"), globalConfigTuple.Item2);
                 Assert.Equal("NuGet.Config", globalConfigTuple.Item1);
@@ -77,7 +77,7 @@ namespace NuGet.Configuration.Test
                 var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 #endif
                 // Assert 
-                Assert.Equal(commonApplicationData, machineWidePathTuple.Item2);
+                Assert.Equal(Path.Combine(commonApplicationData, "nuget"), machineWidePathTuple.Item2);
                 Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
                 Assert.Equal(Path.Combine(userSetting, "NuGet"), globalConfigTuple.Item2);
                 Assert.Equal("NuGet.Config", globalConfigTuple.Item1);
@@ -98,7 +98,7 @@ namespace NuGet.Configuration.Test
                 var userSetting = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 #endif
                 // Assert 
-                Assert.Equal(commonApplicationData, machineWidePathTuple.Item2);
+                Assert.Equal(Path.Combine(commonApplicationData, "nuget"), machineWidePathTuple.Item2);
                 Assert.Equal("NuGet.Config", machineWidePathTuple.Item1);
                 Assert.Equal(Path.Combine(userSetting, "NuGet"), globalConfigTuple.Item2);
                 Assert.Equal("NuGet.Config", globalConfigTuple.Item1);


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2653
there are three bugs which are fixed here.
1. Nuget loads default sources from wrong path.
2. Push Command doesn't load push source from nuget.config and NuGetDefault.Config
3. PackageSourceProvider doesn't load package sources from NuGetDefault.Config
