### PR TITLE
Display useful error message with misnamed restore target.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -482,6 +482,11 @@ namespace NuGet.CommandLine
             {
                 ProcessSolutionFile(projectFilePath, packageRestoreInputs);
             }
+            else
+            {
+                // Not a file we know about. Try to be helpful without response.
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, RestoreRunner.GetInvalidInputErrorMessage(projectFileName), projectFileName));
+            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -196,16 +196,31 @@ namespace NuGet.Commands
 
             if (File.Exists(input) || Directory.Exists(input))
             {
-                throw new InvalidOperationException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.Error_InvalidCommandLineInput,
-                        input));
+                // Not a file or directory we know about. Try to be helpful without response.
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, GetInvalidInputErrorMessage(input), input));
             }
-            else
+
+            throw new FileNotFoundException(input);
+        }
+
+        public static string GetInvalidInputErrorMessage(string input)
+        {
+            Debug.Assert(File.Exists(input) || Directory.Exists(input));
+            if (File.Exists(input))
             {
-                throw new FileNotFoundException(input);
+                var fileExtension = Path.GetExtension(input);
+                if (".json".Equals(fileExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Strings.Error_InvalidCommandLineInputJson;
+                }
+
+                if (".config".Equals(fileExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Strings.Error_InvalidCommandLineInputConfig;
+                }
             }
+
+            return Strings.Error_InvalidCommandLineInput;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -105,6 +105,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Invalid input &apos;{0}&apos;. Valid file names are &apos;packages.config&apos; or &apos;packages.*.config&apos;..
+        /// </summary>
+        public static string Error_InvalidCommandLineInputConfig {
+            get {
+                return ResourceManager.GetString("Error_InvalidCommandLineInputConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Invalid input &apos;{0}&apos;. Valid file names are &apos;project.json&apos; or &apos;*.project.json&apos;..
+        /// </summary>
+        public static string Error_InvalidCommandLineInputJson {
+            get {
+                return ResourceManager.GetString("Error_InvalidCommandLineInputJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Failed to build package because of an unsupported targetFramework value on &apos;{0}&apos;..
         /// </summary>
         public static string Error_InvalidTargetFramework {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -256,6 +256,12 @@
   <data name="Error_InvalidCommandLineInput" xml:space="preserve">
     <value>Invalid input '{0}'. The file type was not recognized.</value>
   </data>
+  <data name="Error_InvalidCommandLineInputJson" xml:space="preserve">
+    <value>Invalid input '{0}'. Valid file names are 'project.json' or '*.project.json'.</value>
+  </data>
+  <data name="Error_InvalidCommandLineInputConfig" xml:space="preserve">
+    <value>Invalid input '{0}'. Valid file names are 'packages.config' or 'packages.*.config'.</value>
+  </data>
   <data name="Log_RestoringToolPackages" xml:space="preserve">
     <value>Restoring packages for tool '{0}' in {1}...</value>
     <comment>String format parameters:


### PR DESCRIPTION
Currently when you specify an invalid restore target (for example, `project.foo.json` instead of `foo.project.json`), you get an inconsistent and not very useful result:
- From nuget.exe, there is no error message.
- From dotnet.exe, the error message simply says `error: Invalid input 'XXX'. The file type was not recognized.`

This change implements consistent and useful error messages in both scenarios:
- If you specify an invalid .json file, the error message says `Invalid input 'XXX'. Valid file names are 'project.json' or '*.project.json'.`
- If you specify an invalid .config file, the error message says `Invalid input 'XXX'.  Valid file names are 'packages.config' or 'packages.*.config'.`
- For any other files, the error message is as before (except that it is also displayed when using nuget.exe).

This resolves https://github.com/NuGet/Home/issues/2654
