### PR TITLE
part 2 of fix for watson crash for infinite scroll list

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -77,7 +77,7 @@ namespace NuGet.PackageManagement.UI
 
         public bool IsSolution { get; set; }
 
-        private ObservableCollection<object> _items = new ObservableCollection<object>(); 
+        private readonly ObservableCollection<object> _items = new ObservableCollection<object>(); 
 
         public ObservableCollection<object> Items
         {
@@ -197,7 +197,8 @@ namespace NuGet.PackageManagement.UI
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-               // multiple loads may occur at the same time
+               // multiple loads may occur at the same time as a result of multiple instances,
+               // makes sure we update using the relevant one.
                 if (currentLoader == _loader)
                 {
                     _loadingStatusBar.ItemsLoaded = currentLoader.State.ItemsCount;

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -707,8 +707,13 @@ namespace NuGet.PackageManagement.UI
             }
             else
             {
-                var installedPackages = GetInstalledPackages(Model.Context.Projects);
-                _packageList.UpdatePackageStatus(installedPackages);
+                NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    var installedPackages = await PackageCollection.FromProjectsAsync(Model.Context.Projects,
+                        CancellationToken.None);
+                    _packageList.UpdatePackageStatus(installedPackages.ToArray());
+                });
             }
 
             RefreshAvailableUpdatesCount();


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/2673

There were some Debug asserts being hit because the observable collection was being accessed on a Non UI Thread. This fixes the problem by moving that to UI Thread. Also addresses some feedback from Yishai on the previous pull request : https://github.com/NuGet/NuGet.Client/pull/545

CC : @yishaigalatzer @alpaix @emgarten @rrelyea @joelverhagen 
