### PR TITLE
Additional project file path checks for web sites

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -98,9 +98,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 var projectFileFullPath = dteReference.Path;
                 var project = dteReference.Project;
 
-                if (!uniqueNames.Add(projectFileFullPath))
+                if (string.IsNullOrEmpty(projectFileFullPath) || !uniqueNames.Add(projectFileFullPath))
                 {
-                    // This has already been processed
+                    // This has already been processed or does not exist
                     continue;
                 }
 
@@ -215,7 +215,8 @@ namespace NuGet.PackageManagement.VisualStudio
                         var childName = EnvDTEProjectUtility.GetFullProjectPath(childReference.SourceProject);
 
                         // Skip projects which have ReferenceOutputAssembly=false
-                        if (!excludedProjects.Contains(childName, StringComparer.OrdinalIgnoreCase))
+                        if (!string.IsNullOrEmpty(childName)
+                            && !excludedProjects.Contains(childName, StringComparer.OrdinalIgnoreCase))
                         {
                             childReferences.Add(childName);
 
@@ -298,10 +299,14 @@ namespace NuGet.PackageManagement.VisualStudio
                         if (pathToProject.TryGetValue(xProjPath, out xProjDTE))
                         {
                             var xProjFullPath = EnvDTEProjectUtility.GetFullProjectPath(xProjDTE);
-                            childReferences.Add(xProjFullPath);
 
-                            // Continue walking this project if it has not been walked already
-                            result.ToProcess.Add(new DTEReference(xProjDTE, xProjFullPath));
+                            if (!string.IsNullOrEmpty(xProjFullPath))
+                            {
+                                childReferences.Add(xProjFullPath);
+
+                                // Continue walking this project if it has not been walked already
+                                result.ToProcess.Add(new DTEReference(xProjDTE, xProjFullPath));
+                            }
                         }
                     }
                 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
@@ -118,29 +119,26 @@ namespace NuGet.PackageManagement.VisualStudio
             Debug.Assert(envDTEProject != null);
             if (IsUnloaded(envDTEProject))
             {
-                // To get the directory of an unloaded project, we use the UniqueName property,
-                // which is the path of the project file relative to the solution directory.
+                // Find the project file path from the UniqueName which contains the file path 
+                // relative to the solution directory for unloaded projects.
                 var solutionDirectory = Path.GetDirectoryName(envDTEProject.DTE.Solution.FullName);
                 return Path.Combine(solutionDirectory, envDTEProject.UniqueName);
             }
 
             // FullPath
-            string fullPath = GetPropertyValue<string>(envDTEProject, "FullPath");
+            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, "FullPath"));
 
-            if (!String.IsNullOrEmpty(fullPath))
+            if (fullPath != null)
             {
-                // Some Project System implementations (JS metro app) return the project 
-                // file as FullPath. We only need the parent directory
-                if (File.Exists(fullPath))
-                {
-                    return fullPath;
-                }
+                return fullPath;
             }
 
             // FullName
-            if (!String.IsNullOrEmpty(envDTEProject.FullName))
+            var fullName = GetPotentialFullPathOrNull(envDTEProject.FullName);
+
+            if (fullName != null)
             {
-                return Path.GetFullPath(envDTEProject.FullName);
+                return fullName;
             }
 
             Debug.Fail("Unable to find the project path");
@@ -1016,7 +1014,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var localProjectAssemblies = GetLocalProjectAssemblies(envDTEProject);
             CollectionsUtility.AddRange(assemblies, localProjectAssemblies);
-            
+
             var referencedProjects = GetReferencedProjects(envDTEProject);
             foreach (var project in referencedProjects)
             {
@@ -1056,7 +1054,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     // Get the referenced project from the reference if any
                     // In C++ projects if reference3.Resolved is false reference3.SourceProject will throw.
-                    if (reference3 != null 
+                    if (reference3 != null
                         && reference3.Resolved
                         && reference.SourceProject == null
                         && reference.CopyLocal
@@ -1204,6 +1202,43 @@ namespace NuGet.PackageManagement.VisualStudio
             return token == "*" ? @"(.*)" : @"(" + token + ")";
         }
 
+        /// <summary>
+        /// A DTE specific helper method that validates a path to ensure that it 
+        /// could be for a file as opposed to a URL or other invalid path, and
+        /// not for a directory. This is used to help determine if a value returned
+        /// from DTE is a directory or file, since the file may still be in 
+        /// memory and not yet written to disk File.Exists will not work.
+        /// </summary>
+        private static string GetPotentialFullPathOrNull(string path)
+        {
+            string fullPath = null;
+
+            try
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    // Attempt to get the full path
+                    fullPath = Path.GetFullPath(path);
+
+                    if (Directory.Exists(fullPath))
+                    {
+                        // Ignore directories
+                        fullPath = null;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is ArgumentException
+                || ex is NotSupportedException
+                || ex is PathTooLongException
+                || ex is SecurityException)
+            {
+                // Ignore invalid paths
+                // This can occur if the path was a URL
+            }
+
+            return fullPath;
+        }
+
         #endregion // Get "Project" Information
 
         #region Check Project Types
@@ -1280,9 +1315,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var hier = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
 
-            foreach(var unsupportedProjectCapability in UnsupportedProjectCapabilities)
+            foreach (var unsupportedProjectCapability in UnsupportedProjectCapabilities)
             {
-                if(hier.IsCapabilityMatch(unsupportedProjectCapability))
+                if (hier.IsCapabilityMatch(unsupportedProjectCapability))
                 {
                     return true;
                 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSNuGetProjectFactory.cs
@@ -58,44 +58,58 @@ namespace NuGet.PackageManagement.VisualStudio
             if (projectK != null)
             {
                 result = new ProjectKNuGetProject(
-                    projectK, 
-                    envDTEProject.Name, 
+                    projectK,
+                    envDTEProject.Name,
                     EnvDTEProjectUtility.GetCustomUniqueName(envDTEProject));
             }
             else
             {
                 var msBuildNuGetProjectSystem = MSBuildNuGetProjectSystemFactory.CreateMSBuildNuGetProjectSystem(
-                    envDTEProject, 
+                    envDTEProject,
                     nuGetProjectContext);
 
-                var msbuildProjectFile = new FileInfo(EnvDTEProjectUtility.GetFullProjectPath(envDTEProject));
-                var projectNameFromMSBuildPath = Path.GetFileNameWithoutExtension(msbuildProjectFile.Name);
+                var isWebSite = msBuildNuGetProjectSystem is WebSiteProjectSystem;
 
-                // Treat projects with project.json as build integrated projects
-                // Search for projectName.project.json first, then project.json
-                // For website project, since projectNameFromMSBuildPath is empty, only search project.json
-                string projectJsonPath = null;
-                if (string.IsNullOrEmpty(projectNameFromMSBuildPath))
+                // Web sites cannot have project.json
+                if (!isWebSite)
                 {
-                    projectJsonPath = Path.Combine(msbuildProjectFile.DirectoryName, 
-                        ProjectJsonPathUtilities.ProjectConfigFileName);
-                }
-                else
-                {
-                    projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(msbuildProjectFile.DirectoryName,
-                    projectNameFromMSBuildPath);
+                    // Find the project file path
+                    var projectFilePath = EnvDTEProjectUtility.GetFullProjectPath(envDTEProject);
+
+                    if (!string.IsNullOrEmpty(projectFilePath))
+                    {
+                        var msbuildProjectFile = new FileInfo(projectFilePath);
+                        var projectNameFromMSBuildPath = Path.GetFileNameWithoutExtension(msbuildProjectFile.Name);
+
+                        // Treat projects with project.json as build integrated projects
+                        // Search for projectName.project.json first, then project.json
+                        // If the name cannot be determined, search only for project.json
+                        string projectJsonPath = null;
+                        if (string.IsNullOrEmpty(projectNameFromMSBuildPath))
+                        {
+                            projectJsonPath = Path.Combine(msbuildProjectFile.DirectoryName,
+                                ProjectJsonPathUtilities.ProjectConfigFileName);
+                        }
+                        else
+                        {
+                            projectJsonPath = ProjectJsonPathUtilities.GetProjectConfigPath(msbuildProjectFile.DirectoryName,
+                            projectNameFromMSBuildPath);
+                        }
+
+                        if (File.Exists(projectJsonPath))
+                        {
+                            result = new BuildIntegratedProjectSystem(
+                                projectJsonPath,
+                                msbuildProjectFile.FullName,
+                                envDTEProject,
+                                msBuildNuGetProjectSystem,
+                                EnvDTEProjectUtility.GetCustomUniqueName(envDTEProject));
+                        }
+                    }
                 }
 
-                if (File.Exists(projectJsonPath))
-                {
-                    result = new BuildIntegratedProjectSystem(
-                        projectJsonPath,
-                        msbuildProjectFile.FullName,
-                        envDTEProject,
-                        msBuildNuGetProjectSystem,
-                        EnvDTEProjectUtility.GetCustomUniqueName(envDTEProject));
-                }
-                else
+                // Create a normal MSBuild project if no project.json was found
+                if (result == null)
                 {
                     var folderNuGetProjectFullPath = _packagesPath();
 
@@ -103,8 +117,8 @@ namespace NuGet.PackageManagement.VisualStudio
                     var packagesConfigFolderPath = EnvDTEProjectUtility.GetFullPath(envDTEProject);
 
                     result = new MSBuildNuGetProject(
-                        msBuildNuGetProjectSystem, 
-                        folderNuGetProjectFullPath, 
+                        msBuildNuGetProjectSystem,
+                        folderNuGetProjectFullPath,
                         packagesConfigFolderPath);
                 }
             }


### PR DESCRIPTION
This change adds handling for WebSite projects which can return the server URL for the project path.

The primary fix for this is to skip looking for project.json completely for web site projects, it would not work if it was there since these do not have msbuild.

In addition to this I've made a fix to the DTE helper to handle bad paths gracefully. Callers of this helper will now check the output, this should cover any 3rd party project systems that return URLs, and it ensures that if a web site project is referenced as a dependency that it will be ignored without causing a crash.

https://github.com/NuGet/Home/issues/2667

//cc @rrelyea @zhili1208 @joelverhagen @alpaix 
