### PR TITLE
Fix to save packages.config projects after adding a nuget package

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -186,6 +186,16 @@ namespace NuGet.PackageManagement.VisualStudio
             return projects;
         }
 
+        public void SaveProject(NuGetProject nuGetProject)
+        {
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var safeName = GetNuGetProjectSafeName(nuGetProject);
+                EnvDTEProjectUtility.Save(GetDTEProject(safeName));
+            });
+        }
+
         private IEnumerable<EnvDTEProject> GetEnvDTEProjects()
         {
             Debug.Assert(ThreadHelper.CheckAccess());

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -90,6 +90,12 @@ namespace NuGet.PackageManagement
         /// </summary>
         /// <param name="actions"></param>
         void OnActionsExecuted(IEnumerable<ResolvedAction> actions);
+
+        /// <summary>
+        /// Saves the specified project
+        /// </summary>
+        /// <param name="nuGetProject"></param>
+        void SaveProject(NuGetProject nuGetProject);
     }
 
     public class NuGetProjectEventArgs : EventArgs

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1706,6 +1706,9 @@ namespace NuGet.PackageManagement
                     }
                 }
 
+                // Save project
+                SolutionManager?.SaveProject(nuGetProject);
+
                 // Clear direct install
                 SetDirectInstall(null, nuGetProjectContext);
 

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -179,6 +179,11 @@ namespace Test.Utility
             }
         }
 
+        public void SaveProject(NuGetProject nuGetProject)
+        {
+            //do nothing.
+        }
+
         public void Dispose()
         {
             var testDirectory = _testDirectory;


### PR DESCRIPTION
Fix for : https://github.com/NuGet/Home/issues/2214

After all operations are completed, this fix saves the NuGet project after installing a package.

CC: @alpaix @emgarten @joelverhagen @zhili1208  @rrelyea 
