### PR TITLE
fixed https://github.com/NuGet/Home/issues/2739

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/FileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/FileSystemUtility.cs
@@ -210,7 +210,7 @@ namespace NuGet.ProjectManagement
             {
                 MakeWritable(fullPath);
                 var sourceControlManager = SourceControlUtility.GetSourceControlManager(nuGetProjectContext);
-                if (sourceControlManager != null)
+                if (sourceControlManager != null && sourceControlManager.IsPackagesFolderBoundToSourceControl())
                 {
                     sourceControlManager.PendDeleteFiles(new List<string> { fullPath }, string.Empty, nuGetProjectContext);
                 }
@@ -253,7 +253,7 @@ namespace NuGet.ProjectManagement
             }
 
             var sourceControlManager = SourceControlUtility.GetSourceControlManager(nuGetProjectContext);
-            if (sourceControlManager != null)
+            if (sourceControlManager != null && sourceControlManager.IsPackagesFolderBoundToSourceControl())
             {
                 sourceControlManager.PendDeleteFiles(filesToDelete, packagesDir, nuGetProjectContext);
                 foreach (var fileToDelete in filesToDelete)


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2739

the bug is during uninstalling packages, nuget will delete package files from TFS, but if user set disableSourceControllntegration to true, package files are not added to TFS workplace during installing, so TFS can't find those files during uninstalling,

The fix is to check disableSourceControlIntegration before deleting package files from TFS.
