### PR TITLE
Adding Serializable to ActivityCorrelationContext

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
+++ b/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
@@ -16,6 +16,9 @@ namespace NuGet.Common
     /// Single activity engages multiple method calls at different layers.
     /// Sometimes it's necessary to identify separate calls belonging to the same activity if shared state is needed.
     /// </summary>
+#if !IS_CORECLR
+    [Serializable]
+#endif
     public class ActivityCorrelationContext : IDisposable
     {
 #if IS_CORECLR


### PR DESCRIPTION
Functional tests are failing with a message saying that it cannot serialize ActivityCorrelationContext. Adding the attribute fixes this, it's not clear why this is needed and if this affects product scenarios.

//cc @alpaix @zhili1208 
