### PR TITLE
Remove VersionRange.IncludePrerelease

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -269,16 +269,6 @@ namespace NuGet.DependencyResolver
                             var versionRange = childNode.Key.VersionRange;
                             var checkVersion = acceptedNode.Item.Key.Version;
 
-                            // Allow prerelease versions if the selected library is prerelease and the range is
-                            // using the default behavior of filtering to stable versions.
-                            // Ex: [4.0.0, ) should allow 4.0.10-beta if that library was selected during the graph walk
-                            // The decision on if a prerelease version should be allowed should happen previous to this
-                            // check during the walk.
-                            if (checkVersion.IsPrerelease && !versionRange.IncludePrerelease)
-                            {
-                                versionRange = VersionRange.SetIncludePrerelease(versionRange, includePrerelease: true);
-                            }
-
                             if (!versionRange.Satisfies(checkVersion))
                             {
                                 versionConflicts.Add(new VersionConflictResult<TItem>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2302,7 +2302,6 @@ namespace NuGet.PackageManagement
             var packages = await dependencyInfoResource.ResolvePackages(packageId, framework, log, token);
             packages = packages.Select(package =>
             {
-                package.SetIncludePrereleaseForDependencies();
                 return package;
             });
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -266,8 +266,6 @@ namespace NuGet.PackageManagement
                     // Installed packages should exist, but if they do not an attempt will be made to find them in the sources.
                     if (packageInfo != null)
                     {
-                        packageInfo.SetIncludePrereleaseForDependencies();
-
                         // Create a request and result to match the other packages
                         var request = new GatherRequest(
                             source: null,
@@ -474,7 +472,6 @@ namespace NuGet.PackageManagement
                     var packages = await resource.ResolvePackages(packageId, targetFramework, _context.Log, token);
                     packages = packages.Select(package =>
                     {
-                        package.SetIncludePrereleaseForDependencies();
                         return package;
                     });
 
@@ -488,7 +485,6 @@ namespace NuGet.PackageManagement
 
                     if (package != null)
                     {
-                        package.SetIncludePrereleaseForDependencies();
                         results.Add(package);
                     }
                 }

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageDependency.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageDependency.cs
@@ -66,14 +66,6 @@ namespace NuGet.Packaging.Core
         /// </summary>
         public IReadOnlyList<string> Exclude { get; }
 
-        /// <summary>
-        /// Sets the version range to also include prerelease versions
-        /// </summary>
-        public void SetIncludePrerelease()
-        {
-            _versionRange = VersionRange.SetIncludePrerelease(_versionRange, includePrerelease: true);
-        }
-
         public bool Equals(PackageDependency other)
         {
             return PackageDependencyComparer.Default.Equals(this, other);

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/PackageDependencyInfo.cs
@@ -50,17 +50,6 @@ namespace NuGet.Packaging.Core
             get { return _dependencies; }
         }
 
-        /// <summary>
-        /// sets every dependency to include the prerelease versions in its range
-        /// </summary>
-        public void SetIncludePrereleaseForDependencies()
-        {
-            foreach (var dependency in _dependencies)
-            {
-                dependency.SetIncludePrerelease();
-            }
-        }
-
         public bool Equals(PackageDependencyInfo other)
         {
             return PackageDependencyInfoComparer.Default.Equals(this, other);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/ResolverMetadataClient.cs
@@ -50,7 +50,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
 
                     if (range.Satisfies(version))
                     {
-                        results.Add(ProcessPackageVersion(packageObj, version, includePrerelease: true));
+                        results.Add(ProcessPackageVersion(packageObj, version));
                     }
                 }
             }
@@ -63,9 +63,8 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
         /// </summary>
         /// <param name="packageObj"></param>
         /// <param name="version"></param>
-        /// <param name="includePrerelease"></param>
         /// <returns>Returns the RemoteSourceDependencyInfo object corresponding to this package version</returns>
-        private static RemoteSourceDependencyInfo ProcessPackageVersion(JObject packageObj, NuGetVersion version, bool includePrerelease)
+        private static RemoteSourceDependencyInfo ProcessPackageVersion(JObject packageObj, NuGetVersion version)
         {
             var catalogEntry = (JObject)packageObj["catalogEntry"];
 
@@ -94,7 +93,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
                         foreach (JObject dependencyObj in dependenciesObj)
                         {
                             var dependencyId = dependencyObj.Value<string>("id");
-                            var dependencyRange = Utils.CreateVersionRange(dependencyObj.Value<string>("range"), includePrerelease);
+                            var dependencyRange = Utils.CreateVersionRange(dependencyObj.Value<string>("range"));
 
                             groupDependencies.Add(new PackageDependency(dependencyId, dependencyRange));
                         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/ResolverMetadataClient.cs
@@ -50,7 +50,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
 
                     if (range.Satisfies(version))
                     {
-                        results.Add(ProcessPackageVersion(packageObj, version, range.IncludePrerelease));
+                        results.Add(ProcessPackageVersion(packageObj, version, includePrerelease: true));
                     }
                 }
             }
@@ -128,7 +128,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
             var result = new HashSet<RegistrationInfo>();
             var registrationInfo = new RegistrationInfo();
 
-            registrationInfo.IncludePrerelease = range.IncludePrerelease;
+            registrationInfo.IncludePrerelease = true;
             foreach (var item in dependencies)
             {
                 var packageInfo = new PackageInfo

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
         public static VersionRange CreateVersionRange(string stringToParse, bool includePrerelease)
         {
             var range = VersionRange.Parse(string.IsNullOrEmpty(stringToParse) ? "[0.0.0-alpha,)" : stringToParse);
-            return new VersionRange(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive, includePrerelease);
+            return new VersionRange(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive);
         }
 
         public async static Task<IEnumerable<JObject>> LoadRanges(
@@ -38,8 +38,6 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
                 return Enumerable.Empty<JObject>();
             }
 
-            var preFilterRange = VersionRange.SetIncludePrerelease(range, includePrerelease: true);
-
             IList<Task<JObject>> rangeTasks = new List<Task<JObject>>();
 
             foreach (JObject item in index["items"])
@@ -47,7 +45,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
                 var lower = NuGetVersion.Parse(item["lower"].ToString());
                 var upper = NuGetVersion.Parse(item["upper"].ToString());
 
-                if (IsItemRangeRequired(preFilterRange, lower, upper))
+                if (IsItemRangeRequired(range, lower, upper))
                 {
                     JToken items;
                     if (!item.TryGetValue("items", out items))
@@ -75,7 +73,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
         private static bool IsItemRangeRequired(VersionRange dependencyRange, NuGetVersion catalogItemLower, NuGetVersion catalogItemUpper)
         {
             var catalogItemVersionRange = new VersionRange(minVersion: catalogItemLower, includeMinVersion: true,
-                maxVersion: catalogItemUpper, includeMaxVersion: true, includePrerelease: true);
+                maxVersion: catalogItemUpper, includeMaxVersion: true);
 
             if (dependencyRange.HasLowerAndUpperBounds) // Mainly to cover the '!dependencyRange.IsMaxInclusive && !dependencyRange.IsMinInclusive' case
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Core.v3.DependencyInfo
 {
     internal static class Utils
     {
-        public static VersionRange CreateVersionRange(string stringToParse, bool includePrerelease)
+        public static VersionRange CreateVersionRange(string stringToParse)
         {
             var range = VersionRange.Parse(string.IsNullOrEmpty(stringToParse) ? "[0.0.0-alpha,)" : stringToParse);
             return new VersionRange(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive);

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -204,6 +204,15 @@ namespace NuGet.Versioning
                 return false;
             }
 
+            // If the range contains only stable versions disallow prerelease versions
+            if (!HasPrereleaseBounds 
+                && considering.IsPrerelease 
+                && _floatRange?.FloatBehavior != NuGetVersionFloatBehavior.Prerelease
+                && _floatRange?.FloatBehavior != NuGetVersionFloatBehavior.AbsoluteLatest)
+            {
+                return false;
+            }
+
             if (!Satisfies(considering))
             {
                 // keep null over a value outside of the range

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -30,7 +30,13 @@ namespace NuGet.Versioning
         /// <param name="minVersion">Lower bound of the version range.</param>
         /// <param name="floatRange">Floating behavior.</param>
         public VersionRange(NuGetVersion minVersion, FloatRange floatRange)
-            : this(minVersion, true, null, false, null, floatRange)
+            : this(
+                  minVersion: minVersion,
+                  includeMinVersion: true,
+                  maxVersion: null,
+                  includeMaxVersion: false,
+                  originalString: null,
+                  floatRange: floatRange)
         {
         }
 
@@ -38,7 +44,7 @@ namespace NuGet.Versioning
         /// Clones a version range and applies a new float range.
         /// </summary>
         public VersionRange(VersionRange range, FloatRange floatRange)
-            : this(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive, range.IncludePrerelease, floatRange)
+            : this(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive, floatRange)
         {
         }
 
@@ -49,12 +55,11 @@ namespace NuGet.Versioning
         /// <param name="includeMinVersion">True if minVersion satisfies the condition.</param>
         /// <param name="maxVersion">Upper bound of the version range.</param>
         /// <param name="includeMaxVersion">True if maxVersion satisfies the condition.</param>
-        /// <param name="includePrerelease">True if prerelease versions should satisfy the condition.</param>
         /// <param name="floatRange">The floating range subset used to find the best version match.</param>
         /// <param name="originalString">The original string being parsed to this object.</param>
         public VersionRange(NuGetVersion minVersion = null, bool includeMinVersion = true, NuGetVersion maxVersion = null,
-            bool includeMaxVersion = false, bool? includePrerelease = null, FloatRange floatRange = null, string originalString = null)
-            : base(minVersion, includeMinVersion, maxVersion, includeMaxVersion, includePrerelease)
+            bool includeMaxVersion = false, FloatRange floatRange = null, string originalString = null)
+            : base(minVersion, includeMinVersion, maxVersion, includeMaxVersion)
         {
             _floatRange = floatRange;
             _originalString = originalString;
@@ -288,8 +293,7 @@ namespace NuGet.Versioning
                     minVersion,
                     IsMinInclusive,
                     MaxVersion,
-                    IsMaxInclusive,
-                    IncludePrerelease);
+                    IsMaxInclusive);
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
@@ -14,7 +14,6 @@ namespace NuGet.Versioning
         private readonly bool _includeMaxVersion;
         private readonly NuGetVersion _minVersion;
         private readonly NuGetVersion _maxVersion;
-        private readonly bool _includePrerelease;
 
         /// <summary>
         /// Creates a VersionRange with the given min and max.
@@ -23,24 +22,16 @@ namespace NuGet.Versioning
         /// <param name="includeMinVersion">True if minVersion satisfies the condition.</param>
         /// <param name="maxVersion">Upper bound of the version range.</param>
         /// <param name="includeMaxVersion">True if maxVersion satisfies the condition.</param>
-        /// <param name="includePrerelease">True if prerelease versions should satisfy the condition.</param>
-        public VersionRangeBase(NuGetVersion minVersion = null, bool includeMinVersion = true, NuGetVersion maxVersion = null,
-            bool includeMaxVersion = false, bool? includePrerelease = null)
+        public VersionRangeBase(
+            NuGetVersion minVersion = null,
+            bool includeMinVersion = true,
+            NuGetVersion maxVersion = null,
+            bool includeMaxVersion = false)
         {
             _minVersion = minVersion;
             _maxVersion = maxVersion;
             _includeMinVersion = includeMinVersion;
             _includeMaxVersion = includeMaxVersion;
-
-            if (includePrerelease == null)
-            {
-                _includePrerelease = (_maxVersion != null && IsPrerelease(_maxVersion) == true) ||
-                                     (_minVersion != null && IsPrerelease(_minVersion) == true);
-            }
-            else
-            {
-                _includePrerelease = includePrerelease == true;
-            }
         }
 
         /// <summary>
@@ -97,14 +88,6 @@ namespace NuGet.Versioning
         public NuGetVersion MinVersion
         {
             get { return _minVersion; }
-        }
-
-        /// <summary>
-        /// True if pre-release versions are included in this range.
-        /// </summary>
-        public bool IncludePrerelease
-        {
-            get { return _includePrerelease; }
         }
 
         /// <summary>
@@ -166,11 +149,6 @@ namespace NuGet.Versioning
                 {
                     condition &= comparer.Compare(MaxVersion, version) > 0;
                 }
-            }
-
-            if (!IncludePrerelease)
-            {
-                condition &= IsPrerelease(version) != true;
             }
 
             return condition;
@@ -277,12 +255,6 @@ namespace NuGet.Versioning
             }
 
             var result = true;
-
-            if (possibleSubSet.IncludePrerelease
-                && !target.IncludePrerelease)
-            {
-                result = false;
-            }
 
             if (possibleSubSet.HasLowerBound)
             {

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeBase.cs
@@ -303,6 +303,19 @@ namespace NuGet.Versioning
             return result;
         }
 
+        /// <summary>
+        /// Infer if the range should allow prerelease versions based on if the lower or upper bounds 
+        /// contain prerelease labels.
+        /// </summary>
+        protected bool HasPrereleaseBounds
+        {
+            get
+            {
+                return IsPrerelease(_minVersion) == true
+                    || IsPrerelease(_maxVersion) == true;
+            }
+        }
+
         private static bool? IsPrerelease(SemanticVersion version)
         {
             bool? b = null;

--- a/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRangeFactory.cs
@@ -16,27 +16,27 @@ namespace NuGet.Versioning
         /// <summary>
         /// A range that accepts all versions, prerelease and stable.
         /// </summary>
-        public static readonly VersionRange All = new VersionRange(null, true, null, true, true);
+        public static readonly VersionRange All = new VersionRange(null, true, null, true);
 
         /// <summary>
         /// A range that accepts all versions, prerelease and stable, and floats to the highest.
         /// </summary>
-        public static readonly VersionRange AllFloating = new VersionRange(null, true, null, true, true, new FloatRange(NuGetVersionFloatBehavior.AbsoluteLatest));
+        public static readonly VersionRange AllFloating = new VersionRange(null, true, null, true, new FloatRange(NuGetVersionFloatBehavior.AbsoluteLatest));
 
         /// <summary>
         /// A range that accepts all stable versions
         /// </summary>
-        public static readonly VersionRange AllStable = new VersionRange(null, true, null, true, false);
+        public static readonly VersionRange AllStable = new VersionRange(null, true, null, true);
 
         /// <summary>
         /// A range that accepts all versions, prerelease and stable, and floats to the highest.
         /// </summary>
-        public static readonly VersionRange AllStableFloating = new VersionRange(null, true, null, true, false, new FloatRange(NuGetVersionFloatBehavior.Major));
+        public static readonly VersionRange AllStableFloating = new VersionRange(null, true, null, true, new FloatRange(NuGetVersionFloatBehavior.Major));
 
         /// <summary>
         /// A range that rejects all versions
         /// </summary>
-        public static readonly VersionRange None = new VersionRange(new NuGetVersion(0, 0, 0), false, new NuGetVersion(0, 0, 0), false, false);
+        public static readonly VersionRange None = new VersionRange(new NuGetVersion(0, 0, 0), false, new NuGetVersion(0, 0, 0), false);
 
         /// <summary>
         /// The version string is either a simple version or an arithmetic range
@@ -99,7 +99,7 @@ namespace NuGet.Versioning
                 && charArray.Length == 1
                 && charArray[0] == '*')
             {
-                versionRange = new VersionRange(null, true, null, true, false, new FloatRange(NuGetVersionFloatBehavior.Major), originalString: value);
+                versionRange = new VersionRange(null, true, null, true, new FloatRange(NuGetVersionFloatBehavior.Major), originalString: value);
                 return true;
             }
 
@@ -232,38 +232,10 @@ namespace NuGet.Versioning
                 includeMinVersion: isMinInclusive,
                 maxVersion: maxVersion,
                 includeMaxVersion: isMaxInclusive,
-                includePrerelease: null,
                 floatRange: floatRange,
                 originalString: value);
 
             return true;
-        }
-
-        /// <summary>
-        /// Modify an existing range to allow or disallow prerelease versions.
-        /// </summary>
-        /// <param name="range">Existing version range to modify.</param>
-        /// <param name="includePrerelease">True if Satisfies() should allow prerelease versions.</param>
-        /// <returns>A modified version range.</returns>
-        public static VersionRange SetIncludePrerelease(VersionRange range, bool includePrerelease)
-        {
-            if (range.IncludePrerelease == includePrerelease)
-            {
-                // The range is already has this prerelease setting.
-                return range;
-            }
-            else
-            {
-                // Copy the range and apply the new include prerelease setting.
-                return new VersionRange(
-                    range.MinVersion,
-                    range.IsMinInclusive,
-                    range.MaxVersion,
-                    range.IsMaxInclusive,
-                    includePrerelease,
-                    floatRange: range.Float,
-                    originalString: range.OriginalString);
-            }
         }
 
         /// <summary>
@@ -330,7 +302,6 @@ namespace NuGet.Versioning
 
                 var lowest = first.MinVersion;
                 var highest = first.MaxVersion;
-                var includePre = first.IncludePrerelease;
 
                 // To keep things consistent set min/max inclusive to false when there is no boundary
                 // It is possible to denote an inclusive range with no bounds, but it has no useful meaning for combine
@@ -340,9 +311,6 @@ namespace NuGet.Versioning
                 // expand the range to inclue all other ranges
                 foreach (var range in ranges.Skip(1))
                 {
-                    // allow prerelease versions in the range if any range allows them
-                    includePre |= range.IncludePrerelease;
-
                     // once we have an unbounded lower we can stop checking
                     if (lowest != null)
                     {
@@ -401,7 +369,7 @@ namespace NuGet.Versioning
                 }
 
                 // Create the new range using the maximums found
-                result = new VersionRange(lowest, includeLowest, highest, includeHighest, includePre);
+                result = new VersionRange(lowest, includeLowest, highest, includeHighest);
             }
 
             return result;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4505,7 +4505,6 @@ namespace NuGet.Test
             var packageDependency = packageInfo.Dependencies.Single();
             Assert.Equal("b", packageDependency.Id);
             Assert.Equal(bVersionRange.ToString(), packageDependency.VersionRange.ToString());
-            Assert.True(packageDependency.VersionRange.IncludePrerelease);
         }
 
         private class TestDownloadResourceProvider : ResourceProvider

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeFloatParsingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeFloatParsingTests.cs
@@ -13,7 +13,6 @@ namespace NuGet.Versioning.Test
         {
             var range = VersionRange.Parse("1.0.0-*");
 
-            Assert.True(range.IncludePrerelease);
             Assert.True(range.MinVersion.IsPrerelease);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeOperationTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeOperationTests.cs
@@ -95,7 +95,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(a.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.False(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -109,7 +108,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.None.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.False(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -123,7 +121,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.None.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.False(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -137,7 +134,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.All.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.True(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -170,7 +166,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal("[1.0.0, 2.0.0]", combined.ToNormalizedString());
-            Assert.False(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -188,14 +183,13 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.All.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.True(combined.IncludePrerelease);
         }
 
         [Fact]
         public void VersionRangeSet_SpecialCaseRangeCombine_AllStablePlusPre()
         {
             // Arrange
-            var pre = new VersionRange(new NuGetVersion("1.0.0"), true, new NuGetVersion("2.0.0"), true, includePrerelease: true);
+            var pre = new VersionRange(new NuGetVersion("1.0.0"), true, new NuGetVersion("2.0.0"), true);
             var ranges = new List<VersionRange>() { VersionRange.AllStable, pre };
 
             // Act
@@ -203,7 +197,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.All.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.True(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -218,7 +211,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal(VersionRange.AllStable.ToNormalizedString(), combined.ToNormalizedString());
-            Assert.False(combined.IncludePrerelease);
         }
 
         [Fact]
@@ -242,7 +234,6 @@ namespace NuGet.Versioning.Test
 
             // Assert
             Assert.Equal("[1.0.0, 5.0.1-rc4]", combined.ToNormalizedString());
-            Assert.True(combined.IncludePrerelease);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -9,6 +9,37 @@ namespace NuGet.Versioning.Test
 {
     public class VersionRangeTests
     {
+        [Theory]
+        [InlineData("1.0.0", "1.0.1-beta", false)]
+        [InlineData("1.0.0", "1.0.1", true)]
+        [InlineData("1.0.0-*", "1.0.0-beta", true)]
+        [InlineData("1.0.0-beta.*", "1.0.0-beta.1", true)]
+        [InlineData("1.0.0-beta-*", "1.0.0-beta-01", true)]
+        [InlineData("1.0.0-beta-*", "2.0.0-beta", true)]
+        [InlineData("1.0.*", "1.0.0-beta", false)]
+        [InlineData("1.*", "1.0.0-beta", false)]
+        [InlineData("*", "1.0.0-beta", false)]
+        [InlineData("[1.0.0, 2.0.0]", "1.5.0-beta", false)]
+        [InlineData("[1.0.0, 2.0.0-beta]", "1.5.0-beta", true)]
+        [InlineData("[1.0.0-beta, 2.0.0]", "1.5.0-beta", true)]
+        [InlineData("[1.0.0-beta, 2.0.0]", "3.5.0-beta", false)]
+        [InlineData("[1.0.0-beta, 2.0.0]", "0.5.0-beta", false)]
+        [InlineData("[1.0.0-beta, 2.0.0)", "2.0.0", false)]
+        [InlineData("[1.0.0-beta, 2.0.0)", "2.0.0-beta", true)]
+        [InlineData("[1.0.*, 2.0.0-beta]", "2.0.0-beta", true)]
+        public void VersionRange_IsBetter_Prerelease(string rangeString, string versionString, bool expected)
+        {
+            // Arrange 
+            var range = VersionRange.Parse(rangeString);
+            var considering = NuGetVersion.Parse(versionString);
+
+            // Act
+            var result = range.IsBetter(current: null, considering: considering);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
         [Fact]
         public void VersionRange_MetadataIsIgnored_Satisfy()
         {
@@ -140,30 +171,10 @@ namespace NuGet.Versioning.Test
         public void VersionRange_Exact()
         {
             // Act 
-            var versionInfo = new VersionRange(new NuGetVersion(4, 3, 0), true, new NuGetVersion(4, 3, 0), true, false);
+            var versionInfo = new VersionRange(new NuGetVersion(4, 3, 0), true, new NuGetVersion(4, 3, 0), true);
 
             // Assert
             Assert.True(versionInfo.Satisfies(NuGetVersion.Parse("4.3.0")));
-        }
-
-        [Fact]
-        public void ParseVersionRangePrerelease()
-        {
-            // Act 
-            var versionInfo = VersionRange.Parse("(1.2-Alpha, 1.3-Beta)");
-
-            // Assert
-            Assert.True(versionInfo.IncludePrerelease);
-        }
-
-        [Fact]
-        public void ParseVersionRangeNoPrerelease()
-        {
-            // Act 
-            var versionInfo = new VersionRange(minVersion: new NuGetVersion("1.2-Alpha"), includePrerelease: false);
-
-            // Assert
-            Assert.False(versionInfo.IncludePrerelease);
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -114,45 +114,15 @@ namespace NuGet.Versioning.Test
         [InlineData("(1.0.0, 2.0.0-alpha)")]
         [InlineData("1.0.0-beta-*")]
         [InlineData("[1.0.0-beta-*, ]")]
-        public void VersionRange_SetIncludePrerelease_True(string s)
+        public void VersionRange_IncludePrerelease(string s)
         {
             // Arrange
             var range = VersionRange.Parse(s);
 
-            // Act
-            var updated = VersionRange.SetIncludePrerelease(range, true);
-
-            // Assert
-            Assert.Equal(range.IsFloating, updated.IsFloating);
-            Assert.Equal(range.Float, updated.Float);
-            Assert.True(updated.IncludePrerelease);
-            Assert.Equal(range.ToNormalizedString(), updated.ToNormalizedString());
-        }
-
-        [Theory]
-        [InlineData("[1.0.0]")]
-        [InlineData("[1.0.0, 2.0.0]")]
-        [InlineData("[1.0.0, 2.0.0]")]
-        [InlineData("1.0.0")]
-        [InlineData("1.0.0-beta")]
-        [InlineData("(1.0.0-beta, 2.0.0-alpha)")]
-        [InlineData("(1.0.0-beta, 2.0.0)")]
-        [InlineData("(1.0.0, 2.0.0-alpha)")]
-        [InlineData("1.0.0-beta-*")]
-        [InlineData("[1.0.0-beta-*, ]")]
-        public void VersionRange_SetIncludePrerelease_False(string s)
-        {
-            // Arrange
-            var range = VersionRange.Parse(s);
-
-            // Act
-            var updated = VersionRange.SetIncludePrerelease(range, false);
-
-            // Assert
-            Assert.Equal(range.IsFloating, updated.IsFloating);
-            Assert.Equal(range.Float, updated.Float);
-            Assert.False(updated.IncludePrerelease);
-            Assert.Equal(range.ToNormalizedString(), updated.ToNormalizedString());
+            // Act && Assert
+            Assert.Equal(range.IsFloating, range.IsFloating);
+            Assert.Equal(range.Float, range.Float);
+            Assert.Equal(range.ToNormalizedString(), range.ToNormalizedString());
         }
 
         [Fact]


### PR DESCRIPTION
This change removes VersionRange.IncludePrerelease which has been a major source of bugs since it was added to make the legacy behavior of auto inferring if prerelease should be allowed from the bounds more explicit. Since this flag cannot be included in the version range string it cannot be round tripped and the result is often incorrect.

Packages.config operations already set this flag to true everywhere and handle the check separately. For project.json operations the only place this was being used was in IsBetter which I've updated to keep the same behavior.

//cc @joelverhagen @zhili1208 @alpaix @rrelyea @jainaashish 
