### PR TITLE
Fix for making ObservableCollection in InfiniteScrollList thread-safe

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -197,11 +197,10 @@ namespace NuGet.PackageManagement.UI
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                _loadingStatusBar.ItemsLoaded = currentLoader.State.ItemsCount;
-                
-                // multiple loads may occur at the same time
+               // multiple loads may occur at the same time
                 if (currentLoader == _loader)
                 {
+                    _loadingStatusBar.ItemsLoaded = currentLoader.State.ItemsCount;
                     UpdatePackageList(loadedItems, refresh: false);
                 }
                 

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -314,11 +314,11 @@ namespace NuGet.PackageManagement.UI
             }
 
             // add newly loaded items
-            foreach (PackageItemListViewModel pItem in packages)
+            foreach (var package in packages)
             {
-                pItem.PropertyChanged += Package_PropertyChanged;
-                Items.Add(pItem);
-                _selectedCount = pItem.Selected ? _selectedCount + 1 : _selectedCount;
+                package.PropertyChanged += Package_PropertyChanged;
+                Items.Add(package);
+                _selectedCount = package.Selected ? _selectedCount + 1 : _selectedCount;
             }
 
             Items.Add(_loadingStatusIndicator);
@@ -326,9 +326,9 @@ namespace NuGet.PackageManagement.UI
 
         private void ClearPackageList()
         {
-            foreach (PackageItemListViewModel pItem in PackageItems)
+            foreach (var package in PackageItems)
             {
-                pItem.PropertyChanged -= Package_PropertyChanged;
+                package.PropertyChanged -= Package_PropertyChanged;
             }
 
             Items.Clear();
@@ -339,9 +339,9 @@ namespace NuGet.PackageManagement.UI
         {
             // in this case, we only need to update PackageStatus of
             // existing items in the package list
-            foreach (PackageItemListViewModel pItem in PackageItems)
+            foreach (var package in PackageItems)
             {
-                pItem.UpdatePackageStatus(installedPackages);
+                package.UpdatePackageStatus(installedPackages);
             }
         }
 


### PR DESCRIPTION
Fix for issue: https://github.com/NuGet/Home/issues/2673

This fix avoids accessing the ObservableCollection (Items) from a background thread at all, thereby removing the need for synchronizing access to the collection.

We have also added guard conditions whenever Items is accessed to make sure that it is only accessible from the UI Thread.

CC: @alpaix @emgarten @joelverhagen @yishaigalatzer @rrelyea 
