### PR TITLE
Support ./NuGet.CommandLine.XPlat -v <verbosity> <mode>

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/RestoreCommand.cs
@@ -81,8 +81,10 @@ namespace NuGet.CommandLine.XPlat
                 restore.OnExecute(async () =>
                 {
                     var log = getLogger();
-                    var logLevel = XPlatUtility.GetLogLevel(verbosity);
-                    log.SetLogLevel(logLevel);
+                    if (verbosity.HasValue())
+                    {
+                        log.LogLevel = XPlatUtility.GetLogLevel(verbosity);
+                    }
 
                     using (var cacheContext = new SourceCacheContext())
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/CommandOutputLogger.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Text;
-using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Common;
 
 namespace NuGet.CommandLine.XPlat
@@ -22,9 +21,10 @@ namespace NuGet.CommandLine.XPlat
             _logLevel = logLevel;
         }
 
-        public void SetLogLevel(LogLevel logLevel)
+        public LogLevel LogLevel
         {
-            _logLevel = logLevel;
+            get { return _logLevel; }
+            set { _logLevel = value; }
         }
 
         public void LogDebug(string data)

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -10,6 +10,7 @@ namespace NuGet.Test.Utility
         /// </summary>
         public ConcurrentQueue<string> Messages { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> DebugMessages { get; } = new ConcurrentQueue<string>();
+        public ConcurrentQueue<string> VerboseMessages { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> MinimalMessages { get; } = new ConcurrentQueue<string>();
         public ConcurrentQueue<string> ErrorMessages { get; } = new ConcurrentQueue<string>();
 
@@ -48,6 +49,7 @@ namespace NuGet.Test.Utility
         public void LogVerbose(string data)
         {
             Messages.Enqueue(data);
+            VerboseMessages.Enqueue(data);
             DumpMessage("TRACE", data);
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
@@ -6,13 +6,101 @@ namespace NuGet.XPlat.FuncTest
     public class BasicLoggingTests
     {
         [Fact]
-        public void BasicLogging_VerifyExceptionLogged()
+        public void BasicLogging_VersionHeading()
         {
             // Arrange
-            var log = new TestCommandOutputLogger();
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
 
             var args = new string[]
             {
+                "--verbosity",
+                "verbose"
+            };
+
+            // Act
+            var exitCode = Program.MainInternal(args, log);
+
+            // Assert
+            Assert.Equal(0, exitCode);
+            Assert.Equal(1, log.VerboseMessages.Count);
+            Assert.Equal(1, log.Messages.Count);
+            Assert.Contains("NuGet Command Line Version:", log.ShowMessages());
+        }
+
+        [Fact]
+        public void BasicLogging_RestoreVerbosityCanBeMoreVerboseThanGlobal()
+        {
+            // Arrange
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
+
+            var args = new string[]
+            {
+                "--verbosity", "error", // Set the verbosity at a global level.
+                "restore",
+                "--configfile", "MyNuGet.config", // Cause a failure since we don't want a real restore to happen.
+                "--disable-parallel", // Generate a verbose level log.
+                "--verbosity", "verbose" // Set the verbosity at the command level.
+            };
+
+            // Act
+            Program.MainInternal(args, log);
+
+            // Assert
+            Assert.Contains("Running non-parallel restore.", log.ShowMessages());
+        }
+
+        [Fact]
+        public void BasicLogging_RestoreVerbosityCanBeLessVerboseThanGlobal()
+        {
+            // Arrange
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
+
+            var args = new string[]
+            {
+                "--verbosity", "verbose", // Set the verbosity at a global level.
+                "restore",
+                "--configfile", "MyNuGet.config", // Cause a failure since we don't want a real restore to happen.
+                "--disable-parallel", // Generate a verbose level log.
+                "--verbosity", "error" // Set the verbosity at the command level.
+            };
+
+            // Act
+            Program.MainInternal(args, log);
+
+            // Assert
+            Assert.DoesNotContain("Running non-parallel restore.", log.ShowMessages());
+        }
+
+        [Fact]
+        public void BasicLogging_RestoreVerbosityDefaultsToGlobalVerbosity()
+        {
+            // Arrange
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
+
+            var args = new string[]
+            {
+                "--verbosity", "verbose", // Set the verbosity at a global level.
+                "restore",
+                "--configfile", "MyNuGet.config", // Cause a failure since we don't want a real restore to happen.
+                "--disable-parallel", // Generate a verbose level log.
+            };
+
+            // Act
+            Program.MainInternal(args, log);
+
+            // Assert
+            Assert.Contains("Running non-parallel restore.", log.ShowMessages());
+        }
+
+        [Fact]
+        public void BasicLogging_VerifyExceptionLoggedWhenVerbose()
+        {
+            // Arrange
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
+
+            var args = new string[]
+            {
+                "--verbosity", "verbose",
                 "--unknown",
             };
 
@@ -26,6 +114,30 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(0, log.Warnings);
             Assert.Contains("--unknown", log.ShowErrors());  // error
             Assert.Contains("NuGet.CommandLine.XPlat.Program.", log.ShowMessages()); // verbose stack trace
+        }
+
+        [Fact]
+        public void BasicLogging_VerifyExceptionNotLoggedLessThanVerbose()
+        {
+            // Arrange
+            var log = new TestCommandOutputLogger(observeLogLevel: true);
+
+            var args = new string[]
+            {
+                "--verbosity", "info",
+                "--unknown",
+            };
+
+            // Act
+            var exitCode = Program.MainInternal(args, log);
+
+            // Assert
+            Assert.Equal(1, exitCode);
+            Assert.Equal(1, log.Messages.Count);
+            Assert.Equal(1, log.Errors);
+            Assert.Equal(0, log.Warnings);
+            Assert.Contains("--unknown", log.ShowErrors());  // error
+            Assert.DoesNotContain("NuGet.CommandLine.XPlat.Program.", log.ShowMessages()); // verbose stack trace
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/TestCommandOutputLogger.cs
@@ -8,15 +8,23 @@ namespace NuGet.XPlat.FuncTest
 {
     public class TestCommandOutputLogger : CommandOutputLogger
     {
+        private readonly bool _observeLogLevel;
+
         public TestLogger Logger { get; set; } = new TestLogger();
 
-        public TestCommandOutputLogger()
+        public TestCommandOutputLogger(bool observeLogLevel = false)
             : base(LogLevel.Debug)
         {
+            _observeLogLevel = observeLogLevel;
         }
 
         protected override void LogInternal(LogLevel logLevel, string message)
         {
+            if (_observeLogLevel && logLevel < LogLevel)
+            {
+                return;
+            }
+
             switch (logLevel)
             {
                 case LogLevel.Debug:
@@ -56,6 +64,14 @@ namespace NuGet.XPlat.FuncTest
             get
             {
                 return Logger.ErrorMessages;
+            }
+        }
+
+        public ConcurrentQueue<string> VerboseMessages
+        {
+            get
+            {
+                return Logger.VerboseMessages;
             }
         }
 


### PR DESCRIPTION
There was a regression. This used to be supported:

```
NuGet.CommandLine.XPlat --verbosity Error restore
```

Right now, the code is rejecting this with:

```
Specify --help for a list of available options and commands.
error: Unexpected value 'Error' for option 'verbosity'`
```

This regression is blocking https://github.com/dotnet/cli/pull/3004.

@emgarten @rrelyea @TimBarham @sridhar-ms
