### PR TITLE
Add `DotnetCliTool` and `Dependency` package types

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core/INuspecCoreReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/INuspecCoreReader.cs
@@ -29,6 +29,11 @@ namespace NuGet.Packaging.Core
         NuGetVersion GetMinClientVersion();
 
         /// <summary>
+        /// Gets zero or more package types from the .nuspec.
+        /// </summary>
+        IReadOnlyList<PackageType> GetPackageTypes();
+
+        /// <summary>
         /// Id and Version of a package.
         /// </summary>
         PackageIdentity GetIdentity();

--- a/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
@@ -28,10 +28,9 @@ namespace NuGet.Packaging.Core
         NuGetVersion GetMinClientVersion();
 
         /// <summary>
-        /// Gets the <see cref="PackageType"/> of the package.
+        /// Gets zero or more package types from the .nuspec.
         /// </summary>
-        /// <returns>The <see cref="PackageType"/>.</returns>
-        PackageType GetPackageType();
+        IReadOnlyList<PackageType> GetPackageTypes();
 
         /// <summary>
         /// Returns a file stream from the package.

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
@@ -2,11 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGet.Shared;
 
 namespace NuGet.Packaging.Core
 {
-    public class PackageType
+    public class PackageType : IEquatable<PackageType>
     {
+        public static readonly Version EmptyVersion = new Version(0, 0);
+        public static readonly PackageType Legacy = new PackageType("Legacy", version: EmptyVersion);
+        public static readonly PackageType DotnetCliTool = new PackageType("DotnetCliTool", version: EmptyVersion);
+        public static readonly PackageType Dependency = new PackageType("Dependency", version: EmptyVersion);
+
         public PackageType(string name, Version version)
         {
             if (string.IsNullOrEmpty(name))
@@ -22,11 +28,41 @@ namespace NuGet.Packaging.Core
             Name = name;
             Version = version;
         }
-
-        public static PackageType Default { get; } = new PackageType("Legacy", version: new Version(0, 0));
-
+        
         public string Name { get; }
 
         public Version Version { get; }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as PackageType);
+        }
+
+        public bool Equals(PackageType other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return
+                Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase) &&
+                Version == other.Version;
+        }
+
+        public override int GetHashCode()
+        {
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddObject(Name, StringComparer.OrdinalIgnoreCase);
+            combiner.AddObject(Version);
+
+            return combiner.CombinedHash;
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging.Core/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/Strings.Designer.cs
@@ -60,6 +60,15 @@ namespace NuGet.Packaging.Core {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Nuspec file contains a package type with an invalid package version &apos;{0}&apos;..
+        /// </summary>
+        public static string InvalidPackageTypeVersion {
+            get {
+                return ResourceManager.GetString("InvalidPackageTypeVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Nuspec file does not contain the &apos;{0}&apos; node..
         /// </summary>
         public static string MissingMetadataNode {
@@ -78,11 +87,29 @@ namespace NuGet.Packaging.Core {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Nuspec file contains a package type that is missing the name attribute..
+        /// </summary>
+        public static string MissingPackageTypeName {
+            get {
+                return ResourceManager.GetString("MissingPackageTypeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package contains multiple nuspec files..
         /// </summary>
         public static string MultipleNuspecFiles {
             get {
                 return ResourceManager.GetString("MultipleNuspecFiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Nuspec file contains multiple package types. Zero or one package type nodes are allowed..
+        /// </summary>
+        public static string MultiplePackageTypes {
+            get {
+                return ResourceManager.GetString("MultiplePackageTypes", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Packaging.Core/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging.Core/Strings.resx
@@ -117,14 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidPackageTypeVersion" xml:space="preserve">
+    <value>Nuspec file contains a package type with an invalid package version '{0}'.</value>
+    <comment>{0} is the invalid version string.</comment>
+  </data>
   <data name="MissingMetadataNode" xml:space="preserve">
     <value>Nuspec file does not contain the '{0}' node.</value>
   </data>
   <data name="MissingNuspec" xml:space="preserve">
     <value>Nuspec file does not exist in package.</value>
   </data>
+  <data name="MissingPackageTypeName" xml:space="preserve">
+    <value>Nuspec file contains a package type that is missing the name attribute.</value>
+  </data>
   <data name="MultipleNuspecFiles" xml:space="preserve">
     <value>Package contains multiple nuspec files.</value>
+  </data>
+  <data name="MultiplePackageTypes" xml:space="preserve">
+    <value>Nuspec file contains multiple package types. Zero or one package type nodes are allowed.</value>
   </data>
   <data name="StringCannotBeNullOrEmpty" xml:space="preserve">
     <value>String argument '{0}' cannot be null or empty</value>

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -80,7 +80,10 @@ namespace NuGet.Packaging
             return NuspecReader.GetMinClientVersion();
         }
 
-        public virtual PackageType GetPackageType() => NuspecReader.GetPackageType();
+        public virtual IReadOnlyList<PackageType> GetPackageTypes()
+        {
+            return NuspecReader.GetPackageTypes();
+        }
 
         public virtual Stream GetNuspec()
         {

--- a/src/NuGet.Core/NuGet.Shared/HashCodeCombiner.cs
+++ b/src/NuGet.Core/NuGet.Shared/HashCodeCombiner.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace NuGet.Shared
 {
     /// <summary>
@@ -35,6 +37,15 @@ namespace NuGet.Shared
         {
             CheckInitialized();
             AddInt32(b.GetHashCode());
+        }
+
+        internal void AddObject<TValue>(TValue o, IEqualityComparer<TValue> comparer)
+        {
+            CheckInitialized();
+            if (o != null)
+            {
+                AddInt32(comparer.GetHashCode(o));
+            }
         }
 
         internal void AddObject(object o)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
@@ -13,9 +11,9 @@ namespace NuGet.Test
 {
     internal class TestNuGetProject : NuGetProject
     {
-        IList<NuGet.Packaging.PackageReference> _installedPackages;
+        IList<Packaging.PackageReference> _installedPackages;
 
-        public TestNuGetProject(IList<NuGet.Packaging.PackageReference> installedPackages)
+        public TestNuGetProject(IList<Packaging.PackageReference> installedPackages)
             : base(CreateMetadata())
         {
             _installedPackages = installedPackages;
@@ -30,14 +28,14 @@ namespace NuGet.Test
             };
         }
 
-        public override Task<IEnumerable<NuGet.Packaging.PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
+        public override Task<IEnumerable<Packaging.PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
         {
-            return Task.FromResult<IEnumerable<NuGet.Packaging.PackageReference>>(_installedPackages);
+            return Task.FromResult<IEnumerable<Packaging.PackageReference>>(_installedPackages);
         }
 
         public override Task<bool> InstallPackageAsync(PackageIdentity packageIdentity, DownloadResourceResult downloadResourceResult, INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(true);
         }
 
         public override Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/PackageTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/PackageTypeTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace NuGet.Packaging.Core.Test
+{
+    public class PackageTypeTests
+    {
+        [Fact]
+        public void PackageType_Equals_WithDifferentName()
+        {
+            // Arrange
+            var a = new PackageType("Foo", new Version(1, 0));
+            var b = new PackageType("Bar", new Version(1, 0));
+
+            // Act & Assert
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void PackageType_Equals_WithDifferentVersion()
+        {
+            // Arrange
+            var a = new PackageType("Foo", new Version(1, 0));
+            var b = new PackageType("Foo", new Version(2, 0));
+
+            // Act & Assert
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void PackageType_Equals_DifferentNameCase()
+        {
+            // Arrange
+            var a = new PackageType("FOO", new Version(1, 0));
+            var b = new PackageType("foo", new Version(1, 0));
+
+            // Act & Assert
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void PackageType_Equals_SameNameAndVersion()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+            var b = new PackageType("foo", new Version(1, 0));
+
+            // Act & Assert
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void PackageType_Equals_Same()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+            var b = a;
+
+            // Act & Assert
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void PackageType_Equals_OtherType()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+
+            // Act & Assert
+            Assert.False(a.Equals("foo"));
+        }
+
+        [Fact]
+        public void PackageType_Equals_Null()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+
+            // Act & Assert
+            Assert.False(a.Equals(null));
+        }
+
+        [Fact]
+        public void PackageType_GetHashCode_Equal()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+            var b = new PackageType("foo", new Version(1, 0));
+
+            // Act
+            var aHashCode = a.GetHashCode();
+            var bHashCode = b.GetHashCode();
+
+            // Assert
+            Assert.Equal(aHashCode, bHashCode);
+        }
+
+        [Fact]
+        public void PackageType_GetHashCode_DifferentCase()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+            var b = new PackageType("FOO", new Version(1, 0));
+
+            // Act
+            var aHashCode = a.GetHashCode();
+            var bHashCode = b.GetHashCode();
+
+            // Assert
+            Assert.Equal(aHashCode, bHashCode);
+        }
+
+        [Fact]
+        public void PackageType_GetHashCode_Different()
+        {
+            // Arrange
+            var a = new PackageType("foo", new Version(1, 0));
+            var b = new PackageType("bar", new Version(1, 0));
+
+            // Act
+            var aHashCode = a.GetHashCode();
+            var bHashCode = b.GetHashCode();
+
+            // Assert
+            Assert.NotEqual(aHashCode, bHashCode);
+        }
+
+        [Fact]
+        public void PackageType_InHashSet()
+        {
+            // Arrange
+            var inSet = new PackageType("a", new Version(1, 0));
+            var notInSet = new PackageType("b", new Version(1, 0));
+            var set = new HashSet<PackageType>
+            {
+                new PackageType("a", new Version(1, 0)),
+                new PackageType("b", new Version(2, 0)),
+                new PackageType("c", new Version(1, 0)),
+                new PackageType("d", new Version(1, 0))
+            };
+
+            // Act & Assert
+            Assert.True(set.Contains(inSet));
+            Assert.False(set.Contains(notInSet));
+        }
+    }
+}


### PR DESCRIPTION
Add `DotnetCliTool` and `Dependency` package types. They are not yet supported for installation.

This is an attempt to make multiple, smaller, atomic PRs working towards package type.
https://github.com/NuGet/Home/issues/2476

Particular points to be reviewed:
- I have a notion of version for `DotnetCliTool` and `Dependency`. Since the we wanted the tool's project.json just to have `"packageType": "DotnetCliTool"` with no version mentioned, I chose to leave the existing default version: `0.0`. Alternatively we could start with `1.0` and change the project.json to  `"packageType": { "name": "DotnetCliTool", "version": "1.0" }`.
- I changed the package type name from the element text (existing code for the not-yet-complete quirking effort) to the `"name"` attribute. 

@emgarten @yishaigalatzer @pranavkm 
