### PR TITLE
Avoid throwing missing primary target in case of update all packages

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -730,7 +730,8 @@ namespace NuGet.PackageManagement
                     AllSources = allSources.ToList(),
                     PackagesFolderSource = PackagesFolderSourceRepository,
                     ResolutionContext = resolutionContext,
-                    AllowDowngrades = allowDowngrades
+                    AllowDowngrades = allowDowngrades,
+                    IsUpdateAll = isUpdateAll
                 };
 
                 var availablePackageDependencyInfoWithSourceSet = await ResolverGather.GatherAsync(gatherContext, token);

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherContext.cs
@@ -70,6 +70,11 @@ namespace NuGet.PackageManagement
         public INuGetProjectContext ProjectContext { get; set; }
 
         /// <summary>
+        /// If true, missing primary targets will be ignored.
+        /// </summary>
+        public bool IsUpdateAll { get; set; }
+
+        /// <summary>
         /// Logging adapter
         /// </summary>
         public Common.ILogger Log

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -193,25 +193,29 @@ namespace NuGet.PackageManagement
 
             var allPrimarySources = String.Join(",", allPrimarySourcesList);
 
-            // Throw if a primary target was not found
-            // The primary package may be missing if there are network issues and the sources were unreachable
-            foreach (var targetId in allPrimaryTargets)
+            // When it's update all packages scenario, then ignore throwing error for missing primary targets in specified sources.
+            if (!_context.IsUpdateAll)
             {
-                if (!combinedResults.Any(package => string.Equals(package.Id, targetId, StringComparison.OrdinalIgnoreCase)))
+                // Throw if a primary target was not found
+                // The primary package may be missing if there are network issues and the sources were unreachable
+                foreach (var targetId in allPrimaryTargets)
                 {
-                    string packageIdentity = targetId;
-
-                    foreach (var pid in _context.PrimaryTargets)
+                    if (!combinedResults.Any(package => string.Equals(package.Id, targetId, StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (string.Equals(targetId, pid.Id, StringComparison.OrdinalIgnoreCase))
-                        {
-                            packageIdentity = String.Concat(targetId, ",", pid.Version);
-                            break;
-                        }
-                    }
+                        string packageIdentity = targetId;
 
-                    string message = String.Format(Strings.PackageNotFoundInPrimarySources, packageIdentity, allPrimarySources);
-                    throw new InvalidOperationException(message);
+                        foreach (var pid in _context.PrimaryTargets)
+                        {
+                            if (string.Equals(targetId, pid.Id, StringComparison.OrdinalIgnoreCase))
+                            {
+                                packageIdentity = String.Concat(targetId, ",", pid.Version);
+                                break;
+                            }
+                        }
+
+                        string message = String.Format(Strings.PackageNotFoundInPrimarySources, packageIdentity, allPrimarySources);
+                        throw new InvalidOperationException(message);
+                    }
                 }
             }
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -711,6 +711,50 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public async Task ResolverGather_UpdateAllWithMissingPrimaryPackage()
+        {
+            // Arrange
+            var targetA = CreatePackage("a", "2.0.0");
+            var targetB = CreatePackage("b", "2.0.0");
+            IEnumerable<PackageIdentity> targets = new[] { targetA, targetB };
+
+            var framework = NuGetFramework.Parse("net451");
+
+            var repoA = new List<SourcePackageDependencyInfo>
+                {
+                    CreateDependencyInfo("a", "1.0.0"),
+                    CreateDependencyInfo("a", "2.0.0")
+                };
+
+            var primaryRepo = new List<SourceRepository>();
+            primaryRepo.Add(CreateRepo("a", repoA));
+
+            var repos = new List<SourceRepository>();
+            repos.Add(CreateRepo("a", repoA));
+
+            var installedPackages = new List<PackageIdentity>
+                {
+                    CreatePackage("a", "1.0.0"),
+                    CreatePackage("b", "1.0.0")
+                };
+
+            var context = new GatherContext();
+            context.PrimaryTargets = targets.ToList();
+            context.InstalledPackages = installedPackages;
+            context.TargetFramework = framework;
+            context.PrimarySources = primaryRepo;
+            context.AllSources = repos;
+            context.IsUpdateAll = true;
+            context.PackagesFolderSource = CreateRepo("installed", new List<SourcePackageDependencyInfo>());
+
+            // Act
+            var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1, results.Count);
+        }
+
+        [Fact]
         public async Task ResolverGather_MissingPackageGatheredFromSource()
         {
             // Arrange


### PR DESCRIPTION
In case of update all packages scenario, will avoid throwing missing primary target exception. It's a regression over V2. 

Fix https://github.com/NuGet/Home/issues/1013

@emgarten @alpaix @rrelyea @joelverhagen 
