### PR TITLE
Normalize file names to lowercase ID and version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,7 @@ then
 fi
 
 # restore packages
+echo "$DOTNET restore src/NuGet.Core test/NuGet.Core.Tests --verbosity minimal"
 $DOTNET restore src/NuGet.Core test/NuGet.Core.Tests --verbosity minimal
 if [ $? -ne 0 ]; then
 	echo "Restore failed!!"
@@ -54,7 +55,7 @@ do
 	if grep -q "netcoreapp1.0" "$testProject"; then
 		pushd $testDir
 
-		echo "$DOTNET $testDir --configuration release --framework netcoreapp1.0"
+		echo "$DOTNET test $testDir --configuration release --framework netcoreapp1.0"
 		$DOTNET test $testDir --configuration release --framework netcoreapp1.0
 
 		if [ $? -ne 0 ]; then

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellInstalledPackage.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellInstalledPackage.cs
@@ -59,7 +59,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                     if (packageFolder != null)
                     {
-                        var defaultPackagePathResolver = new VersionFolderPathResolver(packageFolder, normalizePackageId: false);
+                        var defaultPackagePathResolver = new VersionFolderPathResolver(packageFolder);
                         installPackagePath = defaultPackagePathResolver.GetPackageFilePath(package.PackageIdentity.Id, package.PackageIdentity.Version);
                     }
                     else if (packageFolderProject != null)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -316,9 +316,7 @@ namespace NuGet.Commands
                 packageIdentity,
                 packagesDirectory,
                 _logger,
-                fixNuspecIdCasing: true,
                 packageSaveMode: _request.PackageSaveMode,
-                normalizeFileNames: false,
                 xmlDocFileSaveMode: _request.XmlDocFileSaveMode);
 
             await PackageExtractor.InstallFromSourceAsync(

--- a/src/NuGet.Core/NuGet.DependencyResolver/NuGetDependencyResolver.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver/NuGetDependencyResolver.cs
@@ -23,7 +23,7 @@ namespace NuGet.DependencyResolver
 
         public NuGetDependencyResolver(string packagesPath)
         {
-            _repository = new NuGetv3LocalRepository(packagesPath, checkPackageIdCase: false);
+            _repository = new NuGetv3LocalRepository(packagesPath);
         }
 
         public bool SupportsType(LibraryDependencyTarget libraryType)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -663,7 +663,7 @@ namespace NuGet.Packaging
 
         private static void CreatePart(ZipArchive package, string path, Stream sourceStream)
         {
-            if (PackageHelper.IsManifest(path) || ProjectJsonPathUtilities.IsProjectConfig(path))
+            if (PackageHelper.IsNuspec(path) || ProjectJsonPathUtilities.IsProjectConfig(path))
             {
                 return;
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
@@ -21,6 +21,8 @@ namespace NuGet.Packaging
             "[Content_Types].xml"
         };
 
+        private static readonly char[] Slashes = new char[] { '/', '\\' };
+
         private const string ExcludeExtension = ".nupkg.sha512";
 
         public static bool IsAssembly(string path)
@@ -30,15 +32,26 @@ namespace NuGet.Packaging
                    path.EndsWith(".exe", StringComparison.OrdinalIgnoreCase); 
         }
 
+        public static bool IsNuspec(string path)
+        {
+            return path.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase);
+        }
+
         public static bool IsManifest(string path)
         {
-            return Path.GetExtension(path).Equals(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase);
+            return IsRoot(path) && IsNuspec(path);
+        }
+
+        private static bool IsRoot(string path)
+        {
+            // True if the path contains no directory slashes.
+            return path.IndexOfAny(Slashes) == -1;
         }
 
         public static bool IsPackageFile(string packageFileName, PackageSaveMode packageSaveMode)
         {
-            if (String.IsNullOrEmpty(packageFileName)
-                || String.IsNullOrEmpty(Path.GetFileName(packageFileName)))
+            if (string.IsNullOrEmpty(packageFileName)
+                || string.IsNullOrEmpty(Path.GetFileName(packageFileName)))
             {
                 // This is to ignore archive entries that are not really files
                 return false;
@@ -51,7 +64,8 @@ namespace NuGet.Packaging
 
             if ((packageSaveMode & PackageSaveMode.Files) == PackageSaveMode.Files)
             {
-                return !ExcludePaths.Any(p => packageFileName.StartsWith(p, StringComparison.OrdinalIgnoreCase)) &&
+                return !ExcludePaths.Any(p =>
+                    packageFileName.StartsWith(p, StringComparison.OrdinalIgnoreCase)) &&
                     !packageFileName.EndsWith(ExcludeExtension, StringComparison.OrdinalIgnoreCase);
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackagePathHelper.cs
@@ -62,7 +62,7 @@ namespace NuGet.Packaging
             return Enumerable.Empty<string>();
         }
 
-        internal static IEnumerable<string> GetPackageFiles(string root, string filter)
+        private static IEnumerable<string> GetPackageFiles(string root, string filter)
         {
             filter = filter ?? "*" + PackagingCoreConstants.NupkgExtension;
             Debug.Assert(
@@ -117,7 +117,7 @@ namespace NuGet.Packaging
                 throw new ArgumentNullException("packagePathResolver");
             }
 
-            var packageId = packageIdentity.Id;
+            var packageId = packageIdentity.Id.ToLowerInvariant();
             var version = packageIdentity.Version;
 
             var root = packagePathResolver.Root;

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 
@@ -51,10 +50,29 @@ namespace NuGet.Packaging
             {
                 var packageIdentityFromNuspec = packageReader.GetIdentity();
 
-                var packageDirectoryInfo = Directory.CreateDirectory(packagePathResolver.GetInstallPath(packageIdentityFromNuspec));
+                var installPath = packagePathResolver.GetInstallPath(packageIdentityFromNuspec);
+                var packageDirectoryInfo = Directory.CreateDirectory(installPath);
                 var packageDirectory = packageDirectoryInfo.FullName;
 
                 var packageFiles = packageReader.GetPackageFiles(packageSaveMode);
+
+                if ((packageSaveMode & PackageSaveMode.Nuspec) == PackageSaveMode.Nuspec)
+                {
+                    var sourceNuspecFile = packageFiles.Single(p => PackageHelper.IsManifest(p));
+
+                    var targetNuspecPath = Path.Combine(
+                        packageDirectory,
+                        packagePathResolver.GetManifestFileName(packageIdentityFromNuspec));
+
+                    // Extract the .nuspec file with a well known file name.
+                    filesAdded.Add(packageReader.ExtractFile(
+                        sourceNuspecFile,
+                        targetNuspecPath,
+                        packageExtractionContext.Logger));
+
+                    packageFiles = packageFiles.Except(new[] { sourceNuspecFile });
+                }
+
                 var packageFileExtractor = new PackageFileExtractor(packageFiles, packageExtractionContext.XmlDocFileSaveMode);
 
                 filesAdded.AddRange(packageReader.CopyFiles(
@@ -64,13 +82,17 @@ namespace NuGet.Packaging
                     packageExtractionContext.Logger,
                     token));
 
-                var nupkgFilePath = Path.Combine(packageDirectory, packagePathResolver.GetPackageFileName(packageIdentityFromNuspec));
-                if (packageSaveMode.HasFlag(PackageSaveMode.Nupkg))
+                if ((packageSaveMode & PackageSaveMode.Nupkg) == PackageSaveMode.Nupkg)
                 {
                     // During package extraction, nupkg is the last file to be created
                     // Since all the packages are already created, the package stream is likely positioned at its end
                     // Reset it to the nupkgStartPosition
                     packageStream.Seek(nupkgStartPosition, SeekOrigin.Begin);
+
+                    var nupkgFilePath = Path.Combine(
+                        packageDirectory,
+                        packagePathResolver.GetPackageFileName(packageIdentityFromNuspec));
+
                     filesAdded.Add(packageStream.CopyToFile(nupkgFilePath));
                 }
 
@@ -178,8 +200,7 @@ namespace NuGet.Packaging
                 throw new ArgumentNullException(nameof(versionFolderPathContext));
             }
 
-            var packagePathResolver = new VersionFolderPathResolver(
-                versionFolderPathContext.PackagesDirectory, versionFolderPathContext.NormalizeFileNames);
+            var packagePathResolver = new VersionFolderPathResolver(versionFolderPathContext.PackagesDirectory);
 
             var packageIdentity = versionFolderPathContext.Package;
             var logger = versionFolderPathContext.Logger;
@@ -257,23 +278,15 @@ namespace NuGet.Packaging
                                 if ((packageSaveMode & PackageSaveMode.Nuspec) == PackageSaveMode.Nuspec)
                                 {
                                     packageReader.ExtractFile(nuspecFile, targetNuspec, logger);
-                                    if (versionFolderPathContext.FixNuspecIdCasing)
-                                    {
-                                        // DNU REFACTORING TODO: delete the hacky FixNuSpecIdCasing()
-                                        // and uncomment logic below after we
-                                        // have implementation of NuSpecFormatter.Read()
-                                        // Fixup the casing of the nuspec on disk to match what we expect
-                                        nuspecFile = Directory.EnumerateFiles(targetPath, "*" + PackagingCoreConstants.NuspecExtension).Single();
-                                        FixNuSpecIdCasing(nuspecFile, targetNuspec, packageIdentity.Id);
-                                    }
                                 }
 
                                 if ((packageSaveMode & PackageSaveMode.Files) == PackageSaveMode.Files)
                                 {
                                     var nupkgFileName = Path.GetFileName(targetNupkg);
+                                    var nuspecFileName = Path.GetFileName(targetNuspec);
                                     var hashFileName = Path.GetFileName(hashPath);
                                     var packageFiles = packageReader.GetFiles()
-                                        .Where(file => ShouldInclude(file, nupkgFileName, nuspecFile, hashFileName));
+                                        .Where(file => ShouldInclude(file, nupkgFileName, nuspecFileName, hashFileName));
                                     var packageFileExtractor = new PackageFileExtractor(
                                         packageFiles,
                                         versionFolderPathContext.XmlDocFileSaveMode);
@@ -333,38 +346,10 @@ namespace NuGet.Packaging
                 token: token);
         }
 
-        // DNU REFACTORING TODO: delete this temporary workaround after we have NuSpecFormatter.Read()
-        private static void FixNuSpecIdCasing(string nuspecFile, string targetNuspec, string correctedId)
-        {
-            var actualNuSpecName = Path.GetFileName(nuspecFile);
-            var expectedNuSpecName = Path.GetFileName(targetNuspec);
-
-            if (!string.Equals(actualNuSpecName, expectedNuSpecName, StringComparison.Ordinal))
-            {
-                var xDoc = XDocument.Parse(File.ReadAllText(nuspecFile),
-                    LoadOptions.PreserveWhitespace);
-                var metadataNode = xDoc.Root.Elements()
-                    .Where(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata")).First();
-                var node = metadataNode.Elements(XName.Get("id", metadataNode.GetDefaultNamespace().NamespaceName))
-                    .First();
-                node.Value = correctedId;
-
-                var tmpNuspecFile = nuspecFile + ".tmp";
-                File.Move(nuspecFile, tmpNuspecFile);
-
-                using (var stream = File.OpenWrite(targetNuspec))
-                {
-                    xDoc.Save(stream);
-                }
-
-                File.Delete(tmpNuspecFile);
-            }
-        }
-
         private static bool ShouldInclude(
             string fullName,
             string nupkgFileName,
-            string nuspecFile,
+            string nuspecFileName,
             string hashFileName)
         {
             // Not all the files from a zip file are needed
@@ -390,11 +375,8 @@ namespace NuGet.Packaging
 
             if (string.Equals(fullName, nupkgFileName, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(fullName, hashFileName, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(fullName, nuspecFile, StringComparison.OrdinalIgnoreCase))
+                || string.Equals(fullName, nuspecFileName, StringComparison.OrdinalIgnoreCase))
             {
-                // Return false when the fullName is the nupkg file or the hash file.
-                // Some packages accidentally have the nupkg file or the nupkg hash file in the package.
-                // We filter them out during package extraction
                 return false;
             }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
@@ -14,9 +15,11 @@ namespace NuGet.Packaging
 
         public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true)
         {
-            if (String.IsNullOrEmpty(rootDirectory))
+            if (string.IsNullOrEmpty(rootDirectory))
             {
-                throw new ArgumentException(String.Format(Strings.StringCannotBeNullOrEmpty, "rootDirectory"));
+                throw new ArgumentException(
+                    string.Format(Strings.StringCannotBeNullOrEmpty, nameof(rootDirectory)),
+                    nameof(rootDirectory));
             }
             _rootDirectory = rootDirectory;
             _useSideBySidePaths = useSideBySidePaths;
@@ -27,44 +30,60 @@ namespace NuGet.Packaging
             get { return _rootDirectory; }
         }
 
-        public virtual string GetPackageDirectoryName(PackageIdentity packageIdentity)
+        public string GetPackageDirectoryName(PackageIdentity packageIdentity)
         {
-            var directoryName = packageIdentity.Id;
-            if (_useSideBySidePaths)
-            {
-                directoryName += ".";
-                // Always use legacy package install path. Otherwise, restore may be broken for packages like 'Microsoft.Web.Infrastructure.1.0.0.0', installed using old clients
-                directoryName += packageIdentity.Version.ToString();
-            }
+            var directory = GetPathBase(packageIdentity);
 
-            return directoryName;
+            return directory.ToString();
         }
 
-        public virtual string GetPackageFileName(PackageIdentity packageIdentity)
+        public string GetPackageFileName(PackageIdentity packageIdentity)
         {
-            var fileNameBase = packageIdentity.Id;
-            if (_useSideBySidePaths)
-            {
-                fileNameBase += "." + packageIdentity.Version.ToString();
-            }
+            var fileNameBase = GetPathBase(packageIdentity);
 
-            return fileNameBase + PackagingCoreConstants.NupkgExtension;
+            fileNameBase.Append(PackagingCoreConstants.NupkgExtension);
+
+            return fileNameBase.ToString();
         }
 
-        public virtual string GetInstallPath(PackageIdentity packageIdentity)
+        public string GetManifestFileName(PackageIdentity packageIdentity)
+        {
+            return packageIdentity.Id.ToLowerInvariant() + PackagingCoreConstants.NuspecExtension;
+        }
+
+        public string GetInstallPath(PackageIdentity packageIdentity)
         {
             return Path.Combine(_rootDirectory, GetPackageDirectoryName(packageIdentity));
         }
 
-        public virtual string GetInstalledPath(PackageIdentity packageIdentity)
+        public string GetInstalledPath(PackageIdentity packageIdentity)
         {
             var installedPackageFilePath = GetInstalledPackageFilePath(packageIdentity);
-            return String.IsNullOrEmpty(installedPackageFilePath) ? null : Path.GetDirectoryName(installedPackageFilePath);
+
+            return string.IsNullOrEmpty(installedPackageFilePath) ? null : Path.GetDirectoryName(installedPackageFilePath);
         }
 
-        public virtual string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
+        public string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
         {
             return PackagePathHelper.GetInstalledPackageFilePath(packageIdentity, this);
+        }
+
+        private StringBuilder GetPathBase(PackageIdentity packageIdentity)
+        {
+            var builder = new StringBuilder();
+
+            builder.Append(packageIdentity.Id.ToLowerInvariant());
+
+            if (_useSideBySidePaths)
+            {
+                builder.Append('.');
+
+                // Always use legacy package install path. Otherwise, restore may be broken for
+                // packages like 'Microsoft.Web.Infrastructure.1.0.0.0', installed using old clients.
+                builder.Append(packageIdentity.Version.ToString().ToLowerInvariant());
+            }
+
+            return builder;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -91,8 +91,8 @@ namespace NuGet.Packaging
             // PackageArchiveReader and PackageFolderReader.
 
             // Find all nuspecs in the root folder.
-            var nuspecPaths = GetFiles().Where(entryPath => IsRoot(entryPath)
-                && entryPath.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase))
+            var nuspecPaths = GetFiles()
+                .Where(entryPath => PackageHelper.IsManifest(entryPath))
                 .ToList();
 
             if (nuspecPaths.Count == 0)
@@ -121,13 +121,6 @@ namespace NuGet.Packaging
 
                 return _nuspecReader;
             }
-        }
-
-        private static readonly char[] Slashes = new char[] { '/', '\\' };
-        private static bool IsRoot(string path)
-        {
-            // True if the path contains no directory slashes.
-            return path.IndexOfAny(Slashes) == -1;
         }
 
         #endregion

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
@@ -10,7 +10,9 @@ namespace NuGet.Packaging
     {
         public static IEnumerable<string> GetPackageFiles(this IPackageCoreReader packageReader, PackageSaveMode packageSaveMode)
         {
-            return packageReader.GetFiles().Where(file => PackageHelper.IsPackageFile(file, packageSaveMode));
+            return packageReader
+                .GetFiles()
+                .Where(file => PackageHelper.IsPackageFile(file, packageSaveMode));
         }
 
         public static IEnumerable<string> GetSatelliteFiles(this IPackageContentReader packageReader, string packageLanguage)

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathContext.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathContext.cs
@@ -10,18 +10,14 @@ namespace NuGet.Packaging
         public PackageIdentity Package { get; }
         public string PackagesDirectory { get; }
         public ILogger Logger { get; }
-        public bool FixNuspecIdCasing { get; }
         public PackageSaveMode PackageSaveMode { get; }
-        public bool NormalizeFileNames { get; }
         public XmlDocFileSaveMode XmlDocFileSaveMode { get; set; }
 
         public VersionFolderPathContext(
             PackageIdentity package,
             string packagesDirectory,
             ILogger logger,
-            bool fixNuspecIdCasing,
             PackageSaveMode packageSaveMode,
-            bool normalizeFileNames,
             XmlDocFileSaveMode xmlDocFileSaveMode)
         {
             if (package == null)
@@ -45,9 +41,7 @@ namespace NuGet.Packaging
             Package = package;
             PackagesDirectory = packagesDirectory;
             Logger = logger;
-            FixNuspecIdCasing = fixNuspecIdCasing;
             PackageSaveMode = packageSaveMode;
-            NormalizeFileNames = normalizeFileNames;
             XmlDocFileSaveMode = xmlDocFileSaveMode;
         }
     }

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -9,67 +9,78 @@ namespace NuGet.Packaging
     public class VersionFolderPathResolver
     {
         private readonly string _path;
-        private readonly bool _normalizePackageId;
 
-        public VersionFolderPathResolver(string path, bool normalizePackageId = false)
+        public VersionFolderPathResolver(string path)
         {
             _path = path;
-            _normalizePackageId = normalizePackageId;
         }
 
-        public virtual string GetInstallPath(string packageId, NuGetVersion version)
+        public string GetInstallPath(string packageId, NuGetVersion version)
         {
-            packageId = Normalize(packageId);
-            return Path.Combine(_path, GetPackageDirectory(packageId, version));
+            return Path.Combine(
+                _path,
+                GetPackageDirectory(packageId, version));
+        }
+
+        public string GetVersionListPath(string packageId)
+        {
+            return Path.Combine(
+                _path,
+                GetVersionListDirectory(packageId));
         }
 
         public string GetPackageFilePath(string packageId, NuGetVersion version)
         {
-            packageId = Normalize(packageId);
-            return Path.Combine(GetInstallPath(packageId, version),
+            return Path.Combine(
+                GetInstallPath(packageId, version),
                 GetPackageFileName(packageId, version));
         }
 
         public string GetManifestFilePath(string packageId, NuGetVersion version)
         {
             packageId = Normalize(packageId);
-            return Path.Combine(GetInstallPath(packageId, version),
+            return Path.Combine(
+                GetInstallPath(packageId, version),
                 GetManifestFileName(packageId, version));
         }
 
         public string GetHashPath(string packageId, NuGetVersion version)
         {
-            packageId = Normalize(packageId);
-            return Path.Combine(GetInstallPath(packageId, version),
-                $"{packageId}.{version.ToNormalizedString()}.nupkg.sha512");
+            return Path.Combine(
+                GetInstallPath(packageId, version),
+                $"{Normalize(packageId)}.{Normalize(version)}.nupkg.sha512");
         }
 
-        public virtual string GetPackageDirectory(string packageId, NuGetVersion version)
+        public string GetVersionListDirectory(string packageId)
         {
-            packageId = Normalize(packageId);
-            return Path.Combine(packageId, version.ToNormalizedString());
+            return Normalize(packageId);
         }
 
-        public virtual string GetPackageFileName(string packageId, NuGetVersion version)
+        public string GetPackageDirectory(string packageId, NuGetVersion version)
         {
-            packageId = Normalize(packageId);
-            return $"{packageId}.{version.ToNormalizedString()}.nupkg";
+            return Path.Combine(
+                GetVersionListDirectory(packageId),
+                Normalize(version));
         }
 
-        public virtual string GetManifestFileName(string packageId, NuGetVersion version)
+        public string GetPackageFileName(string packageId, NuGetVersion version)
         {
-            packageId = Normalize(packageId);
-            return packageId + ".nuspec";
+            return $"{Normalize(packageId)}.{Normalize(version)}.nupkg";
+        }
+
+        public string GetManifestFileName(string packageId, NuGetVersion version)
+        {
+            return $"{Normalize(packageId)}.nuspec";
+        }
+
+        private string Normalize(NuGetVersion version)
+        {
+            return version.ToNormalizedString().ToLowerInvariant();
         }
 
         private string Normalize(string packageId)
         {
-            if (_normalizePackageId)
-            {
-                packageId = packageId.ToLowerInvariant();
-            }
-
-            return packageId;
+            return packageId.ToLowerInvariant();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ToolPathResolver.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ToolPathResolver.cs
@@ -21,8 +21,8 @@ namespace NuGet.ProjectModel
             return Path.Combine(
                 _packagesDirectory,
                 ".tools",
-                packageId,
-                version.ToNormalizedString(),
+                packageId.ToLowerInvariant(),
+                version.ToNormalizedString().ToLowerInvariant(),
                 framework.GetShortFolderName(),
                 LockFileFormat.LockFileName);
         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GlobalPackagesFolderUtility.cs
@@ -30,9 +30,7 @@ namespace NuGet.Protocol
             }
 
             var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
-            var defaultPackagePathResolver = new VersionFolderPathResolver(
-                globalPackagesFolder,
-                normalizePackageId: false);
+            var defaultPackagePathResolver = new VersionFolderPathResolver(globalPackagesFolder);
 
             var hashPath = defaultPackagePathResolver.GetHashPath(packageIdentity.Id, packageIdentity.Version);
 
@@ -104,9 +102,7 @@ namespace NuGet.Protocol
                 packageIdentity,
                 globalPackagesFolder,
                 logger,
-                fixNuspecIdCasing: false,
                 packageSaveMode: PackageSaveMode.Defaultv3,
-                normalizeFileNames: false,
                 xmlDocFileSaveMode: PackageExtractionBehavior.XmlDocFileSaveMode);
 
             await PackageExtractor.InstallFromSourceAsync(

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/OfflineFeedUtility.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(offlineFeed));
             }
 
-            var versionFolderPathResolver = new VersionFolderPathResolver(offlineFeed, normalizePackageId: true);
+            var versionFolderPathResolver = new VersionFolderPathResolver(offlineFeed);
             string nupkgFilePath = versionFolderPathResolver.GetPackageFilePath(packageIdentity.Id, packageIdentity.Version);
             string hashFilePath = versionFolderPathResolver.GetHashPath(packageIdentity.Id, packageIdentity.Version);
             string nuspecFilePath = versionFolderPathResolver.GetManifestFilePath(packageIdentity.Id, packageIdentity.Version);
@@ -70,7 +70,7 @@ namespace NuGet.Protocol.Core.Types
         }
         public static string GetPackageDirectory(PackageIdentity packageIdentity, string offlineFeed)
         {
-            var versionFolderPathResolver = new VersionFolderPathResolver(offlineFeed, normalizePackageId: true);
+            var versionFolderPathResolver = new VersionFolderPathResolver(offlineFeed);
             return Path.GetDirectoryName(
                 versionFolderPathResolver.GetPackageFilePath(packageIdentity.Id, packageIdentity.Version));
         }
@@ -192,9 +192,7 @@ namespace NuGet.Protocol.Core.Types
                             packageIdentity,
                             source,
                             logger,
-                            fixNuspecIdCasing: false,
                             packageSaveMode: packageSaveMode,
-                            normalizeFileNames: true,
                             xmlDocFileSaveMode: PackageExtractionBehavior.XmlDocFileSaveMode);
 
                         await PackageExtractor.InstallFromSourceAsync(

--- a/src/NuGet.Core/NuGet.Test.Utility/GlobalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/GlobalFolderUtility.cs
@@ -29,9 +29,7 @@ namespace NuGet.Test.Utility
                     package: reader.GetIdentity(),
                     packagesDirectory: globalFolder,
                     logger: Common.NullLogger.Instance,
-                    fixNuspecIdCasing: true,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: true,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 using (var stream = File.OpenRead(packagePath))

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -65,7 +65,9 @@ namespace NuGet.Test.Utility
             var version = packageContext.Version;
             var runtimeJson = packageContext.RuntimeJson;
 
-            var file = new FileInfo(Path.Combine(repositoryDir, $"{id}.{version}.nupkg"));
+            var pathResolver = new VersionFolderPathResolver(null);
+            var packagePath = Path.Combine(repositoryDir, pathResolver.GetPackageFileName(id, new NuGetVersion(version)));
+            var file = new FileInfo(packagePath);
 
             file.Directory.Create();
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetAddCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetAddCommandTests.cs
@@ -201,9 +201,7 @@ namespace NuGet.CommandLine.Test
                 Util.VerifyResultSuccess(result);
                 Util.VerifyPackageExists(testInfo.Package, testInfo.SourceParamFolder);
 
-                var versionFolderPathResolver = new VersionFolderPathResolver(
-                    testInfo.SourceParamFolder,
-                    normalizePackageId: true);
+                var versionFolderPathResolver = new VersionFolderPathResolver(testInfo.SourceParamFolder);
 
                 File.Delete(
                     versionFolderPathResolver.GetManifestFilePath(testInfo.Package.Id, testInfo.Package.Version));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -120,8 +120,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.True(content.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\B.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\A.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\B.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\A.dll</HintPath>"));
                 Assert.True(content.Contains(@"<Content Include=""test.txt"" />"));
             }
         }
@@ -200,8 +200,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -321,16 +321,16 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content1 = File.ReadAllText(projectFile1);
-                Assert.False(content1.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content1.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content1.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\b.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\file.dll</HintPath>"));
 
                 var content2 = File.ReadAllText(projectFile2);
-                Assert.True(content2.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content2.Contains(@"<HintPath>..\packages\b.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -408,7 +408,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.2.0.0-beta\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.2.0.0-beta\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -423,7 +423,7 @@ namespace NuGet.CommandLine.Test
                 var packagesDirectory = Path.Combine(solutionDirectory, "packages");
 
                 var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
-                var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0-beta"));
+                var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0-BETA"));
 
                 var a1Package = Util.CreateTestPackage(
                     a1.Id,
@@ -487,8 +487,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0-beta\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0-beta\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -577,9 +577,9 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.3.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.3.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -668,9 +668,9 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.3.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.3.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -748,8 +748,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -828,8 +828,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -1031,8 +1031,8 @@ namespace NuGet.CommandLine.Test
 
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
-                Assert.False(content1.Contains(@"<HintPath>..\custom-pcks\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\custom-pcks\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\custom-pcks\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\custom-pcks\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -1121,8 +1121,8 @@ namespace NuGet.CommandLine.Test
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
                 var customPackageFolderName = new DirectoryInfo(packagesDirectory.Path).Name;
-                Assert.False(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\A.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\a.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\a.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -741,7 +741,7 @@ EndProject";
             string packagesDirectory)
         {
             var versionFolderPathResolver
-                = new VersionFolderPathResolver(packagesDirectory, normalizePackageId: true);
+                = new VersionFolderPathResolver(packagesDirectory);
 
             var packageFiles = new[]
             {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -192,7 +192,7 @@ namespace NuGet.Commands.FuncTest
                     MinClientVersion = "9.9.9"
                 };
 
-                var packagePath = Path.Combine(workingDir, "packageA.1.0.0.nupkg");
+                var packagePath = Path.Combine(workingDir, "packagea.1.0.0.nupkg");
 
                 SimpleTestPackageUtility.CreatePackages(workingDir, packageContext);
 
@@ -201,13 +201,12 @@ namespace NuGet.Commands.FuncTest
                 {
                     await PackageExtractor.InstallFromSourceAsync((stream) =>
                         fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
-                        new VersionFolderPathContext(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")),
-                        packagesDir,
-                        logger,
-                        false,
-                        PackageSaveMode.Defaultv3,
-                        false,
-                        XmlDocFileSaveMode.None),
+                        new VersionFolderPathContext(
+                            new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")),
+                            packagesDir,
+                            logger,
+                            PackageSaveMode.Defaultv3,
+                            XmlDocFileSaveMode.None),
                         CancellationToken.None);
                 }
 
@@ -424,8 +423,9 @@ namespace NuGet.Commands.FuncTest
                 var logger = new TestLogger();
 
                 // Create left over nupkg to simulate a corrupted install
-                var nupkgFolder = Path.Combine(packagesDir, "Newtonsoft.Json", "7.0.1");
-                var nupkgPath = Path.Combine(nupkgFolder, "Newtonsoft.Json.7.0.1.nupkg");
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
+                var nupkgFolder = pathResolver.GetInstallPath("Newtonsoft.Json", new NuGetVersion("7.0.1"));
+                var nupkgPath = pathResolver.GetPackageFilePath("Newtonsoft.Json", new NuGetVersion("7.0.1"));
 
                 Directory.CreateDirectory(nupkgFolder);
 
@@ -1128,9 +1128,10 @@ namespace NuGet.Commands.FuncTest
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                var nuspecPath = Path.Combine(packagesDir, "NuGet.Versioning", "1.0.7", "NuGet.Versioning.nuspec");
 
                 // Assert
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
+                var nuspecPath = pathResolver.GetManifestFilePath("NuGet.Versioning", new NuGetVersion("1.0.7"));
                 Assert.True(File.Exists(nuspecPath));
             }
         }
@@ -1160,9 +1161,10 @@ namespace NuGet.Commands.FuncTest
                 // Act
                 var command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
-                var nuspecPath = Path.Combine(packagesDir, "owin", "1.0.0", "owin.nuspec");
 
                 // Assert
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
+                var nuspecPath = pathResolver.GetManifestFilePath("owin", new NuGetVersion("1.0.0"));
                 Assert.True(File.Exists(nuspecPath));
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV1.json
@@ -11538,10 +11538,8 @@
     "Microsoft.CSharp/4.0.0": {
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "package",
-      "path": "Microsoft.CSharp/4.0.0",
+      "path": "microsoft.csharp/4.0.0",
       "files": [
-        "Microsoft.CSharp.4.0.0.nupkg.sha512",
-        "Microsoft.CSharp.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/Microsoft.CSharp.dll",
@@ -11552,6 +11550,8 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "microsoft.csharp.4.0.0.nupkg.sha512",
+        "microsoft.csharp.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/dotnet/Microsoft.CSharp.dll",
@@ -11578,30 +11578,28 @@
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "package",
-      "path": "Microsoft.NETCore/5.0.0",
+      "path": "microsoft.netcore/5.0.0",
       "files": [
-        "Microsoft.NETCore.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.5.0.0.nupkg.sha512",
+        "microsoft.netcore.nuspec"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "package",
-      "path": "Microsoft.NETCore.Platforms/1.0.0",
+      "path": "microsoft.netcore.platforms/1.0.0",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Platforms.nuspec",
+        "microsoft.netcore.platforms.1.0.0.nupkg.sha512",
+        "microsoft.netcore.platforms.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "package",
-      "path": "Microsoft.NETCore.Portable.Compatibility/1.0.0",
+      "path": "microsoft.netcore.portable.compatibility/1.0.0",
       "files": [
-        "Microsoft.NETCore.Portable.Compatibility.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.Net.dll",
@@ -11630,6 +11628,8 @@
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "microsoft.netcore.portable.compatibility.1.0.0.nupkg.sha512",
+        "microsoft.netcore.portable.compatibility.nuspec",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
         "ref/dotnet/System.Net.dll",
@@ -11678,20 +11678,20 @@
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime/1.0.0",
+      "path": "microsoft.netcore.runtime/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.nuspec",
+        "microsoft.netcore.runtime.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0": {
       "sha512": "hoJfIl981eXwn9Tz8onO/J1xaYApIfp/YrhjSh9rRhml1U5Wj80LBgyp/6n+KI3VlvcAraThhnHnCTp+M3Uh+w==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-arm/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
+        "microsoft.netcore.runtime.coreclr-arm.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-arm.nuspec",
         "ref/dotnet/_._",
         "runtimes/win8-arm/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win8-arm/native/clretwrc.dll",
@@ -11706,10 +11706,10 @@
     "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0": {
       "sha512": "DaY5Z13xCZpnVIGluC5sCo4/0wy1rl6mptBH7v3RYi3guAmG88aSeFoQzyZepo0H0jEixUxNFM0+MB6Jc+j0bw==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-x64/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
+        "microsoft.netcore.runtime.coreclr-x64.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-x64.nuspec",
         "ref/dotnet/_._",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x64/native/clretwrc.dll",
@@ -11724,10 +11724,10 @@
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-x86/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "microsoft.netcore.runtime.coreclr-x86.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-x86.nuspec",
         "ref/dotnet/_._",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
@@ -11742,50 +11742,50 @@
     "Microsoft.NETCore.Runtime.Native/1.0.0": {
       "sha512": "tMsWWrH1AJCguiM22zK/vr6COxqz62Q1F02B07IXAUN405R3HGk5SkD/DL0Hte+OTjNtW9LkKXpOggGBRwYFNg==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.Native/1.0.0",
+      "path": "microsoft.netcore.runtime.native/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.Native.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.Native.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.runtime.native.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.native.nuspec"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "package",
-      "path": "Microsoft.NETCore.Targets/1.0.0",
+      "path": "microsoft.netcore.targets/1.0.0",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Targets.nuspec",
+        "microsoft.netcore.targets.1.0.0.nupkg.sha512",
+        "microsoft.netcore.targets.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {
       "sha512": "jszcJ6okLlhqF4OQbhSbixLOuLUyVT3BP7Y7/i7fcDMwnHBd1Pmdz6M1Al9SMDKVLA2oSaItg4tq6C0ydv8lYQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0",
+      "path": "microsoft.netcore.targets.universalwindowsplatform/5.0.0",
       "files": [
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
+        "microsoft.netcore.targets.universalwindowsplatform.5.0.0.nupkg.sha512",
+        "microsoft.netcore.targets.universalwindowsplatform.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
       "sha512": "D0nsAm+yTk0oSSC7E6PcmuuEewBAQbGgIXNcCnRqQ4qLPdQLMjMHg8cilGs3xZgwTRQmMtEn45TAatrU1otWPQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0",
+      "path": "microsoft.netcore.universalwindowsplatform/5.0.0",
       "files": [
-        "Microsoft.NETCore.UniversalWindowsPlatform.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.universalwindowsplatform.5.0.0.nupkg.sha512",
+        "microsoft.netcore.universalwindowsplatform.nuspec"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0": {
       "sha512": "NC+dpFMdhujz2sWAdJ8EmBk07p1zOlNi0FCCnZEbzftABpw9xZ99EMP/bUJrPTgCxHfzJAiuLPOtAauzVINk0w==",
       "type": "package",
-      "path": "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0",
+      "path": "microsoft.netcore.windows.apisets-x64/1.0.0",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets-x64.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
+        "microsoft.netcore.windows.apisets-x64.1.0.0.nupkg.sha512",
+        "microsoft.netcore.windows.apisets-x64.nuspec",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
@@ -11948,10 +11948,10 @@
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0",
+      "path": "microsoft.netcore.windows.apisets-x86/1.0.0",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets-x86.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "microsoft.netcore.windows.apisets-x86.1.0.0.nupkg.sha512",
+        "microsoft.netcore.windows.apisets-x86.nuspec",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
@@ -12114,15 +12114,15 @@
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "package",
-      "path": "Microsoft.VisualBasic/10.0.0",
+      "path": "microsoft.visualbasic/10.0.0",
       "files": [
-        "Microsoft.VisualBasic.10.0.0.nupkg.sha512",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "microsoft.visualbasic.10.0.0.nupkg.sha512",
+        "microsoft.visualbasic.nuspec",
         "ref/dotnet/Microsoft.VisualBasic.dll",
         "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
@@ -12144,16 +12144,16 @@
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "package",
-      "path": "Microsoft.Win32.Primitives/4.0.0",
+      "path": "microsoft.win32.primitives/4.0.0",
       "files": [
-        "Microsoft.Win32.Primitives.4.0.0.nupkg.sha512",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "microsoft.win32.primitives.4.0.0.nupkg.sha512",
+        "microsoft.win32.primitives.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/dotnet/Microsoft.Win32.Primitives.dll",
@@ -12175,10 +12175,8 @@
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "package",
-      "path": "System.AppContext/4.0.0",
+      "path": "system.appcontext/4.0.0",
       "files": [
-        "System.AppContext.4.0.0.nupkg.sha512",
-        "System.AppContext.nuspec",
         "lib/DNXCore50/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12201,16 +12199,16 @@
         "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.appcontext.4.0.0.nupkg.sha512",
+        "system.appcontext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "package",
-      "path": "System.Collections/4.0.10",
+      "path": "system.collections/4.0.10",
       "files": [
-        "System.Collections.4.0.10.nupkg.sha512",
-        "System.Collections.nuspec",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12234,16 +12232,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "system.collections.4.0.10.nupkg.sha512",
+        "system.collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "package",
-      "path": "System.Collections.Concurrent/4.0.10",
+      "path": "system.collections.concurrent/4.0.10",
       "files": [
-        "System.Collections.Concurrent.4.0.10.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.Concurrent.dll",
@@ -12265,29 +12263,29 @@
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.concurrent.4.0.10.nupkg.sha512",
+        "system.collections.concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "package",
-      "path": "System.Collections.Immutable/1.1.37",
+      "path": "system.collections.immutable/1.1.37",
       "files": [
-        "System.Collections.Immutable.1.1.37.nupkg.sha512",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "system.collections.immutable.1.1.37.nupkg.sha512",
+        "system.collections.immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "package",
-      "path": "System.Collections.NonGeneric/4.0.0",
+      "path": "system.collections.nongeneric/4.0.0",
       "files": [
-        "System.Collections.NonGeneric.4.0.0.nupkg.sha512",
-        "System.Collections.NonGeneric.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.NonGeneric.dll",
@@ -12309,16 +12307,16 @@
         "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.nongeneric.4.0.0.nupkg.sha512",
+        "system.collections.nongeneric.nuspec"
       ]
     },
     "System.Collections.Specialized/4.0.0": {
       "sha512": "poJFwQCUOoXqvdoGxx+3p8Z63yawcYKPBSFP67Z2jICeOINvEIQZN7mVOAnC7gsVF0WU+A2wtVwfhagC7UCgAg==",
       "type": "package",
-      "path": "System.Collections.Specialized/4.0.0",
+      "path": "system.collections.specialized/4.0.0",
       "files": [
-        "System.Collections.Specialized.4.0.0.nupkg.sha512",
-        "System.Collections.Specialized.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.Specialized.dll",
@@ -12340,16 +12338,16 @@
         "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.specialized.4.0.0.nupkg.sha512",
+        "system.collections.specialized.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "package",
-      "path": "System.ComponentModel/4.0.0",
+      "path": "system.componentmodel/4.0.0",
       "files": [
-        "System.ComponentModel.4.0.0.nupkg.sha512",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ComponentModel.dll",
@@ -12372,16 +12370,16 @@
         "ref/netcore50/System.ComponentModel.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.componentmodel.4.0.0.nupkg.sha512",
+        "system.componentmodel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "package",
-      "path": "System.ComponentModel.Annotations/4.0.10",
+      "path": "system.componentmodel.annotations/4.0.10",
       "files": [
-        "System.ComponentModel.Annotations.4.0.10.nupkg.sha512",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
@@ -12403,16 +12401,16 @@
         "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.componentmodel.annotations.4.0.10.nupkg.sha512",
+        "system.componentmodel.annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "package",
-      "path": "System.ComponentModel.EventBasedAsync/4.0.10",
+      "path": "system.componentmodel.eventbasedasync/4.0.10",
       "files": [
-        "System.ComponentModel.EventBasedAsync.4.0.10.nupkg.sha512",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
@@ -12434,16 +12432,16 @@
         "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.componentmodel.eventbasedasync.4.0.10.nupkg.sha512",
+        "system.componentmodel.eventbasedasync.nuspec"
       ]
     },
     "System.Data.Common/4.0.0": {
       "sha512": "SA7IdoTWiImVr0exDM68r0mKmR4f/qFGxZUrJQKu4YS7F+3afWzSOCezHxWdevQ0ONi4WRQsOiv+Zf9p8H0Feg==",
       "type": "package",
-      "path": "System.Data.Common/4.0.0",
+      "path": "system.data.common/4.0.0",
       "files": [
-        "System.Data.Common.4.0.0.nupkg.sha512",
-        "System.Data.Common.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Data.Common.dll",
@@ -12465,16 +12463,16 @@
         "ref/dotnet/zh-hant/System.Data.Common.xml",
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.data.common.4.0.0.nupkg.sha512",
+        "system.data.common.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "package",
-      "path": "System.Diagnostics.Contracts/4.0.0",
+      "path": "system.diagnostics.contracts/4.0.0",
       "files": [
-        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Contracts.dll",
@@ -12498,16 +12496,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "system.diagnostics.contracts.4.0.0.nupkg.sha512",
+        "system.diagnostics.contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "package",
-      "path": "System.Diagnostics.Debug/4.0.10",
+      "path": "system.diagnostics.debug/4.0.10",
       "files": [
-        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12531,16 +12529,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "system.diagnostics.debug.4.0.10.nupkg.sha512",
+        "system.diagnostics.debug.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "package",
-      "path": "System.Diagnostics.StackTrace/4.0.0",
+      "path": "system.diagnostics.stacktrace/4.0.0",
       "files": [
-        "System.Diagnostics.StackTrace.4.0.0.nupkg.sha512",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12564,16 +12562,16 @@
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "system.diagnostics.stacktrace.4.0.0.nupkg.sha512",
+        "system.diagnostics.stacktrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "package",
-      "path": "System.Diagnostics.Tools/4.0.0",
+      "path": "system.diagnostics.tools/4.0.0",
       "files": [
-        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Tools.dll",
@@ -12597,16 +12595,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "system.diagnostics.tools.4.0.0.nupkg.sha512",
+        "system.diagnostics.tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "package",
-      "path": "System.Diagnostics.Tracing/4.0.20",
+      "path": "system.diagnostics.tracing/4.0.20",
       "files": [
-        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12630,16 +12628,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "system.diagnostics.tracing.4.0.20.nupkg.sha512",
+        "system.diagnostics.tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "package",
-      "path": "System.Dynamic.Runtime/4.0.10",
+      "path": "system.dynamic.runtime/4.0.10",
       "files": [
-        "System.Dynamic.Runtime.4.0.10.nupkg.sha512",
-        "System.Dynamic.Runtime.nuspec",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12664,16 +12662,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "system.dynamic.runtime.4.0.10.nupkg.sha512",
+        "system.dynamic.runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "package",
-      "path": "System.Globalization/4.0.10",
+      "path": "system.globalization/4.0.10",
       "files": [
-        "System.Globalization.4.0.10.nupkg.sha512",
-        "System.Globalization.nuspec",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12697,16 +12695,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "system.globalization.4.0.10.nupkg.sha512",
+        "system.globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "package",
-      "path": "System.Globalization.Calendars/4.0.0",
+      "path": "system.globalization.calendars/4.0.0",
       "files": [
-        "System.Globalization.Calendars.4.0.0.nupkg.sha512",
-        "System.Globalization.Calendars.nuspec",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12730,16 +12728,16 @@
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "system.globalization.calendars.4.0.0.nupkg.sha512",
+        "system.globalization.calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "package",
-      "path": "System.Globalization.Extensions/4.0.0",
+      "path": "system.globalization.extensions/4.0.0",
       "files": [
-        "System.Globalization.Extensions.4.0.0.nupkg.sha512",
-        "System.Globalization.Extensions.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Globalization.Extensions.dll",
@@ -12761,16 +12759,16 @@
         "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.globalization.extensions.4.0.0.nupkg.sha512",
+        "system.globalization.extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "package",
-      "path": "System.IO/4.0.10",
+      "path": "system.io/4.0.10",
       "files": [
-        "System.IO.4.0.10.nupkg.sha512",
-        "System.IO.nuspec",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12794,16 +12792,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "system.io.4.0.10.nupkg.sha512",
+        "system.io.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "package",
-      "path": "System.IO.Compression/4.0.0",
+      "path": "system.io.compression/4.0.0",
       "files": [
-        "System.IO.Compression.4.0.0.nupkg.sha512",
-        "System.IO.Compression.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.Compression.dll",
@@ -12833,49 +12831,49 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json"
+        "runtime.json",
+        "system.io.compression.4.0.0.nupkg.sha512",
+        "system.io.compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-arm/4.0.0": {
       "sha512": "Kk21GecAbI+H6tMP6/lMssGObbhoHwLiREiB5UkNMCypdxACuF+6gmrdDTousCUcbH28CJeo7tArrnUc+bchuw==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-arm/4.0.0",
+      "path": "system.io.compression.clrcompression-arm/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-arm.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-arm.nuspec",
         "runtimes/win10-arm/native/ClrCompression.dll",
-        "runtimes/win7-arm/native/clrcompression.dll"
+        "runtimes/win7-arm/native/clrcompression.dll",
+        "system.io.compression.clrcompression-arm.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-arm.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x64/4.0.0": {
       "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-x64/4.0.0",
+      "path": "system.io.compression.clrcompression-x64/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x64.nuspec",
         "runtimes/win10-x64/native/ClrCompression.dll",
-        "runtimes/win7-x64/native/clrcompression.dll"
+        "runtimes/win7-x64/native/clrcompression.dll",
+        "system.io.compression.clrcompression-x64.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-x64.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-x86/4.0.0",
+      "path": "system.io.compression.clrcompression-x86/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-x86.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x86.nuspec",
         "runtimes/win10-x86/native/ClrCompression.dll",
-        "runtimes/win7-x86/native/clrcompression.dll"
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "system.io.compression.clrcompression-x86.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "package",
-      "path": "System.IO.Compression.ZipFile/4.0.0",
+      "path": "system.io.compression.zipfile/4.0.0",
       "files": [
-        "System.IO.Compression.ZipFile.4.0.0.nupkg.sha512",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
@@ -12897,16 +12895,16 @@
         "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.compression.zipfile.4.0.0.nupkg.sha512",
+        "system.io.compression.zipfile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "package",
-      "path": "System.IO.FileSystem/4.0.0",
+      "path": "system.io.filesystem/4.0.0",
       "files": [
-        "System.IO.FileSystem.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12929,16 +12927,16 @@
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.filesystem.4.0.0.nupkg.sha512",
+        "system.io.filesystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "package",
-      "path": "System.IO.FileSystem.Primitives/4.0.0",
+      "path": "system.io.filesystem.primitives/4.0.0",
       "files": [
-        "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
@@ -12960,16 +12958,16 @@
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.filesystem.primitives.4.0.0.nupkg.sha512",
+        "system.io.filesystem.primitives.nuspec"
       ]
     },
     "System.IO.IsolatedStorage/4.0.0": {
       "sha512": "d5KimUbZ49Ki6A/uwU+Iodng+nhJvpRs7hr/828cfeXC02LxUiggnRnAu+COtWcKvJ2YbBmAGOcO4GLK4fX1+w==",
       "type": "package",
-      "path": "System.IO.IsolatedStorage/4.0.0",
+      "path": "system.io.isolatedstorage/4.0.0",
       "files": [
-        "System.IO.IsolatedStorage.4.0.0.nupkg.sha512",
-        "System.IO.IsolatedStorage.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/netcore50/System.IO.IsolatedStorage.dll",
@@ -12989,16 +12987,16 @@
         "ref/dotnet/zh-hans/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hant/System.IO.IsolatedStorage.xml",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.isolatedstorage.4.0.0.nupkg.sha512",
+        "system.io.isolatedstorage.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "package",
-      "path": "System.IO.UnmanagedMemoryStream/4.0.0",
+      "path": "system.io.unmanagedmemorystream/4.0.0",
       "files": [
-        "System.IO.UnmanagedMemoryStream.4.0.0.nupkg.sha512",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
@@ -13020,16 +13018,16 @@
         "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.unmanagedmemorystream.4.0.0.nupkg.sha512",
+        "system.io.unmanagedmemorystream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "package",
-      "path": "System.Linq/4.0.0",
+      "path": "system.linq/4.0.0",
       "files": [
-        "System.Linq.4.0.0.nupkg.sha512",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
@@ -13052,16 +13050,16 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.4.0.0.nupkg.sha512",
+        "system.linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "package",
-      "path": "System.Linq.Expressions/4.0.10",
+      "path": "system.linq.expressions/4.0.10",
       "files": [
-        "System.Linq.Expressions.4.0.10.nupkg.sha512",
-        "System.Linq.Expressions.nuspec",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13086,16 +13084,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "system.linq.expressions.4.0.10.nupkg.sha512",
+        "system.linq.expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "package",
-      "path": "System.Linq.Parallel/4.0.0",
+      "path": "system.linq.parallel/4.0.0",
       "files": [
-        "System.Linq.Parallel.4.0.0.nupkg.sha512",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
@@ -13116,16 +13114,16 @@
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.parallel.4.0.0.nupkg.sha512",
+        "system.linq.parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "package",
-      "path": "System.Linq.Queryable/4.0.0",
+      "path": "system.linq.queryable/4.0.0",
       "files": [
-        "System.Linq.Queryable.4.0.0.nupkg.sha512",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
@@ -13148,16 +13146,16 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.queryable.4.0.0.nupkg.sha512",
+        "system.linq.queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "package",
-      "path": "System.Net.Http/4.0.0",
+      "path": "system.net.http/4.0.0",
       "files": [
-        "System.Net.Http.4.0.0.nupkg.sha512",
-        "System.Net.Http.nuspec",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Net.Http.dll",
@@ -13178,16 +13176,16 @@
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.net.http.4.0.0.nupkg.sha512",
+        "system.net.http.nuspec"
       ]
     },
     "System.Net.Http.Rtc/4.0.0": {
       "sha512": "PlE+oJgXdbxPmZYR6GBywRkyIPovjB1Y0SYHizj2Iflgu80uJQC4szl9gue4rKI2FgXiEbj9JL7wL5K3mp9HAQ==",
       "type": "package",
-      "path": "System.Net.Http.Rtc/4.0.0",
+      "path": "system.net.http.rtc/4.0.0",
       "files": [
-        "System.Net.Http.Rtc.4.0.0.nupkg.sha512",
-        "System.Net.Http.Rtc.nuspec",
         "lib/netcore50/System.Net.Http.Rtc.dll",
         "lib/win8/_._",
         "ref/dotnet/System.Net.Http.Rtc.dll",
@@ -13203,16 +13201,16 @@
         "ref/dotnet/zh-hant/System.Net.Http.Rtc.xml",
         "ref/netcore50/System.Net.Http.Rtc.dll",
         "ref/netcore50/System.Net.Http.Rtc.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.net.http.rtc.4.0.0.nupkg.sha512",
+        "system.net.http.rtc.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "package",
-      "path": "System.Net.NetworkInformation/4.0.0",
+      "path": "system.net.networkinformation/4.0.0",
       "files": [
-        "System.Net.NetworkInformation.4.0.0.nupkg.sha512",
-        "System.Net.NetworkInformation.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -13242,16 +13240,16 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.networkinformation.4.0.0.nupkg.sha512",
+        "system.net.networkinformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "package",
-      "path": "System.Net.Primitives/4.0.10",
+      "path": "system.net.primitives/4.0.10",
       "files": [
-        "System.Net.Primitives.4.0.10.nupkg.sha512",
-        "System.Net.Primitives.nuspec",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13274,16 +13272,16 @@
         "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.primitives.4.0.10.nupkg.sha512",
+        "system.net.primitives.nuspec"
       ]
     },
     "System.Net.Requests/4.0.10": {
       "sha512": "A6XBR7TztiIQg6hx7VGfbBKmRTAavUERm2E7pmNz/gZeGvwyP0lcKHZxylJtNVKj7DPwr91bD87oLY6zZYntcg==",
       "type": "package",
-      "path": "System.Net.Requests/4.0.10",
+      "path": "system.net.requests/4.0.10",
       "files": [
-        "System.Net.Requests.4.0.10.nupkg.sha512",
-        "System.Net.Requests.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Net.Requests.dll",
@@ -13305,16 +13303,16 @@
         "ref/dotnet/zh-hant/System.Net.Requests.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.requests.4.0.10.nupkg.sha512",
+        "system.net.requests.nuspec"
       ]
     },
     "System.Net.Sockets/4.0.0": {
       "sha512": "7bBNLdO6Xw0BGyFVSxjloGXMvsc3qQmW+70bYMLwHEAVivMK8zx+E7XO8CeJnAko2mFj6R402E798EGYUksFcQ==",
       "type": "package",
-      "path": "System.Net.Sockets/4.0.0",
+      "path": "system.net.sockets/4.0.0",
       "files": [
-        "System.Net.Sockets.4.0.0.nupkg.sha512",
-        "System.Net.Sockets.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Sockets.dll",
@@ -13336,16 +13334,16 @@
         "ref/dotnet/zh-hant/System.Net.Sockets.xml",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.sockets.4.0.0.nupkg.sha512",
+        "system.net.sockets.nuspec"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.0": {
       "sha512": "IsIZAsHm/yK7R/XASnEc4EMffFLIMgYchG3/zJv6B4LwMnXZwrVlSPpNbPgEVb0lSXyztsn7A6sIPAACQQ2vTQ==",
       "type": "package",
-      "path": "System.Net.WebHeaderCollection/4.0.0",
+      "path": "system.net.webheadercollection/4.0.0",
       "files": [
-        "System.Net.WebHeaderCollection.4.0.0.nupkg.sha512",
-        "System.Net.WebHeaderCollection.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Net.WebHeaderCollection.dll",
@@ -13367,16 +13365,16 @@
         "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.webheadercollection.4.0.0.nupkg.sha512",
+        "system.net.webheadercollection.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "package",
-      "path": "System.Numerics.Vectors/4.1.0",
+      "path": "system.numerics.vectors/4.1.0",
       "files": [
-        "System.Numerics.Vectors.4.1.0.nupkg.sha512",
-        "System.Numerics.Vectors.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Numerics.Vectors.dll",
@@ -13388,26 +13386,26 @@
         "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.numerics.vectors.4.1.0.nupkg.sha512",
+        "system.numerics.vectors.nuspec"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
       "sha512": "Ly7GvoPFZq6GyfZpfS0E7uCk1cinl5BANAngXVuau3lD2QqZJMHitzlPv6n1FlIn6krfv99X2IPkIaVzUwDHXA==",
       "type": "package",
-      "path": "System.Numerics.Vectors.WindowsRuntime/4.0.0",
+      "path": "system.numerics.vectors.windowsruntime/4.0.0",
       "files": [
-        "System.Numerics.Vectors.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec",
-        "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll"
+        "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll",
+        "system.numerics.vectors.windowsruntime.4.0.0.nupkg.sha512",
+        "system.numerics.vectors.windowsruntime.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "package",
-      "path": "System.ObjectModel/4.0.10",
+      "path": "system.objectmodel/4.0.10",
       "files": [
-        "System.ObjectModel.4.0.10.nupkg.sha512",
-        "System.ObjectModel.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ObjectModel.dll",
@@ -13429,71 +13427,71 @@
         "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.objectmodel.4.0.10.nupkg.sha512",
+        "system.objectmodel.nuspec"
       ]
     },
     "System.Private.DataContractSerialization/4.0.0": {
       "sha512": "uQvzoXHXHn/9YqUmPtgD8ZPJIlBuuL3QHegbuik97W/umoI28fOnGLnvjRHhju1VMWvFLRQoh7uZkBaoZ+KpVQ==",
       "type": "package",
-      "path": "System.Private.DataContractSerialization/4.0.0",
+      "path": "system.private.datacontractserialization/4.0.0",
       "files": [
-        "System.Private.DataContractSerialization.4.0.0.nupkg.sha512",
-        "System.Private.DataContractSerialization.nuspec",
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
         "lib/netcore50/System.Private.DataContractSerialization.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
+        "system.private.datacontractserialization.4.0.0.nupkg.sha512",
+        "system.private.datacontractserialization.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "package",
-      "path": "System.Private.Networking/4.0.0",
+      "path": "system.private.networking/4.0.0",
       "files": [
-        "System.Private.Networking.4.0.0.nupkg.sha512",
-        "System.Private.Networking.nuspec",
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._"
+        "ref/netcore50/_._",
+        "system.private.networking.4.0.0.nupkg.sha512",
+        "system.private.networking.nuspec"
       ]
     },
     "System.Private.ServiceModel/4.0.0": {
       "sha512": "cm2wEa1f9kuUq/2k8uIwepgZJi5HdxXSnjGQIeXmAb7RaWfZPEC/iamv9GJ67b5LPnCZHR0KvtFqh82e8AAYSw==",
       "type": "package",
-      "path": "System.Private.ServiceModel/4.0.0",
+      "path": "system.private.servicemodel/4.0.0",
       "files": [
-        "System.Private.ServiceModel.4.0.0.nupkg.sha512",
-        "System.Private.ServiceModel.nuspec",
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._"
+        "ref/netcore50/_._",
+        "system.private.servicemodel.4.0.0.nupkg.sha512",
+        "system.private.servicemodel.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "package",
-      "path": "System.Private.Uri/4.0.0",
+      "path": "system.private.uri/4.0.0",
       "files": [
-        "System.Private.Uri.4.0.0.nupkg.sha512",
-        "System.Private.Uri.nuspec",
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "system.private.uri.4.0.0.nupkg.sha512",
+        "system.private.uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "package",
-      "path": "System.Reflection/4.0.10",
+      "path": "system.reflection/4.0.10",
       "files": [
-        "System.Reflection.4.0.10.nupkg.sha512",
-        "System.Reflection.nuspec",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13517,16 +13515,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "system.reflection.4.0.10.nupkg.sha512",
+        "system.reflection.nuspec"
       ]
     },
     "System.Reflection.Context/4.0.0": {
       "sha512": "Gz4sUHHFd/52RjHccSHbOXdujJEWKfL3gIaA+ekxvQaQfJGbI2tPzA0Uv3WTCTDRGHgtoNq5WS9E007Dt4P/VQ==",
       "type": "package",
-      "path": "System.Reflection.Context/4.0.0",
+      "path": "system.reflection.context/4.0.0",
       "files": [
-        "System.Reflection.Context.4.0.0.nupkg.sha512",
-        "System.Reflection.Context.nuspec",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Context.dll",
         "lib/win8/_._",
@@ -13544,16 +13542,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.Reflection.Context.dll",
         "ref/netcore50/System.Reflection.Context.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.reflection.context.4.0.0.nupkg.sha512",
+        "system.reflection.context.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "package",
-      "path": "System.Reflection.DispatchProxy/4.0.0",
+      "path": "system.reflection.dispatchproxy/4.0.0",
       "files": [
-        "System.Reflection.DispatchProxy.4.0.0.nupkg.sha512",
-        "System.Reflection.DispatchProxy.nuspec",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13577,16 +13575,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "system.reflection.dispatchproxy.4.0.0.nupkg.sha512",
+        "system.reflection.dispatchproxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "package",
-      "path": "System.Reflection.Emit/4.0.0",
+      "path": "system.reflection.emit/4.0.0",
       "files": [
-        "System.Reflection.Emit.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
@@ -13605,16 +13603,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/net45/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.reflection.emit.4.0.0.nupkg.sha512",
+        "system.reflection.emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "package",
-      "path": "System.Reflection.Emit.ILGeneration/4.0.0",
+      "path": "system.reflection.emit.ilgeneration/4.0.0",
       "files": [
-        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
@@ -13631,16 +13629,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
-        "ref/wp80/_._"
+        "ref/wp80/_._",
+        "system.reflection.emit.ilgeneration.4.0.0.nupkg.sha512",
+        "system.reflection.emit.ilgeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "package",
-      "path": "System.Reflection.Emit.Lightweight/4.0.0",
+      "path": "system.reflection.emit.lightweight/4.0.0",
       "files": [
-        "System.Reflection.Emit.Lightweight.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
@@ -13657,16 +13655,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
-        "ref/wp80/_._"
+        "ref/wp80/_._",
+        "system.reflection.emit.lightweight.4.0.0.nupkg.sha512",
+        "system.reflection.emit.lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "package",
-      "path": "System.Reflection.Extensions/4.0.0",
+      "path": "system.reflection.extensions/4.0.0",
       "files": [
-        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Extensions.dll",
@@ -13690,29 +13688,29 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "system.reflection.extensions.4.0.0.nupkg.sha512",
+        "system.reflection.extensions.nuspec"
       ]
     },
     "System.Reflection.Metadata/1.0.22": {
       "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
       "type": "package",
-      "path": "System.Reflection.Metadata/1.0.22",
+      "path": "system.reflection.metadata/1.0.22",
       "files": [
-        "System.Reflection.Metadata.1.0.22.nupkg.sha512",
-        "System.Reflection.Metadata.nuspec",
         "lib/dotnet/System.Reflection.Metadata.dll",
         "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "system.reflection.metadata.1.0.22.nupkg.sha512",
+        "system.reflection.metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "package",
-      "path": "System.Reflection.Primitives/4.0.0",
+      "path": "system.reflection.primitives/4.0.0",
       "files": [
-        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Primitives.dll",
@@ -13736,16 +13734,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "system.reflection.primitives.4.0.0.nupkg.sha512",
+        "system.reflection.primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "package",
-      "path": "System.Reflection.TypeExtensions/4.0.0",
+      "path": "system.reflection.typeextensions/4.0.0",
       "files": [
-        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13769,16 +13767,16 @@
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "system.reflection.typeextensions.4.0.0.nupkg.sha512",
+        "system.reflection.typeextensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "package",
-      "path": "System.Resources.ResourceManager/4.0.0",
+      "path": "system.resources.resourcemanager/4.0.0",
       "files": [
-        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Resources.ResourceManager.dll",
@@ -13802,16 +13800,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "system.resources.resourcemanager.4.0.0.nupkg.sha512",
+        "system.resources.resourcemanager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "package",
-      "path": "System.Runtime/4.0.20",
+      "path": "system.runtime/4.0.20",
       "files": [
-        "System.Runtime.4.0.20.nupkg.sha512",
-        "System.Runtime.nuspec",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13835,16 +13833,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "system.runtime.4.0.20.nupkg.sha512",
+        "system.runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "package",
-      "path": "System.Runtime.Extensions/4.0.10",
+      "path": "system.runtime.extensions/4.0.10",
       "files": [
-        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13868,16 +13866,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "system.runtime.extensions.4.0.10.nupkg.sha512",
+        "system.runtime.extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "package",
-      "path": "System.Runtime.Handles/4.0.0",
+      "path": "system.runtime.handles/4.0.0",
       "files": [
-        "System.Runtime.Handles.4.0.0.nupkg.sha512",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13901,16 +13899,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "system.runtime.handles.4.0.0.nupkg.sha512",
+        "system.runtime.handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "package",
-      "path": "System.Runtime.InteropServices/4.0.20",
+      "path": "system.runtime.interopservices/4.0.20",
       "files": [
-        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13934,16 +13932,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "system.runtime.interopservices.4.0.20.nupkg.sha512",
+        "system.runtime.interopservices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
       "sha512": "K5MGSvw/sGPKQYdOVqSpsVbHBE8HccHIDEhUNjM1lui65KGF/slNZfijGU87ggQiVXTI802ebKiOYBkwiLotow==",
       "type": "package",
-      "path": "System.Runtime.InteropServices.WindowsRuntime/4.0.0",
+      "path": "system.runtime.interopservices.windowsruntime/4.0.0",
       "files": [
-        "System.Runtime.InteropServices.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
         "lib/win8/_._",
@@ -13966,16 +13964,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "system.runtime.interopservices.windowsruntime.4.0.0.nupkg.sha512",
+        "system.runtime.interopservices.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "package",
-      "path": "System.Runtime.Numerics/4.0.0",
+      "path": "system.runtime.numerics/4.0.0",
       "files": [
-        "System.Runtime.Numerics.4.0.0.nupkg.sha512",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
@@ -13996,16 +13994,16 @@
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.runtime.numerics.4.0.0.nupkg.sha512",
+        "system.runtime.numerics.nuspec"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.0": {
       "sha512": "emhWMQP3sdtkAhD0TOeP3FfjS57sfQMQ2sqA6f2Yj5Gd9jkHV4KsQ2TsoJjghca6d8fur7+REQ6ILBXVdGf/0g==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Json/4.0.0",
+      "path": "system.runtime.serialization.json/4.0.0",
       "files": [
-        "System.Runtime.Serialization.Json.4.0.0.nupkg.sha512",
-        "System.Runtime.Serialization.Json.nuspec",
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.Serialization.Json.dll",
@@ -14029,16 +14027,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
+        "system.runtime.serialization.json.4.0.0.nupkg.sha512",
+        "system.runtime.serialization.json.nuspec"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.0.10": {
       "sha512": "NPc8DZIomf5tGjYtz/KTHI01IPcVlypfhCux32AbLPDjTotdvL8TpKRwMyQJ6Kh08yprRVH7uBD1PdJiuoFzag==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Primitives/4.0.10",
+      "path": "system.runtime.serialization.primitives/4.0.10",
       "files": [
-        "System.Runtime.Serialization.Primitives.4.0.10.nupkg.sha512",
-        "System.Runtime.Serialization.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
@@ -14060,16 +14058,16 @@
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.runtime.serialization.primitives.4.0.10.nupkg.sha512",
+        "system.runtime.serialization.primitives.nuspec"
       ]
     },
     "System.Runtime.Serialization.Xml/4.0.10": {
       "sha512": "xsy7XbH8RTpKoDPNcibSGCOpujsmwUmOWAby3PssqkZFpLBXUbDO2s6JKITRjxejET2g0PK8t+mdIvu3xmUuKA==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Xml/4.0.10",
+      "path": "system.runtime.serialization.xml/4.0.10",
       "files": [
-        "System.Runtime.Serialization.Xml.4.0.10.nupkg.sha512",
-        "System.Runtime.Serialization.Xml.nuspec",
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14093,16 +14091,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
+        "system.runtime.serialization.xml.4.0.10.nupkg.sha512",
+        "system.runtime.serialization.xml.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.10": {
       "sha512": "9w6ypdnEw8RrLRlxTbLAYrap4eL1xIQeNoOaumQVOQ8TTD/5g9FGrBtY3KLiGxAPieN9AwAAEIDkugU85Cwuvg==",
       "type": "package",
-      "path": "System.Runtime.WindowsRuntime/4.0.10",
+      "path": "system.runtime.windowsruntime/4.0.10",
       "files": [
-        "System.Runtime.WindowsRuntime.4.0.10.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.nuspec",
         "lib/netcore50/System.Runtime.WindowsRuntime.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
@@ -14121,16 +14119,16 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll",
+        "system.runtime.windowsruntime.4.0.10.nupkg.sha512",
+        "system.runtime.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
       "sha512": "2GY3fkXBMQOyyO9ovaH46CN6MD2ck/Gvk4VNAgVDvtmfO3HXYFNd+bB05WhVcJrHKbfKZNwfwZKpYZ+OsVFsLw==",
       "type": "package",
-      "path": "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0",
+      "path": "system.runtime.windowsruntime.ui.xaml/4.0.0",
       "files": [
-        "System.Runtime.WindowsRuntime.UI.Xaml.4.0.0.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec",
         "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
@@ -14148,16 +14146,16 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.runtime.windowsruntime.ui.xaml.4.0.0.nupkg.sha512",
+        "system.runtime.windowsruntime.ui.xaml.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "package",
-      "path": "System.Security.Claims/4.0.0",
+      "path": "system.security.claims/4.0.0",
       "files": [
-        "System.Security.Claims.4.0.0.nupkg.sha512",
-        "System.Security.Claims.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Security.Claims.dll",
@@ -14179,16 +14177,16 @@
         "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.security.claims.4.0.0.nupkg.sha512",
+        "system.security.claims.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "package",
-      "path": "System.Security.Principal/4.0.0",
+      "path": "system.security.principal/4.0.0",
       "files": [
-        "System.Security.Principal.4.0.0.nupkg.sha512",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Security.Principal.dll",
@@ -14211,16 +14209,16 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.security.principal.4.0.0.nupkg.sha512",
+        "system.security.principal.nuspec"
       ]
     },
     "System.ServiceModel.Duplex/4.0.0": {
       "sha512": "JFeDn+IsiwAVJkNNnM7MLefJOnzYhovaHnjk3lzEnUWkYZJeAKrcgLdK6GE2GNjb5mEV8Pad/E0JcA8eCr3eWQ==",
       "type": "package",
-      "path": "System.ServiceModel.Duplex/4.0.0",
+      "path": "system.servicemodel.duplex/4.0.0",
       "files": [
-        "System.ServiceModel.Duplex.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Duplex.nuspec",
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
@@ -14239,16 +14237,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/netcore50/System.ServiceModel.Duplex.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.duplex.4.0.0.nupkg.sha512",
+        "system.servicemodel.duplex.nuspec"
       ]
     },
     "System.ServiceModel.Http/4.0.10": {
       "sha512": "Vyl7lmvMlXJamtnDugoXuAgAQGSqtA7omK3zDBYByhbYeBC2hRBchgyXox7e5vEO+29TeB1IpoLWQGb7tO9h6A==",
       "type": "package",
-      "path": "System.ServiceModel.Http/4.0.10",
+      "path": "system.servicemodel.http/4.0.10",
       "files": [
-        "System.ServiceModel.Http.4.0.10.nupkg.sha512",
-        "System.ServiceModel.Http.nuspec",
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14271,16 +14269,16 @@
         "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.servicemodel.http.4.0.10.nupkg.sha512",
+        "system.servicemodel.http.nuspec"
       ]
     },
     "System.ServiceModel.NetTcp/4.0.0": {
       "sha512": "lV2Cdcso9jOS0KBtgHZHzTLe/Lx/ERdPcvF4dlepUie6/+BOMYTOgg2C7OdpIjp3fwUNXq8nhU+IilmEyjuf/A==",
       "type": "package",
-      "path": "System.ServiceModel.NetTcp/4.0.0",
+      "path": "system.servicemodel.nettcp/4.0.0",
       "files": [
-        "System.ServiceModel.NetTcp.4.0.0.nupkg.sha512",
-        "System.ServiceModel.NetTcp.nuspec",
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
@@ -14299,16 +14297,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.nettcp.4.0.0.nupkg.sha512",
+        "system.servicemodel.nettcp.nuspec"
       ]
     },
     "System.ServiceModel.Primitives/4.0.0": {
       "sha512": "uF5VYQWR07LgiZkzUr8qjwvqOaIAfwU566MneD4WuC14d8FLJNsAgCJUYhBGB7COjH7HTqnP9ZFmr6c+L83Stg==",
       "type": "package",
-      "path": "System.ServiceModel.Primitives/4.0.0",
+      "path": "system.servicemodel.primitives/4.0.0",
       "files": [
-        "System.ServiceModel.Primitives.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Primitives.nuspec",
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
@@ -14327,16 +14325,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.primitives.4.0.0.nupkg.sha512",
+        "system.servicemodel.primitives.nuspec"
       ]
     },
     "System.ServiceModel.Security/4.0.0": {
       "sha512": "sPVzsnd8w/TJsW/4sYA9eIGP+RtlpN0AhKLGKf9ywdGGmHPi0kkuX2mx412dM3GN0e4oifuISwvZqby/sI8Feg==",
       "type": "package",
-      "path": "System.ServiceModel.Security/4.0.0",
+      "path": "system.servicemodel.security/4.0.0",
       "files": [
-        "System.ServiceModel.Security.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Security.nuspec",
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Security.dll",
@@ -14355,16 +14353,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.security.4.0.0.nupkg.sha512",
+        "system.servicemodel.security.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "package",
-      "path": "System.Text.Encoding/4.0.10",
+      "path": "system.text.encoding/4.0.10",
       "files": [
-        "System.Text.Encoding.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.nuspec",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14388,16 +14386,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "system.text.encoding.4.0.10.nupkg.sha512",
+        "system.text.encoding.nuspec"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.0": {
       "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
       "type": "package",
-      "path": "System.Text.Encoding.CodePages/4.0.0",
+      "path": "system.text.encoding.codepages/4.0.0",
       "files": [
-        "System.Text.Encoding.CodePages.4.0.0.nupkg.sha512",
-        "System.Text.Encoding.CodePages.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Text.Encoding.CodePages.dll",
@@ -14417,16 +14415,16 @@
         "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.text.encoding.codepages.4.0.0.nupkg.sha512",
+        "system.text.encoding.codepages.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "package",
-      "path": "System.Text.Encoding.Extensions/4.0.10",
+      "path": "system.text.encoding.extensions/4.0.10",
       "files": [
-        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14450,16 +14448,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "system.text.encoding.extensions.4.0.10.nupkg.sha512",
+        "system.text.encoding.extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "package",
-      "path": "System.Text.RegularExpressions/4.0.10",
+      "path": "system.text.regularexpressions/4.0.10",
       "files": [
-        "System.Text.RegularExpressions.4.0.10.nupkg.sha512",
-        "System.Text.RegularExpressions.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Text.RegularExpressions.dll",
@@ -14481,16 +14479,16 @@
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.text.regularexpressions.4.0.10.nupkg.sha512",
+        "system.text.regularexpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "package",
-      "path": "System.Threading/4.0.10",
+      "path": "system.threading/4.0.10",
       "files": [
-        "System.Threading.4.0.10.nupkg.sha512",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14514,16 +14512,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "system.threading.4.0.10.nupkg.sha512",
+        "system.threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "package",
-      "path": "System.Threading.Overlapped/4.0.0",
+      "path": "system.threading.overlapped/4.0.0",
       "files": [
-        "System.Threading.Overlapped.4.0.0.nupkg.sha512",
-        "System.Threading.Overlapped.nuspec",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
@@ -14538,16 +14536,16 @@
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll"
+        "ref/net46/System.Threading.Overlapped.dll",
+        "system.threading.overlapped.4.0.0.nupkg.sha512",
+        "system.threading.overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "package",
-      "path": "System.Threading.Tasks/4.0.10",
+      "path": "system.threading.tasks/4.0.10",
       "files": [
-        "System.Threading.Tasks.4.0.10.nupkg.sha512",
-        "System.Threading.Tasks.nuspec",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14571,31 +14569,31 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "system.threading.tasks.4.0.10.nupkg.sha512",
+        "system.threading.tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "package",
-      "path": "System.Threading.Tasks.Dataflow/4.5.25",
+      "path": "system.threading.tasks.dataflow/4.5.25",
       "files": [
-        "System.Threading.Tasks.Dataflow.4.5.25.nupkg.sha512",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "system.threading.tasks.dataflow.4.5.25.nupkg.sha512",
+        "system.threading.tasks.dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "package",
-      "path": "System.Threading.Tasks.Parallel/4.0.0",
+      "path": "system.threading.tasks.parallel/4.0.0",
       "files": [
-        "System.Threading.Tasks.Parallel.4.0.0.nupkg.sha512",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
@@ -14616,16 +14614,16 @@
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.threading.tasks.parallel.4.0.0.nupkg.sha512",
+        "system.threading.tasks.parallel.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "package",
-      "path": "System.Threading.Timer/4.0.0",
+      "path": "system.threading.timer/4.0.0",
       "files": [
-        "System.Threading.Timer.4.0.0.nupkg.sha512",
-        "System.Threading.Timer.nuspec",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
         "lib/netcore50/System.Threading.Timer.dll",
@@ -14647,16 +14645,16 @@
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "system.threading.timer.4.0.0.nupkg.sha512",
+        "system.threading.timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "package",
-      "path": "System.Xml.ReaderWriter/4.0.10",
+      "path": "system.xml.readerwriter/4.0.10",
       "files": [
-        "System.Xml.ReaderWriter.4.0.10.nupkg.sha512",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
@@ -14678,16 +14676,16 @@
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.readerwriter.4.0.10.nupkg.sha512",
+        "system.xml.readerwriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "package",
-      "path": "System.Xml.XDocument/4.0.10",
+      "path": "system.xml.xdocument/4.0.10",
       "files": [
-        "System.Xml.XDocument.4.0.10.nupkg.sha512",
-        "System.Xml.XDocument.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.XDocument.dll",
@@ -14709,16 +14707,16 @@
         "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.xdocument.4.0.10.nupkg.sha512",
+        "system.xml.xdocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "package",
-      "path": "System.Xml.XmlDocument/4.0.0",
+      "path": "system.xml.xmldocument/4.0.0",
       "files": [
-        "System.Xml.XmlDocument.4.0.0.nupkg.sha512",
-        "System.Xml.XmlDocument.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.XmlDocument.dll",
@@ -14740,16 +14738,16 @@
         "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.xmldocument.4.0.0.nupkg.sha512",
+        "system.xml.xmldocument.nuspec"
       ]
     },
     "System.Xml.XmlSerializer/4.0.10": {
       "sha512": "OKhE6vruk88z/hl0lmfrMvXteTASgJUagu6PT6S10i9uLbvDR3pTwB6jVgiwa2D2qtTB+eneZbS9jljhPXhTtg==",
       "type": "package",
-      "path": "System.Xml.XmlSerializer/4.0.10",
+      "path": "system.xml.xmlserializer/4.0.10",
       "files": [
-        "System.Xml.XmlSerializer.4.0.10.nupkg.sha512",
-        "System.Xml.XmlSerializer.nuspec",
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14774,7 +14772,9 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "system.xml.xmlserializer.4.0.10.nupkg.sha512",
+        "system.xml.xmlserializer.nuspec"
       ]
     }
   },

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/compiler/resources/uwpBlankAppV2.json
@@ -12240,10 +12240,8 @@
     "Microsoft.CSharp/4.0.0": {
       "sha512": "oWqeKUxHXdK6dL2CFjgMcaBISbkk+AqEg+yvJHE4DElNzS4QaTsCflgkkqZwVlWby1Dg9zo9n+iCAMFefFdJ/A==",
       "type": "package",
-      "path": "Microsoft.CSharp/4.0.0",
+      "path": "microsoft.csharp/4.0.0",
       "files": [
-        "Microsoft.CSharp.4.0.0.nupkg.sha512",
-        "Microsoft.CSharp.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/Microsoft.CSharp.dll",
@@ -12254,6 +12252,8 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "microsoft.csharp.4.0.0.nupkg.sha512",
+        "microsoft.csharp.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/dotnet/Microsoft.CSharp.dll",
@@ -12280,30 +12280,28 @@
     "Microsoft.NETCore/5.0.0": {
       "sha512": "QQMp0yYQbIdfkKhdEE6Umh2Xonau7tasG36Trw/YlHoWgYQLp7T9L+ZD8EPvdj5ubRhtOuKEKwM7HMpkagB9ZA==",
       "type": "package",
-      "path": "Microsoft.NETCore/5.0.0",
+      "path": "microsoft.netcore/5.0.0",
       "files": [
-        "Microsoft.NETCore.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.5.0.0.nupkg.sha512",
+        "microsoft.netcore.nuspec"
       ]
     },
     "Microsoft.NETCore.Platforms/1.0.0": {
       "sha512": "0N77OwGZpXqUco2C/ynv1os7HqdFYifvNIbveLDKqL5PZaz05Rl9enCwVBjF61aumHKueLWIJ3prnmdAXxww4A==",
       "type": "package",
-      "path": "Microsoft.NETCore.Platforms/1.0.0",
+      "path": "microsoft.netcore.platforms/1.0.0",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Platforms.nuspec",
+        "microsoft.netcore.platforms.1.0.0.nupkg.sha512",
+        "microsoft.netcore.platforms.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Portable.Compatibility/1.0.0": {
       "sha512": "5/IFqf2zN1jzktRJitxO+5kQ+0AilcIbPvSojSJwDG3cGNSMZg44LXLB5E9RkSETE0Wh4QoALdNh1koKoF7/mA==",
       "type": "package",
-      "path": "Microsoft.NETCore.Portable.Compatibility/1.0.0",
+      "path": "microsoft.netcore.portable.compatibility/1.0.0",
       "files": [
-        "Microsoft.NETCore.Portable.Compatibility.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Portable.Compatibility.nuspec",
         "lib/dnxcore50/System.ComponentModel.DataAnnotations.dll",
         "lib/dnxcore50/System.Core.dll",
         "lib/dnxcore50/System.Net.dll",
@@ -12332,6 +12330,8 @@
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "microsoft.netcore.portable.compatibility.1.0.0.nupkg.sha512",
+        "microsoft.netcore.portable.compatibility.nuspec",
         "ref/dotnet/System.ComponentModel.DataAnnotations.dll",
         "ref/dotnet/System.Core.dll",
         "ref/dotnet/System.Net.dll",
@@ -12380,20 +12380,20 @@
     "Microsoft.NETCore.Runtime/1.0.0": {
       "sha512": "AjaMNpXLW4miEQorIqyn6iQ+BZBId6qXkhwyeh1vl6kXLqosZusbwmLNlvj/xllSQrd3aImJbvlHusam85g+xQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime/1.0.0",
+      "path": "microsoft.netcore.runtime/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.nuspec",
+        "microsoft.netcore.runtime.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0": {
       "sha512": "hoJfIl981eXwn9Tz8onO/J1xaYApIfp/YrhjSh9rRhml1U5Wj80LBgyp/6n+KI3VlvcAraThhnHnCTp+M3Uh+w==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-arm/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-arm/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-arm.nuspec",
+        "microsoft.netcore.runtime.coreclr-arm.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-arm.nuspec",
         "ref/dotnet/_._",
         "runtimes/win8-arm/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win8-arm/native/clretwrc.dll",
@@ -12408,10 +12408,10 @@
     "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0": {
       "sha512": "DaY5Z13xCZpnVIGluC5sCo4/0wy1rl6mptBH7v3RYi3guAmG88aSeFoQzyZepo0H0jEixUxNFM0+MB6Jc+j0bw==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-x64/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-x64/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-x64.nuspec",
+        "microsoft.netcore.runtime.coreclr-x64.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-x64.nuspec",
         "ref/dotnet/_._",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x64/native/clretwrc.dll",
@@ -12426,10 +12426,10 @@
     "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0": {
       "sha512": "2LDffu5Is/X01GVPVuye4Wmz9/SyGDNq1Opgl5bXG3206cwNiCwsQgILOtfSWVp5mn4w401+8cjhBy3THW8HQQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0",
+      "path": "microsoft.netcore.runtime.coreclr-x86/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "microsoft.netcore.runtime.coreclr-x86.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.coreclr-x86.nuspec",
         "ref/dotnet/_._",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
@@ -12444,50 +12444,50 @@
     "Microsoft.NETCore.Runtime.Native/1.0.0": {
       "sha512": "tMsWWrH1AJCguiM22zK/vr6COxqz62Q1F02B07IXAUN405R3HGk5SkD/DL0Hte+OTjNtW9LkKXpOggGBRwYFNg==",
       "type": "package",
-      "path": "Microsoft.NETCore.Runtime.Native/1.0.0",
+      "path": "microsoft.netcore.runtime.native/1.0.0",
       "files": [
-        "Microsoft.NETCore.Runtime.Native.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.Native.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.runtime.native.1.0.0.nupkg.sha512",
+        "microsoft.netcore.runtime.native.nuspec"
       ]
     },
     "Microsoft.NETCore.Targets/1.0.0": {
       "sha512": "XfITpPjYLYRmAeZtb9diw6P7ylLQsSC1U2a/xj10iQpnHxkiLEBXop/psw15qMPuNca7lqgxWvzZGpQxphuXaw==",
       "type": "package",
-      "path": "Microsoft.NETCore.Targets/1.0.0",
+      "path": "microsoft.netcore.targets/1.0.0",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Targets.nuspec",
+        "microsoft.netcore.targets.1.0.0.nupkg.sha512",
+        "microsoft.netcore.targets.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0": {
       "sha512": "jszcJ6okLlhqF4OQbhSbixLOuLUyVT3BP7Y7/i7fcDMwnHBd1Pmdz6M1Al9SMDKVLA2oSaItg4tq6C0ydv8lYQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Targets.UniversalWindowsPlatform/5.0.0",
+      "path": "microsoft.netcore.targets.universalwindowsplatform/5.0.0",
       "files": [
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Targets.UniversalWindowsPlatform.nuspec",
+        "microsoft.netcore.targets.universalwindowsplatform.5.0.0.nupkg.sha512",
+        "microsoft.netcore.targets.universalwindowsplatform.nuspec",
         "runtime.json"
       ]
     },
     "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0": {
       "sha512": "D0nsAm+yTk0oSSC7E6PcmuuEewBAQbGgIXNcCnRqQ4qLPdQLMjMHg8cilGs3xZgwTRQmMtEn45TAatrU1otWPQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.UniversalWindowsPlatform/5.0.0",
+      "path": "microsoft.netcore.universalwindowsplatform/5.0.0",
       "files": [
-        "Microsoft.NETCore.UniversalWindowsPlatform.5.0.0.nupkg.sha512",
-        "Microsoft.NETCore.UniversalWindowsPlatform.nuspec",
-        "_._"
+        "_._",
+        "microsoft.netcore.universalwindowsplatform.5.0.0.nupkg.sha512",
+        "microsoft.netcore.universalwindowsplatform.nuspec"
       ]
     },
     "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0": {
       "sha512": "NC+dpFMdhujz2sWAdJ8EmBk07p1zOlNi0FCCnZEbzftABpw9xZ99EMP/bUJrPTgCxHfzJAiuLPOtAauzVINk0w==",
       "type": "package",
-      "path": "Microsoft.NETCore.Windows.ApiSets-x64/1.0.0",
+      "path": "microsoft.netcore.windows.apisets-x64/1.0.0",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets-x64.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Windows.ApiSets-x64.nuspec",
+        "microsoft.netcore.windows.apisets-x64.1.0.0.nupkg.sha512",
+        "microsoft.netcore.windows.apisets-x64.nuspec",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
@@ -12650,10 +12650,10 @@
     "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0": {
       "sha512": "/HDRdhz5bZyhHwQ/uk/IbnDIX5VDTsHntEZYkTYo57dM+U3Ttel9/OJv0mjL64wTO/QKUJJNKp9XO+m7nSVjJQ==",
       "type": "package",
-      "path": "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0",
+      "path": "microsoft.netcore.windows.apisets-x86/1.0.0",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets-x86.1.0.0.nupkg.sha512",
-        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "microsoft.netcore.windows.apisets-x86.1.0.0.nupkg.sha512",
+        "microsoft.netcore.windows.apisets-x86.nuspec",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
@@ -12816,15 +12816,15 @@
     "Microsoft.VisualBasic/10.0.0": {
       "sha512": "5BEm2/HAVd97whRlCChU7rmSh/9cwGlZ/NTNe3Jl07zuPWfKQq5TUvVNUmdvmEe8QRecJLZ4/e7WF1i1O8V42g==",
       "type": "package",
-      "path": "Microsoft.VisualBasic/10.0.0",
+      "path": "microsoft.visualbasic/10.0.0",
       "files": [
-        "Microsoft.VisualBasic.10.0.0.nupkg.sha512",
-        "Microsoft.VisualBasic.nuspec",
         "lib/dotnet/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
+        "microsoft.visualbasic.10.0.0.nupkg.sha512",
+        "microsoft.visualbasic.nuspec",
         "ref/dotnet/Microsoft.VisualBasic.dll",
         "ref/dotnet/Microsoft.VisualBasic.xml",
         "ref/dotnet/de/Microsoft.VisualBasic.xml",
@@ -12846,16 +12846,16 @@
     "Microsoft.Win32.Primitives/4.0.0": {
       "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "type": "package",
-      "path": "Microsoft.Win32.Primitives/4.0.0",
+      "path": "microsoft.win32.primitives/4.0.0",
       "files": [
-        "Microsoft.Win32.Primitives.4.0.0.nupkg.sha512",
-        "Microsoft.Win32.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/Microsoft.Win32.Primitives.dll",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "microsoft.win32.primitives.4.0.0.nupkg.sha512",
+        "microsoft.win32.primitives.nuspec",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/dotnet/Microsoft.Win32.Primitives.dll",
@@ -12877,10 +12877,8 @@
     "System.AppContext/4.0.0": {
       "sha512": "gUoYgAWDC3+xhKeU5KSLbYDhTdBYk9GssrMSCcWUADzOglW+s0AmwVhOUGt2tL5xUl7ZXoYTPdA88zCgKrlG0A==",
       "type": "package",
-      "path": "System.AppContext/4.0.0",
+      "path": "system.appcontext/4.0.0",
       "files": [
-        "System.AppContext.4.0.0.nupkg.sha512",
-        "System.AppContext.nuspec",
         "lib/DNXCore50/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12903,16 +12901,16 @@
         "ref/dotnet/zh-hant/System.AppContext.xml",
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.appcontext.4.0.0.nupkg.sha512",
+        "system.appcontext.nuspec"
       ]
     },
     "System.Collections/4.0.10": {
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "type": "package",
-      "path": "System.Collections/4.0.10",
+      "path": "system.collections/4.0.10",
       "files": [
-        "System.Collections.4.0.10.nupkg.sha512",
-        "System.Collections.nuspec",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -12936,16 +12934,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "system.collections.4.0.10.nupkg.sha512",
+        "system.collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "type": "package",
-      "path": "System.Collections.Concurrent/4.0.10",
+      "path": "system.collections.concurrent/4.0.10",
       "files": [
-        "System.Collections.Concurrent.4.0.10.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.Concurrent.dll",
@@ -12967,29 +12965,29 @@
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.concurrent.4.0.10.nupkg.sha512",
+        "system.collections.concurrent.nuspec"
       ]
     },
     "System.Collections.Immutable/1.1.37": {
       "sha512": "fTpqwZYBzoklTT+XjTRK8KxvmrGkYHzBiylCcKyQcxiOM8k+QvhNBxRvFHDWzy4OEP5f8/9n+xQ9mEgEXY+muA==",
       "type": "package",
-      "path": "System.Collections.Immutable/1.1.37",
+      "path": "system.collections.immutable/1.1.37",
       "files": [
-        "System.Collections.Immutable.1.1.37.nupkg.sha512",
-        "System.Collections.Immutable.nuspec",
         "lib/dotnet/System.Collections.Immutable.dll",
         "lib/dotnet/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
-        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "system.collections.immutable.1.1.37.nupkg.sha512",
+        "system.collections.immutable.nuspec"
       ]
     },
     "System.Collections.NonGeneric/4.0.0": {
       "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
       "type": "package",
-      "path": "System.Collections.NonGeneric/4.0.0",
+      "path": "system.collections.nongeneric/4.0.0",
       "files": [
-        "System.Collections.NonGeneric.4.0.0.nupkg.sha512",
-        "System.Collections.NonGeneric.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.NonGeneric.dll",
@@ -13011,16 +13009,16 @@
         "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.nongeneric.4.0.0.nupkg.sha512",
+        "system.collections.nongeneric.nuspec"
       ]
     },
     "System.Collections.Specialized/4.0.0": {
       "sha512": "poJFwQCUOoXqvdoGxx+3p8Z63yawcYKPBSFP67Z2jICeOINvEIQZN7mVOAnC7gsVF0WU+A2wtVwfhagC7UCgAg==",
       "type": "package",
-      "path": "System.Collections.Specialized/4.0.0",
+      "path": "system.collections.specialized/4.0.0",
       "files": [
-        "System.Collections.Specialized.4.0.0.nupkg.sha512",
-        "System.Collections.Specialized.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Collections.Specialized.dll",
@@ -13042,16 +13040,16 @@
         "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.collections.specialized.4.0.0.nupkg.sha512",
+        "system.collections.specialized.nuspec"
       ]
     },
     "System.ComponentModel/4.0.0": {
       "sha512": "BzpLdSi++ld7rJLOOt5f/G9GxujP202bBgKORsHcGV36rLB0mfSA2h8chTMoBzFhgN7TE14TmJ2J7Q1RyNCTAw==",
       "type": "package",
-      "path": "System.ComponentModel/4.0.0",
+      "path": "system.componentmodel/4.0.0",
       "files": [
-        "System.ComponentModel.4.0.0.nupkg.sha512",
-        "System.ComponentModel.nuspec",
         "lib/dotnet/System.ComponentModel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ComponentModel.dll",
@@ -13074,16 +13072,16 @@
         "ref/netcore50/System.ComponentModel.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.componentmodel.4.0.0.nupkg.sha512",
+        "system.componentmodel.nuspec"
       ]
     },
     "System.ComponentModel.Annotations/4.0.10": {
       "sha512": "7+XGyEZx24nP1kpHxCB9e+c6D0fdVDvFwE1xujE9BzlXyNVcy5J5aIO0H/ECupx21QpyRvzZibGAHfL/XLL6dw==",
       "type": "package",
-      "path": "System.ComponentModel.Annotations/4.0.10",
+      "path": "system.componentmodel.annotations/4.0.10",
       "files": [
-        "System.ComponentModel.Annotations.4.0.10.nupkg.sha512",
-        "System.ComponentModel.Annotations.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ComponentModel.Annotations.dll",
@@ -13105,16 +13103,16 @@
         "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.componentmodel.annotations.4.0.10.nupkg.sha512",
+        "system.componentmodel.annotations.nuspec"
       ]
     },
     "System.ComponentModel.EventBasedAsync/4.0.10": {
       "sha512": "d6kXcHUgP0jSPXEQ6hXJYCO6CzfoCi7t9vR3BfjSQLrj4HzpuATpx1gkN7itmTW1O+wjuw6rai4378Nj6N70yw==",
       "type": "package",
-      "path": "System.ComponentModel.EventBasedAsync/4.0.10",
+      "path": "system.componentmodel.eventbasedasync/4.0.10",
       "files": [
-        "System.ComponentModel.EventBasedAsync.4.0.10.nupkg.sha512",
-        "System.ComponentModel.EventBasedAsync.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
@@ -13136,16 +13134,16 @@
         "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.componentmodel.eventbasedasync.4.0.10.nupkg.sha512",
+        "system.componentmodel.eventbasedasync.nuspec"
       ]
     },
     "System.Data.Common/4.0.0": {
       "sha512": "SA7IdoTWiImVr0exDM68r0mKmR4f/qFGxZUrJQKu4YS7F+3afWzSOCezHxWdevQ0ONi4WRQsOiv+Zf9p8H0Feg==",
       "type": "package",
-      "path": "System.Data.Common/4.0.0",
+      "path": "system.data.common/4.0.0",
       "files": [
-        "System.Data.Common.4.0.0.nupkg.sha512",
-        "System.Data.Common.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Data.Common.dll",
@@ -13167,16 +13165,16 @@
         "ref/dotnet/zh-hant/System.Data.Common.xml",
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.data.common.4.0.0.nupkg.sha512",
+        "system.data.common.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "type": "package",
-      "path": "System.Diagnostics.Contracts/4.0.0",
+      "path": "system.diagnostics.contracts/4.0.0",
       "files": [
-        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Contracts.dll",
@@ -13200,16 +13198,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "system.diagnostics.contracts.4.0.0.nupkg.sha512",
+        "system.diagnostics.contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "type": "package",
-      "path": "System.Diagnostics.Debug/4.0.10",
+      "path": "system.diagnostics.debug/4.0.10",
       "files": [
-        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13233,16 +13231,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "system.diagnostics.debug.4.0.10.nupkg.sha512",
+        "system.diagnostics.debug.nuspec"
       ]
     },
     "System.Diagnostics.StackTrace/4.0.0": {
       "sha512": "PItgenqpRiMqErvQONBlfDwctKpWVrcDSW5pppNZPJ6Bpiyz+KjsWoSiaqs5dt03HEbBTMNCrZb8KCkh7YfXmw==",
       "type": "package",
-      "path": "System.Diagnostics.StackTrace/4.0.0",
+      "path": "system.diagnostics.stacktrace/4.0.0",
       "files": [
-        "System.Diagnostics.StackTrace.4.0.0.nupkg.sha512",
-        "System.Diagnostics.StackTrace.nuspec",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13266,16 +13264,16 @@
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "system.diagnostics.stacktrace.4.0.0.nupkg.sha512",
+        "system.diagnostics.stacktrace.nuspec"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "type": "package",
-      "path": "System.Diagnostics.Tools/4.0.0",
+      "path": "system.diagnostics.tools/4.0.0",
       "files": [
-        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Tools.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Tools.dll",
@@ -13299,16 +13297,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "system.diagnostics.tools.4.0.0.nupkg.sha512",
+        "system.diagnostics.tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "type": "package",
-      "path": "System.Diagnostics.Tracing/4.0.20",
+      "path": "system.diagnostics.tracing/4.0.20",
       "files": [
-        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13332,16 +13330,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "system.diagnostics.tracing.4.0.20.nupkg.sha512",
+        "system.diagnostics.tracing.nuspec"
       ]
     },
     "System.Dynamic.Runtime/4.0.10": {
       "sha512": "r10VTLdlxtYp46BuxomHnwx7vIoMOr04CFoC/jJJfY22f7HQQ4P+cXY2Nxo6/rIxNNqOxwdbQQwv7Gl88Jsu1w==",
       "type": "package",
-      "path": "System.Dynamic.Runtime/4.0.10",
+      "path": "system.dynamic.runtime/4.0.10",
       "files": [
-        "System.Dynamic.Runtime.4.0.10.nupkg.sha512",
-        "System.Dynamic.Runtime.nuspec",
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13366,16 +13364,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "system.dynamic.runtime.4.0.10.nupkg.sha512",
+        "system.dynamic.runtime.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "type": "package",
-      "path": "System.Globalization/4.0.10",
+      "path": "system.globalization/4.0.10",
       "files": [
-        "System.Globalization.4.0.10.nupkg.sha512",
-        "System.Globalization.nuspec",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13399,16 +13397,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "system.globalization.4.0.10.nupkg.sha512",
+        "system.globalization.nuspec"
       ]
     },
     "System.Globalization.Calendars/4.0.0": {
       "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
       "type": "package",
-      "path": "System.Globalization.Calendars/4.0.0",
+      "path": "system.globalization.calendars/4.0.0",
       "files": [
-        "System.Globalization.Calendars.4.0.0.nupkg.sha512",
-        "System.Globalization.Calendars.nuspec",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13432,16 +13430,16 @@
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "system.globalization.calendars.4.0.0.nupkg.sha512",
+        "system.globalization.calendars.nuspec"
       ]
     },
     "System.Globalization.Extensions/4.0.0": {
       "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
       "type": "package",
-      "path": "System.Globalization.Extensions/4.0.0",
+      "path": "system.globalization.extensions/4.0.0",
       "files": [
-        "System.Globalization.Extensions.4.0.0.nupkg.sha512",
-        "System.Globalization.Extensions.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Globalization.Extensions.dll",
@@ -13463,16 +13461,16 @@
         "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.globalization.extensions.4.0.0.nupkg.sha512",
+        "system.globalization.extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "type": "package",
-      "path": "System.IO/4.0.10",
+      "path": "system.io/4.0.10",
       "files": [
-        "System.IO.4.0.10.nupkg.sha512",
-        "System.IO.nuspec",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13496,16 +13494,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "system.io.4.0.10.nupkg.sha512",
+        "system.io.nuspec"
       ]
     },
     "System.IO.Compression/4.0.0": {
       "sha512": "S+ljBE3py8pujTrsOOYHtDg2cnAifn6kBu/pfh1hMWIXd8DoVh0ADTA6Puv4q+nYj+Msm6JoFLNwuRSmztbsDQ==",
       "type": "package",
-      "path": "System.IO.Compression/4.0.0",
+      "path": "system.io.compression/4.0.0",
       "files": [
-        "System.IO.Compression.4.0.0.nupkg.sha512",
-        "System.IO.Compression.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.Compression.dll",
@@ -13535,49 +13533,49 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json"
+        "runtime.json",
+        "system.io.compression.4.0.0.nupkg.sha512",
+        "system.io.compression.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-arm/4.0.0": {
       "sha512": "Kk21GecAbI+H6tMP6/lMssGObbhoHwLiREiB5UkNMCypdxACuF+6gmrdDTousCUcbH28CJeo7tArrnUc+bchuw==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-arm/4.0.0",
+      "path": "system.io.compression.clrcompression-arm/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-arm.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-arm.nuspec",
         "runtimes/win10-arm/native/ClrCompression.dll",
-        "runtimes/win7-arm/native/clrcompression.dll"
+        "runtimes/win7-arm/native/clrcompression.dll",
+        "system.io.compression.clrcompression-arm.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-arm.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x64/4.0.0": {
       "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-x64/4.0.0",
+      "path": "system.io.compression.clrcompression-x64/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x64.nuspec",
         "runtimes/win10-x64/native/ClrCompression.dll",
-        "runtimes/win7-x64/native/clrcompression.dll"
+        "runtimes/win7-x64/native/clrcompression.dll",
+        "system.io.compression.clrcompression-x64.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-x64.nuspec"
       ]
     },
     "System.IO.Compression.clrcompression-x86/4.0.0": {
       "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
       "type": "package",
-      "path": "System.IO.Compression.clrcompression-x86/4.0.0",
+      "path": "system.io.compression.clrcompression-x86/4.0.0",
       "files": [
-        "System.IO.Compression.clrcompression-x86.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x86.nuspec",
         "runtimes/win10-x86/native/ClrCompression.dll",
-        "runtimes/win7-x86/native/clrcompression.dll"
+        "runtimes/win7-x86/native/clrcompression.dll",
+        "system.io.compression.clrcompression-x86.4.0.0.nupkg.sha512",
+        "system.io.compression.clrcompression-x86.nuspec"
       ]
     },
     "System.IO.Compression.ZipFile/4.0.0": {
       "sha512": "pwntmtsJqtt6Lez4Iyv4GVGW6DaXUTo9Rnlsx0MFagRgX+8F/sxG5S/IzDJabBj68sUWViz1QJrRZL4V9ngWDg==",
       "type": "package",
-      "path": "System.IO.Compression.ZipFile/4.0.0",
+      "path": "system.io.compression.zipfile/4.0.0",
       "files": [
-        "System.IO.Compression.ZipFile.4.0.0.nupkg.sha512",
-        "System.IO.Compression.ZipFile.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.Compression.ZipFile.dll",
@@ -13599,16 +13597,16 @@
         "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.compression.zipfile.4.0.0.nupkg.sha512",
+        "system.io.compression.zipfile.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "type": "package",
-      "path": "System.IO.FileSystem/4.0.0",
+      "path": "system.io.filesystem/4.0.0",
       "files": [
-        "System.IO.FileSystem.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.nuspec",
         "lib/DNXCore50/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13631,16 +13629,16 @@
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.filesystem.4.0.0.nupkg.sha512",
+        "system.io.filesystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "type": "package",
-      "path": "System.IO.FileSystem.Primitives/4.0.0",
+      "path": "system.io.filesystem.primitives/4.0.0",
       "files": [
-        "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
@@ -13662,16 +13660,16 @@
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.filesystem.primitives.4.0.0.nupkg.sha512",
+        "system.io.filesystem.primitives.nuspec"
       ]
     },
     "System.IO.IsolatedStorage/4.0.0": {
       "sha512": "d5KimUbZ49Ki6A/uwU+Iodng+nhJvpRs7hr/828cfeXC02LxUiggnRnAu+COtWcKvJ2YbBmAGOcO4GLK4fX1+w==",
       "type": "package",
-      "path": "System.IO.IsolatedStorage/4.0.0",
+      "path": "system.io.isolatedstorage/4.0.0",
       "files": [
-        "System.IO.IsolatedStorage.4.0.0.nupkg.sha512",
-        "System.IO.IsolatedStorage.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/netcore50/System.IO.IsolatedStorage.dll",
@@ -13691,16 +13689,16 @@
         "ref/dotnet/zh-hans/System.IO.IsolatedStorage.xml",
         "ref/dotnet/zh-hant/System.IO.IsolatedStorage.xml",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.isolatedstorage.4.0.0.nupkg.sha512",
+        "system.io.isolatedstorage.nuspec"
       ]
     },
     "System.IO.UnmanagedMemoryStream/4.0.0": {
       "sha512": "i2xczgQfwHmolORBNHxV9b5izP8VOBxgSA2gf+H55xBvwqtR+9r9adtzlc7at0MAwiLcsk6V1TZlv2vfRQr8Sw==",
       "type": "package",
-      "path": "System.IO.UnmanagedMemoryStream/4.0.0",
+      "path": "system.io.unmanagedmemorystream/4.0.0",
       "files": [
-        "System.IO.UnmanagedMemoryStream.4.0.0.nupkg.sha512",
-        "System.IO.UnmanagedMemoryStream.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
@@ -13722,16 +13720,16 @@
         "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.io.unmanagedmemorystream.4.0.0.nupkg.sha512",
+        "system.io.unmanagedmemorystream.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "type": "package",
-      "path": "System.Linq/4.0.0",
+      "path": "system.linq/4.0.0",
       "files": [
-        "System.Linq.4.0.0.nupkg.sha512",
-        "System.Linq.nuspec",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
@@ -13754,16 +13752,16 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.4.0.0.nupkg.sha512",
+        "system.linq.nuspec"
       ]
     },
     "System.Linq.Expressions/4.0.10": {
       "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "type": "package",
-      "path": "System.Linq.Expressions/4.0.10",
+      "path": "system.linq.expressions/4.0.10",
       "files": [
-        "System.Linq.Expressions.4.0.10.nupkg.sha512",
-        "System.Linq.Expressions.nuspec",
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13788,16 +13786,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "system.linq.expressions.4.0.10.nupkg.sha512",
+        "system.linq.expressions.nuspec"
       ]
     },
     "System.Linq.Parallel/4.0.0": {
       "sha512": "PtH7KKh1BbzVow4XY17pnrn7Io63ApMdwzRE2o2HnzsKQD/0o7X5xe6mxrDUqTm9ZCR3/PNhAlP13VY1HnHsbA==",
       "type": "package",
-      "path": "System.Linq.Parallel/4.0.0",
+      "path": "system.linq.parallel/4.0.0",
       "files": [
-        "System.Linq.Parallel.4.0.0.nupkg.sha512",
-        "System.Linq.Parallel.nuspec",
         "lib/dotnet/System.Linq.Parallel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.Parallel.dll",
@@ -13818,16 +13816,16 @@
         "ref/netcore50/System.Linq.Parallel.dll",
         "ref/netcore50/System.Linq.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.parallel.4.0.0.nupkg.sha512",
+        "system.linq.parallel.nuspec"
       ]
     },
     "System.Linq.Queryable/4.0.0": {
       "sha512": "DIlvCNn3ucFvwMMzXcag4aFnFJ1fdxkQ5NqwJe9Nh7y8ozzhDm07YakQL/yoF3P1dLzY1T2cTpuwbAmVSdXyBA==",
       "type": "package",
-      "path": "System.Linq.Queryable/4.0.0",
+      "path": "system.linq.queryable/4.0.0",
       "files": [
-        "System.Linq.Queryable.4.0.0.nupkg.sha512",
-        "System.Linq.Queryable.nuspec",
         "lib/dotnet/System.Linq.Queryable.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.Queryable.dll",
@@ -13850,16 +13848,16 @@
         "ref/netcore50/System.Linq.Queryable.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.linq.queryable.4.0.0.nupkg.sha512",
+        "system.linq.queryable.nuspec"
       ]
     },
     "System.Net.Http/4.0.0": {
       "sha512": "mZuAl7jw/mFY8jUq4ITKECxVBh9a8SJt9BC/+lJbmo7cRKspxE3PsITz+KiaCEsexN5WYPzwBOx0oJH/0HlPyQ==",
       "type": "package",
-      "path": "System.Net.Http/4.0.0",
+      "path": "system.net.http/4.0.0",
       "files": [
-        "System.Net.Http.4.0.0.nupkg.sha512",
-        "System.Net.Http.nuspec",
         "lib/DNXCore50/System.Net.Http.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Net.Http.dll",
@@ -13880,16 +13878,16 @@
         "ref/netcore50/System.Net.Http.dll",
         "ref/netcore50/System.Net.Http.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.net.http.4.0.0.nupkg.sha512",
+        "system.net.http.nuspec"
       ]
     },
     "System.Net.Http.Rtc/4.0.0": {
       "sha512": "PlE+oJgXdbxPmZYR6GBywRkyIPovjB1Y0SYHizj2Iflgu80uJQC4szl9gue4rKI2FgXiEbj9JL7wL5K3mp9HAQ==",
       "type": "package",
-      "path": "System.Net.Http.Rtc/4.0.0",
+      "path": "system.net.http.rtc/4.0.0",
       "files": [
-        "System.Net.Http.Rtc.4.0.0.nupkg.sha512",
-        "System.Net.Http.Rtc.nuspec",
         "lib/netcore50/System.Net.Http.Rtc.dll",
         "lib/win8/_._",
         "ref/dotnet/System.Net.Http.Rtc.dll",
@@ -13905,16 +13903,16 @@
         "ref/dotnet/zh-hant/System.Net.Http.Rtc.xml",
         "ref/netcore50/System.Net.Http.Rtc.dll",
         "ref/netcore50/System.Net.Http.Rtc.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.net.http.rtc.4.0.0.nupkg.sha512",
+        "system.net.http.rtc.nuspec"
       ]
     },
     "System.Net.NetworkInformation/4.0.0": {
       "sha512": "D68KCf5VK1G1GgFUwD901gU6cnMITksOdfdxUCt9ReCZfT1pigaDqjJ7XbiLAM4jm7TfZHB7g5mbOf1mbG3yBA==",
       "type": "package",
-      "path": "System.Net.NetworkInformation/4.0.0",
+      "path": "system.net.networkinformation/4.0.0",
       "files": [
-        "System.Net.NetworkInformation.4.0.0.nupkg.sha512",
-        "System.Net.NetworkInformation.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
@@ -13944,16 +13942,16 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.networkinformation.4.0.0.nupkg.sha512",
+        "system.net.networkinformation.nuspec"
       ]
     },
     "System.Net.Primitives/4.0.10": {
       "sha512": "YQqIpmMhnKjIbT7rl6dlf7xM5DxaMR+whduZ9wKb9OhMLjoueAJO3HPPJI+Naf3v034kb+xZqdc3zo44o3HWcg==",
       "type": "package",
-      "path": "System.Net.Primitives/4.0.10",
+      "path": "system.net.primitives/4.0.10",
       "files": [
-        "System.Net.Primitives.4.0.10.nupkg.sha512",
-        "System.Net.Primitives.nuspec",
         "lib/DNXCore50/System.Net.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -13976,16 +13974,16 @@
         "ref/dotnet/zh-hant/System.Net.Primitives.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.primitives.4.0.10.nupkg.sha512",
+        "system.net.primitives.nuspec"
       ]
     },
     "System.Net.Requests/4.0.10": {
       "sha512": "A6XBR7TztiIQg6hx7VGfbBKmRTAavUERm2E7pmNz/gZeGvwyP0lcKHZxylJtNVKj7DPwr91bD87oLY6zZYntcg==",
       "type": "package",
-      "path": "System.Net.Requests/4.0.10",
+      "path": "system.net.requests/4.0.10",
       "files": [
-        "System.Net.Requests.4.0.10.nupkg.sha512",
-        "System.Net.Requests.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Net.Requests.dll",
@@ -14007,16 +14005,16 @@
         "ref/dotnet/zh-hant/System.Net.Requests.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.requests.4.0.10.nupkg.sha512",
+        "system.net.requests.nuspec"
       ]
     },
     "System.Net.Sockets/4.0.0": {
       "sha512": "7bBNLdO6Xw0BGyFVSxjloGXMvsc3qQmW+70bYMLwHEAVivMK8zx+E7XO8CeJnAko2mFj6R402E798EGYUksFcQ==",
       "type": "package",
-      "path": "System.Net.Sockets/4.0.0",
+      "path": "system.net.sockets/4.0.0",
       "files": [
-        "System.Net.Sockets.4.0.0.nupkg.sha512",
-        "System.Net.Sockets.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Net.Sockets.dll",
@@ -14038,16 +14036,16 @@
         "ref/dotnet/zh-hant/System.Net.Sockets.xml",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.sockets.4.0.0.nupkg.sha512",
+        "system.net.sockets.nuspec"
       ]
     },
     "System.Net.WebHeaderCollection/4.0.0": {
       "sha512": "IsIZAsHm/yK7R/XASnEc4EMffFLIMgYchG3/zJv6B4LwMnXZwrVlSPpNbPgEVb0lSXyztsn7A6sIPAACQQ2vTQ==",
       "type": "package",
-      "path": "System.Net.WebHeaderCollection/4.0.0",
+      "path": "system.net.webheadercollection/4.0.0",
       "files": [
-        "System.Net.WebHeaderCollection.4.0.0.nupkg.sha512",
-        "System.Net.WebHeaderCollection.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Net.WebHeaderCollection.dll",
@@ -14069,16 +14067,16 @@
         "ref/dotnet/zh-hant/System.Net.WebHeaderCollection.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.net.webheadercollection.4.0.0.nupkg.sha512",
+        "system.net.webheadercollection.nuspec"
       ]
     },
     "System.Numerics.Vectors/4.1.0": {
       "sha512": "jpubR06GWPoZA0oU5xLM7kHeV59/CKPBXZk4Jfhi0T3DafxbrdueHZ8kXlb+Fb5nd3DAyyMh2/eqEzLX0xv6Qg==",
       "type": "package",
-      "path": "System.Numerics.Vectors/4.1.0",
+      "path": "system.numerics.vectors/4.1.0",
       "files": [
-        "System.Numerics.Vectors.4.1.0.nupkg.sha512",
-        "System.Numerics.Vectors.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Numerics.Vectors.dll",
@@ -14090,26 +14088,26 @@
         "ref/dotnet/System.Numerics.Vectors.dll",
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.numerics.vectors.4.1.0.nupkg.sha512",
+        "system.numerics.vectors.nuspec"
       ]
     },
     "System.Numerics.Vectors.WindowsRuntime/4.0.0": {
       "sha512": "Ly7GvoPFZq6GyfZpfS0E7uCk1cinl5BANAngXVuau3lD2QqZJMHitzlPv6n1FlIn6krfv99X2IPkIaVzUwDHXA==",
       "type": "package",
-      "path": "System.Numerics.Vectors.WindowsRuntime/4.0.0",
+      "path": "system.numerics.vectors.windowsruntime/4.0.0",
       "files": [
-        "System.Numerics.Vectors.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec",
-        "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll"
+        "lib/dotnet/System.Numerics.Vectors.WindowsRuntime.dll",
+        "system.numerics.vectors.windowsruntime.4.0.0.nupkg.sha512",
+        "system.numerics.vectors.windowsruntime.nuspec"
       ]
     },
     "System.ObjectModel/4.0.10": {
       "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
       "type": "package",
-      "path": "System.ObjectModel/4.0.10",
+      "path": "system.objectmodel/4.0.10",
       "files": [
-        "System.ObjectModel.4.0.10.nupkg.sha512",
-        "System.ObjectModel.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.ObjectModel.dll",
@@ -14131,71 +14129,71 @@
         "ref/dotnet/zh-hant/System.ObjectModel.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.objectmodel.4.0.10.nupkg.sha512",
+        "system.objectmodel.nuspec"
       ]
     },
     "System.Private.DataContractSerialization/4.0.0": {
       "sha512": "uQvzoXHXHn/9YqUmPtgD8ZPJIlBuuL3QHegbuik97W/umoI28fOnGLnvjRHhju1VMWvFLRQoh7uZkBaoZ+KpVQ==",
       "type": "package",
-      "path": "System.Private.DataContractSerialization/4.0.0",
+      "path": "system.private.datacontractserialization/4.0.0",
       "files": [
-        "System.Private.DataContractSerialization.4.0.0.nupkg.sha512",
-        "System.Private.DataContractSerialization.nuspec",
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
         "lib/netcore50/System.Private.DataContractSerialization.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
+        "system.private.datacontractserialization.4.0.0.nupkg.sha512",
+        "system.private.datacontractserialization.nuspec"
       ]
     },
     "System.Private.Networking/4.0.0": {
       "sha512": "RUEqdBdJjISC65dO8l4LdN7vTdlXH+attUpKnauDUHVtLbIKdlDB9LKoLzCQsTQRP7vzUJHWYXznHJBkjAA7yA==",
       "type": "package",
-      "path": "System.Private.Networking/4.0.0",
+      "path": "system.private.networking/4.0.0",
       "files": [
-        "System.Private.Networking.4.0.0.nupkg.sha512",
-        "System.Private.Networking.nuspec",
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._"
+        "ref/netcore50/_._",
+        "system.private.networking.4.0.0.nupkg.sha512",
+        "system.private.networking.nuspec"
       ]
     },
     "System.Private.ServiceModel/4.0.0": {
       "sha512": "cm2wEa1f9kuUq/2k8uIwepgZJi5HdxXSnjGQIeXmAb7RaWfZPEC/iamv9GJ67b5LPnCZHR0KvtFqh82e8AAYSw==",
       "type": "package",
-      "path": "System.Private.ServiceModel/4.0.0",
+      "path": "system.private.servicemodel/4.0.0",
       "files": [
-        "System.Private.ServiceModel.4.0.0.nupkg.sha512",
-        "System.Private.ServiceModel.nuspec",
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
-        "ref/netcore50/_._"
+        "ref/netcore50/_._",
+        "system.private.servicemodel.4.0.0.nupkg.sha512",
+        "system.private.servicemodel.nuspec"
       ]
     },
     "System.Private.Uri/4.0.0": {
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "type": "package",
-      "path": "System.Private.Uri/4.0.0",
+      "path": "system.private.uri/4.0.0",
       "files": [
-        "System.Private.Uri.4.0.0.nupkg.sha512",
-        "System.Private.Uri.nuspec",
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "system.private.uri.4.0.0.nupkg.sha512",
+        "system.private.uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "type": "package",
-      "path": "System.Reflection/4.0.10",
+      "path": "system.reflection/4.0.10",
       "files": [
-        "System.Reflection.4.0.10.nupkg.sha512",
-        "System.Reflection.nuspec",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14219,16 +14217,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "system.reflection.4.0.10.nupkg.sha512",
+        "system.reflection.nuspec"
       ]
     },
     "System.Reflection.Context/4.0.0": {
       "sha512": "Gz4sUHHFd/52RjHccSHbOXdujJEWKfL3gIaA+ekxvQaQfJGbI2tPzA0Uv3WTCTDRGHgtoNq5WS9E007Dt4P/VQ==",
       "type": "package",
-      "path": "System.Reflection.Context/4.0.0",
+      "path": "system.reflection.context/4.0.0",
       "files": [
-        "System.Reflection.Context.4.0.0.nupkg.sha512",
-        "System.Reflection.Context.nuspec",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Context.dll",
         "lib/win8/_._",
@@ -14246,16 +14244,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.Reflection.Context.dll",
         "ref/netcore50/System.Reflection.Context.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.reflection.context.4.0.0.nupkg.sha512",
+        "system.reflection.context.nuspec"
       ]
     },
     "System.Reflection.DispatchProxy/4.0.0": {
       "sha512": "Kd/4o6DqBfJA4058X8oGEu1KlT8Ej0A+WGeoQgZU2h+3f2vC8NRbHxeOSZvxj9/MPZ1RYmZMGL1ApO9xG/4IVA==",
       "type": "package",
-      "path": "System.Reflection.DispatchProxy/4.0.0",
+      "path": "system.reflection.dispatchproxy/4.0.0",
       "files": [
-        "System.Reflection.DispatchProxy.4.0.0.nupkg.sha512",
-        "System.Reflection.DispatchProxy.nuspec",
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14279,16 +14277,16 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "system.reflection.dispatchproxy.4.0.0.nupkg.sha512",
+        "system.reflection.dispatchproxy.nuspec"
       ]
     },
     "System.Reflection.Emit/4.0.0": {
       "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
       "type": "package",
-      "path": "System.Reflection.Emit/4.0.0",
+      "path": "system.reflection.emit/4.0.0",
       "files": [
-        "System.Reflection.Emit.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
         "lib/net45/_._",
@@ -14307,16 +14305,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
         "ref/net45/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.reflection.emit.4.0.0.nupkg.sha512",
+        "system.reflection.emit.nuspec"
       ]
     },
     "System.Reflection.Emit.ILGeneration/4.0.0": {
       "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
       "type": "package",
-      "path": "System.Reflection.Emit.ILGeneration/4.0.0",
+      "path": "system.reflection.emit.ilgeneration/4.0.0",
       "files": [
-        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.ILGeneration.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
@@ -14333,16 +14331,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
         "ref/net45/_._",
-        "ref/wp80/_._"
+        "ref/wp80/_._",
+        "system.reflection.emit.ilgeneration.4.0.0.nupkg.sha512",
+        "system.reflection.emit.ilgeneration.nuspec"
       ]
     },
     "System.Reflection.Emit.Lightweight/4.0.0": {
       "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
       "type": "package",
-      "path": "System.Reflection.Emit.Lightweight/4.0.0",
+      "path": "system.reflection.emit.lightweight/4.0.0",
       "files": [
-        "System.Reflection.Emit.Lightweight.4.0.0.nupkg.sha512",
-        "System.Reflection.Emit.Lightweight.nuspec",
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
@@ -14359,16 +14357,16 @@
         "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
         "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
         "ref/net45/_._",
-        "ref/wp80/_._"
+        "ref/wp80/_._",
+        "system.reflection.emit.lightweight.4.0.0.nupkg.sha512",
+        "system.reflection.emit.lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "type": "package",
-      "path": "System.Reflection.Extensions/4.0.0",
+      "path": "system.reflection.extensions/4.0.0",
       "files": [
-        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Extensions.dll",
@@ -14392,29 +14390,29 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "system.reflection.extensions.4.0.0.nupkg.sha512",
+        "system.reflection.extensions.nuspec"
       ]
     },
     "System.Reflection.Metadata/1.0.22": {
       "sha512": "ltoL/teiEdy5W9fyYdtFr2xJ/4nHyksXLK9dkPWx3ubnj7BVfsSWxvWTg9EaJUXjhWvS/AeTtugZA1/IDQyaPQ==",
       "type": "package",
-      "path": "System.Reflection.Metadata/1.0.22",
+      "path": "system.reflection.metadata/1.0.22",
       "files": [
-        "System.Reflection.Metadata.1.0.22.nupkg.sha512",
-        "System.Reflection.Metadata.nuspec",
         "lib/dotnet/System.Reflection.Metadata.dll",
         "lib/dotnet/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
-        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "system.reflection.metadata.1.0.22.nupkg.sha512",
+        "system.reflection.metadata.nuspec"
       ]
     },
     "System.Reflection.Primitives/4.0.0": {
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "type": "package",
-      "path": "System.Reflection.Primitives/4.0.0",
+      "path": "system.reflection.primitives/4.0.0",
       "files": [
-        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Primitives.dll",
@@ -14438,16 +14436,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "system.reflection.primitives.4.0.0.nupkg.sha512",
+        "system.reflection.primitives.nuspec"
       ]
     },
     "System.Reflection.TypeExtensions/4.0.0": {
       "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
       "type": "package",
-      "path": "System.Reflection.TypeExtensions/4.0.0",
+      "path": "system.reflection.typeextensions/4.0.0",
       "files": [
-        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
-        "System.Reflection.TypeExtensions.nuspec",
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14471,16 +14469,16 @@
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "system.reflection.typeextensions.4.0.0.nupkg.sha512",
+        "system.reflection.typeextensions.nuspec"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "type": "package",
-      "path": "System.Resources.ResourceManager/4.0.0",
+      "path": "system.resources.resourcemanager/4.0.0",
       "files": [
-        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Resources.ResourceManager.dll",
@@ -14504,16 +14502,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "system.resources.resourcemanager.4.0.0.nupkg.sha512",
+        "system.resources.resourcemanager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "type": "package",
-      "path": "System.Runtime/4.0.20",
+      "path": "system.runtime/4.0.20",
       "files": [
-        "System.Runtime.4.0.20.nupkg.sha512",
-        "System.Runtime.nuspec",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14537,16 +14535,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "system.runtime.4.0.20.nupkg.sha512",
+        "system.runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "type": "package",
-      "path": "System.Runtime.Extensions/4.0.10",
+      "path": "system.runtime.extensions/4.0.10",
       "files": [
-        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14570,16 +14568,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "system.runtime.extensions.4.0.10.nupkg.sha512",
+        "system.runtime.extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "type": "package",
-      "path": "System.Runtime.Handles/4.0.0",
+      "path": "system.runtime.handles/4.0.0",
       "files": [
-        "System.Runtime.Handles.4.0.0.nupkg.sha512",
-        "System.Runtime.Handles.nuspec",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14603,16 +14601,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "system.runtime.handles.4.0.0.nupkg.sha512",
+        "system.runtime.handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "type": "package",
-      "path": "System.Runtime.InteropServices/4.0.20",
+      "path": "system.runtime.interopservices/4.0.20",
       "files": [
-        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14636,16 +14634,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "system.runtime.interopservices.4.0.20.nupkg.sha512",
+        "system.runtime.interopservices.nuspec"
       ]
     },
     "System.Runtime.InteropServices.WindowsRuntime/4.0.0": {
       "sha512": "K5MGSvw/sGPKQYdOVqSpsVbHBE8HccHIDEhUNjM1lui65KGF/slNZfijGU87ggQiVXTI802ebKiOYBkwiLotow==",
       "type": "package",
-      "path": "System.Runtime.InteropServices.WindowsRuntime/4.0.0",
+      "path": "system.runtime.interopservices.windowsruntime/4.0.0",
       "files": [
-        "System.Runtime.InteropServices.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
         "lib/win8/_._",
@@ -14668,16 +14666,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "system.runtime.interopservices.windowsruntime.4.0.0.nupkg.sha512",
+        "system.runtime.interopservices.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.Numerics/4.0.0": {
       "sha512": "aAYGEOE01nabQLufQ4YO8WuSyZzOqGcksi8m1BRW8ppkmssR7en8TqiXcBkB2gTkCnKG/Ai2NQY8CgdmgZw/fw==",
       "type": "package",
-      "path": "System.Runtime.Numerics/4.0.0",
+      "path": "system.runtime.numerics/4.0.0",
       "files": [
-        "System.Runtime.Numerics.4.0.0.nupkg.sha512",
-        "System.Runtime.Numerics.nuspec",
         "lib/dotnet/System.Runtime.Numerics.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.Numerics.dll",
@@ -14698,16 +14696,16 @@
         "ref/netcore50/System.Runtime.Numerics.dll",
         "ref/netcore50/System.Runtime.Numerics.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.runtime.numerics.4.0.0.nupkg.sha512",
+        "system.runtime.numerics.nuspec"
       ]
     },
     "System.Runtime.Serialization.Json/4.0.0": {
       "sha512": "emhWMQP3sdtkAhD0TOeP3FfjS57sfQMQ2sqA6f2Yj5Gd9jkHV4KsQ2TsoJjghca6d8fur7+REQ6ILBXVdGf/0g==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Json/4.0.0",
+      "path": "system.runtime.serialization.json/4.0.0",
       "files": [
-        "System.Runtime.Serialization.Json.4.0.0.nupkg.sha512",
-        "System.Runtime.Serialization.Json.nuspec",
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Runtime.Serialization.Json.dll",
@@ -14731,16 +14729,16 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
+        "system.runtime.serialization.json.4.0.0.nupkg.sha512",
+        "system.runtime.serialization.json.nuspec"
       ]
     },
     "System.Runtime.Serialization.Primitives/4.0.10": {
       "sha512": "NPc8DZIomf5tGjYtz/KTHI01IPcVlypfhCux32AbLPDjTotdvL8TpKRwMyQJ6Kh08yprRVH7uBD1PdJiuoFzag==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Primitives/4.0.10",
+      "path": "system.runtime.serialization.primitives/4.0.10",
       "files": [
-        "System.Runtime.Serialization.Primitives.4.0.10.nupkg.sha512",
-        "System.Runtime.Serialization.Primitives.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
@@ -14762,16 +14760,16 @@
         "ref/dotnet/zh-hant/System.Runtime.Serialization.Primitives.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.runtime.serialization.primitives.4.0.10.nupkg.sha512",
+        "system.runtime.serialization.primitives.nuspec"
       ]
     },
     "System.Runtime.Serialization.Xml/4.0.10": {
       "sha512": "xsy7XbH8RTpKoDPNcibSGCOpujsmwUmOWAby3PssqkZFpLBXUbDO2s6JKITRjxejET2g0PK8t+mdIvu3xmUuKA==",
       "type": "package",
-      "path": "System.Runtime.Serialization.Xml/4.0.10",
+      "path": "system.runtime.serialization.xml/4.0.10",
       "files": [
-        "System.Runtime.Serialization.Xml.4.0.10.nupkg.sha512",
-        "System.Runtime.Serialization.Xml.nuspec",
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14795,16 +14793,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
+        "system.runtime.serialization.xml.4.0.10.nupkg.sha512",
+        "system.runtime.serialization.xml.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime/4.0.10": {
       "sha512": "9w6ypdnEw8RrLRlxTbLAYrap4eL1xIQeNoOaumQVOQ8TTD/5g9FGrBtY3KLiGxAPieN9AwAAEIDkugU85Cwuvg==",
       "type": "package",
-      "path": "System.Runtime.WindowsRuntime/4.0.10",
+      "path": "system.runtime.windowsruntime/4.0.10",
       "files": [
-        "System.Runtime.WindowsRuntime.4.0.10.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.nuspec",
         "lib/netcore50/System.Runtime.WindowsRuntime.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
@@ -14823,16 +14821,16 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.WindowsRuntime.dll",
+        "system.runtime.windowsruntime.4.0.10.nupkg.sha512",
+        "system.runtime.windowsruntime.nuspec"
       ]
     },
     "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0": {
       "sha512": "2GY3fkXBMQOyyO9ovaH46CN6MD2ck/Gvk4VNAgVDvtmfO3HXYFNd+bB05WhVcJrHKbfKZNwfwZKpYZ+OsVFsLw==",
       "type": "package",
-      "path": "System.Runtime.WindowsRuntime.UI.Xaml/4.0.0",
+      "path": "system.runtime.windowsruntime.ui.xaml/4.0.0",
       "files": [
-        "System.Runtime.WindowsRuntime.UI.Xaml.4.0.0.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.UI.Xaml.nuspec",
         "lib/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
@@ -14850,16 +14848,16 @@
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.dll",
         "ref/netcore50/System.Runtime.WindowsRuntime.UI.Xaml.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.runtime.windowsruntime.ui.xaml.4.0.0.nupkg.sha512",
+        "system.runtime.windowsruntime.ui.xaml.nuspec"
       ]
     },
     "System.Security.Claims/4.0.0": {
       "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
       "type": "package",
-      "path": "System.Security.Claims/4.0.0",
+      "path": "system.security.claims/4.0.0",
       "files": [
-        "System.Security.Claims.4.0.0.nupkg.sha512",
-        "System.Security.Claims.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Security.Claims.dll",
@@ -14881,16 +14879,16 @@
         "ref/dotnet/zh-hant/System.Security.Claims.xml",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.security.claims.4.0.0.nupkg.sha512",
+        "system.security.claims.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
       "sha512": "FOhq3jUOONi6fp5j3nPYJMrKtSJlqAURpjiO3FaDIV4DJNEYymWW5uh1pfxySEB8dtAW+I66IypzNge/w9OzZQ==",
       "type": "package",
-      "path": "System.Security.Principal/4.0.0",
+      "path": "system.security.principal/4.0.0",
       "files": [
-        "System.Security.Principal.4.0.0.nupkg.sha512",
-        "System.Security.Principal.nuspec",
         "lib/dotnet/System.Security.Principal.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Security.Principal.dll",
@@ -14913,16 +14911,16 @@
         "ref/netcore50/System.Security.Principal.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.security.principal.4.0.0.nupkg.sha512",
+        "system.security.principal.nuspec"
       ]
     },
     "System.ServiceModel.Duplex/4.0.0": {
       "sha512": "JFeDn+IsiwAVJkNNnM7MLefJOnzYhovaHnjk3lzEnUWkYZJeAKrcgLdK6GE2GNjb5mEV8Pad/E0JcA8eCr3eWQ==",
       "type": "package",
-      "path": "System.ServiceModel.Duplex/4.0.0",
+      "path": "system.servicemodel.duplex/4.0.0",
       "files": [
-        "System.ServiceModel.Duplex.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Duplex.nuspec",
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Duplex.dll",
@@ -14941,16 +14939,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Duplex.dll",
         "ref/netcore50/System.ServiceModel.Duplex.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.duplex.4.0.0.nupkg.sha512",
+        "system.servicemodel.duplex.nuspec"
       ]
     },
     "System.ServiceModel.Http/4.0.10": {
       "sha512": "Vyl7lmvMlXJamtnDugoXuAgAQGSqtA7omK3zDBYByhbYeBC2hRBchgyXox7e5vEO+29TeB1IpoLWQGb7tO9h6A==",
       "type": "package",
-      "path": "System.ServiceModel.Http/4.0.10",
+      "path": "system.servicemodel.http/4.0.10",
       "files": [
-        "System.ServiceModel.Http.4.0.10.nupkg.sha512",
-        "System.ServiceModel.Http.nuspec",
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -14973,16 +14971,16 @@
         "ref/dotnet/zh-hant/System.ServiceModel.Http.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.servicemodel.http.4.0.10.nupkg.sha512",
+        "system.servicemodel.http.nuspec"
       ]
     },
     "System.ServiceModel.NetTcp/4.0.0": {
       "sha512": "lV2Cdcso9jOS0KBtgHZHzTLe/Lx/ERdPcvF4dlepUie6/+BOMYTOgg2C7OdpIjp3fwUNXq8nhU+IilmEyjuf/A==",
       "type": "package",
-      "path": "System.ServiceModel.NetTcp/4.0.0",
+      "path": "system.servicemodel.nettcp/4.0.0",
       "files": [
-        "System.ServiceModel.NetTcp.4.0.0.nupkg.sha512",
-        "System.ServiceModel.NetTcp.nuspec",
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.NetTcp.dll",
@@ -15001,16 +14999,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.NetTcp.dll",
         "ref/netcore50/System.ServiceModel.NetTcp.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.nettcp.4.0.0.nupkg.sha512",
+        "system.servicemodel.nettcp.nuspec"
       ]
     },
     "System.ServiceModel.Primitives/4.0.0": {
       "sha512": "uF5VYQWR07LgiZkzUr8qjwvqOaIAfwU566MneD4WuC14d8FLJNsAgCJUYhBGB7COjH7HTqnP9ZFmr6c+L83Stg==",
       "type": "package",
-      "path": "System.ServiceModel.Primitives/4.0.0",
+      "path": "system.servicemodel.primitives/4.0.0",
       "files": [
-        "System.ServiceModel.Primitives.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Primitives.nuspec",
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Primitives.dll",
@@ -15029,16 +15027,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Primitives.dll",
         "ref/netcore50/System.ServiceModel.Primitives.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.primitives.4.0.0.nupkg.sha512",
+        "system.servicemodel.primitives.nuspec"
       ]
     },
     "System.ServiceModel.Security/4.0.0": {
       "sha512": "sPVzsnd8w/TJsW/4sYA9eIGP+RtlpN0AhKLGKf9ywdGGmHPi0kkuX2mx412dM3GN0e4oifuISwvZqby/sI8Feg==",
       "type": "package",
-      "path": "System.ServiceModel.Security/4.0.0",
+      "path": "system.servicemodel.security/4.0.0",
       "files": [
-        "System.ServiceModel.Security.4.0.0.nupkg.sha512",
-        "System.ServiceModel.Security.nuspec",
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
         "lib/netcore50/System.ServiceModel.Security.dll",
@@ -15057,16 +15055,16 @@
         "ref/net45/_._",
         "ref/netcore50/System.ServiceModel.Security.dll",
         "ref/netcore50/System.ServiceModel.Security.xml",
-        "ref/win8/_._"
+        "ref/win8/_._",
+        "system.servicemodel.security.4.0.0.nupkg.sha512",
+        "system.servicemodel.security.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "type": "package",
-      "path": "System.Text.Encoding/4.0.10",
+      "path": "system.text.encoding/4.0.10",
       "files": [
-        "System.Text.Encoding.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.nuspec",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15090,16 +15088,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "system.text.encoding.4.0.10.nupkg.sha512",
+        "system.text.encoding.nuspec"
       ]
     },
     "System.Text.Encoding.CodePages/4.0.0": {
       "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
       "type": "package",
-      "path": "System.Text.Encoding.CodePages/4.0.0",
+      "path": "system.text.encoding.codepages/4.0.0",
       "files": [
-        "System.Text.Encoding.CodePages.4.0.0.nupkg.sha512",
-        "System.Text.Encoding.CodePages.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Text.Encoding.CodePages.dll",
@@ -15119,16 +15117,16 @@
         "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.text.encoding.codepages.4.0.0.nupkg.sha512",
+        "system.text.encoding.codepages.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "type": "package",
-      "path": "System.Text.Encoding.Extensions/4.0.10",
+      "path": "system.text.encoding.extensions/4.0.10",
       "files": [
-        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15152,16 +15150,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "system.text.encoding.extensions.4.0.10.nupkg.sha512",
+        "system.text.encoding.extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "type": "package",
-      "path": "System.Text.RegularExpressions/4.0.10",
+      "path": "system.text.regularexpressions/4.0.10",
       "files": [
-        "System.Text.RegularExpressions.4.0.10.nupkg.sha512",
-        "System.Text.RegularExpressions.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Text.RegularExpressions.dll",
@@ -15183,16 +15181,16 @@
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.text.regularexpressions.4.0.10.nupkg.sha512",
+        "system.text.regularexpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "type": "package",
-      "path": "System.Threading/4.0.10",
+      "path": "system.threading/4.0.10",
       "files": [
-        "System.Threading.4.0.10.nupkg.sha512",
-        "System.Threading.nuspec",
         "lib/DNXCore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15216,16 +15214,16 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "system.threading.4.0.10.nupkg.sha512",
+        "system.threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "type": "package",
-      "path": "System.Threading.Overlapped/4.0.0",
+      "path": "system.threading.overlapped/4.0.0",
       "files": [
-        "System.Threading.Overlapped.4.0.0.nupkg.sha512",
-        "System.Threading.Overlapped.nuspec",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
@@ -15240,16 +15238,16 @@
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll"
+        "ref/net46/System.Threading.Overlapped.dll",
+        "system.threading.overlapped.4.0.0.nupkg.sha512",
+        "system.threading.overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "type": "package",
-      "path": "System.Threading.Tasks/4.0.10",
+      "path": "system.threading.tasks/4.0.10",
       "files": [
-        "System.Threading.Tasks.4.0.10.nupkg.sha512",
-        "System.Threading.Tasks.nuspec",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15273,31 +15271,31 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "system.threading.tasks.4.0.10.nupkg.sha512",
+        "system.threading.tasks.nuspec"
       ]
     },
     "System.Threading.Tasks.Dataflow/4.5.25": {
       "sha512": "Y5/Dj+tYlDxHBwie7bFKp3+1uSG4vqTJRF7Zs7kaUQ3ahYClffCTxvgjrJyPclC+Le55uE7bMLgjZQVOQr3Jfg==",
       "type": "package",
-      "path": "System.Threading.Tasks.Dataflow/4.5.25",
+      "path": "system.threading.tasks.dataflow/4.5.25",
       "files": [
-        "System.Threading.Tasks.Dataflow.4.5.25.nupkg.sha512",
-        "System.Threading.Tasks.Dataflow.nuspec",
         "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
         "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll"
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "system.threading.tasks.dataflow.4.5.25.nupkg.sha512",
+        "system.threading.tasks.dataflow.nuspec"
       ]
     },
     "System.Threading.Tasks.Parallel/4.0.0": {
       "sha512": "GXDhjPhF3nE4RtDia0W6JR4UMdmhOyt9ibHmsNV6GLRT4HAGqU636Teo4tqvVQOFp2R6b1ffxPXiRaoqtzGxuA==",
       "type": "package",
-      "path": "System.Threading.Tasks.Parallel/4.0.0",
+      "path": "system.threading.tasks.parallel/4.0.0",
       "files": [
-        "System.Threading.Tasks.Parallel.4.0.0.nupkg.sha512",
-        "System.Threading.Tasks.Parallel.nuspec",
         "lib/dotnet/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Threading.Tasks.Parallel.dll",
@@ -15318,16 +15316,16 @@
         "ref/netcore50/System.Threading.Tasks.Parallel.dll",
         "ref/netcore50/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "system.threading.tasks.parallel.4.0.0.nupkg.sha512",
+        "system.threading.tasks.parallel.nuspec"
       ]
     },
     "System.Threading.Timer/4.0.0": {
       "sha512": "BIdJH5/e4FnVl7TkRUiE3pWytp7OYiRUGtwUbyLewS/PhKiLepFetdtlW+FvDYOVn60Q2NMTrhHhJ51q+sVW5g==",
       "type": "package",
-      "path": "System.Threading.Timer/4.0.0",
+      "path": "system.threading.timer/4.0.0",
       "files": [
-        "System.Threading.Timer.4.0.0.nupkg.sha512",
-        "System.Threading.Timer.nuspec",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
         "lib/netcore50/System.Threading.Timer.dll",
@@ -15349,16 +15347,16 @@
         "ref/netcore50/System.Threading.Timer.xml",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "system.threading.timer.4.0.0.nupkg.sha512",
+        "system.threading.timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "type": "package",
-      "path": "System.Xml.ReaderWriter/4.0.10",
+      "path": "system.xml.readerwriter/4.0.10",
       "files": [
-        "System.Xml.ReaderWriter.4.0.10.nupkg.sha512",
-        "System.Xml.ReaderWriter.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
@@ -15380,16 +15378,16 @@
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.readerwriter.4.0.10.nupkg.sha512",
+        "system.xml.readerwriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "type": "package",
-      "path": "System.Xml.XDocument/4.0.10",
+      "path": "system.xml.xdocument/4.0.10",
       "files": [
-        "System.Xml.XDocument.4.0.10.nupkg.sha512",
-        "System.Xml.XDocument.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.XDocument.dll",
@@ -15411,16 +15409,16 @@
         "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.xdocument.4.0.10.nupkg.sha512",
+        "system.xml.xdocument.nuspec"
       ]
     },
     "System.Xml.XmlDocument/4.0.0": {
       "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
       "type": "package",
-      "path": "System.Xml.XmlDocument/4.0.0",
+      "path": "system.xml.xmldocument/4.0.0",
       "files": [
-        "System.Xml.XmlDocument.4.0.0.nupkg.sha512",
-        "System.Xml.XmlDocument.nuspec",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/dotnet/System.Xml.XmlDocument.dll",
@@ -15442,16 +15440,16 @@
         "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "system.xml.xmldocument.4.0.0.nupkg.sha512",
+        "system.xml.xmldocument.nuspec"
       ]
     },
     "System.Xml.XmlSerializer/4.0.10": {
       "sha512": "OKhE6vruk88z/hl0lmfrMvXteTASgJUagu6PT6S10i9uLbvDR3pTwB6jVgiwa2D2qtTB+eneZbS9jljhPXhTtg==",
       "type": "package",
-      "path": "System.Xml.XmlSerializer/4.0.10",
+      "path": "system.xml.xmlserializer/4.0.10",
       "files": [
-        "System.Xml.XmlSerializer.4.0.10.nupkg.sha512",
-        "System.Xml.XmlSerializer.nuspec",
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15476,7 +15474,9 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "system.xml.xmlserializer.4.0.10.nupkg.sha512",
+        "system.xml.xmlserializer.nuspec"
       ]
     }
   },

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/MinClientVersionTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/MinClientVersionTests.cs
@@ -150,7 +150,7 @@ namespace NuGet.XPlat.FuncTest
                     MinClientVersion = "9.9.9"
                 };
 
-                var packagePath = Path.Combine(workingDir, "packageA.1.0.0.nupkg");
+                var packagePath = Path.Combine(workingDir, "packagea.1.0.0.nupkg");
 
                 SimpleTestPackageUtility.CreatePackages(workingDir, packageContext);
 
@@ -160,12 +160,10 @@ namespace NuGet.XPlat.FuncTest
                     await PackageExtractor.InstallFromSourceAsync((stream) =>
                         fileStream.CopyToAsync(stream, 4096, CancellationToken.None),
                         new VersionFolderPathContext(new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0")),
-                        packagesDir,
-                        logger,
-                        false,
-                        PackageSaveMode.Defaultv3,
-                        false,
-                        XmlDocFileSaveMode.None),
+                            packagesDir,
+                            logger,
+                            PackageSaveMode.Defaultv3,
+                            XmlDocFileSaveMode.None),
                         CancellationToken.None);
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -468,7 +468,7 @@ namespace NuGet.Commands.Test
                 Assert.True(result.Success);
                 var library = lockFile.Libraries.FirstOrDefault(l => l.Name == "packageA");
                 Assert.NotNull(library);
-                Assert.Equal("packageA/1.0.0", library.Path);
+                Assert.Equal("packagea/1.0.0", library.Path);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -26,6 +26,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -33,9 +34,7 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -47,14 +46,13 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
-
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
                 AssertDirectoryExists(packageDir, packageDir + " does not exist");
 
-                var nupkgPath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
+                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
                 Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
@@ -70,6 +68,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -77,9 +76,7 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -91,14 +88,13 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
-
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
                 AssertDirectoryExists(packageDir, packageDir + " does not exist");
 
-                var nupkgPath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
+                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
                 Assert.True(File.Exists(nupkgPath), nupkgPath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
@@ -113,6 +109,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -120,17 +117,15 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
 
                 Directory.CreateDirectory(packageDir);
 
-                var nupkgPath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
-                var shaPath = nupkgPath + ".sha512";
+                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
+                var shaPath = pathResolver.GetHashPath(package.Id, identity.Version);
 
                 File.WriteAllBytes(shaPath, new byte[] { });
 
@@ -149,7 +144,7 @@ namespace Commands.Test
 
                 Assert.False(File.Exists(nupkgPath), nupkgPath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.False(File.Exists(dllPath), dllPath + " does not exist");
 
                 Assert.Equal(1, Directory.EnumerateFiles(packageDir).Count());
@@ -166,6 +161,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -173,12 +169,10 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
 
                 var randomFile = Path.Combine(packageDir, package.Id + "." + package.Version + ".random");
 
@@ -202,10 +196,10 @@ namespace Commands.Test
                 // Assert
                 AssertDirectoryExists(packageDir, packageDir + " does not exist");
 
-                var filePath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
+                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
                 Assert.True(File.Exists(filePath), filePath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.True(File.Exists(dllPath), dllPath + " does not exist");
 
                 Assert.False(File.Exists(randomFile), randomFile + " does exist");
@@ -224,6 +218,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -231,12 +226,10 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
                 Assert.False(Directory.Exists(packageDir), packageDir + " exist");
 
                 // Act
@@ -261,10 +254,10 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var filePath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
+                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
                 Assert.True(File.Exists(filePath), filePath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.True(File.Exists(dllPath), dllPath + " does not exist");
             }
         }
@@ -280,6 +273,7 @@ namespace Commands.Test
                 var identity = new PackageIdentity(package.Id, version);
 
                 var packagesDir = TestFileSystemUtility.CreateRandomTestFolder();
+                var pathResolver = new VersionFolderPathResolver(packagesDir);
 
                 var token = CancellationToken.None;
                 var logger = NullLogger.Instance;
@@ -287,15 +281,13 @@ namespace Commands.Test
                     identity,
                     packagesDir,
                     logger,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
-                var packageDir = Path.Combine(packagesDir, package.Id, package.Version);
+                var packageDir = pathResolver.GetInstallPath(package.Id, identity.Version);
                 Assert.False(Directory.Exists(packageDir), packageDir + " exist");
 
-                string filePathToLock = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "two.dll");
+                string filePathToLock = Path.Combine(packageDir, "lib", "net40", "two.dll");
 
                 // Act
                 using (var stream = package.File.OpenRead())
@@ -327,10 +319,10 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var filePath = Path.Combine(packageDir, package.Id + "." + package.Version + ".nupkg");
+                var filePath = pathResolver.GetPackageFilePath(package.Id, identity.Version);
                 Assert.True(File.Exists(filePath), filePath + " does not exist");
 
-                var dllPath = Path.Combine(packageDir, "lib" + Path.DirectorySeparatorChar + "net40" + Path.DirectorySeparatorChar + "one.dll");
+                var dllPath = Path.Combine(packageDir, "lib", "net40", "one.dll");
                 Assert.True(File.Exists(dllPath), dllPath + " does not exist");
 
                 Assert.True(File.Exists(filePathToLock));
@@ -349,13 +341,12 @@ namespace Commands.Test
             using (var packageFileInfo = TestPackages.GetLegacyTestPackage())
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var versionFolderPathContext = new VersionFolderPathContext(
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -368,16 +359,14 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id);
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
 
-                AssertDirectoryExists(packageIdDirectory);
                 AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg");
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec");
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg.sha512");
+                AssertFileExists(packageVersionDirectory, pathResolver.GetPackageFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, pathResolver.GetManifestFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, "packagea.2.0.3.nupkg.sha512");
 
-                AssertFileExists(packageVersionDirectory, @"lib", "test.dll");
+                AssertFileExists(packageVersionDirectory, "lib", "test.dll");
             }
         }
 
@@ -390,13 +379,12 @@ namespace Commands.Test
             using (var packageFileInfo = TestPackages.GetLegacyTestPackage())
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var versionFolderPathContext = new VersionFolderPathContext(
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Nuspec | PackageSaveMode.Nupkg,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -409,58 +397,14 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id);
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
-                AssertDirectoryExists(packageIdDirectory);
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
+
                 AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg");
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec");
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg.sha512");
+                AssertFileExists(packageVersionDirectory, pathResolver.GetPackageFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, pathResolver.GetManifestFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, "packagea.2.0.3.nupkg.sha512");
 
-                Assert.False(File.Exists(Path.Combine(packageVersionDirectory, @"lib", "test.dll")));
-            }
-        }
-
-        [Fact]
-        public async Task Test_ExtractNuspecOnly_NormalizeFileNames()
-        {
-            // Arrange
-            var package = new PackageIdentity("packageA", new NuGetVersion("2.0.3"));
-            using (var packageFile = TestPackages.GetLegacyTestPackage())
-            using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
-            {
-                var versionFolderPathContext = new VersionFolderPathContext(
-                    package,
-                    packagesDirectory,
-                    NullLogger.Instance,
-                    fixNuspecIdCasing: false,
-                    packageSaveMode: PackageSaveMode.Nuspec | PackageSaveMode.Nupkg,
-                    normalizeFileNames: true,
-                    xmlDocFileSaveMode: XmlDocFileSaveMode.None);
-
-                // Act
-                using (var packageFileStream = File.OpenRead(packageFile))
-                {
-                    await PackageExtractor.InstallFromSourceAsync(
-                        stream => packageFileStream.CopyToAsync(stream),
-                        versionFolderPathContext,
-                        CancellationToken.None);
-                }
-
-                // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id.ToLowerInvariant());
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
-                AssertDirectoryExists(packageIdDirectory);
-                AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg.sha512".ToLowerInvariant());
-
-                Assert.False(File.Exists(Path.Combine(packageVersionDirectory, @"lib", "test.dll")));
-
-                // The following check ensures that the file name is normalized
-                var nuspecFile = Directory.EnumerateFiles(packageVersionDirectory, "*.nuspec").FirstOrDefault();
-                Assert.True(nuspecFile.EndsWith("packagea.nuspec", StringComparison.Ordinal));
+                Assert.False(File.Exists(Path.Combine(packageVersionDirectory, "lib", "test.dll")));
             }
         }
 
@@ -472,6 +416,7 @@ namespace Commands.Test
 
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var packageFileInfo = await TestPackages.GetPackageWithSHA512AtRoot(
                     packagesDirectory,
                     package.Id,
@@ -481,9 +426,7 @@ namespace Commands.Test
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: true,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -496,15 +439,14 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id.ToLowerInvariant());
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
-                AssertDirectoryExists(packageIdDirectory);
-                AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, @"lib", "net45", "A.dll");
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
 
-                var hashPath = Path.Combine(packageVersionDirectory, "packageA.2.0.3.nupkg.sha512".ToLowerInvariant());
+                AssertDirectoryExists(packageVersionDirectory);
+                AssertFileExists(packageVersionDirectory, pathResolver.GetPackageFilePath(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, pathResolver.GetManifestFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, "lib", "net45", "A.dll");
+
+                var hashPath = pathResolver.GetHashPath(package.Id, package.Version);
                 var hashFileInfo = new FileInfo(hashPath);
                 Assert.True(File.Exists(hashFileInfo.FullName));
                 Assert.NotEqual(0, hashFileInfo.Length);
@@ -528,6 +470,7 @@ namespace Commands.Test
             var package = new PackageIdentity("packageA", new NuGetVersion("2.0.3"));
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var packageFileInfo = await TestPackages.GetPackageWithNupkgAtRoot(
                     packagesDirectory,
                     package.Id,
@@ -537,9 +480,7 @@ namespace Commands.Test
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: true,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -552,15 +493,14 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id.ToLowerInvariant());
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
-                AssertDirectoryExists(packageIdDirectory);
-                AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec".ToLowerInvariant());
-                AssertFileExists(packageVersionDirectory, @"lib", "net45", "A.dll");
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
 
-                var nupkgPath = Path.Combine(packageVersionDirectory, "packageA.2.0.3.nupkg".ToLowerInvariant());
+                AssertDirectoryExists(packageVersionDirectory);
+                AssertFileExists(packageVersionDirectory, pathResolver.GetPackageFilePath(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, pathResolver.GetManifestFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, "lib", "net45", "A.dll");
+
+                var nupkgPath = pathResolver.GetPackageFilePath(package.Id, package.Version);
                 var nupkgFileInfo = new FileInfo(nupkgPath);
                 Assert.True(File.Exists(nupkgFileInfo.FullName));
                 Assert.NotEqual(0, nupkgFileInfo.Length);
@@ -580,6 +520,7 @@ namespace Commands.Test
             var entryModifiedTime = new DateTimeOffset(1985, 11, 20, 12, 0, 0, TimeSpan.FromHours(-7.0)).DateTime;
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                     packagesDirectory,
                     package.Id,
@@ -591,9 +532,7 @@ namespace Commands.Test
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Defaultv3,
-                    normalizeFileNames: true,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -606,7 +545,7 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageVersionDirectory = Path.Combine(packagesDirectory, package.Id.ToLowerInvariant(), package.Version.ToNormalizedString());
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
                 AssertDirectoryExists(packageVersionDirectory);
 
                 var dllPath = Path.Combine(packageVersionDirectory, "lib", "net45", "A.dll");
@@ -625,13 +564,12 @@ namespace Commands.Test
             using (var packageFileInfo = TestPackages.GetLegacyTestPackage())
             using (var packagesDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var pathResolver = new VersionFolderPathResolver(packagesDirectory);
                 var versionFolderPathContext = new VersionFolderPathContext(
                     package,
                     packagesDirectory,
                     NullLogger.Instance,
-                    fixNuspecIdCasing: false,
                     packageSaveMode: PackageSaveMode.Nupkg | PackageSaveMode.Nuspec,
-                    normalizeFileNames: false,
                     xmlDocFileSaveMode: XmlDocFileSaveMode.None);
 
                 // Act
@@ -644,16 +582,14 @@ namespace Commands.Test
                 }
 
                 // Assert
-                var packageIdDirectory = Path.Combine(packagesDirectory, package.Id);
-                var packageVersionDirectory = Path.Combine(packageIdDirectory, package.Version.ToNormalizedString());
-
-                AssertDirectoryExists(packageIdDirectory);
+                var packageVersionDirectory = pathResolver.GetInstallPath(package.Id, package.Version);
+                
                 AssertDirectoryExists(packageVersionDirectory);
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg");
-                AssertFileExists(packageVersionDirectory, "packageA.nuspec");
-                AssertFileExists(packageVersionDirectory, "packageA.2.0.3.nupkg.sha512");
+                AssertFileExists(packageVersionDirectory, pathResolver.GetPackageFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, pathResolver.GetManifestFileName(package.Id, package.Version));
+                AssertFileExists(packageVersionDirectory, "packagea.2.0.3.nupkg.sha512");
 
-                Assert.False(File.Exists(Path.Combine(packageVersionDirectory, @"lib", "test.dll")));
+                Assert.False(File.Exists(Path.Combine(packageVersionDirectory, "lib", "test.dll")));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageExtractorTests.cs
@@ -5,7 +5,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.Packaging.Test
@@ -13,25 +15,28 @@ namespace NuGet.Packaging.Test
     public class PackageExtractorTests
     {
         [Fact]
-        public void PackageExtractor_withContentXmlFile()
+        public void PackageExtractor_WithContentXmlFile()
         {
             // Arrange
             using (var packageStream = TestPackages.GetTestPackageWithContentXmlFile())
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packageReader = new PackageArchiveReader(packageStream))
             {
-                var packagePath = Path.Combine(root, "packageA.2.0.3");
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("packageA", new NuGetVersion("2.0.3"));
 
                 // Act
                 var files = PackageExtractor.ExtractPackage(
                     packageReader,
                     packageStream,
-                    new PackagePathResolver(root),
+                    resolver,
                     new PackageExtractionContext(NullLogger.Instance),
                     CancellationToken.None);
+
                 // Assert
-                Assert.DoesNotContain(Path.Combine(packagePath + "[Content_Types].xml"), files);
-                Assert.Contains(Path.Combine(packagePath, "content" + Path.DirectorySeparatorChar + "[Content_Types].xml"), files);
+                var packagePath = resolver.GetInstallPath(identity);
+                Assert.DoesNotContain(Path.Combine(packagePath, "[Content_Types].xml"), files);
+                Assert.Contains(Path.Combine(packagePath, "content", "[Content_Types].xml"), files);
             }
         }
 
@@ -72,10 +77,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "content/A.nupkg");
 
@@ -89,12 +96,13 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "content", "A.nupkg")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "content", "A.nupkg")));
                 }
             }
         }
@@ -198,8 +206,13 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
-                var packageFileInfo = await TestPackages.GetRuntimePackageAsync(root, "A", "2.0.3");
-                var satellitePackageInfo = await TestPackages.GetSatellitePackageAsync(root, "A", "2.0.3", "fr");
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
+                var satelliteIdentity = new PackageIdentity(identity.Id + ".fr", identity.Version);
+                var packageFileInfo = await TestPackages.GetRuntimePackageAsync(root, identity.Id, identity.Version.ToString());
+                var satellitePackageInfo = await TestPackages.GetSatellitePackageAsync(root, identity.Id, identity.Version.ToString(), "fr");
+                
+
 
                 using (var packageStream = File.OpenRead(packageFileInfo.FullName))
                 using (var satellitePackageStream = File.OpenRead(satellitePackageInfo.FullName))
@@ -208,19 +221,19 @@ namespace NuGet.Packaging.Test
 
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(packageStream,
-                                                                     new PackagePathResolver(root),
+                                                                     resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
 
                     var satellitePackageFiles = PackageExtractor.ExtractPackage(satellitePackageStream,
-                                                                     new PackagePathResolver(root),
+                                                                     resolver,
                                                                      packageExtractionContext,
                                                                      CancellationToken.None);
 
                     var pathToAFrDllInSatellitePackage
-                        = Path.Combine(root, "A.fr.2.0.3", "lib", "net45", "fr", "A.resources.dll");
+                        = Path.Combine(resolver.GetInstallPath(satelliteIdentity), "lib", "net45", "fr", "A.resources.dll");
                     var pathToAFrDllInRunTimePackage
-                        = Path.Combine(root, "A.2.0.3", "lib", "net45", "fr", "A.resources.dll");
+                        = Path.Combine(resolver.GetInstallPath(identity), "lib", "net45", "fr", "A.resources.dll");
 
                     Assert.True(File.Exists(pathToAFrDllInSatellitePackage));
                     Assert.True(File.Exists(pathToAFrDllInRunTimePackage));
@@ -234,10 +247,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml",
@@ -253,14 +268,15 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.dll")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.xml")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "appconfig.xml")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "appconfig.xml")));
                 }
             }
         }
@@ -271,10 +287,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml",
@@ -290,16 +308,17 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    var xmlZip = Path.Combine(root, "A.2.0.4", "lib", "net45", "A.xml.zip");
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.dll")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.xml")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    var xmlZip = Path.Combine(installPath, "lib", "net45", "A.xml.zip");
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml")));
                     Assert.True(File.Exists(xmlZip));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "appconfig.xml")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "appconfig.xml")));
 
                     // Verify the zip has a A.xml in it.
                     using (var fileStream = File.OpenRead(xmlZip))
@@ -318,10 +337,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "ref/dotnet5.4/A.xml",
                    "ref/dotnet5.4/fr/B.xml",
@@ -339,12 +360,12 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    var packageRoot = Path.Combine(root, "A.2.0.4", "ref", "dotnet5.4");
+                    var packageRoot = Path.Combine(resolver.GetInstallPath(identity), "ref", "dotnet5.4");
                     Assert.False(File.Exists(Path.Combine(packageRoot, "fr", "B.xml")));
                     Assert.True(File.Exists(Path.Combine(packageRoot, "fr", "B.xml.zip")));
                     Assert.False(File.Exists(Path.Combine(packageRoot, "zh-hans", "A.xml.zip")));
@@ -360,10 +381,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml",
@@ -379,15 +402,16 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.dll")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.xml")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "A.xml.zip")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.4", "lib", "net45", "appconfig.xml")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml.zip")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "appconfig.xml")));
                 }
             }
         }
@@ -398,10 +422,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.4",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "ref/portable-net40+win8+netcore/A.dll",
                    "ref/portable-net40+win8+netcore/A.xml",
@@ -419,12 +445,12 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    var packageRoot = Path.Combine(root, "A.2.0.4", "ref", "portable-net40+win8+netcore");
+                    var packageRoot = Path.Combine(resolver.GetInstallPath(identity), "ref", "portable-net40+win8+netcore");
                     Assert.True(File.Exists(Path.Combine(packageRoot, "A.dll")));
                     Assert.False(File.Exists(Path.Combine(packageRoot, "A.xml")));
                     Assert.False(File.Exists(Path.Combine(packageRoot, "A.xml.zip")));
@@ -444,17 +470,20 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml");
+                var satelliteIdentity = new PackageIdentity(identity.Id + ".fr", identity.Version);
                 var satellitePackageInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A.fr",
-                   "2.0.3",
+                   satelliteIdentity.Id,
+                   satelliteIdentity.Version.ToString(),
                    language: "fr",
                    entryModifiedTime: DateTimeOffset.UtcNow.LocalDateTime,
                    zipEntries: new[] { "lib/net45/fr/A.resources.dll", "lib/net45/fr/A.xml" });
@@ -470,22 +499,25 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     var satellitePackageFiles = PackageExtractor.ExtractPackage(
                         satellitePackageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.xml")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.xml.zip")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.fr.2.0.3", "lib", "net45", "fr", "A.xml")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.fr.2.0.3", "lib", "net45", "fr", "A.xml.zip")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "fr", "A.resources.dll")));
+                    // Assert
+                    var installPath = resolver.GetInstallPath(identity);
+                    var satelliteInstallPath = resolver.GetInstallPath(satelliteIdentity);
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml.zip")));
+                    Assert.False(File.Exists(Path.Combine(satelliteInstallPath, "lib", "net45", "fr", "A.xml")));
+                    Assert.False(File.Exists(Path.Combine(satelliteInstallPath, "lib", "net45", "fr", "A.xml.zip")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "fr", "A.resources.dll")));
                 }
             }
         }
@@ -496,10 +528,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml",
@@ -515,13 +549,14 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.xml.zip")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml.zip")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
 
                     // If we got this far, extraction did not throw.
                 }
@@ -534,10 +569,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "lib/net45/A.xml",
@@ -553,13 +590,14 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.xml.zip")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.xml.zip")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
                 }
             }
         }
@@ -570,10 +608,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "content/net40/B.txt");
@@ -588,15 +628,16 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "A.2.0.3.nupkg")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "A.nuspec")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "content", "net40", "B.txt")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.2.0.3.nupkg")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.nuspec")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "content", "net40", "B.txt")));
                 }
             }
         }
@@ -607,10 +648,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "content/net40/B.txt");
@@ -625,15 +668,96 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "A.2.0.3.nupkg")));
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "A.nuspec")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "content", "net40", "B.txt")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.2.0.3.nupkg")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "a.nuspec")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "content", "net40", "B.txt")));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PackageExtractor_WithPackageSaveModeNuspec_ExtractsInnerNuspec()
+        {
+            // Arrange
+            using (var root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
+                var packageFileInfo = await TestPackages.GeneratePackageAsync(
+                   root,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "lib/net45/A.dll",
+                   "content/net40/B.nuspec");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
+                    {
+                        PackageSaveMode = PackageSaveMode.Nupkg | PackageSaveMode.Files | PackageSaveMode.Nuspec
+                    };
+
+                    // Act
+                    var packageFiles = PackageExtractor.ExtractPackage(
+                        packageStream,
+                        resolver,
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    // Assert
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.2.0.3.nupkg")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.nuspec")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "content", "net40", "B.nuspec")));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PackageExtractor_WithoutPackageSaveModeNuspec_ExtractsInnerNuspec()
+        {
+            // Arrange
+            using (var root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
+                var packageFileInfo = await TestPackages.GeneratePackageAsync(
+                   root,
+                   identity.Id,
+                   identity.Version.ToString(),
+                   DateTimeOffset.UtcNow.LocalDateTime,
+                   "lib/net45/A.dll",
+                   "content/net40/B.nuspec");
+
+                using (var packageStream = File.OpenRead(packageFileInfo.FullName))
+                {
+                    var packageExtractionContext = new PackageExtractionContext(NullLogger.Instance)
+                    {
+                        PackageSaveMode = PackageSaveMode.Nupkg | PackageSaveMode.Files
+                    };
+
+                    // Act
+                    var packageFiles = PackageExtractor.ExtractPackage(
+                        packageStream,
+                        resolver,
+                        packageExtractionContext,
+                        CancellationToken.None);
+
+                    // Assert
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.2.0.3.nupkg")));
+                    Assert.False(File.Exists(Path.Combine(installPath, "a.nuspec")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "content", "net40", "B.nuspec")));
                 }
             }
         }
@@ -644,10 +768,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll",
                    "content/net40/B.txt");
@@ -662,15 +788,16 @@ namespace NuGet.Packaging.Test
                     // Act
                     var packageFiles = PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
                     // Assert
-                    Assert.False(File.Exists(Path.Combine(root, "A.2.0.3", "A.2.0.3.nupkg")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "A.nuspec")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll")));
-                    Assert.True(File.Exists(Path.Combine(root, "A.2.0.3", "content", "net40", "B.txt")));
+                    var installPath = resolver.GetInstallPath(identity);
+                    Assert.False(File.Exists(Path.Combine(installPath, "a.2.0.3.nupkg")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "a.nuspec")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(Path.Combine(installPath, "content", "net40", "B.txt")));
                 }
             }
         }
@@ -681,10 +808,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new VersionFolderPathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll");
 
@@ -694,19 +823,17 @@ namespace NuGet.Packaging.Test
                     await PackageExtractor.InstallFromSourceAsync(
                         packageStream.CopyToAsync,
                         new VersionFolderPathContext(
-                            new Core.PackageIdentity("A", new Versioning.NuGetVersion("2.0.3")),
+                            identity,
                             root,
                             NullLogger.Instance,
-                            fixNuspecIdCasing: false,
                             packageSaveMode: PackageSaveMode.Nupkg | PackageSaveMode.Files,
-                            normalizeFileNames: false,
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None),
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "A.2.0.3.nupkg")));
-                    Assert.False(File.Exists(Path.Combine(root, "A", "2.0.3", "A.nuspec")));
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)), "The .nupkg should exist.");
+                    Assert.False(File.Exists(resolver.GetManifestFilePath(identity.Id, identity.Version)), "The .nuspec should not exist.");
+                    Assert.True(File.Exists(Path.Combine(resolver.GetInstallPath(identity.Id, identity.Version), "lib", "net45", "A.dll")), "The asset should exist.");
                 }
             }
         }
@@ -717,10 +844,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new VersionFolderPathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll");
 
@@ -730,19 +859,17 @@ namespace NuGet.Packaging.Test
                     await PackageExtractor.InstallFromSourceAsync(
                         packageStream.CopyToAsync,
                         new VersionFolderPathContext(
-                            new Core.PackageIdentity("A", new Versioning.NuGetVersion("2.0.3")),
+                            identity,
                             root,
                             NullLogger.Instance,
-                            fixNuspecIdCasing: false,
                             packageSaveMode: PackageSaveMode.Nuspec | PackageSaveMode.Files,
-                            normalizeFileNames: false,
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None),
                         CancellationToken.None);
 
                     // Assert
-                    Assert.False(File.Exists(Path.Combine(root, "A", "2.0.3", "A.2.0.3.nupkg")));
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "A.nuspec")));
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "lib", "net45", "A.dll")));
+                    Assert.False(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)), "The .nupkg should not exist.");
+                    Assert.True(File.Exists(resolver.GetManifestFilePath(identity.Id, identity.Version)), "The .nuspec should exist.");
+                    Assert.True(File.Exists(Path.Combine(resolver.GetInstallPath(identity.Id, identity.Version), "lib", "net45", "A.dll")), "The asset should exist.");
 
                 }
             }
@@ -754,10 +881,12 @@ namespace NuGet.Packaging.Test
             // Arrange
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
             {
+                var resolver = new VersionFolderPathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
                 var packageFileInfo = await TestPackages.GeneratePackageAsync(
                    root,
-                   "A",
-                   "2.0.3",
+                   identity.Id,
+                   identity.Version.ToString(),
                    DateTimeOffset.UtcNow.LocalDateTime,
                    "lib/net45/A.dll");
 
@@ -767,19 +896,17 @@ namespace NuGet.Packaging.Test
                     await PackageExtractor.InstallFromSourceAsync(
                         packageStream.CopyToAsync,
                         new VersionFolderPathContext(
-                            new Core.PackageIdentity("A", new Versioning.NuGetVersion("2.0.3")),
+                            identity,
                             root,
                             NullLogger.Instance,
-                            fixNuspecIdCasing: false,
                             packageSaveMode: PackageSaveMode.Nupkg | PackageSaveMode.Nuspec,
-                            normalizeFileNames: false,
                             xmlDocFileSaveMode: XmlDocFileSaveMode.None),
                         CancellationToken.None);
 
                     // Assert
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "A.2.0.3.nupkg")));
-                    Assert.True(File.Exists(Path.Combine(root, "A", "2.0.3", "A.nuspec")));
-                    Assert.False(File.Exists(Path.Combine(root, "A", "2.0.3", "lib", "net45", "A.dll")));
+                    Assert.True(File.Exists(resolver.GetPackageFilePath(identity.Id, identity.Version)), "The .nupkg should exist.");
+                    Assert.True(File.Exists(resolver.GetManifestFilePath(identity.Id, identity.Version)), "The .nuspec should exist.");
+                    Assert.False(File.Exists(Path.Combine(resolver.GetInstallPath(identity.Id, identity.Version), "lib", "net45", "A.dll")), "The asset should not exist.");
                 }
             }
         }
@@ -794,7 +921,13 @@ namespace NuGet.Packaging.Test
                     System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.AdjustToUniversal);
 
-                FileInfo packageFileInfo = await TestPackages.GeneratePackageAsync(root, "A", "2.0.3", time.ToLocalTime(), "lib/net45/A.dll");
+                var resolver = new PackagePathResolver(root);
+                var identity = new PackageIdentity("A", new NuGetVersion("2.0.3"));
+                var packageFileInfo = await TestPackages.GeneratePackageAsync(
+                        root,
+                        identity.Id,
+                        identity.Version.ToString(),
+                        time.ToLocalTime(), "lib/net45/A.dll");
 
                 using (FileStream packageStream = File.OpenRead(packageFileInfo.FullName))
                 {
@@ -806,11 +939,12 @@ namespace NuGet.Packaging.Test
                     // Act
                     PackageExtractor.ExtractPackage(
                         packageStream,
-                        new PackagePathResolver(root),
+                        resolver,
                         packageExtractionContext,
                         CancellationToken.None);
 
-                    string outputDll = Path.Combine(root, "A.2.0.3", "lib", "net45", "A.dll");
+                    var installPath = resolver.GetInstallPath(identity);
+                    string outputDll = Path.Combine(installPath, "lib", "net45", "A.dll");
                     DateTime outputTime = File.GetLastWriteTimeUtc(outputDll);
 
                     // Assert

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class PackagePathResolverTests
+    {
+        private const string InMemoryRootDirectory = ".";
+        private static readonly PackageIdentity PackageIdentity = new PackageIdentity("PackageA", new NuGetVersion("1.0.0.0-BETA"));
+
+        [Fact]
+        public void PackagePathResolver_RejectsNullRootDirectory()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => new PackagePathResolver(
+                rootDirectory: null,
+                useSideBySidePaths: true));
+            Assert.Equal("rootDirectory", exception.ParamName);
+        }
+
+        [Fact]
+        public void PackagePathResolver_RejectsEmptyRootDirectory()
+        {
+            // Arrange & Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => new PackagePathResolver(
+                rootDirectory: string.Empty,
+                useSideBySidePaths: true));
+            Assert.Equal("rootDirectory", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(true, "packagea.1.0.0.0-beta")]
+        [InlineData(false, "packagea")]
+        public void PackagePathResolver_GetPackageDirectoryName(bool useSideBySidePaths, string expected)
+        {
+            // Arrange
+            var target = new PackagePathResolver(
+                rootDirectory: InMemoryRootDirectory,
+                useSideBySidePaths: useSideBySidePaths);
+
+            // Act
+            var actual = target.GetPackageDirectoryName(PackageIdentity);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(true, "packagea.1.0.0.0-beta.nupkg")]
+        [InlineData(false, "packagea.nupkg")]
+        public void PackagePathResolver_GetPackageFileName(bool useSideBySidePaths, string expected)
+        {
+            // Arrange
+            var target = new PackagePathResolver(
+                rootDirectory: InMemoryRootDirectory,
+                useSideBySidePaths: useSideBySidePaths);
+
+            // Act
+            var actual = target.GetPackageFileName(PackageIdentity);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(true, "packagea.nuspec")]
+        [InlineData(false, "packagea.nuspec")]
+        public void PackagePathResolver_GetManifestFileName(bool useSideBySidePaths, string expected)
+        {
+            // Arrange
+            var target = new PackagePathResolver(
+                rootDirectory: InMemoryRootDirectory,
+                useSideBySidePaths: useSideBySidePaths);
+
+            // Act
+            var actual = target.GetManifestFileName(PackageIdentity);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(true, "packagea.1.0.0.0-beta")]
+        [InlineData(false, "packagea")]
+        public void PackagePathResolver_GetInstallPath(bool useSideBySidePaths, string expected)
+        {
+            // Arrange
+            var target = new PackagePathResolver(
+                rootDirectory: InMemoryRootDirectory,
+                useSideBySidePaths: useSideBySidePaths);
+            expected = Path.Combine(InMemoryRootDirectory, expected);
+
+            // Act
+            var actual = target.GetInstallPath(PackageIdentity);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
@@ -1,0 +1,164 @@
+﻿using System.IO;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Packaging.Test
+{
+    public class VersionFolderPathResolverTests
+    {
+        [Fact]
+        public void VersionFolderPathResolver_GetInstallPath()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetInstallPath(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(Path.Combine(tc.PackagesPath, "nuget.packaging", "3.4.3-beta"), actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetPackageFilePath()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetPackageFilePath(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(
+                Path.Combine(
+                    tc.PackagesPath,
+                    "nuget.packaging",
+                    "3.4.3-beta",
+                    "nuget.packaging.3.4.3-beta.nupkg"),
+                actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetManifestFilePath()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetManifestFilePath(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(
+                Path.Combine(
+                    tc.PackagesPath, "nuget.packaging", "3.4.3-beta", "nuget.packaging.nuspec"),
+                actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetHashPath()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetHashPath(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(
+                Path.Combine(
+                    tc.PackagesPath,
+                    "nuget.packaging",
+                    "3.4.3-beta",
+                    "nuget.packaging.3.4.3-beta.nupkg.sha512"),
+                actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetPackageDirectory()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetPackageDirectory(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(Path.Combine("nuget.packaging", "3.4.3-beta"), actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetPackageFileName()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetPackageFileName(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal("nuget.packaging.3.4.3-beta.nupkg", actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetManifestFileName()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetManifestFileName(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal("nuget.packaging.nuspec", actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetVersionListPath()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetVersionListPath(tc.Id);
+
+            // Assert
+            Assert.Equal(
+                Path.Combine(
+                    tc.PackagesPath,
+                    "nuget.packaging"),
+                actual);
+        }
+
+        [Fact]
+        public void VersionFolderPathResolver_GetVersionListDirectory()
+        {
+            // Arrange
+            var tc = new TestContext();
+
+            // Act
+            var actual = tc.Target.GetVersionListDirectory(tc.Id);
+
+            // Assert
+            Assert.Equal("nuget.packaging", actual);
+        }
+
+        private class TestContext
+        {
+            public TestContext()
+            {
+                // data
+                PackagesPath = "prefix";
+                Id = "NuGet.Packaging";
+                Version = new NuGetVersion("3.04.3-Beta");
+            }
+
+            public string Id { get; private set; }
+            public string PackagesPath { get; set; }
+            public NuGetVersion Version { get; set; }
+            public VersionFolderPathResolver Target
+            {
+                get { return new VersionFolderPathResolver(PackagesPath); }
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ToolPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ToolPathResolverTests.cs
@@ -15,15 +15,15 @@ namespace NuGet.ProjectModel.Test
             var expected = Path.Combine(
                 "packages",
                 ".tools",
-                "packageA",
-                "3.1.4",
+                "packagea",
+                "3.1.4-beta",
                 "netstandard1.3",
                 "project.lock.json");
 
             // Act
             var actual = target.GetLockFilePath(
                 "packageA",
-                NuGetVersion.Parse("3.1.4"),
+                NuGetVersion.Parse("3.1.4-BETA"),
                 FrameworkConstants.CommonFrameworks.NetStandard13);
 
             // Assert


### PR DESCRIPTION
Changes readers and writers of the global packages folder or V2 style packages folder to make the ID and version component of the path lowercase.

.nupkgs written to package folders have file names `{id-lower}.{version-lower}.nupkg`, unless we are writting a V2 package folder (e.g. `nuget.exe install`) with `-ExcludeVersion`. Then the format is `{id-lower}.nupkg`.

.nuspec files have file names `{id-lower}.nuspec`.

Previously, the path to the .nupkg for Newtonsoft.Json 8.0.3 installed locally on Windows would look something like this:

<pre>
C:\Users\jver\.nuget\packages\<b>Newtonsoft.Json</b>\<b>8.0.3</b>\<b>Newtonsoft.Json</b>.<b>8.0.3</b>.nupkg
</pre>


After the change, this would look like:

<pre>
C:\Users\jver\.nuget\packages\<b>newtonsoft.json</b>\<b>8.0.3</b>\<b>newtonsoft.json</b>.<b>8.0.3</b>.nupkg
</pre>


@emgarten @alpaix @yishaigalatzer @rrelyea
