### PR TITLE
Trimming leading slashes from File target parameters

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -304,12 +304,12 @@ namespace NuGet.Packaging
                     continue;
                 }
 
-                string target = file.GetOptionalAttributeValue("target").SafeTrim();
+                string target = file.GetOptionalAttributeValue("target").SafeTrim()?.TrimStart(new[] { '\\', '/' });
                 string exclude = file.GetOptionalAttributeValue("exclude").SafeTrim();
 
                 // Multiple sources can be specified by using semi-colon separated values. 
                 files.AddRange(from source in srcElement.Value.Trim(';').Split(';')
-                               select new ManifestFile { Source = source.SafeTrim(), Target = target.SafeTrim(), Exclude = exclude.SafeTrim() });
+                               select new ManifestFile { Source = source.SafeTrim().TrimStart(new[] { '\\', '/' }), Target = target, Exclude = exclude });
             }
             return files;
         }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -304,12 +304,18 @@ namespace NuGet.Packaging
                     continue;
                 }
 
-                string target = file.GetOptionalAttributeValue("target").SafeTrim()?.TrimStart(new[] { '\\', '/' });
+                var slashes = new[] { '\\', '/' };
+                string target = file.GetOptionalAttributeValue("target").SafeTrim()?.TrimStart(slashes);
                 string exclude = file.GetOptionalAttributeValue("exclude").SafeTrim();
 
                 // Multiple sources can be specified by using semi-colon separated values. 
-                files.AddRange(from source in srcElement.Value.Trim(';').Split(';')
-                               select new ManifestFile { Source = source.SafeTrim().TrimStart(new[] { '\\', '/' }), Target = target, Exclude = exclude });
+                files.AddRange(srcElement.Value.Trim(';').Split(';').Select(s => 
+                    new ManifestFile
+                    {
+                        Source = s.SafeTrim().TrimStart(slashes),
+                        Target = target,
+                        Exclude = exclude
+                    }));
             }
             return files;
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -25,6 +25,10 @@ namespace NuGet.CommandLine.Test
                     Path.Combine(workingDirectory, "contentFiles/any/any"),
                     "image.jpg",
                     "");
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "contentFiles/any/any"),
+                    "image2.jpg",
+                    "");
 
                 Util.CreateFile(
                     workingDirectory,
@@ -48,6 +52,10 @@ namespace NuGet.CommandLine.Test
         </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src=""contentFiles/any/any/image.jpg"" target=""\Content\image.jpg"" />
+    <file src=""/contentFiles/any/any/image2.jpg"" target=""Content\other\image2.jpg"" />
+  </files>
 </package>");
 
                 // Act
@@ -80,6 +88,10 @@ namespace NuGet.CommandLine.Test
     <dependency id=""packageE"" version=""1.0.0"" exclude=""z"" />
   </group>
 </dependencies>".Replace("\r\n", "\n"), actual);
+
+                    var files = package.GetFiles().Select(f => f.Path).ToArray();
+                    Assert.Contains(@"Content\image.jpg", files);
+                    Assert.Contains(@"Content\other\image2.jpg", files);
                 }
             }
         }


### PR DESCRIPTION
Trimming leading slashes from File target parameters in nuspec files so that the package is created correctly.  This matches NuGet 3.3.0 behavior. Also adding a unit test to cover this case.

Fixes https://github.com/NuGet/Home/issues/2749

@emgarten @joelverhagen @spadapet @rrelyea 
