### PR TITLE
Find matching source before installing to INuGetIntegratedProject

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -333,7 +333,7 @@ namespace NuGet.Frameworks
                             FrameworkConstants.CommonFrameworks.NetCoreApp10,
                             FrameworkConstants.CommonFrameworks.NetStandard16),
 
-                        // NetCoreApp projects support NetStandard
+                        // net463 projects support NetStandard
                         CreateStandardMapping(
                             FrameworkConstants.CommonFrameworks.Net463,
                             FrameworkConstants.CommonFrameworks.NetStandard16)

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1111,12 +1111,21 @@ namespace NuGet.PackageManagement
             {
                 throw new ArgumentNullException("packageIdentity.Version");
             }
-
-            // The following special case for ProjectK is not correct, if they used nuget.exe
-            // and multiple repositories in the -Source switch
+            
             if (nuGetProject is INuGetIntegratedProject)
             {
-                var action = NuGetProjectAction.CreateInstallProjectAction(packageIdentity, primarySources.First());
+                SourceRepository sourceRepository;
+                if (primarySources.Count() > 1)
+                {
+                    var logger = new ProjectContextLogger(nuGetProjectContext);
+                    sourceRepository = await GetSourceRepository(packageIdentity, primarySources, logger);
+                }
+                else
+                {
+                    sourceRepository = primarySources.First();
+                }
+
+                var action = NuGetProjectAction.CreateInstallProjectAction(packageIdentity, sourceRepository);
                 var actions = new[] { action };
 
                 var buildIntegratedProject = nuGetProject as BuildIntegratedNuGetProject;


### PR DESCRIPTION
The scenario here is:
- `INuGetIntegrationProject` (e.g. ProjectK project)
- Installing a package from the NuGet UI in Visual Studio or Install-Package
- Using the All Source
- The package doesn't exist on the first source.

Fixes: 
https://github.com/NuGet/Home/issues/2557
https://github.com/NuGet/Home/issues/2322

We bounced around a couple solutions a month or two back but I think this is simplest.

@alpaix @emgarten @rrelyea @yishaigalatzer @zhili1208 @rohit21agrawal 

Also fix a bad comment.
