### PR TITLE
Fixed allowing downgrade for batch update.

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -726,7 +726,21 @@ namespace NuGet.PackageManagement
                 }
 
                 // Unless the packageIdentity was explicitly asked for we should remove any potential downgrades
-                var allowDowngrades = packageIdentities.Count > 0;
+                var allowDowngrades = false;
+                if (packageIdentities.Count == 1)
+                {
+                    // Get installed package version
+                    var packageTargetsForResolver = new HashSet<PackageIdentity>(oldListOfInstalledPackages, PackageIdentity.Comparer);
+                    var installedPackageWithSameId = packageTargetsForResolver.Where(p => p.Id.Equals(packageIdentities[0].Id, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    if (installedPackageWithSameId != null)
+                    {
+                        if (installedPackageWithSameId.Version > packageIdentities[0].Version)
+                        {
+                            // Looks like the installed package is of higher version than one being installed. So, we take it that downgrade is allowed
+                            allowDowngrades = true;
+                        }
+                    }
+                }
 
                 var gatherContext = new GatherContext()
                 {
@@ -2398,6 +2412,6 @@ namespace NuGet.PackageManagement
                     string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedPackageFeature,
                     packageIdentity.Id + " " + packageIdentity.Version.ToNormalizedString()));
             }
-        }
+        }        
     }
 }


### PR DESCRIPTION
allowedDowngrade flag was wrongly set before. there is no way down grade is allowed for batch update so fixed that. Even for single update, it will first check if main update is down grade or not before setting this flag.

Fix https://github.com/NuGet/Home/issues/1903
