### PR TITLE
Improved Resolver failure messages to give correct error details.

### DIFF
--- a/src/NuGet.Core/NuGet.Resolver/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Resolver/Strings.Designer.cs
@@ -96,6 +96,15 @@ namespace NuGet.Resolver {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to One or more unresolved package dependency constraints detected in the existing packages.config file. All dependency constraints must be resolved to add or update packages. If these packages are being updated this message may be ignored, if not the following error(s) may be blocking the current package operation: {0}.
+        /// </summary>
+        public static string InvalidPackageConfig {
+            get {
+                return ResourceManager.GetString("InvalidPackageConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Unable to find package &apos;{0}&apos;. Existing packages must be restored before performing an install or update..
         /// </summary>
         public static string MissingDependencyInfo {

--- a/src/NuGet.Core/NuGet.Resolver/Strings.resx
+++ b/src/NuGet.Core/NuGet.Resolver/Strings.resx
@@ -129,6 +129,9 @@
   <data name="FatalError" xml:space="preserve">
     <value>A fatal error occured while resolving dependencies.</value>
   </data>
+  <data name="InvalidPackageConfig" xml:space="preserve">
+    <value>One or more unresolved package dependency constraints detected in the existing packages.config file. All dependency constraints must be resolved to add or update packages. If these packages are being updated this message may be ignored, if not the following error(s) may be blocking the current package operation: {0}</value>
+  </data>
   <data name="MissingDependencyInfo" xml:space="preserve">
     <value>Unable to find package '{0}'. Existing packages must be restored before performing an install or update.</value>
   </data>


### PR DESCRIPTION
Instead of completely refactoring existing failure messages code, i've added another special case there which will cover most of the generic update/install issues and give an correct error message. Still fallback will be the existing code so that there is no regression.

Fix https://github.com/NuGet/Home/issues/1373
