### PR TITLE
Move Dev14 VSIX to artifacts folder to support downstream scenarios

### DIFF
--- a/src/NuGet.Clients/VsExtension/VsExtension.csproj
+++ b/src/NuGet.Clients/VsExtension/VsExtension.csproj
@@ -14,7 +14,6 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGetVSExtension</RootNamespace>
-    <AssemblyName>NuGet.Tools</AssemblyName>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeCopyLocalReferencesInVSIXContainer>true</IncludeCopyLocalReferencesInVSIXContainer>
@@ -28,10 +27,12 @@
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <DefineConstants>$(DefineConstants);VS14</DefineConstants>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AssemblyName>NuGet.Tools</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <DefineConstants>$(DefineConstants);VS15</DefineConstants>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <AssemblyName>NuGet.Tools.Dev15</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Coverage' Or '$(Configuration)' == 'Mono Debug'">
     <DebugSymbols>true</DebugSymbols>
@@ -319,11 +320,12 @@
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <PreBuildEvent>copy /y "$(MSBuildProjectDirectory)\project.dev14.json" "$(MSBuildProjectDirectory)\project.json"</PreBuildEvent>
-    <PostBuildEvent>"$(MSBuildProjectDirectory)\EnsureDirectoryAndCopy.bat" "$(TargetVsixContainer)" "$(ArtifactRoot)\dev14"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <PreBuildEvent>copy /y "$(MSBuildProjectDirectory)\project.dev15.json" "$(MSBuildProjectDirectory)\project.json"</PreBuildEvent>
-    <PostBuildEvent>"$(MSBuildProjectDirectory)\EnsureDirectoryAndCopy.bat" "$(TargetVsixContainer)" "$(ArtifactRoot)\dev15"</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>"$(MSBuildProjectDirectory)\EnsureDirectoryAndCopy.bat" "$(TargetVsixContainer)" "$(ArtifactRoot)"</PostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
     <VsixIncludeFile Include=".vsixinclude" />


### PR DESCRIPTION
Move Dev14 VSIX back to artifacts folder to support downstream scenarios during the transition to Dev14+Dev15 builds.
