### PR TITLE
Setting prerelease flag from Version specified while installing package

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -219,9 +219,11 @@ namespace NuGet.CommandLine
 
             var primaryRepositories = packageSources.Select(sourceRepositoryProvider.CreateRepository);
 
+            var allowPrerelease = Prerelease || (version != null && version.IsPrerelease);
+
             var resolutionContext = new ResolutionContext(
                 DependencyBehavior.Lowest,
-                includePrelease: Prerelease,
+                includePrelease: allowPrerelease,
                 includeUnlisted: true,
                 versionConstraints: VersionConstraints.None);
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -685,6 +685,45 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        // Tests that when prerelease version is specified, and -Prerelease is not specified,
+        [Fact]
+        public void InstallCommand_WithPrereleaseVersionSpecified()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Add a nuget.config to clear out sources and set the global packages folder
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+                var package1 = new ZipPackage(packageFileName);
+
+                packageFileName = Util.CreateTestPackage("testPackage1", "1.2.0-beta1", packageDirectory);
+                var package2 = new ZipPackage(packageFileName);
+
+                using (var server = Util.CreateMockServer(new[] { package1, package2 }))
+                {
+                    server.Start();
+
+                    // Act
+                    var args = "install testPackage1 -Version 1.2.0-beta1 -Source " + server.Uri + "nuget";
+                    var r1 = CommandRunner.Run(
+                        nugetexe,
+                        workingPath,
+                        args,
+                        waitForExit: true);
+
+                    // Assert
+                    Assert.Equal(0, r1.Item1);
+
+                    // testPackage1 1.2.0-beta1 is installed
+                    Assert.True(Directory.Exists(Path.Combine(workingPath, "packages", "testPackage1.1.2.0-beta1")));
+                }
+            }
+        }
+
         // Tests that when -Version is specified, nuget will use request
         // Packages(Id='id',Version='version') to get the specified version
         [Fact]


### PR DESCRIPTION
So far we were only taking prerelease flag into consideration while installing a package, but we can also access it through specified version (with install command) to check whether installing version is prerelease or not.

Fix https://github.com/NuGet/Home/issues/2512

@joelverhagen @emgarten @alpaix 
