### PR TITLE
Restrict NuGet.Clients project dependencies to 3.5.0-beta-*

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/project.json
+++ b/src/NuGet.Clients/NuGet.CommandLine/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.5.0-*",
-    "NuGet.PackageManagement": "3.5.0-*"
+    "NuGet.ProjectManagement": "3.5.0-beta-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.Credentials/project.json
+++ b/src/NuGet.Clients/NuGet.Credentials/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.5.0-*"
+    "NuGet.PackageManagement": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.5.0-*",
+    "NuGet.Resolver": "3.5.0-beta-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.5.0-*"
+    "NuGet.Resolver": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.UI/project.json
+++ b/src/NuGet.Clients/PackageManagement.UI/project.json
@@ -13,11 +13,11 @@
     "Microsoft.VisualStudio.Shell.Interop.8.0": "8.0.50727",
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
-    "NuGet.Indexing": "3.5.0-*",
-    "NuGet.PackageManagement": "3.5.0-*",
-    "NuGet.ProjectManagement": "3.5.0-*",
-    "NuGet.Protocol.Core.Types": "3.5.0-*",
-    "NuGet.Resolver": "3.5.0-*"
+    "NuGet.Indexing": "3.5.0-beta-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*",
+    "NuGet.ProjectManagement": "3.5.0-beta-*",
+    "NuGet.Protocol.Core.Types": "3.5.0-beta-*",
+    "NuGet.Resolver": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.5.0-*",
-    "NuGet.Protocol.VisualStudio": "3.5.0-*",
-    "NuGet.Common": "3.5.0-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*",
+    "NuGet.Protocol.VisualStudio": "3.5.0-beta-*",
+    "NuGet.Common": "3.5.0-beta-*",
     "Microsoft.VisualStudio.Shell.14.0": "14.0.23107",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",

--- a/src/NuGet.Clients/SampleCommandLineExtensions/project.json
+++ b/src/NuGet.Clients/SampleCommandLineExtensions/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
-    "NuGet.ProjectManagement": "3.5.0-*",
-    "NuGet.PackageManagement": "3.5.0-*"
+    "NuGet.ProjectManagement": "3.5.0-beta-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/StandaloneConsole/project.json
+++ b/src/NuGet.Clients/StandaloneConsole/project.json
@@ -1,11 +1,11 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.5.0-*",
-    "NuGet.ProjectManagement": "3.5.0-*",
-    "NuGet.Protocol.Core.Types": "3.5.0-*",
-    "NuGet.Protocol.VisualStudio": "3.5.0-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*",
+    "NuGet.ProjectManagement": "3.5.0-beta-*",
+    "NuGet.Protocol.Core.Types": "3.5.0-beta-*",
+    "NuGet.Protocol.VisualStudio": "3.5.0-beta-*",
     "System.Management.Automation_PowerShell_3.0": "6.3.9600.17400",
-    "Test.Utility": "3.5.0-*"
+    "Test.Utility": "3.5.0-beta-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/StandaloneUI/project.json
+++ b/src/NuGet.Clients/StandaloneUI/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
     "Newtonsoft.Json": "6.0.4",
-    "NuGet.Protocol.VisualStudio": "3.5.0-*",
-    "NuGet.ProjectManagement": "3.5.0-*",
-    "NuGet.PackageManagement": "3.5.0-*",
-    "Test.Utility": "3.5.0-*"
+    "NuGet.Protocol.VisualStudio": "3.5.0-beta-*",
+    "NuGet.ProjectManagement": "3.5.0-beta-*",
+    "NuGet.PackageManagement": "3.5.0-beta-*",
+    "Test.Utility": "3.5.0-beta-*"
   },
   "frameworks": {
     "net451": {}

--- a/src/NuGet.Clients/VisualStudio/project.json
+++ b/src/NuGet.Clients/VisualStudio/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Protocol.VisualStudio": "3.5.0-*"
+    "NuGet.Protocol.VisualStudio": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/Console.Types/project.json
+++ b/src/NuGet.Clients/VsConsole/Console.Types/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.5.0-*"
+    "NuGet.PackageManagement": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Resolver": "3.5.0-*"
+    "NuGet.Resolver": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.PackageManagement": "3.5.0-*"
+    "NuGet.PackageManagement": "3.5.0-beta-*"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Clients/VsExtension/project.json
+++ b/src/NuGet.Clients/VsExtension/project.json
@@ -19,8 +19,8 @@
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Microsoft.VSSDK.BuildTools": "14.0.23107",
     "Microsoft.WindowsAzure.ConfigurationManager": "1.7.0",
-    "NuGet.Commands": "3.5.0-*",
-    "NuGet.Indexing": "3.5.0-*",
+    "NuGet.Commands": "3.5.0-beta-*",
+    "NuGet.Indexing": "3.5.0-beta-*",
     "System.IdentityModel.Tokens.Jwt": "4.0.0"
   },
   "frameworks": {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.5.0-*",
+    "Test.Utility": "3.5.0-beta-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.5.0-*",
+    "Test.Utility": "3.5.0-beta-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.5.0-*",
+    "Test.Utility": "3.5.0-beta-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/project.json
@@ -16,7 +16,7 @@
     "Microsoft.VisualStudio.Shell.Interop.9.0": "9.0.30729",
     "Microsoft.VisualStudio.Threading": "14.0.50702",
     "Moq": "4.2.1507.118",
-    "Test.Utility": "3.5.0-*",
+    "Test.Utility": "3.5.0-beta-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },


### PR DESCRIPTION
CI builds on release-3.5.0-beta branch fail due to incorrect dependency
model. The problem is NuGet.Clients project dependencies were restored to
3.5.0-rc-\* NuGet.Core packages published at MyGet feed.
