### PR TITLE
Add support for net40-client in NuGet.Frameworks

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.Shared;
 
+#if IS_NET40_CLIENT
+using FallbackList = System.Collections.Generic.IList<NuGet.Frameworks.NuGetFramework>;
+#else
+using FallbackList = System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>;
+#endif
+
 namespace NuGet.Frameworks
 {
     public class FallbackFramework : NuGetFramework, IEquatable<FallbackFramework>
@@ -10,10 +16,10 @@ namespace NuGet.Frameworks
         /// <summary>
         /// List framework to fall back to.
         /// </summary>
-        public IReadOnlyList<NuGetFramework> Fallback { get; }
+        public FallbackList Fallback { get; }
         private int? _hashCode;
 
-        public FallbackFramework(NuGetFramework framework, IReadOnlyList<NuGetFramework> fallbackFrameworks)
+        public FallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
             : base(framework)
         {
             if (framework == null)

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -19,12 +19,15 @@
   "compile": [
     "../NuGet.Shared/*.cs"
   ],
-  "dependencies": {
-    "NuGet.Versioning": {
-      "target": "project"
-    }
-  },
   "frameworks": {
+    "net40-client": {
+      "compilationOptions": {
+        "define": [
+          "IS_DESKTOP",
+          "IS_NET40_CLIENT"
+        ]
+      }
+    },
     "net45": {
       "compilationOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "NuGet.Frameworks": {
       "target": "project"
+    },
+    "NuGet.Versioning": {
+      "target": "project"
     }
   },
   "compilationOptions": {

--- a/src/NuGet.Core/NuGet.Shared/TypeExtensions.cs
+++ b/src/NuGet.Core/NuGet.Shared/TypeExtensions.cs
@@ -1,0 +1,23 @@
+#if IS_NET40_CLIENT
+using NuGet.Shared;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods for the <see cref="Type"/> type.
+    /// </summary>
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Expose the type itself as the type info. This is to make TypeInfo available on
+        /// .NET Framework 4 Client Profile. This method is used in the automatically generated
+        /// resource C# files. To avoid manual changes to an automatically generated file, expose
+        /// this method as an extension method in an used namespace.
+        /// </summary>
+        public static TypeInfo GetTypeInfo(this Type type)
+        {
+            return new TypeInfo(type);
+        }
+    }
+}
+#endif

--- a/src/NuGet.Core/NuGet.Shared/TypeInfo.cs
+++ b/src/NuGet.Core/NuGet.Shared/TypeInfo.cs
@@ -1,0 +1,25 @@
+#if IS_NET40_CLIENT
+using System;
+using System.Reflection;
+
+namespace NuGet.Shared
+{
+    /// <summary>
+    /// A minimal implementation of TypeInfo for net40-client.
+    /// </summary>
+    internal class TypeInfo
+    {
+        private readonly Type _type;
+
+        public TypeInfo(Type type)
+        {
+            _type = type;
+        }
+
+        public Assembly Assembly
+        {
+            get { return _type.Assembly; }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
This is to support using NuGet 3.x inside of NuGet 2.x (NuGet.Core.dll), which targets `net40-client`.

@emgarten @yishaigalatzer @alpaix @rrelyea 
