### PR TITLE
Issue 1887: Display NuGet version with detailed verbosity.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -2,8 +2,10 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
@@ -122,8 +124,31 @@ namespace NuGet.CommandLine
 
                 UserAgent.SetUserAgentString(new UserAgentStringBuilder(CommandLineConstants.UserAgent));
 
+                OutputNuGetVersion();
                 ExecuteCommandAsync().Wait();
             }
+        }
+
+        /// <summary>
+        /// Outputs the current NuGet version (by default, only when vebosity is detailed).
+        /// </summary>
+        private void OutputNuGetVersion()
+        {
+            if (ShouldOutputNuGetVersion)
+            {
+                var assemblyName = Assembly.GetExecutingAssembly().GetName();
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("OutputNuGetVersion"),
+                    assemblyName.Name,
+                    assemblyName.Version);
+                Console.WriteLine(message);
+            }
+        }
+
+        protected virtual bool ShouldOutputNuGetVersion
+        {
+            get { return Console.Verbosity == Verbosity.Detailed; }
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/HelpCommand.cs
@@ -17,7 +17,6 @@ namespace NuGet.CommandLine
         private readonly string _commandExe;
         private readonly ICommandManager _commandManager;
         private readonly string _helpUrl;
-        private readonly string _productName;
 
         private string CommandName
         {
@@ -49,7 +48,6 @@ namespace NuGet.CommandLine
         {
             _commandManager = commandManager;
             _commandExe = commandExe;
-            _productName = productName;
             _helpUrl = helpUrl;
         }
 
@@ -75,7 +73,6 @@ namespace NuGet.CommandLine
 
         public void ViewHelp()
         {
-            Console.WriteLine("{0} Version: {1}", _productName, this.GetType().Assembly.GetName().Version);
             Console.WriteLine("usage: {0} <command> [args] [options] ", _commandExe);
             Console.WriteLine("Type '{0} help <command>' for help on a specific command.", _commandExe);
             Console.WriteLine();
@@ -102,6 +99,9 @@ namespace NuGet.CommandLine
                     _helpUrl));
             }
         }
+
+        // Help command always outputs NuGet version
+        protected override bool ShouldOutputNuGetVersion { get { return true; } }
 
         private void PrintCommand(int maxWidth, CommandAttribute commandAttribute)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -6802,6 +6802,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} Version: {1}.
+        /// </summary>
+        public static string OutputNuGetVersion {
+            get {
+                return ResourceManager.GetString("OutputNuGetVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Added file &apos;{0}&apos;..
         /// </summary>
         public static string PackageCommandAddedFile {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6086,4 +6086,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The remote server indicated that the previous request was forbidden. Please provide credentials for: {0}</value>
     <comment>{0} will be replaced with the URL that needs credentials.</comment>
   </data>
+  <data name="OutputNuGetVersion" xml:space="preserve">
+    <value>{0} Version: {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -375,6 +375,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to {0} Version: {1}.
+        /// </summary>
+        public static string OutputNuGetVersion {
+            get {
+                return ResourceManager.GetString("OutputNuGetVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Attempting to build package from &apos;{0}&apos;..
         /// </summary>
         public static string PackageCommandAttemptingToBuildPackage {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -299,4 +299,7 @@
   <data name="ForceEnglishOutput_Description" xml:space="preserve">
     <value>Forces the application to run using an invariant, English-based culture.</value>
   </data>
+  <data name="OutputNuGetVersion" xml:space="preserve">
+    <value>{0} Version: {1}</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -100,11 +100,11 @@ namespace NuGet.CommandLine.Test
                 var output = r.Item2;
                 string[] lines = output.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
-                Assert.Equal(4, lines.Length);
-                Assert.Equal("testPackage1", lines[0]);
-                Assert.Equal(" 1.1.0", lines[1]);
-                Assert.Equal(" desc of testPackage1 1.1.0", lines[2]);
-                Assert.Equal(" License url: http://kaka", lines[3]);
+                Assert.Equal(5, lines.Length);
+                Assert.Equal("testPackage1", lines[1]);
+                Assert.Equal(" 1.1.0", lines[2]);
+                Assert.Equal(" desc of testPackage1 1.1.0", lines[3]);
+                Assert.Equal(" License url: http://kaka", lines[4]);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.CommandLine.XPlat.Test/BasicLoggingTests.cs
@@ -21,11 +21,11 @@ namespace NuGet.CommandLine.XPlat.Test
 
             // Assert
             Assert.Equal(1, exitCode);
-            Assert.Equal(2, log.Messages.Count);
+            Assert.Equal(3, log.Messages.Count);
             Assert.Equal(1, log.Errors);
             Assert.Equal(0, log.Warnings);
-            Assert.Contains("--unknown", log.Messages.ToArray()[0]);  // error
-            Assert.Contains("Program.cs", log.Messages.ToArray()[1]); // verbose stack trace
+            Assert.Contains("--unknown", log.Messages.ToArray()[1]);  // error
+            Assert.Contains("Program.cs", log.Messages.ToArray()[2]); // verbose stack trace
         }
 
         [Fact]
@@ -108,11 +108,11 @@ namespace NuGet.CommandLine.XPlat.Test
 
             // Assert
             Assert.Equal(1, exitCode);
-            Assert.Equal(2, log.Messages.Count);
+            Assert.Equal(3, log.Messages.Count);
             Assert.Equal(1, log.Errors);
             Assert.Equal(0, log.Warnings);
-            Assert.Contains("--unknown", log.Messages.ToArray()[0]);  // error
-            Assert.Contains("Program.cs", log.Messages.ToArray()[1]); // verbose stack trace
+            Assert.Contains("--unknown", log.Messages.ToArray()[1]);  // error
+            Assert.Contains("Program.cs", log.Messages.ToArray()[2]); // verbose stack trace
         }
     }
 }


### PR DESCRIPTION
This change is just for NuGet.exe.

I have the equivalent change for x-plat, but need to resolve some issues with the existing logic to check verbosity in `NuGet.CommandLine.XPlat/Program.cs`.

This resolves NuGet/Home#1887
