### PR TITLE
Content files in referenced projects are not always included

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -251,12 +251,8 @@ namespace NuGet.CommandLine
             // Add output files
             ApplyAction(p => p.AddOutputFiles(builder));
 
-            // if there is a .nuspec file, only add content files if the <files /> element is not empty.
-            if (manifest == null || manifest.Files == null || manifest.Files.Count > 0 || IncludeReferencedProjects)
-            {
-                // Add content files
-                ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));
-            }
+            // Add content files if there are any. They could come from a project or nuspec file
+            ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));
 
             // Add sources if this is a symbol package
             if (IncludeSymbols)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -252,7 +252,7 @@ namespace NuGet.CommandLine
             ApplyAction(p => p.AddOutputFiles(builder));
 
             // if there is a .nuspec file, only add content files if the <files /> element is not empty.
-            if (manifest == null || manifest.Files == null || manifest.Files.Count > 0)
+            if (manifest == null || manifest.Files == null || manifest.Files.Count > 0 || IncludeReferencedProjects)
             {
                 // Add content files
                 ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));


### PR DESCRIPTION
There was an optimization put in the code to skip checking for content files if there was a nuspec file and no content files in it, but that misses content files referenced by the project file or by referenced projects. This change removes the bad optimization and just always checking for content files. It's a quick check so it won't impact perf.

Fixes https://github.com/NuGet/Home/issues/2658

@emgarten @spadapet @joelverhagen @yishaigalatzer @rrelyea @alpaix 
