### PR TITLE
Download packages for packages.config in parallel

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -265,12 +265,12 @@ namespace NuGet.PackageManagement
         /// and <paramref name="nuGetProjectContext" /> are used in the process.
         /// </summary>
         public async Task<IEnumerable<NuGetProjectAction>> PreviewInstallPackageAsync(
-            NuGetProject nuGetProject, 
+            NuGetProject nuGetProject,
             string packageId,
-            ResolutionContext resolutionContext, 
+            ResolutionContext resolutionContext,
             INuGetProjectContext nuGetProjectContext,
-            IEnumerable<SourceRepository> primarySources, 
-            IEnumerable<SourceRepository> secondarySources, 
+            IEnumerable<SourceRepository> primarySources,
+            IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
             if (nuGetProject == null)
@@ -1609,10 +1609,41 @@ namespace NuGet.PackageManagement
                     await ideExecutionContext.SaveExpandedNodeStates(SolutionManager);
                 }
 
+                var logger = new ProjectContextLogger(nuGetProjectContext);
+                Dictionary<PackageIdentity, PackagePreFetcherResult> downloadTasks = null;
+                CancellationTokenSource downloadTokenSource = null;
+
                 try
                 {
+                    // PreProcess projects
                     await nuGetProject.PreProcessAsync(nuGetProjectContext, token);
-                    foreach (var nuGetProjectAction in nuGetProjectActions)
+
+                    var actionsList = nuGetProjectActions.ToList();
+
+                    var hasInstalls = actionsList.Any(action =>
+                        action.NuGetProjectActionType == NuGetProjectActionType.Install);
+
+                    if (hasInstalls)
+                    {
+                        // Make this independently cancelable.
+                        downloadTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+                        // Download all packages up front in parallel
+                        downloadTasks = await PackagePreFetcher.GetPackagesAsync(
+                            actionsList,
+                            PackagesFolderNuGetProject,
+                            Settings,
+                            logger,
+                            downloadTokenSource.Token);
+
+                        // Log download information
+                        PackagePreFetcher.LogFetchMessages(
+                            downloadTasks.Values,
+                            PackagesFolderNuGetProject.Root,
+                            logger);
+                    }
+
+                    foreach (var nuGetProjectAction in actionsList)
                     {
                         executedNuGetProjectActions.Push(nuGetProjectAction);
                         if (nuGetProjectAction.NuGetProjectActionType == NuGetProjectActionType.Uninstall)
@@ -1624,17 +1655,21 @@ namespace NuGet.PackageManagement
                         }
                         else
                         {
-                            using (var downloadPackageResult = await
-                                    PackageDownloader.GetDownloadResourceResultAsync(nuGetProjectAction.SourceRepository,
-                                    nuGetProjectAction.PackageIdentity,
-                                    Settings,
-                                    new ProjectContextLogger(nuGetProjectContext),
-                                    token))
+                            // Retrieve the downloaded package
+                            // This will wait on the package if it is still downloading
+                            var preFetchResult = downloadTasks[nuGetProjectAction.PackageIdentity];
+                            using (var downloadPackageResult = await preFetchResult.GetResultAsync())
                             {
                                 // use the version exactly as specified in the nuspec file
                                 var packageIdentity = downloadPackageResult.PackageReader.GetIdentity();
 
-                                await ExecuteInstallAsync(nuGetProject, packageIdentity, downloadPackageResult, packageWithDirectoriesToBeDeleted, nuGetProjectContext, token);
+                                await ExecuteInstallAsync(
+                                    nuGetProject,
+                                    packageIdentity,
+                                    downloadPackageResult,
+                                    packageWithDirectoriesToBeDeleted,
+                                    nuGetProjectContext,
+                                    token);
                             }
                         }
 
@@ -1660,13 +1695,32 @@ namespace NuGet.PackageManagement
                                 nuGetProject.GetMetadata<string>(NuGetProjectMetadataKeys.Name));
                         }
                     }
+
+                    // Post process
                     await nuGetProject.PostProcessAsync(nuGetProjectContext, token);
 
+                    // Open readme file
                     await OpenReadmeFile(nuGetProject, nuGetProjectContext, token);
                 }
                 catch (Exception ex)
                 {
                     exceptionInfo = ExceptionDispatchInfo.Capture(ex);
+                }
+                finally
+                {
+                    if (downloadTasks != null)
+                    {
+                        // Wait for all downloads to cancel and dispose
+                        downloadTokenSource.Cancel();
+
+                        foreach (var result in downloadTasks.Values)
+                        {
+                            await result.EnsureResultAsync();
+                            result.Dispose();
+                        }
+
+                        downloadTokenSource.Dispose();
+                    }
                 }
 
                 if (exceptionInfo != null)

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetProjectAction.cs
@@ -61,7 +61,7 @@ namespace NuGet.PackageManagement
             return new NuGetProjectAction(packageIdentity, NuGetProjectActionType.Install, sourceRepository);
         }
 
-        internal static NuGetProjectAction CreateUninstallProjectAction(PackageIdentity packageIdentity)
+        public static NuGetProjectAction CreateUninstallProjectAction(PackageIdentity packageIdentity)
         {
             return new NuGetProjectAction(packageIdentity, NuGetProjectActionType.Uninstall);
         }

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
@@ -66,12 +66,10 @@ namespace NuGet.PackageManagement
             foreach (var action in actions)
             {
                 // Ignore uninstalls here
+                // Avoid duplicate downloads
                 if (action.NuGetProjectActionType == NuGetProjectActionType.Install
-                    && !seen.Contains(action.PackageIdentity))
+                    && seen.Add(action.PackageIdentity))
                 {
-                    // Avoid duplicate downloads
-                    seen.Add(action.PackageIdentity);
-
                     string installPath = null;
 
                     // Packages that are also being uninstalled cannot come from the
@@ -88,6 +86,8 @@ namespace NuGet.PackageManagement
                         }
                     }
 
+                    // installPath will contain the full path of the already installed nupkg if it
+                    // exists. If the path is empty it will need to be downloaded.
                     if (!string.IsNullOrEmpty(installPath))
                     {
                         // Create a download result using the already installed package

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement
+{
+    public static class PackagePreFetcher
+    {
+        /// <summary>
+        /// Download all needed packages for install actions.
+        /// </summary>
+        public static async Task<Dictionary<PackageIdentity, PackagePreFetcherResult>> GetPackagesAsync(
+            IEnumerable<NuGetProjectAction> actions,
+            FolderNuGetProject packagesFolder,
+            Configuration.ISettings settings,
+            Common.ILogger logger,
+            CancellationToken token)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            if (packagesFolder == null)
+            {
+                throw new ArgumentNullException(nameof(packagesFolder));
+            }
+
+            if (actions == null)
+            {
+                throw new ArgumentNullException(nameof(actions));
+            }
+
+            var result = new Dictionary<PackageIdentity, PackagePreFetcherResult>();
+            var maxParallelTasks = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
+            var toDownload = new Queue<NuGetProjectAction>();
+            var seen = new HashSet<PackageIdentity>();
+
+            // Find all uninstalled packages
+            var uninstalledPackages = new HashSet<PackageIdentity>(
+                actions.Where(action => action.NuGetProjectActionType == NuGetProjectActionType.Uninstall)
+                .Select(action => action.PackageIdentity));
+
+            // Check the packages folder for each package
+            // If the package is not found mark it for download
+            // These actions need to stay in order!
+            foreach (var action in actions)
+            {
+                // Ignore uninstalls here
+                if (action.NuGetProjectActionType == NuGetProjectActionType.Install
+                    && !seen.Contains(action.PackageIdentity))
+                {
+                    // Avoid duplicate downloads
+                    seen.Add(action.PackageIdentity);
+
+                    string installPath = null;
+
+                    // Packages that are also being uninstalled cannot come from the
+                    // packages folder since it will be gone. This is true for reinstalls.
+                    if (!uninstalledPackages.Contains(action.PackageIdentity))
+                    {
+                        // Check the packages folder for the id and version
+                        installPath = packagesFolder.GetInstalledPackageFilePath(action.PackageIdentity);
+
+                        // Verify the nupkg exists
+                        if (!File.Exists(installPath))
+                        {
+                            installPath = null;
+                        }
+                    }
+
+                    if (!string.IsNullOrEmpty(installPath))
+                    {
+                        // Create a download result using the already installed package
+                        var downloadResult = new PackagePreFetcherResult(installPath, action.PackageIdentity);
+                        result.Add(action.PackageIdentity, downloadResult);
+                    }
+                    else
+                    {
+                        // Download this package
+                        toDownload.Enqueue(action);
+                    }
+                }
+            }
+
+            // Check if any packages are not already in the packages folder
+            if (toDownload.Count > 0)
+            {
+                var downloadResults = new List<PackagePreFetcherResult>(maxParallelTasks);
+
+                while (toDownload.Count > 0)
+                {
+                    // Throttle tasks
+                    if (downloadResults.Count == maxParallelTasks)
+                    {
+                        // Wait for a task to complete
+                        // This will not throw, exceptions are stored in the result
+                        await Task.WhenAny(downloadResults.Select(e => e.EnsureResultAsync()));
+
+                        // Remove all completed tasks
+                        downloadResults.RemoveAll(e => e.IsComplete);
+                    }
+
+                    var action = toDownload.Dequeue();
+
+                    // Download the package if it does not exist in the packages folder already
+                    // Start the download task
+                    var task = Task.Run(async () => await PackageDownloader.GetDownloadResourceResultAsync(
+                                        action.SourceRepository,
+                                        action.PackageIdentity,
+                                        settings,
+                                        logger,
+                                        token));
+
+                    var downloadResult = new PackagePreFetcherResult(
+                        task,
+                        action.PackageIdentity,
+                        action.SourceRepository.PackageSource);
+
+                    downloadResults.Add(downloadResult);
+                    result.Add(action.PackageIdentity, downloadResult);
+                }
+            }
+
+            // Do not wait for the remaining tasks to finish, these will download
+            // in the background while other operations such as uninstall run first.
+            return result;
+        }
+
+        /// <summary>
+        /// Log a message to indicate where each package is being downloaded from
+        /// </summary>
+        public static void LogFetchMessages(
+            IEnumerable<PackagePreFetcherResult> fetchResults,
+            string packagesFolderRoot,
+            Common.ILogger logger)
+        {
+            if (fetchResults == null)
+            {
+                throw new ArgumentNullException(nameof(fetchResults));
+            }
+
+            if (packagesFolderRoot == null)
+            {
+                throw new ArgumentNullException(nameof(packagesFolderRoot));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            // Order by package identity
+            var preFetchTasks = fetchResults.OrderBy(
+                result => result.Package,
+                PackageIdentityComparer.Default);
+
+            foreach (var fetchResult in preFetchTasks)
+            {
+                string message = null;
+
+                if (fetchResult.InPackagesFolder)
+                {
+                    // Found package .. in packages folder
+                    message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.FoundPackageInPackagesFolder,
+                        fetchResult.Package.Id,
+                        fetchResult.Package.Version.ToNormalizedString(),
+                        packagesFolderRoot);
+                }
+                else
+                {
+                    // Retrieving package .. from source ..
+                    message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.RetrievingPackageStart,
+                        fetchResult.Package.Id,
+                        fetchResult.Package.Version.ToNormalizedString(),
+                        fetchResult.Source.Name);
+                }
+
+                logger.LogMinimal(message);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcherResult.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement
+{
+    public class PackagePreFetcherResult : IDisposable
+    {
+        private readonly Task<DownloadResourceResult> _downloadTask;
+        private readonly string _nupkgPath;
+        private DownloadResourceResult _result;
+        private ExceptionDispatchInfo _exception;
+
+        /// <summary>
+        /// True if the result came from the packages folder.
+        /// </summary>
+        /// <remarks>Not thread safe.</remarks>
+        public bool InPackagesFolder { get; }
+
+        /// <summary>
+        /// Package identity.
+        /// </summary>
+        public PackageIdentity Package { get; }
+
+        /// <summary>
+        /// PackageSource for the download. This is null if the packages folder was used.
+        /// </summary>
+        public Configuration.PackageSource Source { get; }
+
+        /// <summary>
+        /// True if the download is complete.
+        /// </summary>
+        public bool IsComplete { get; private set; }
+
+        /// <summary>
+        /// Create a PreFetcher result for a downloaded package.
+        /// </summary>
+        public PackagePreFetcherResult(
+            Task<DownloadResourceResult> downloadTask,
+            PackageIdentity package,
+            Configuration.PackageSource source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (downloadTask == null)
+            {
+                throw new ArgumentNullException(nameof(downloadTask));
+            }
+
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            _downloadTask = downloadTask;
+            Package = package;
+            InPackagesFolder = false;
+            Source = source;
+        }
+
+        /// <summary>
+        /// Create a PreFetcher result for a package in the packages folder.
+        /// </summary>
+        public PackagePreFetcherResult(
+            string nupkgPath,
+            PackageIdentity package)
+        {
+            if (nupkgPath == null)
+            {
+                throw new ArgumentNullException(nameof(nupkgPath));
+            }
+
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            InPackagesFolder = true;
+            IsComplete = true;
+            Package = package;
+            _nupkgPath = nupkgPath;
+        }
+
+        /// <summary>
+        /// A safe wait for the download task. Exceptions are caught and stored.
+        /// </summary>
+        public async Task EnsureResultAsync()
+        {
+            // This is a noop if this has been called before, or if the result is in the packages folder.
+            if (!InPackagesFolder && _result == null)
+            {
+                try
+                {
+                    _result = await _downloadTask;
+                }
+                catch (Exception ex)
+                {
+                    _exception = ExceptionDispatchInfo.Capture(ex);
+                }
+
+                IsComplete = true;
+            }
+        }
+
+        /// <summary>
+        /// Ensure and retrieve the download result.
+        /// </summary>
+        public async Task<DownloadResourceResult> GetResultAsync()
+        {
+            DownloadResourceResult result = null;
+
+            if (InPackagesFolder)
+            {
+                // Results from the packages folder are created on demand
+                result = GetPackagesFolderResult(_nupkgPath);
+            }
+            else
+            {
+                // Wait for the download to finish
+                await EnsureResultAsync();
+
+                if (_exception != null)
+                {
+                    // Rethrow the exception if the download failed
+                    _exception.Throw();
+                }
+
+                // Use the downloadTask result
+                result = _result;
+            }
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            // The task should be awaited before calling dispose
+            if (_result != null)
+            {
+                _result.Dispose();
+            }
+        }
+
+        private static DownloadResourceResult GetPackagesFolderResult(string nupkgPath)
+        {
+            // Create a download result for the package that already exists
+            return new DownloadResourceResult(
+                File.OpenRead(nupkgPath),
+                new PackageArchiveReader(nupkgPath));
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -159,6 +159,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Found package &apos;{0} {1}&apos; in &apos;{2}&apos;..
+        /// </summary>
+        public static string FoundPackageInPackagesFolder {
+            get {
+                return ResourceManager.GetString("FoundPackageInPackagesFolder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Gathering dependency information took {0}.
         /// </summary>
         public static string GatherTotalTime {
@@ -452,6 +461,15 @@ namespace NuGet.PackageManagement {
         public static string RestoringPackage {
             get {
                 return ResourceManager.GetString("RestoringPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Retrieving package &apos;{0} {1}&apos; from &apos;{2}&apos;..
+        /// </summary>
+        public static string RetrievingPackageStart {
+            get {
+                return ResourceManager.GetString("RetrievingPackageStart", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -291,4 +291,10 @@
   <data name="NugetActionsTotalTime" xml:space="preserve">
     <value>Executing nuget actions took {0}</value>
   </data>
+  <data name="RetrievingPackageStart" xml:space="preserve">
+    <value>Retrieving package '{0} {1}' from '{2}'.</value>
+  </data>
+  <data name="FoundPackageInPackagesFolder" xml:space="preserve">
+    <value>Found package '{0} {1}' in '{2}'.</value>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -99,20 +99,9 @@ namespace NuGet.Test
                     var packagePathResolver = new PackagePathResolver(packagesFolderPath);
                     var projectA = testSolutionManager.AddNewMSBuildProject();
 
-                    var builder = new Packaging.PackageBuilder()
-                    {
-                        Id = "packageA",
-                        Version = NuGetVersion.Parse("1.0.0"),
-                        Description = "Descriptions",
-                    };
-
-                    builder.Authors.Add("testAuthor");
-                    builder.Files.Add(CreatePackageFile(@"lib" + Path.DirectorySeparatorChar + "net45" + Path.DirectorySeparatorChar + "_._"));
-
-                    using (var stream = File.OpenWrite(Path.Combine(packageSource, "packagea.1.0.0.nupkg")))
-                    {
-                        builder.Save(stream);
-                    }
+                    var packageContext = new SimpleTestPackageContext("packageA");
+                    packageContext.AddFile("lib/net45/a.dll");
+                    SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
 
                     var run = true;
 
@@ -4681,20 +4670,6 @@ namespace NuGet.Test
             {
                 return obj.GetHashCode();
             }
-        }
-
-        private static Packaging.IPackageFile CreatePackageFile(string name)
-        {
-            var file = new Mock<Packaging.IPackageFile>();
-            file.SetupGet(f => f.Path).Returns(name);
-            file.Setup(f => f.GetStream()).Returns(new MemoryStream());
-
-            string effectivePath;
-            var fx = FrameworkNameUtility.ParseFrameworkNameFromFilePath(name, out effectivePath);
-            file.SetupGet(f => f.EffectivePath).Returns(effectivePath);
-            file.SetupGet(f => f.TargetFramework).Returns(fx);
-
-            return file.Object;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
@@ -1,0 +1,433 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.VisualStudio;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class PackagePreFetcherTests
+    {
+
+        [Fact]
+        public async Task PackagePreFetcher_NoActionsInput()
+        {
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(0, result.Count);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_NoInstallActionsInput()
+        {
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var target2 = new PackageIdentity("packageB", NuGetVersion.Parse("1.0.0"));
+
+                actions.Add(NuGetProjectAction.CreateUninstallProjectAction(target));
+                actions.Add(NuGetProjectAction.CreateUninstallProjectAction(target2));
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(0, result.Count);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageAlreadyExists()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                // Add package
+                AddToPackagesFolder(target, packagesFolderDir);
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
+
+                AddToSource(target, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var downloadResult = await result[target].GetResultAsync();
+
+                // Assert
+                Assert.Equal(1, result.Count);
+                Assert.True(result[target].InPackagesFolder);
+                Assert.Null(result[target].Source);
+                Assert.Equal(target, result[target].Package);
+                Assert.True(result[target].IsComplete);
+                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                Assert.NotNull(downloadResult.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageAlreadyExistsReinstall()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                // Add package
+                AddToPackagesFolder(target, packagesFolderDir);
+                actions.Add(NuGetProjectAction.CreateUninstallProjectAction(target));
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
+
+                AddToSource(target, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var downloadResult = await result[target].GetResultAsync();
+
+                // Assert
+                Assert.Equal(1, result.Count);
+                Assert.False(result[target].InPackagesFolder);
+                Assert.Equal(source.PackageSource, result[target].Source);
+                Assert.Equal(target, result[target].Package);
+                Assert.True(result[target].IsComplete);
+                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                Assert.NotNull(downloadResult.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_UpdateMultiplePackages()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+
+
+                var targetA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var targetA2 = new PackageIdentity("packageA", NuGetVersion.Parse("2.0.0"));
+                var targetB1 = new PackageIdentity("packageB", NuGetVersion.Parse("1.0.0"));
+                var targetB2 = new PackageIdentity("packageB", NuGetVersion.Parse("2.0.0"));
+                var targetC2 = new PackageIdentity("packageC", NuGetVersion.Parse("2.0.0"));
+
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                // Add packages
+                AddToPackagesFolder(targetA1, packagesFolderDir);
+                AddToPackagesFolder(targetB1, packagesFolderDir);
+                AddToPackagesFolder(targetA2, packagesFolderDir);
+
+                // Update A and B, install C, A already exists
+                actions.Add(NuGetProjectAction.CreateUninstallProjectAction(targetA1));
+                actions.Add(NuGetProjectAction.CreateUninstallProjectAction(targetB1));
+
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(targetC2, source));
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(targetB2, source));
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(targetA2, source));
+
+                AddToSource(targetA2, sourceDir);
+                AddToSource(targetB2, sourceDir);
+                AddToSource(targetC2, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var resultA2 = await result[targetA2].GetResultAsync();
+                var resultB2 = await result[targetB2].GetResultAsync();
+                var resultC2 = await result[targetC2].GetResultAsync();
+
+                // Assert
+                Assert.Equal(3, result.Count);
+
+                Assert.True(result[targetA2].InPackagesFolder);
+                Assert.Null(result[targetA2].Source);
+                Assert.Equal(targetA2, result[targetA2].Package);
+                Assert.True(result[targetA2].IsComplete);
+                Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
+                Assert.NotNull(resultA2.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
+
+                Assert.False(result[targetB2].InPackagesFolder);
+                Assert.Equal(source.PackageSource, result[targetB2].Source);
+                Assert.Equal(targetB2, result[targetB2].Package);
+                Assert.True(result[targetB2].IsComplete);
+                Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
+                Assert.NotNull(resultB2.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
+
+                Assert.False(result[targetC2].InPackagesFolder);
+                Assert.Equal(source.PackageSource, result[targetC2].Source);
+                Assert.Equal(targetC2, result[targetC2].Package);
+                Assert.True(result[targetC2].IsComplete);
+                Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
+                Assert.NotNull(resultC2.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageAlreadyExists_NonNormalizedVersionInPackages()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var targetNonNormalized = new PackageIdentity("packageA", NuGetVersion.Parse("1.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                // Add package
+                AddToPackagesFolder(targetNonNormalized, packagesFolderDir);
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
+
+                AddToSource(targetNonNormalized, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var downloadResult = await result[target].GetResultAsync();
+
+                // Assert
+                Assert.Equal(1, result.Count);
+                Assert.True(result[target].InPackagesFolder);
+                Assert.Null(result[target].Source);
+                Assert.Equal(target, result[target].Package);
+                Assert.True(result[target].IsComplete);
+                Assert.NotNull(downloadResult.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageAlreadyExists_NonNormalizedVersionInput()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var targetNonNormalized = new PackageIdentity("packageA", NuGetVersion.Parse("1.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                // Add package
+                AddToPackagesFolder(target, packagesFolderDir);
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(targetNonNormalized, source));
+
+                AddToSource(target, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var downloadResult = await result[target].GetResultAsync();
+
+                // Assert
+                Assert.Equal(1, result.Count);
+                Assert.True(result[target].InPackagesFolder);
+                Assert.Null(result[target].Source);
+                Assert.Equal(target, result[target].Package);
+                Assert.True(result[target].IsComplete);
+                Assert.NotNull(downloadResult.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageDoesNotExistsInPackagesFolder()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
+                AddToSource(target, sourceDir);
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                var downloadResult = await result[target].GetResultAsync();
+
+                // Assert
+                Assert.Equal(1, result.Count);
+                Assert.False(result[target].InPackagesFolder);
+                Assert.Equal(source.PackageSource, result[target].Source);
+                Assert.Equal(target, result[target].Package);
+                Assert.True(result[target].IsComplete);
+                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                Assert.NotNull(downloadResult.PackageStream);
+                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+            }
+        }
+
+        [Fact]
+        public async Task PackagePreFetcher_PackageDoesNotExistAnywhere()
+        {
+            using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var actions = new List<NuGetProjectAction>();
+                var packagesFolder = new FolderNuGetProject(packagesFolderDir);
+                var testSettings = new Configuration.NullSettings();
+                var logger = new TestLogger();
+                var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                var source = Repository.Factory.GetVisualStudio(new Configuration.PackageSource(sourceDir.Path));
+
+                actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
+
+                // Act
+                var result = await PackagePreFetcher.GetPackagesAsync(
+                    actions,
+                    packagesFolder,
+                    testSettings,
+                    logger,
+                    CancellationToken.None);
+
+                Exception exception = null;
+
+                try
+                {
+                    var downloadResult = await result[target].GetResultAsync();
+                    Assert.True(false);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                // Assert
+                Assert.StartsWith("Package 'packageA.1.0.0' is not found on source", exception.Message);
+            }
+        }
+
+        private static void AddToPackagesFolder(PackageIdentity package, string root)
+        {
+            var dir = Path.Combine(root, $"{package.Id}.{package.Version.ToString()}");
+            Directory.CreateDirectory(dir);
+
+            var context = new SimpleTestPackageContext()
+            {
+                Id = package.Id,
+                Version = package.Version.ToString()
+            };
+
+            context.AddFile("lib/net45/a.dll");
+            SimpleTestPackageUtility.CreateOPCPackage(context, dir);
+        }
+
+        private static void AddToSource(PackageIdentity package, string root)
+        {
+            Directory.CreateDirectory(root);
+
+            var context = new SimpleTestPackageContext()
+            {
+                Id = package.Id,
+                Version = package.Version.ToString()
+            };
+
+            context.AddFile("lib/net45/a.dll");
+            SimpleTestPackageUtility.CreateOPCPackage(context, root);
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for downloading packages for install/updates in parallel
- Throttling uses the same limit as restore
- Downloads are done in the background, package uninstalls for updates can occur in parallel

There are also a couple improvements around the packages folder
- Packages folder will now be checked before downloading the package, previously packages were downloaded even if they were installed for other projects
- Looking up a package in the packages folder will first check the expected location. If the package doesn't exist it will fallback to the old behavior of searching all folders.

Error handling
- Exceptions will occur in the same order as before with this change. 
- In a scenario where an install fails downloads still running in the background will be canceled and disposed of.

This adds new logging to display where the package is coming from. This is shown today for http calls, this will now show if the package is coming from the packages folder or the source name to match the format of the rest of the PM logging.

https://github.com/NuGet/Home/issues/2618

//cc @jainaashish @joelverhagen @zhili1208 @alpaix @rrelyea @rohit21agrawal 
### Example output

New packages:

```
Resolving actions install multiple packages
Retrieving package 'Microsoft.CodeDom.Providers.DotNetCompilerPlatform 1.0.1' from 'nuget.org'.
Retrieving package 'Microsoft.Net.Compilers 1.2.1' from 'nuget.org'.
Retrieving package 'Respond 1.4.2' from 'nuget.org'.
Retrieving package 'WebGrease 1.6.0' from 'nuget.org'.
Retrieving package 'jQuery.Validation 1.15.0' from 'nuget.org'.
Retrieving package 'jQuery 2.2.3' from 'nuget.org'.
Retrieving package 'Modernizr 2.8.3' from 'nuget.org'.
Retrieving package 'bootstrap 3.3.6' from 'nuget.org'.
Retrieving package 'Antlr 3.5.0.2' from 'nuget.org'.
Retrieving package 'Newtonsoft.Json 8.0.3' from 'nuget.org'.
Removed package 'WebGrease 1.5.2' from 'packages.config'
```

Already installed:

```
Resolving actions install multiple packages
Found package 'Microsoft.CodeDom.Providers.DotNetCompilerPlatform 1.0.1' in 'D:\mvcTest\1\packages'.
Found package 'Microsoft.Net.Compilers 1.2.1' in 'D:\mvcTest\1\packages'.
Found package 'Respond 1.4.2' in 'D:\mvcTest\1\packages'.
Found package 'WebGrease 1.6.0' in 'D:\mvcTest\1\packages'.
Found package 'jQuery.Validation 1.15.0' in 'D:\mvcTest\1\packages'.
Found package 'jQuery 2.2.3' in 'D:\mvcTest\1\packages'.
Found package 'Modernizr 2.8.3' in 'D:\mvcTest\1\packages'.
Found package 'bootstrap 3.3.6' in 'D:\mvcTest\1\packages'.
Found package 'Antlr 3.5.0.2' in 'D:\mvcTest\1\packages'.
Found package 'Newtonsoft.Json 8.0.3' in 'D:\mvcTest\1\packages'.
Removed package 'WebGrease 1.5.2' from 'packages.config'
```

Example of the existing PM messages:

```

Removing package 'WebGrease 1.5.2' from folder 'D:\mvcTest\1\packages'
Removed package 'WebGrease 1.5.2' from folder 'D:\mvcTest\1\packages'
Removing package 'Respond 1.2.0' from folder 'D:\mvcTest\1\packages'
Removed package 'Respond 1.2.0' from folder 'D:\mvcTest\1\packages'
Removing package 'Newtonsoft.Json 6.0.4' from folder 'D:\mvcTest\1\packages'
Removed package 'Newtonsoft.Json 6.0.4' from folder 'D:\mvcTest\1\packages'
Removing package 'Modernizr 2.6.2' from folder 'D:\mvcTest\1\packages'
Removed package 'Modernizr 2.6.2' from folder 'D:\mvcTest\1\packages'
Removing package 'Microsoft.CodeDom.Providers.DotNetCompilerPlatform 1.0.0' from folder 'D:\mvcTest\1\packages'
Removed package 'Microsoft.CodeDom.Providers.DotNetCompilerPlatform 1.0.0' from folder 'D:\mvcTest\1\packages'
Removing package 'Microsoft.Net.Compilers 1.0.0' from folder 'D:\mvcTest\1\packages'
```
