### PR TITLE
[WIP] Fix CachingSourceProvider so that cached credentials work

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -120,7 +120,7 @@ namespace NuGet.Commands
             if (packageSources.Count < 1)
             {
                 // Add enabled sources
-                foreach (PackageSource source in packageSourceProvider.Value.LoadPackageSources())
+                foreach (var source in packageSourceProvider.Value.LoadPackageSources())
                 {
                     if (source.IsEnabled)
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/CachingSourceProvider.cs
@@ -21,8 +21,8 @@ namespace NuGet.Protocol.Core.v3
         private readonly List<SourceRepository> _repositories = new List<SourceRepository>();
 
         // There should only be one instance of the source repository for each package source.
-        private readonly ConcurrentDictionary<PackageSource, SourceRepository> _cachedSources
-            = new ConcurrentDictionary<PackageSource, SourceRepository>();
+        private readonly ConcurrentDictionary<string, SourceRepository> _cachedSources
+            = new ConcurrentDictionary<string, SourceRepository>(StringComparer.OrdinalIgnoreCase);
 
         public CachingSourceProvider(IPackageSourceProvider packageSourceProvider)
         {
@@ -57,7 +57,7 @@ namespace NuGet.Protocol.Core.v3
         /// </summary>
         public SourceRepository CreateRepository(PackageSource source)
         {
-            return _cachedSources.GetOrAdd(source, new SourceRepository(source, _resourceProviders));
+            return _cachedSources.GetOrAdd(source.Source, new SourceRepository(source, _resourceProviders));
         }
 
         public IPackageSourceProvider PackageSourceProvider

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XPlatAuthenticationTests
+    {
+
+        [Fact]
+        public void Restore_WithAuthenticatedSource_Succeeds()
+        {
+            // Arrange
+            using (var packagesDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configFile = XPlatTestUtils.CopyFuncTestConfig(projectDir);
+
+                var specPath = Path.Combine(projectDir, "XPlatAuthenticationTests", "project.json");
+                var spec = XPlatTestUtils.BasicConfigNetCoreApp;
+
+                XPlatTestUtils.AddDependency(spec, "costura.fody", "1.3.3");
+                XPlatTestUtils.AddDependency(spec, "fody", "1.29.4");
+                XPlatTestUtils.WriteJson(spec, specPath);
+
+                var log = new TestCommandOutputLogger();
+
+                var args = new string[]
+                {
+                    "restore",
+                    projectDir,
+                    "--packages",
+                    packagesDir,
+                    "--no-cache"
+                };
+
+                // Act
+                var exitCode = Program.MainInternal(args, log);
+
+                // Assert
+                //Assert.Equal(0, log.Errors);
+                Assert.Contains("OK http://nugetserverendpoint.azurewebsites.net/nuget/FindPackagesById()?id='fody'", log.ShowMessages());
+
+                var lockFilePath = Path.Combine(projectDir, "project.lock.json");
+                Assert.True(File.Exists(lockFilePath));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.XPlat.FuncTest
                 var exitCode = Program.MainInternal(args, log);
 
                 // Assert
-                //Assert.Equal(0, log.Errors);
+                Assert.Equal(0, log.Errors);
                 Assert.Contains("OK http://nugetserverendpoint.azurewebsites.net/nuget/FindPackagesById()?id='fody'", log.ShowMessages());
 
                 var lockFilePath = Path.Combine(projectDir, "project.lock.json");

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAuthenticationTests.cs
@@ -10,8 +10,7 @@ namespace NuGet.XPlat.FuncTest
 {
     public class XPlatAuthenticationTests
     {
-
-        [Fact]
+        [Fact(Skip = "There are flaky servers in the config file")]
         public void Restore_WithAuthenticatedSource_Succeeds()
         {
             // Arrange
@@ -42,10 +41,52 @@ namespace NuGet.XPlat.FuncTest
                 var exitCode = Program.MainInternal(args, log);
 
                 // Assert
-                Assert.Equal(0, log.Errors);
+                Assert.Equal(string.Empty, log.ShowErrors());
                 Assert.Contains("OK http://nugetserverendpoint.azurewebsites.net/nuget/FindPackagesById()?id='fody'", log.ShowMessages());
 
-                var lockFilePath = Path.Combine(projectDir, "project.lock.json");
+                var lockFilePath = Path.Combine(projectDir, "XPlatAuthenticationTests", "project.lock.json");
+                Assert.True(File.Exists(lockFilePath));
+            }
+        }
+
+        [Fact(Skip = "There are flaky servers in the config file")]
+        public void Restore_WithAuthenticatedSourceSpecificConfig_Succeeds()
+        {
+            // Arrange
+            using (var packagesDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var configDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var configFile = XPlatTestUtils.CopyFuncTestConfig(configDir);
+
+                var specPath = Path.Combine(projectDir, "XPlatAuthenticationTests", "project.json");
+                var spec = XPlatTestUtils.BasicConfigNetCoreApp;
+
+                XPlatTestUtils.AddDependency(spec, "costura.fody", "1.3.3");
+                XPlatTestUtils.AddDependency(spec, "fody", "1.29.4");
+                XPlatTestUtils.WriteJson(spec, specPath);
+
+                var log = new TestCommandOutputLogger();
+
+                var args = new string[]
+                {
+                    "restore",
+                    projectDir,
+                    "--packages",
+                    packagesDir,
+                    "--configfile",
+                    configFile,
+                    "--no-cache"
+                };
+
+                // Act
+                var exitCode = Program.MainInternal(args, log);
+
+                // Assert
+                Assert.Equal(string.Empty, log.ShowErrors());
+                Assert.Contains("OK http://nugetserverendpoint.azurewebsites.net/nuget/FindPackagesById()?id='fody'", log.ShowMessages());
+
+                var lockFilePath = Path.Combine(projectDir, "XPlatAuthenticationTests", "project.lock.json");
                 Assert.True(File.Exists(lockFilePath));
             }
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -52,6 +53,18 @@ namespace NuGet.XPlat.FuncTest
                 var serializer = new JsonSerializer();
                 serializer.Serialize(writer, json);
             }
+        }
+
+        /// <summary>
+        /// Copies test sources configuration to a test folder
+        /// </summary>
+        public static string CopyFuncTestConfig(string destinationFolder)
+        {
+            var sourceConfigFolder = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            var sourceConfigFile = Path.Combine(sourceConfigFolder, "NuGet.Core.FuncTests.Config");
+            var destConfigFile = Path.Combine(destinationFolder, "NuGet.Config");
+            File.Copy(sourceConfigFile, destConfigFile);
+            return destConfigFile;
         }
     }
 }


### PR DESCRIPTION
"dotnet restore" and xplat command line restore were broken when cached credentials needed to be used.

CachingSourceProvider was using the name+URL of a source as the key, but many times the source was looked up by just URL. So the original cached source with name+URL would not be returned. And that caused the cached credentials on that original cached source to be lost.

I changed CachingSourceProvider to only use the URL to look up cached sources. The credentials on the original cached source get preserved, and the bug is fixed.

Now... can anyone think of some other bad code that relied on the cache being broken?

Fixes: https://github.com/dotnet/cli/issues/2510

@alpaix @yishaigalatzer @emgarten @joelverhagen 
