### PR TITLE
Allow DefaultPushSource to use relative paths

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceProvider.cs
@@ -469,7 +469,7 @@ namespace NuGet.Configuration
         {
             get
             {
-                var source = Settings.GetValue(ConfigurationConstants.Config, ConfigurationConstants.DefaultPushSource);
+                string source = SettingsUtility.GetDefaultPushSource(Settings);
 
                 if (string.IsNullOrEmpty(source))
                 {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/ConfigurationDefaults.cs
@@ -86,8 +86,9 @@ namespace NuGet.Configuration
                     && !_defaultPackageSourceInitialized)
                 {
                     _defaultPackageSourceInitialized = true;
-                    _defaultPushSource = _settingsManager.GetValue(ConfigurationConstants.Config, ConfigurationConstants.DefaultPushSource);
+                    _defaultPushSource = SettingsUtility.GetDefaultPushSource(_settingsManager);
                 }
+
                 return _defaultPushSource;
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/ConfigurationDefaultsTests.cs
@@ -121,7 +121,7 @@ namespace NuGet.Configuration
                 // Act & Assert
                 ConfigurationDefaults ConfigurationDefaults = GetConfigurationDefaults(configurationDefaultsContent, mockBaseDirectory);
 
-                Assert.Equal(ConfigurationDefaults.DefaultPushSource, "http://contoso.com/packages/");
+                Assert.Equal("http://contoso.com/packages/", ConfigurationDefaults.DefaultPushSource);
             }
         }
 
@@ -213,7 +213,7 @@ namespace NuGet.Configuration
                 List<PackageSource> packageSources = packageSourceProvider.LoadPackageSources().ToList();
 
                 // Assert
-                Assert.Equal(ConfigurationDefaults.DefaultPushSource, "http://contoso.com/packages/");
+                Assert.Equal("http://contoso.com/packages/", ConfigurationDefaults.DefaultPushSource);
                 Assert.Equal(2, packageSources.Count());
                 Assert.Equal("v2", packageSources[0].Name);
                 Assert.Equal("Contoso Package Source", packageSources[1].Name);


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1746

When "DefaultPushSource" is specified in any nuget.config file, it is now allowed to be a relative file path. The only trickiness is dealing with "foo" where it could be the name or a source, or the name of a relative directory. First I try to resolve it as a name, and if that fails, then resolve it as a directory.

@zhili1208 @emgarten @toddm 
