### PR TITLE
Adding support for nuproj to nuget.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectHelper.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ProjectHelper.cs
@@ -7,7 +7,7 @@ namespace NuGet.Common
 {
     public static class ProjectHelper
     {
-        private static readonly HashSet<string> _supportedProjectExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {  
+        private static readonly HashSet<string> _supportedProjectExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
             ".csproj",
             ".vbproj",
             ".fsproj",
@@ -15,7 +15,8 @@ namespace NuGet.Common
             ".vcxproj",
             ".jsproj",
             ".wixproj",
-            ".xproj"
+            ".xproj",
+            ".nuproj",
         };
 
         public static HashSet<string> SupportedProjectExtensions

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -30,7 +30,8 @@ namespace NuGet.CommandLine
             ".csproj",
             ".vbproj",
             ".fsproj",
-            ".xproj"
+            ".xproj",
+            ".nuproj"
         };
 
         public static bool IsMsBuildBasedProject(string projectFullPath)


### PR DESCRIPTION
A small change for nuget.exe 3.4.4 to add nuproj to the known project extension list. The VSIX determines this through DTE and does not need a change.

https://github.com/NuGet/Home/issues/2711

//cc @rrelyea @joelverhagen @yishaigalatzer 
