### PR TITLE
Package files with future times will not have their times used

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -64,7 +64,10 @@ namespace NuGet.Packaging
         public static void UpdateFileTimeFromEntry(this ZipArchiveEntry entry, string fileFullPath, ILogger logger)
         {
             var attr = File.GetAttributes(fileFullPath);
-            if (!attr.HasFlag(FileAttributes.Directory) && entry.LastWriteTime.DateTime != DateTime.MinValue)
+
+            if (!attr.HasFlag(FileAttributes.Directory) &&
+                entry.LastWriteTime.DateTime != DateTime.MinValue && // Ignore invalid times
+                entry.LastWriteTime.UtcDateTime <= DateTime.UtcNow) // Ignore future times
             {
                 try
                 {


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2794

If the zip package contains a file with a modified time in the future, we won't update the modified time of the unzipped file on disk. It'll continue to have the default modified time of DateTime.Now.

@alpaix @rrelyea @emgarten @toddm 
