### PR TITLE
Fixed confusion in error message for package id with version

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -216,7 +216,7 @@ namespace NuGet.PackageManagement
                         {
                             if (string.Equals(targetId, pid.Id, StringComparison.OrdinalIgnoreCase))
                             {
-                                packageIdentity = String.Concat(targetId, ",", pid.Version);
+                                packageIdentity = string.Format(CultureInfo.CurrentCulture, "{0} {1}", targetId, pid.Version);
                                 break;
                             }
                         }


### PR DESCRIPTION
Current error message is confusing for package id with version so adding a space instead of comma to join package id with version.

Fix https://github.com/NuGet/Home/issues/2771

@rrelyea @yishaigalatzer @alpaix 
