### PR TITLE
Use the push timeout as the HTTP response timeout

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// A request to be handled by <see cref="HttpRetryHandler"/>. This type should contain all
+    /// of the knowledge necessary to make a request, while handling transient transport errors.
+    /// </summary>
+    public class HttpRetryHandlerRequest
+    {
+        public HttpRetryHandlerRequest(HttpClient httpClient, Func<HttpRequestMessage> requestFactory)
+        {
+            HttpClient = httpClient;
+            RequestFactory = requestFactory;
+            CompletionOption = HttpCompletionOption.ResponseHeadersRead;
+            MaxTries = 3;
+            RequestTimeout = TimeSpan.FromSeconds(100);
+            RetryDelay = TimeSpan.FromMilliseconds(200);
+        }
+
+        /// <summary>The HTTP client to use for each request attempt.</summary>
+        public HttpClient HttpClient { get; }
+
+        /// <summary>
+        /// The factory that generates each request message. This factory is invoked for each attempt.
+        /// </summary>
+        public Func<HttpRequestMessage> RequestFactory { get; }
+
+        /// <summary>The HTTP completion option to use for the next attempt.</summary>
+        public HttpCompletionOption CompletionOption { get; set; }
+
+        /// <summary>The maximum number of times to try the request. This value includes the initial attempt.</summary>
+        /// <remarks>This API is intended only for testing purposes and should not be used in product code.</remarks>
+        public int MaxTries { get; set; }
+
+        /// <summary>How long to wait on the request to come back with a response.</summary>
+        public TimeSpan RequestTimeout { get; set; }
+
+        /// <summary>How long to wait before trying again after a failed request.</summary>
+        /// <summary>This API is intended only for testing purposes and should not be used in product code.</summary>
+        public TimeSpan RetryDelay { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IHttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IHttpRetryHandler.cs
@@ -9,9 +9,7 @@ namespace NuGet.Protocol
     public interface IHttpRetryHandler
     {
         Task<HttpResponseMessage> SendAsync(
-            HttpClient client,
-            Func<HttpRequestMessage> requestFactory,
-            HttpCompletionOption completionOption,
+            HttpRetryHandlerRequest request,
             ILogger log,
             CancellationToken cancellationToken);
     }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2785.

The problem here is that the HTTP response timeout is less than the push timeout. I made a change so that the HTTP response timeout on push (the PUT request) is the same as the push timeout.

Up until now, the HTTP response timeout was hard-coded to 100 seconds. To facilitate this change, I had to make this response timeout parameterized. I introduced a new type `HttpRetryHandlerRequest` which has a `ResponseTimeout` property.

/cc @spadapet @toddm @emgarten @rrelyea 

I created a test server that sleeps for 110 seconds before processing the pushed package. Note the response duration is higher than the previously hardcoded response timeout.

<pre>
PS > .\nuget.exe push mypackage.1.0.0.nupkg -s http://localhost:5961/nuget foo -Timeout 120
Pushing mypackage.1.0.0.nupkg to 'http://localhost:5961/nuget'...
  PUT http://localhost:5961/nuget/
  Created http://localhost:5961/nuget/ <b>110250ms</b>
Your package was pushed.
</pre>
