### PR TITLE
Adding a pack validation rule to check for _._ files

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
@@ -249,7 +249,7 @@ namespace NuGet.Commands.Rules {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to A placeholder file &apos;{0}&apos; is in the package and should be removed..
+        ///    Looks up a localized string similar to An empty folder placeholder file &apos;{0}&apos; is in a non-empty folder and should be removed..
         /// </summary>
         public static string PlaceholderFileInPackageDescription {
             get {
@@ -258,7 +258,7 @@ namespace NuGet.Commands.Rules {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Remove the &apos;_._&apos; file from the project..
+        ///    Looks up a localized string similar to Remove the file from the project..
         /// </summary>
         public static string PlaceholderFileInPackageSolution {
             get {
@@ -267,7 +267,7 @@ namespace NuGet.Commands.Rules {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Placeholder file in package..
+        ///    Looks up a localized string similar to Placeholder file in non-empty folder..
         /// </summary>
         public static string PlaceholderFileInPackageTitle {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
@@ -249,6 +249,33 @@ namespace NuGet.Commands.Rules {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to A placeholder file &apos;{0}&apos; is in the package and should be removed..
+        /// </summary>
+        public static string PlaceholderFileInPackageDescription {
+            get {
+                return ResourceManager.GetString("PlaceholderFileInPackageDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Remove the &apos;_._&apos; file from the project..
+        /// </summary>
+        public static string PlaceholderFileInPackageSolution {
+            get {
+                return ResourceManager.GetString("PlaceholderFileInPackageSolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Placeholder file in package..
+        /// </summary>
+        public static string PlaceholderFileInPackageTitle {
+            get {
+                return ResourceManager.GetString("PlaceholderFileInPackageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to The script file &apos;{0}&apos; is outside the &apos;tools&apos; folder and hence will not be executed during installation of this package..
         /// </summary>
         public static string ScriptOutsideToolsDescription {

--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
@@ -180,6 +180,15 @@
   <data name="MissingSummaryTitle" xml:space="preserve">
     <value>Consider providing Summary text.</value>
   </data>
+  <data name="PlaceholderFileInPackageDescription" xml:space="preserve">
+    <value>A placeholder file '{0}' is in the package and should be removed.</value>
+  </data>
+  <data name="PlaceholderFileInPackageSolution" xml:space="preserve">
+    <value>Remove the '_._' file from the project.</value>
+  </data>
+  <data name="PlaceholderFileInPackageTitle" xml:space="preserve">
+    <value>Placeholder file in package.</value>
+  </data>
   <data name="ScriptOutsideToolsDescription" xml:space="preserve">
     <value>The script file '{0}' is outside the 'tools' folder and hence will not be executed during installation of this package.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
@@ -181,13 +181,13 @@
     <value>Consider providing Summary text.</value>
   </data>
   <data name="PlaceholderFileInPackageDescription" xml:space="preserve">
-    <value>A placeholder file '{0}' is in the package and should be removed.</value>
+    <value>An empty folder placeholder file '{0}' is in a non-empty folder and should be removed.</value>
   </data>
   <data name="PlaceholderFileInPackageSolution" xml:space="preserve">
-    <value>Remove the '_._' file from the project.</value>
+    <value>Remove the file from the project.</value>
   </data>
   <data name="PlaceholderFileInPackageTitle" xml:space="preserve">
-    <value>Placeholder file in package.</value>
+    <value>Placeholder file in non-empty folder.</value>
   </data>
   <data name="ScriptOutsideToolsDescription" xml:space="preserve">
     <value>The script file '{0}' is outside the 'tools' folder and hence will not be executed during installation of this package.</value>

--- a/src/NuGet.Core/NuGet.Commands/Rules/DefaultPackageRuleSet.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/DefaultPackageRuleSet.cs
@@ -15,7 +15,8 @@ namespace NuGet.Commands.Rules
                 new MissingSummaryRule(),
                 new InitScriptNotUnderToolsRule(),
                 new WinRTNameIsObsoleteRule(),
-                new DefaultManifestValuesRule()
+                new DefaultManifestValuesRule(),
+                new InvalidPlaceholderFileRule()
             }
         );
 

--- a/src/NuGet.Core/NuGet.Commands/Rules/InvalidPlaceholderFileRule.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/InvalidPlaceholderFileRule.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using NuGet.Packaging;
+
+namespace NuGet.Commands.Rules
+{
+    internal class InvalidPlaceholderFileRule : IPackageRule
+    {
+        private const string PlaceholderFile = "_._";
+
+        public IEnumerable<PackageIssue> Validate(PackageBuilder builder)
+        {
+            foreach (IPackageFile file in builder.Files)
+            {
+                string path = file.Path;
+                if (Path.GetFileName(path).Equals(PlaceholderFile, StringComparison.Ordinal))
+                {
+                    yield return CreatePackageIssueForPlaceholderFile(path);
+                }
+            }
+        }
+
+        private static PackageIssue CreatePackageIssueForPlaceholderFile(string target)
+        {
+            return new PackageIssue(
+                AnalysisResources.PlaceholderFileInPackageTitle,
+                String.Format(CultureInfo.CurrentCulture, AnalysisResources.PlaceholderFileInPackageDescription, target),
+                AnalysisResources.PlaceholderFileInPackageSolution
+            );
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/Rules/InvalidPlaceholderFileRule.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/InvalidPlaceholderFileRule.cs
@@ -2,22 +2,26 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 
 namespace NuGet.Commands.Rules
 {
     internal class InvalidPlaceholderFileRule : IPackageRule
     {
-        private const string PlaceholderFile = "_._";
-
         public IEnumerable<PackageIssue> Validate(PackageBuilder builder)
         {
             foreach (IPackageFile file in builder.Files)
             {
                 string path = file.Path;
-                if (Path.GetFileName(path).Equals(PlaceholderFile, StringComparison.Ordinal))
+                if (Path.GetFileName(path).Equals(PackagingCoreConstants.EmptyFolder, StringComparison.Ordinal))
                 {
-                    yield return CreatePackageIssueForPlaceholderFile(path);
+                    string directory = PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(path));
+                    if (builder.Files.Count(f => PathUtility.EnsureTrailingSlash(Path.GetDirectoryName(f.Path)).StartsWith(directory, StringComparison.OrdinalIgnoreCase)) > 1)
+                    {
+                        yield return CreatePackageIssueForPlaceholderFile(path);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Shows a warning if there is a _._ file in the package.

@emgarten 

Addresses https://github.com/NuGet/Home/issues/2687
