### PR TITLE
Added verbose log to add feed detail from which package is gathered

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -226,6 +226,16 @@ namespace NuGet.PackageManagement
                     }
                 }
             }
+
+            foreach(var targetId in allPrimaryTargets)
+            {
+                var package = combinedResults.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.Id, targetId));
+                if(package != null)
+                {
+                    _context.Log.LogVerbose(string.Format("package '{0}' found from feed '{1}'", package.Id, package.Source.PackageSource.Source));
+                }
+            }
+
             // calculate total time taken to gather all packages as well as with each source
             stopWatch.Stop();
             _context.Log.LogMinimal(


### PR DESCRIPTION
Added verbose log to add feed detail from which package information is gathered

Fix https://github.com/NuGet/Home/issues/2629

@alpaix @emgarten @rrelyea 
