### PR TITLE
Make NuGet.Frameworks conditionally internal and C# 5 compatible

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityCacheKey.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityCacheKey.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace NuGet.Frameworks
 {
@@ -7,25 +8,34 @@ namespace NuGet.Frameworks
     /// </summary>
     internal class CompatibilityCacheKey : IEquatable<CompatibilityCacheKey>
     {
-        public NuGetFramework Target { get; }
-        public NuGetFramework Candidate { get; }
+        public NuGetFramework Target
+        {
+            get { return _target; }
+        }
 
+        public NuGetFramework Candidate
+        {
+            get { return _candidate; }
+        }
+
+        private readonly NuGetFramework _target;
+        private readonly NuGetFramework _candidate;
         private readonly int _hashCode;
 
         public CompatibilityCacheKey(NuGetFramework target, NuGetFramework candidate)
         {
             if (target == null)
             {
-                throw new ArgumentNullException(nameof(target));
+                throw new ArgumentNullException("target");
             }
 
             if (candidate == null)
             {
-                throw new ArgumentNullException(nameof(candidate));
+                throw new ArgumentNullException("candidate");
             }
 
-            Target = target;
-            Candidate = candidate;
+            _target = target;
+            _candidate = candidate;
 
             // This is designed to be cached, just get the hash up front
             var combiner = new HashCodeCombiner();
@@ -62,7 +72,11 @@ namespace NuGet.Frameworks
 
         public override string ToString()
         {
-            return $"{Target.DotNetFrameworkName} -> {Candidate.DotNetFrameworkName}";
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{0} -> {1}",
+                Target.DotNetFrameworkName,
+                Candidate.DotNetFrameworkName);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityListProvider.cs
@@ -7,7 +7,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public sealed class CompatibilityListProvider : IFrameworkCompatibilityListProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class CompatibilityListProvider : IFrameworkCompatibilityListProvider
     {
         private readonly IFrameworkNameProvider _nameProvider;
         private readonly IFrameworkCompatibilityProvider _compatibilityProvider;

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityProvider.cs
@@ -9,7 +9,12 @@ using HashCombiner = NuGet.Frameworks.HashCodeCombiner;
 
 namespace NuGet.Frameworks
 {
-    public class CompatibilityProvider : IFrameworkCompatibilityProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class CompatibilityProvider : IFrameworkCompatibilityProvider
     {
         private readonly IFrameworkNameProvider _mappings;
         private readonly FrameworkExpander _expander;
@@ -33,12 +38,12 @@ namespace NuGet.Frameworks
         {
             if (target == null)
             {
-                throw new ArgumentNullException(nameof(target));
+                throw new ArgumentNullException("target");
             }
 
             if (candidate == null)
             {
-                throw new ArgumentNullException(nameof(candidate));
+                throw new ArgumentNullException("candidate");
             }
 
             // check the cache for a solution

--- a/src/NuGet.Core/NuGet.Frameworks/CompatibilityTable.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/CompatibilityTable.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// Creates a table of compatible frameworks.
     /// </summary>
-    public class CompatibilityTable
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class CompatibilityTable
     {
         private readonly IFrameworkNameProvider _mappings;
         private readonly IFrameworkCompatibilityProvider _compat;

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultCompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultCompatibilityProvider.cs
@@ -3,7 +3,12 @@
 
 namespace NuGet.Frameworks
 {
-    public sealed class DefaultCompatibilityProvider : CompatibilityProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class DefaultCompatibilityProvider : CompatibilityProvider
     {
         public DefaultCompatibilityProvider()
             : base(DefaultFrameworkNameProvider.Instance)

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -7,7 +7,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public sealed class DefaultFrameworkMappings : IFrameworkMappings
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class DefaultFrameworkMappings : IFrameworkMappings
     {
         private static KeyValuePair<string, string>[] _identifierSynonyms;
 

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkNameProvider.cs
@@ -3,7 +3,12 @@
 
 namespace NuGet.Frameworks
 {
-    public sealed class DefaultFrameworkNameProvider : FrameworkNameProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    sealed class DefaultFrameworkNameProvider : FrameworkNameProvider
     {
         public DefaultFrameworkNameProvider()
             : base(new IFrameworkMappings[] { DefaultFrameworkMappings.Instance },

--- a/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// Contains the standard portable framework mappings
     /// </summary>
-    public class DefaultPortableFrameworkMappings : IPortableFrameworkMappings
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class DefaultPortableFrameworkMappings : IPortableFrameworkMappings
     {
 
         private KeyValuePair<int, NuGetFramework[]>[] _profileFrameworks;

--- a/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FallbackFramework.cs
@@ -11,12 +11,22 @@ using FallbackList = System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.N
 
 namespace NuGet.Frameworks
 {
-    public class FallbackFramework : NuGetFramework, IEquatable<FallbackFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FallbackFramework : NuGetFramework, IEquatable<FallbackFramework>
     {
         /// <summary>
         /// List framework to fall back to.
         /// </summary>
-        public FallbackList Fallback { get; }
+        public FallbackList Fallback
+        {
+            get { return _fallback; }
+        }
+
+        private readonly FallbackList _fallback;
         private int? _hashCode;
 
         public FallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
@@ -24,20 +34,20 @@ namespace NuGet.Frameworks
         {
             if (framework == null)
             {
-                throw new ArgumentNullException(nameof(framework));
+                throw new ArgumentNullException("framework");
             }
 
             if (fallbackFrameworks == null)
             {
-                throw new ArgumentNullException(nameof(fallbackFrameworks));
+                throw new ArgumentNullException("fallbackFrameworks");
             }
 
             if (fallbackFrameworks.Count == 0)
             {
-                throw new ArgumentException("Empty fallbackFrameworks is invalid", nameof(fallbackFrameworks));
+                throw new ArgumentException("Empty fallbackFrameworks is invalid", "fallbackFrameworks");
             }
 
-            Fallback = fallbackFrameworks;
+            _fallback = fallbackFrameworks;
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -5,7 +5,12 @@ using System;
 
 namespace NuGet.Frameworks
 {
-    public static class FrameworkConstants
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class FrameworkConstants
     {
         public static readonly Version EmptyVersion = new Version(0, 0, 0, 0);
         public static readonly Version MaxVersion = new Version(Int32.MaxValue, 0, 0, 0);

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkException.cs
@@ -5,7 +5,12 @@ using System;
 
 namespace NuGet.Frameworks
 {
-    public class FrameworkException : Exception
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkException : Exception
     {
         public FrameworkException(string message)
             : base(message)

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkExpander.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// FrameworkExpander finds all equivalent and compatible frameworks for a NuGetFramework
     /// </summary>
-    public class FrameworkExpander
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkExpander
     {
         private readonly IFrameworkNameProvider _mappings;
 

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkExtensions.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkExtensions.cs
@@ -6,7 +6,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public static class NuGetFrameworkExtensions
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class NuGetFrameworkExtensions
     {
         /// <summary>
         /// True if the Framework is .NETFramework

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameHelpers.cs
@@ -7,7 +7,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public static class FrameworkNameHelpers
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class FrameworkNameHelpers
     {
         public static string GetPortableProfileNumberString(int profileNumber)
         {

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -8,7 +8,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public class FrameworkNameProvider : IFrameworkNameProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkNameProvider : IFrameworkNameProvider
     {
         /// <summary>
         /// Contains identifier -> identifier
@@ -237,7 +242,7 @@ namespace NuGet.Frameworks
         {
             if (supportedFrameworks == null)
             {
-                throw new ArgumentNullException(nameof(supportedFrameworks));
+                throw new ArgumentNullException("supportedFrameworks");
             }
 
             profileNumber = -1;
@@ -435,7 +440,7 @@ namespace NuGet.Frameworks
         {
             if (shortPortableProfiles == null)
             {
-                throw new ArgumentNullException(nameof(shortPortableProfiles));
+                throw new ArgumentNullException("shortPortableProfiles");
             }
 
             var shortNames = shortPortableProfiles.Split(new char[] { '+' }, StringSplitOptions.RemoveEmptyEntries);
@@ -548,7 +553,7 @@ namespace NuGet.Frameworks
         {
             if (range == null)
             {
-                throw new ArgumentNullException(nameof(range));
+                throw new ArgumentNullException("range");
             }
 
             var relevant = new HashSet<NuGetFramework>();

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRange.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRange.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// An inclusive range of frameworks
     /// </summary>
-    public class FrameworkRange : IEquatable<FrameworkRange>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkRange : IEquatable<FrameworkRange>
     {
         private readonly NuGetFramework _minFramework;
         private readonly NuGetFramework _maxFramework;
@@ -26,12 +31,12 @@ namespace NuGet.Frameworks
         {
             if (min == null)
             {
-                throw new ArgumentNullException(nameof(min));
+                throw new ArgumentNullException("min");
             }
 
             if (max == null)
             {
-                throw new ArgumentNullException(nameof(max));
+                throw new ArgumentNullException("max");
             }
 
             if (!SameExceptForVersion(min, max))

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkReducer.cs
@@ -11,7 +11,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// Reduces a list of frameworks into the smallest set of frameworks required.
     /// </summary>
-    public class FrameworkReducer
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkReducer
     {
         private readonly IFrameworkNameProvider _mappings;
         private readonly IFrameworkCompatibilityProvider _compat;

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkRuntimePair.cs
@@ -1,18 +1,39 @@
 ﻿using System;
+using System.Globalization;
 
 namespace NuGet.Frameworks
 {
-    public class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkRuntimePair : IEquatable<FrameworkRuntimePair>, IComparable<FrameworkRuntimePair>
     {
-        public NuGetFramework Framework { get; }
-        public string RuntimeIdentifier { get; }
-        public string Name { get; }
+        public NuGetFramework Framework
+        {
+            get { return _framework; }
+        }
+
+        public string RuntimeIdentifier
+        {
+            get { return _runtimeIdentifier; }
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        private readonly NuGetFramework _framework;
+        private readonly string _runtimeIdentifier;
+        private readonly string _name;
 
         public FrameworkRuntimePair(NuGetFramework framework, string runtimeIdentifier)
         {
-            Framework = framework;
-            RuntimeIdentifier = runtimeIdentifier ?? string.Empty;
-            Name = GetName(framework, runtimeIdentifier);
+            _framework = framework;
+            _runtimeIdentifier = runtimeIdentifier ?? string.Empty;
+            _name = GetName(framework, runtimeIdentifier);
         }
 
         public bool Equals(FrameworkRuntimePair other)
@@ -34,7 +55,11 @@ namespace NuGet.Frameworks
 
         public override string ToString()
         {
-            return $"{Framework.GetShortFolderName()}~{RuntimeIdentifier}";
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{0}~{1}",
+                Framework.GetShortFolderName(),
+                RuntimeIdentifier);
         }
 
         public int CompareTo(FrameworkRuntimePair other)
@@ -55,7 +80,11 @@ namespace NuGet.Frameworks
             }
             else
             {
-                return $"{framework} ({runtimeIdentifier})";
+                return string.Format(
+                    CultureInfo.CurrentCulture,
+                    "{0} ({1})",
+                    framework,
+                    runtimeIdentifier);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkSpecificMapping.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkSpecificMapping.cs
@@ -8,7 +8,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// A keyvalue pair specific to a framework identifier
     /// </summary>
-    public class FrameworkSpecificMapping
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkSpecificMapping
     {
         private readonly string _frameworkIdentifier;
         private readonly KeyValuePair<string, string> _mapping;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -12,7 +12,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// A portable implementation of the .NET FrameworkName type with added support for NuGet folder names.
     /// </summary>
-    public partial class NuGetFramework : IEquatable<NuGetFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    partial class NuGetFramework : IEquatable<NuGetFramework>
     {
         private readonly string _frameworkIdentifier;
         private readonly Version _frameworkVersion;
@@ -39,12 +44,12 @@ namespace NuGet.Frameworks
         {
             if (frameworkIdentifier == null)
             {
-                throw new ArgumentNullException(nameof(frameworkIdentifier));
+                throw new ArgumentNullException("frameworkIdentifier");
             }
 
             if (frameworkVersion == null)
             {
-                throw new ArgumentNullException(nameof(frameworkVersion));
+                throw new ArgumentNullException("frameworkVersion");
             }
 
             _frameworkIdentifier = frameworkIdentifier;

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -9,7 +9,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public partial class NuGetFramework
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    partial class NuGetFramework
     {
         /// <summary>
         /// An unknown or invalid framework
@@ -41,12 +46,12 @@ namespace NuGet.Frameworks
         {
             if (folderName == null)
             {
-                throw new ArgumentNullException(nameof(folderName));
+                throw new ArgumentNullException("folderName");
             }
 
             if (mappings == null)
             {
-                throw new ArgumentNullException(nameof(mappings));
+                throw new ArgumentNullException("mappings");
             }
 
             Debug.Assert(folderName.IndexOf(";") < 0, "invalid folder name, this appears to contain multiple frameworks");
@@ -72,12 +77,12 @@ namespace NuGet.Frameworks
         {
             if (frameworkName == null)
             {
-                throw new ArgumentNullException(nameof(frameworkName));
+                throw new ArgumentNullException("frameworkName");
             }
 
             if (mappings == null)
             {
-                throw new ArgumentNullException(nameof(mappings));
+                throw new ArgumentNullException("mappings");
             }
 
             var parts = frameworkName.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToArray();
@@ -152,12 +157,12 @@ namespace NuGet.Frameworks
         {
             if (folderName == null)
             {
-                throw new ArgumentNullException(nameof(folderName));
+                throw new ArgumentNullException("folderName");
             }
 
             if (mappings == null)
             {
-                throw new ArgumentNullException(nameof(mappings));
+                throw new ArgumentNullException("mappings");
             }
 
             if (folderName.IndexOf('%') > -1)

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkUtility.cs
@@ -7,7 +7,12 @@ using System.Linq;
 
 namespace NuGet.Frameworks
 {
-    public static class NuGetFrameworkUtility
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class NuGetFrameworkUtility
     {
         /// <summary>
         /// Find the most compatible group based on target framework
@@ -35,17 +40,17 @@ namespace NuGet.Frameworks
         {
             if (framework == null)
             {
-                throw new ArgumentNullException(nameof(framework));
+                throw new ArgumentNullException("framework");
             }
 
             if (frameworkMappings == null)
             {
-                throw new ArgumentNullException(nameof(frameworkMappings));
+                throw new ArgumentNullException("frameworkMappings");
             }
 
             if (compatibilityProvider == null)
             {
-                throw new ArgumentNullException(nameof(compatibilityProvider));
+                throw new ArgumentNullException("compatibilityProvider");
             }
 
             if (items != null)
@@ -84,17 +89,17 @@ namespace NuGet.Frameworks
         {
             if (framework == null)
             {
-                throw new ArgumentNullException(nameof(framework));
+                throw new ArgumentNullException("framework");
             }
 
             if (frameworkMappings == null)
             {
-                throw new ArgumentNullException(nameof(frameworkMappings));
+                throw new ArgumentNullException("frameworkMappings");
             }
 
             if (compatibilityProvider == null)
             {
-                throw new ArgumentNullException(nameof(compatibilityProvider));
+                throw new ArgumentNullException("compatibilityProvider");
             }
 
             if (items != null)

--- a/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/OneWayCompatibilityMappingEntry.cs
@@ -6,7 +6,12 @@ using System.Globalization;
 
 namespace NuGet.Frameworks
 {
-    public class OneWayCompatibilityMappingEntry : IEquatable<OneWayCompatibilityMappingEntry>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class OneWayCompatibilityMappingEntry : IEquatable<OneWayCompatibilityMappingEntry>
     {
         private readonly FrameworkRange _targetFramework;
         private readonly FrameworkRange _supportedFramework;

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/CompatibilityMappingComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/CompatibilityMappingComparer.cs
@@ -5,7 +5,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public class CompatibilityMappingComparer : IEqualityComparer<OneWayCompatibilityMappingEntry>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class CompatibilityMappingComparer : IEqualityComparer<OneWayCompatibilityMappingEntry>
     {
         public bool Equals(OneWayCompatibilityMappingEntry x, OneWayCompatibilityMappingEntry y)
         {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkPrecedenceSorter.cs
@@ -8,7 +8,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// Sorts frameworks according to the framework mappings
     /// </summary>
-    public class FrameworkPrecedenceSorter : IComparer<NuGetFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkPrecedenceSorter : IComparer<NuGetFramework>
     {
         private readonly IFrameworkNameProvider _mappings;
         private readonly bool _allEquivalent;

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/FrameworkRangeComparer.cs
@@ -6,7 +6,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public class FrameworkRangeComparer : IEqualityComparer<FrameworkRange>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class FrameworkRangeComparer : IEqualityComparer<FrameworkRange>
     {
         public FrameworkRangeComparer()
         {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkFullComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkFullComparer.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// A case insensitive compare of the framework, version, and profile
     /// </summary>
-    public class NuGetFrameworkFullComparer : IEqualityComparer<NuGetFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class NuGetFrameworkFullComparer : IEqualityComparer<NuGetFramework>
     {
         public bool Equals(NuGetFramework x, NuGetFramework y)
         {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkNameComparer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkNameComparer.cs
@@ -9,7 +9,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// A case insensitive compare of the framework name only
     /// </summary>
-    public class NuGetFrameworkNameComparer : IEqualityComparer<NuGetFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class NuGetFrameworkNameComparer : IEqualityComparer<NuGetFramework>
     {
         public bool Equals(NuGetFramework x, NuGetFramework y)
         {

--- a/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/comparers/NuGetFrameworkSorter.cs
@@ -11,7 +11,12 @@ namespace NuGet.Frameworks
     /// The order is not particularly useful here beyond making things deterministic
     /// since it compares completely different frameworks.
     /// </summary>
-    public class NuGetFrameworkSorter : IComparer<NuGetFramework>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class NuGetFrameworkSorter : IComparer<NuGetFramework>
     {
         public NuGetFrameworkSorter()
         {

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityListProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityListProvider.cs
@@ -5,7 +5,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public interface IFrameworkCompatibilityListProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkCompatibilityListProvider
     {
         /// <summary>
         /// Get a list of frameworks supporting the provided framework. This list

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkCompatibilityProvider.cs
@@ -3,7 +3,12 @@
 
 namespace NuGet.Frameworks
 {
-    public interface IFrameworkCompatibilityProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkCompatibilityProvider
     {
         /// <summary>
         /// Ex: IsCompatible(net45, net40) -> true

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkMappings.cs
@@ -11,7 +11,12 @@ namespace NuGet.Frameworks
     /// mirrored so that the IFrameworkMappings implementation only needs to provide the minimum amount of
     /// mappings.
     /// </summary>
-    public interface IFrameworkMappings
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkMappings
     {
         /// <summary>
         /// Synonym &#8210;&gt; Identifier

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkNameProvider.cs
@@ -6,7 +6,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public interface IFrameworkNameProvider
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkNameProvider
     {
         /// <summary>
         /// Returns the official framework identifier for an alias or short name.

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkSpecific.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkSpecific.cs
@@ -6,7 +6,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// A group or object that is specific to a single target framework
     /// </summary>
-    public interface IFrameworkSpecific
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkSpecific
     {
         /// <summary>
         /// Target framework

--- a/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkTargetable.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IFrameworkTargetable.cs
@@ -8,7 +8,12 @@ namespace NuGet.Frameworks
     /// <summary>
     /// Use this to expose the list of target frameworks an object can be used for.
     /// </summary>
-    public interface IFrameworkTargetable
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IFrameworkTargetable
     {
         /// <summary>
         /// All frameworks supported by the parent

--- a/src/NuGet.Core/NuGet.Frameworks/def/IPortableFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/def/IPortableFrameworkMappings.cs
@@ -5,7 +5,12 @@ using System.Collections.Generic;
 
 namespace NuGet.Frameworks
 {
-    public interface IPortableFrameworkMappings
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    interface IPortableFrameworkMappings
     {
         /// <summary>
         /// Ex: 5 -> net4, win8

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -14,7 +14,8 @@
       "CS1591",
       "CS1574",
       "CS1573"
-    ]
+    ],
+    "languageVersion": "csharp5"
   },
   "compile": [
     "../NuGet.Shared/*.cs"

--- a/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
+++ b/src/NuGet.Core/NuGet.Shared/SharedExtensions.cs
@@ -22,8 +22,8 @@ namespace NuGet.Shared
         /// <param name="sequenceComparer">An optional comparer for sequences</param>
         internal static bool OrderedEquals<TSource, TKey>(this IEnumerable<TSource> self, IEnumerable<TSource> other, Func<TSource, TKey> keySelector, IComparer<TKey> orderComparer = null, IEqualityComparer<TSource> sequenceComparer = null)
         {
-            Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + nameof(orderComparer) + " must be provided if " + nameof(TKey) + " is a string.");
-            Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + nameof(sequenceComparer) + " must be provided if " + nameof(TSource) + " is a string.");
+            Debug.Assert(orderComparer != null || typeof(TKey) != typeof(string), "Argument " + "orderComparer" + " must be provided if " + "TKey" + " is a string.");
+            Debug.Assert(sequenceComparer != null || typeof(TSource) != typeof(string), "Argument " + "sequenceComparer" + " must be provided if " + "TSource" + " is a string.");
 
             if (ReferenceEquals(self, other))
             {

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -3,6 +3,9 @@
   "copyright": "Copyright .NET Foundation. All rights reserved.",
   "projectUrl": "https://github.com/NuGet/NuGet.Client",
   "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "compilationOptions": {
+    "languageVersion": "csharp5"
+  },
   "shared": "*.cs",
   "frameworks": {
     "net45": {


### PR DESCRIPTION
To support using NuGet.Frameworks in NuGet 2.x code, do the following:
- Make all of the code in NuGet.Frameworks and NuGet.Shared C# 5 compatible.
  - Can't use `nameof`.
  - Must have a setter on properties.
  - Can't use string interpolation
- Make NuGet.Frameworks types optionally `internal` instead of `public`. This can be achieved with a preprocessor directive.

The net result is the ability to bake NuGet.Frameworks into NuGet.Core as internal code, meaning we don't have to go down the road of crazy dependencies or ILMerge. Symbol package still works and user's API surface area does not change.

@emgarten @yishaigalatzer @rrelyea 
