### PR TITLE
Fixing nuspec pack with empty Files element so it doesn't include other files

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -36,12 +36,19 @@ namespace NuGet.Packaging
             if (files != null)
             {
                 Files = files;
+                HasFilesNode = true;
+            }
+            else
+            {
+                HasFilesNode = false;
             }
         }
 
         public ManifestMetadata Metadata { get; }
 
         public ICollection<ManifestFile> Files { get; } = new List<ManifestFile>();
+
+        public bool HasFilesNode { get; }
 
         /// <summary>
         /// Saves the current manifest to the specified stream.

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -446,7 +446,7 @@ namespace NuGet.Packaging
             // If there's no base path then ignore the files node
             if (basePath != null)
             {
-                if (manifest.Files.Count == 0)
+                if (!manifest.HasFilesNode)
                 {
                     AddFiles(basePath, @"**\*", null);
                 }


### PR DESCRIPTION
The logic to include other files was Files.Any() in 3.4 but should check for whether the Files element even existed.  This change creates a bool HasFilesNode that tracks whether or not there was a Files node.  This keeps the code from having to check Files for null in many places.

Fixes https://github.com/NuGet/Home/issues/2742

@emgarten @spadapet @joelverhagen 
