### PR TITLE
Read package type from input .nuspec and project.json when packing

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -399,6 +400,8 @@ namespace NuGet.Commands
                     AddDependencyGroups(spec.Dependencies, NuGetFramework.AnyFramework, builder);
                 }
             }
+
+            builder.PackageTypes = new Collection<PackageType>(spec.PackOptions?.PackageType?.ToList() ?? new List<PackageType>());
         }
 
         private static void AddDependencyGroups(IEnumerable<LibraryDependency> dependencies, NuGetFramework framework, PackageBuilder builder)

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuspecUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuspecUtility.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NuGet.Packaging.Core
+{
+    /// <summary>
+    /// Until NuspecReader and Manifest are unified, this is a place to share implementations of
+    /// reading and parsing specific elements out of the .nuspec XML.
+    /// </summary>
+    public static class NuspecUtility
+    {
+        public static readonly string PackageTypes = "packageTypes";
+        public static readonly string PackageType = "packageType";
+        public static readonly string PackageTypeName = "name";
+        public static readonly string PackageTypeVersion = "version";
+
+        /// <summary>
+        /// Gets the package types from a .nuspec metadata XML element.
+        /// </summary>
+        /// <param name="metadataNode">The metadata XML element.</param>
+        /// <param name="useMetadataNamespace">
+        /// Whether or not to use the metadata element's namespace when finding the package type
+        /// nodes. If false is specified, only the local names of the package type nodes are used
+        /// for comparison. If true is specified, the package type nodes must have the same
+        /// namespace as the metadata node.
+        /// </param>
+        /// <returns>
+        /// A list of package types. If no package types are found in the metadata node, an empty
+        /// list is returned.
+        /// </returns>
+        public static IReadOnlyList<PackageType> GetPackageTypes(XElement metadataNode, bool useMetadataNamespace)
+        {
+            IEnumerable<XElement> nodes;
+            if (useMetadataNamespace)
+            {
+                var metadataNamespace = metadataNode.GetDefaultNamespace().NamespaceName;
+                nodes = metadataNode
+                    .Elements(XName.Get(PackageTypes, metadataNamespace))
+                    .SelectMany(x => x.Elements(XName.Get(PackageType, metadataNamespace)));
+            }
+            else
+            {
+                nodes = metadataNode
+                    .Elements()
+                    .Where(x => x.Name.LocalName == PackageTypes)
+                    .SelectMany(x => x.Elements())
+                    .Where(x => x.Name.LocalName == PackageType);
+            }
+
+            var packageTypes = new List<PackageType>();
+            foreach (var node in nodes)
+            {
+                // Get the required package type name.
+                var nameAttribute = node.Attribute(XName.Get(PackageTypeName));
+
+                if (nameAttribute == null || string.IsNullOrWhiteSpace(nameAttribute.Value))
+                {
+                    throw new PackagingException(Strings.MissingPackageTypeName);
+                }
+
+                var name = nameAttribute.Value.Trim();
+
+                // Get the optional package type version.
+                var versionAttribute = node.Attribute(XName.Get(PackageTypeVersion));
+                Version version;
+
+                if (versionAttribute != null)
+                {
+                    if (!Version.TryParse(versionAttribute.Value, out version))
+                    {
+                        throw new PackagingException(string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.InvalidPackageTypeVersion,
+                            versionAttribute.Value));
+                    }
+                }
+                else
+                {
+                    version = Core.PackageType.EmptyVersion;
+                }
+
+                packageTypes.Add(new PackageType(name, version));
+            }
+
+            return packageTypes;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/IPackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/IPackageMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace NuGet.Packaging
@@ -47,6 +48,8 @@ namespace NuGet.Packaging
         /// <summary>
         /// Returns sets of Content Files specified in the manifest.
         /// </summary>
-        ICollection<ManifestContentFiles> ContentFiles { get; }
+        IEnumerable<ManifestContentFiles> ContentFiles { get; }
+
+        IEnumerable<PackageType> PackageTypes { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/Manifest.cs
@@ -164,8 +164,22 @@ namespace NuGet.Packaging
             {
                 if (e.Severity == XmlSeverityType.Error)
                 {
+                    var message = e.Message;
+
+                    // To make sure this error message is actionable, try to add the element name
+                    // where the error is occurring.
+                    var senderElement = sender as XElement;
+                    if (senderElement != null)
+                    {
+                        message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.InvalidNuspecElement,
+                            message,
+                            senderElement.Name.LocalName);
+                    }
+
                     // Throw an exception if there is a validation error
-                    throw new InvalidOperationException(e.Message);
+                    throw new InvalidOperationException(message);
                 }
             });
 #endif

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -50,6 +50,7 @@ namespace NuGet.Packaging
             DependencyGroups = copy.DependencyGroups;
             FrameworkReferences = copy.FrameworkReferences;
             PackageAssemblyReferences = copy.PackageAssemblyReferences;
+            PackageTypes = copy.PackageTypes;
             MinClientVersionString = copy.MinClientVersion?.ToString();
             ContentFiles = copy.ContentFiles;
             DevelopmentDependency = copy.DevelopmentDependency;
@@ -219,7 +220,9 @@ namespace NuGet.Packaging
             return groupedReferenceSets;
         }
 
-        public ICollection<ManifestContentFiles> ContentFiles { get; set; } = new List<ManifestContentFiles>();
+        public IEnumerable<ManifestContentFiles> ContentFiles { get; set; } = new List<ManifestContentFiles>();
+        
+        public IEnumerable<PackageType> PackageTypes { get; set; } = new List<PackageType>();
 
         private static IEnumerable<PackageDependencyGroup> MergeDependencyGroups(IEnumerable<PackageDependencyGroup> actualDependencyGroups)
         {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -46,6 +46,8 @@ namespace NuGet.Packaging
                 ReadMetadataValue(manifestMetadata, element, allElements);
             }
 
+            manifestMetadata.PackageTypes = NuspecUtility.GetPackageTypes(xElement, useMetadataNamespace: false);
+
             // now check for required elements, which include <id>, <version>, <authors> and <description>
             foreach (var requiredElement in RequiredElements)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -49,13 +49,19 @@ namespace NuGet.Packaging
         /// </summary>
         internal const string SchemaVersionV6 = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
 
+        /// <summary>
+        /// Added packageTypes element under metadata.
+        /// </summary>
+        internal const string SchemaVersionV7 = "http://schemas.microsoft.com/packaging/2016/04/nuspec.xsd";
+
         private static readonly string[] VersionToSchemaMappings = new[] {
             SchemaVersionV1,
             SchemaVersionV2,
             SchemaVersionV3,
             SchemaVersionV4,
             SchemaVersionV5,
-            SchemaVersionV6
+            SchemaVersionV6,
+            SchemaVersionV7
         };
 
 #if !IS_CORECLR

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
@@ -16,6 +16,7 @@ namespace NuGet.Packaging
         public const int TargetFrameworkSupportForDependencyContentsAndToolsVersion = 4;
         public const int TargetFrameworkSupportForReferencesVersion = 5;
         public const int XdtTransformationVersion = 6;
+        public const int PackageTypeVersion = 7;
 
         public static int GetManifestVersion(ManifestMetadata metadata)
         {
@@ -45,6 +46,11 @@ namespace NuGet.Packaging
             if (metadata.Version != null && metadata.Version.IsPrerelease)
             {
                 return SemverVersion;
+            }
+
+            if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
+            {
+                return PackageTypeVersion;
             }
 
             return DefaultVersion;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -63,6 +63,7 @@ namespace NuGet.Packaging
             FrameworkReferences = new Collection<FrameworkAssemblyReference>();
             ContentFiles = new Collection<ManifestContentFiles>();
             PackageAssemblyReferences = new Collection<PackageReferenceSet>();
+            PackageTypes = new Collection<PackageType>();
             Authors = new HashSet<string>();
             Owners = new HashSet<string>();
             Tags = new HashSet<string>();
@@ -170,7 +171,7 @@ namespace NuGet.Packaging
             private set;
         }
 
-        public Collection<IPackageFile> Files
+        public ICollection<IPackageFile> Files
         {
             get;
             private set;
@@ -192,6 +193,12 @@ namespace NuGet.Packaging
         }
 
         public ICollection<PackageReferenceSet> PackageAssemblyReferences
+        {
+            get;
+            set;
+        }
+
+        public ICollection<PackageType> PackageTypes
         {
             get;
             set;
@@ -242,6 +249,22 @@ namespace NuGet.Packaging
             get
             {
                 return FrameworkReferences;
+            }
+        }
+
+        IEnumerable<ManifestContentFiles> IPackageMetadata.ContentFiles
+        {
+            get
+            {
+                return ContentFiles;
+            }
+        }
+
+        IEnumerable<PackageType> IPackageMetadata.PackageTypes
+        {
+            get
+            {
+                return PackageTypes;
             }
         }
 
@@ -312,8 +335,8 @@ namespace NuGet.Packaging
         }
 
         private static int DetermineMinimumSchemaVersion(
-            Collection<IPackageFile> Files,
-            Collection<PackageDependencyGroup> package)
+            ICollection<IPackageFile> Files,
+            ICollection<PackageDependencyGroup> package)
         {
             if (HasContentFilesV2(Files) || HasIncludeExclude(package))
             {
@@ -477,7 +500,7 @@ namespace NuGet.Packaging
             Language = metadata.Language;
             Copyright = metadata.Copyright;
             MinClientVersion = metadata.MinClientVersion;
-            ContentFiles = new List<ManifestContentFiles>(manifestMetadata.ContentFiles);
+            ContentFiles = new Collection<ManifestContentFiles>(manifestMetadata.ContentFiles.ToList());
 
             if (metadata.Tags != null)
             {
@@ -490,6 +513,11 @@ namespace NuGet.Packaging
             if (manifestMetadata.PackageAssemblyReferences != null)
             {
                 PackageAssemblyReferences.AddRange(manifestMetadata.PackageAssemblyReferences);
+            }
+
+            if (manifestMetadata.PackageTypes != null)
+            {
+                PackageTypes = new Collection<PackageType>(metadata.PackageTypes.ToList());
             }
         }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -51,6 +51,11 @@ namespace NuGet.Packaging.Xml
             AddElementIfNotNull(elem, ns, "copyright", metadata.Copyright);
             AddElementIfNotNull(elem, ns, "language", metadata.Language);
             AddElementIfNotNull(elem, ns, "tags", metadata.Tags);
+            
+            if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
+            {
+                elem.Add(GetXElementFromManifestPackageTypes(ns, metadata.PackageTypes));
+            }
 
             elem.Add(GetXElementFromGroupableItemSets(
                 ns,
@@ -147,7 +152,7 @@ namespace NuGet.Packaging.Xml
 
         private static XElement GetXElementFromPackageDependency(XNamespace ns, PackageDependency dependency)
         {
-            List<XAttribute> attributes = new List<XAttribute>();
+            var attributes = new List<XAttribute>();
 
             attributes.Add(new XAttribute("id", dependency.Id));
 
@@ -199,7 +204,7 @@ namespace NuGet.Packaging.Xml
 
         private static XElement GetXElementFromManifestContentFile(XNamespace ns, ManifestContentFiles file)
         {
-            List<XAttribute> attributes = new List<XAttribute>();
+            var attributes = new List<XAttribute>();
 
             attributes.Add(GetXAttributeFromNameAndValue("include", file.Include));
             attributes.Add(GetXAttributeFromNameAndValue("exclude", file.Exclude));
@@ -210,6 +215,34 @@ namespace NuGet.Packaging.Xml
             attributes = attributes.Where(xAtt => xAtt != null).ToList();
 
             return new XElement(ns + Files, attributes);
+        }
+
+        private static XElement GetXElementFromManifestPackageTypes(XNamespace ns, IEnumerable<PackageType> packageTypes)
+        {
+            var packageTypesElement = new XElement(ns + NuspecUtility.PackageTypes);
+
+            foreach (var packageType in packageTypes)
+            {
+                var packageTypeElement = GetXElementFromManifestPackageType(ns, packageType);
+                packageTypesElement.Add(packageTypeElement);
+            }
+
+            return packageTypesElement;
+        }
+
+        private static XElement GetXElementFromManifestPackageType(XNamespace ns, PackageType packageType)
+        {
+            var attributes = new List<XAttribute>();
+
+            attributes.Add(GetXAttributeFromNameAndValue(NuspecUtility.PackageTypeName, packageType.Name));
+            if (packageType.Version != PackageType.EmptyVersion)
+            {
+                attributes.Add(GetXAttributeFromNameAndValue(NuspecUtility.PackageTypeVersion, packageType.Version));
+            }
+
+            attributes = attributes.Where(xAtt => xAtt != null).ToList();
+
+            return new XElement(ns + NuspecUtility.PackageType, attributes);
         }
 
         private static XAttribute GetXAttributeFromNameAndValue(string name, object value)

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -150,6 +150,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to {0} This validation error occurred in a &apos;{1}&apos; element..
+        /// </summary>
+        public static string InvalidNuspecElement {
+            get {
+                return ResourceManager.GetString("InvalidNuspecElement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to The nuspec contains an invalid entry &apos;{0}&apos; in package &apos;{1}&apos; ..
         /// </summary>
         public static string InvalidNuspecEntry {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -186,4 +186,9 @@
   <data name="UnableToParseClientVersion" xml:space="preserve">
     <value>Unable to parse the current NuGet client version.</value>
   </data>
+  <data name="InvalidNuspecElement" xml:space="preserve">
+    <value>{0} This validation error occurred in a '{1}' element.</value>
+    <comment>{0} is the validation error message.
+{1} is the local name of the XML element that causes the validation error.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -63,6 +63,18 @@
                             <xs:element name="copyright" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="language" maxOccurs="1" minOccurs="0" type="xs:string" default="en-US" />
                             <xs:element name="tags" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="packageTypes" maxOccurs="1" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="packageType" maxOccurs="unbounded" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:attribute name="name" type="xs:string" use="required" />
+                                                <xs:attribute name="version" type="xs:string" use="optional" />
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
                             <xs:element name="dependencies" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>

--- a/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
@@ -214,6 +214,32 @@ namespace NuGet.Test.Utility
             return file;
         }
 
+        public static TempFile GetPackageWithPackageTypes()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/net40/test40.dll", ZeroContent);
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata>
+                                <id>packageA</id>
+                                <version>2.0.3</version>
+                                <authors>Author1, author2</authors>
+                                <description>Sample description</description>
+                                <packageTypes>
+                                  <packageType name=""foo"" />
+                                  <packageType name=""bar"" version=""2.0.0"" />
+                                </packageTypes>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
         public static TempFile GetLegacyTestPackageMinClient(string minClientVersion)
         {
             var file = new TempFile();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/NuSpecCoreReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/NuSpecCoreReaderTests.cs
@@ -12,6 +12,27 @@ namespace NuGet.Packaging.Core.Test
     public class NuspecCoreReaderTests
     {
         [Fact]
+        public void Id_ReturnsNullWithWrongCase()
+        {
+            // Arrange
+            var contents =
+@"<?xml version=""1.0""?>
+<package>
+  <metadata>
+    <ID>foo</ID>
+  </metadata>
+</package>";
+
+            var reader = new TestNuspecCoreReader(contents);
+
+            // Act
+            var id = reader.GetId();
+
+            // Assert
+            Assert.Null(id);
+        }
+
+        [Fact]
         public void GetPackageType_ReturnsEmptyPackageTypeListIfNotSpecifiedInManfiest()
         {
             // Arrange
@@ -38,17 +59,19 @@ namespace NuGet.Packaging.Core.Test
    <somestuff>some-value</somestuff>
    <ver>123</ver>
   </metadata>
-</package>")]
+</package>")] // Elements with no children should be extracted.
         [InlineData(@"<?xml version=""1.0""?>
 <package xmlns=""a-random-xsd"">
   <metadata>
-   <packageType name=""Managed"" version=""2.0"" />
+   <packageTypes>
+     <packageType name=""Managed"" version=""2.0"" />
+   </packageTypes>
    <id>Test</id>
    <somestuff>some-value</somestuff>
    <ver>123</ver>
   </metadata>
-</package>")]
-        public void GetMetadata_SkipsPackageTypeElement(string contents)
+</package>")] // Elements with children should be skipped.
+        public void GetMetadata(string contents)
         {
             // Arrange
             var reader = new TestNuspecCoreReader(contents);
@@ -80,21 +103,27 @@ namespace NuGet.Packaging.Core.Test
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType name=""Managed"" version=""2.0"" />
+    <packageTypes>
+      <packageType name=""Managed"" version=""2.0"" />
+    </packageTypes>
   </metadata>
 </package>", "Managed", "2.0")]
         [InlineData(
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType name=""SomeFormat"" version=""3.5"" />
+    <packageTypes>
+      <packageType name=""SomeFormat"" version=""3.5"" />
+    </packageTypes>
   </metadata>
 </package>", "SomeFormat", "3.5")]
         [InlineData(
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType name=""RandomFormat123"" />
+    <packageTypes>
+      <packageType name=""RandomFormat123"" />
+    </packageTypes>
   </metadata>
 </package>", "RandomFormat123", "0.0")]
         public void GetPackageType_ReadsPackageTypeFromManifest(string contents, string expectedType, string expectedVersion)
@@ -120,7 +149,9 @@ namespace NuGet.Packaging.Core.Test
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType name=""SomeFormat"" version=""3.5-alpha"" />
+    <packageTypes>
+      <packageType name=""SomeFormat"" version=""3.5-alpha"" />
+    </packageTypes>
   </metadata>
 </package>";
             var reader = new TestNuspecCoreReader(contents);
@@ -140,7 +171,9 @@ namespace NuGet.Packaging.Core.Test
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType version=""1.0"">SomeFormat</packageType>
+    <packageTypes>
+      <packageType version=""1.0"">SomeFormat</packageType>
+    </packageTypes>
   </metadata>
 </package>";
             var reader = new TestNuspecCoreReader(contents);
@@ -160,8 +193,10 @@ namespace NuGet.Packaging.Core.Test
 @"<?xml version=""1.0""?>
 <package>
   <metadata>
-   <packageType name=""Foo"" version=""1.0"" />
-   <packageType name=""Bar"" version=""2.0"" />
+    <packageTypes>
+      <packageType name=""Foo"" version=""1.0"" />
+      <packageType name=""Bar"" version=""2.0"" />
+    </packageTypes>
   </metadata>
 </package>";
             var reader = new TestNuspecCoreReader(contents);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
 
@@ -8,6 +9,29 @@ namespace NuGet.Packaging.Test
 {
     public class ManifestVersionUtilityTest
     {
+        [Fact]
+        public void GetManifestVersionReturns7IfPackageTypesAreSet()
+        {
+            // Arrange
+            var metadata = new ManifestMetadata
+            {
+                Id = "Foo",
+                Version = NuGetVersion.Parse("1.0"),
+                Authors = new[] { "A, B" },
+                Description = "Description",
+                PackageTypes = new[]
+                {
+                    new PackageType("Bar", new System.Version(2, 0))
+                }
+            };
+
+            // Act
+            var version = ManifestVersionUtility.GetManifestVersion(metadata);
+
+            // Assert
+            Assert.Equal(7, version);
+        }
+
         [Fact]
         public void GetManifestVersionReturns1IfNoNewPropertiesAreSet()
         {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -182,6 +183,62 @@ namespace NuGet.Packaging.Test
                           <dependency id=""packageE"" version=""1.0.0"" include=""a , b ,c "" />
                         </group>
                     </dependencies>
+                  </metadata>
+                </package>";
+
+        private const string PackageTypes = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <description>package A description.</description>
+                    <packageTypes>
+                      <packageType name=""foo"" />
+                      <packageType name=""bar"" version=""2.0.0"" />
+                    </packageTypes>
+                  </metadata>
+                </package>";
+
+        private const string NoContainerPackageTypesElement = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <description>package A description.</description>
+                    <packageType name=""foo"" />
+                    <packageType name=""bar"" version=""2.0.0"" />
+                  </metadata>
+                </package>";
+
+        private const string EmptyPackageTypesElement = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <description>package A description.</description>
+                    <packageTypes>
+                    </packageTypes>
+                  </metadata>
+                </package>";
+
+        private const string NoPackageTypesElement = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <description>package A description.</description>
                   </metadata>
                 </package>";
 
@@ -389,6 +446,39 @@ namespace NuGet.Packaging.Test
             // Assert
             Assert.Equal(0, dependency.Include.Count);
             Assert.Equal(0, dependency.Exclude.Count);
+        }
+
+        [Fact]
+        public void NuspecReaderTests_PackageTypes()
+        {
+            // Arrange
+            var reader = GetReader(PackageTypes);
+
+            // Act
+            var actual = reader.GetPackageTypes();
+
+            // Assert
+            Assert.Equal(2, actual.Count);
+            Assert.Equal("foo", actual[0].Name);
+            Assert.Equal(new Version(0, 0), actual[0].Version);
+            Assert.Equal("bar", actual[1].Name);
+            Assert.Equal(new Version(2, 0, 0), actual[1].Version);
+        }
+
+        [Theory]
+        [InlineData(NoContainerPackageTypesElement)]
+        [InlineData(EmptyPackageTypesElement)]
+        [InlineData(NoPackageTypesElement)]
+        public void NuspecReaderTests_NoPackageTypes(string nuspec)
+        {
+            // Arrange
+            var reader = GetReader(nuspec);
+
+            // Act
+            var actual = reader.GetPackageTypes();
+
+            // Assert
+            Assert.Equal(0, actual.Count);
         }
 
         private static NuspecReader GetReader(string nuspec)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -456,7 +456,6 @@ namespace NuGet.Packaging.Test
         public void PackageReader_SupportedFrameworks()
         {
             using (var packageFile = TestPackages.GetLegacyTestPackage())
-
             {
                 var zip = TestPackages.GetZip(packageFile);
 
@@ -468,6 +467,29 @@ namespace NuGet.Packaging.Test
                     Assert.Equal(".NETFramework,Version=v4.0", frameworks[1]);
                     Assert.Equal(".NETFramework,Version=v4.5", frameworks[2]);
                     Assert.Equal(3, frameworks.Length);
+                }
+            }
+        }
+
+        [Fact]
+        public void PackageReader_PackageTypes()
+        {
+            // Arrange
+            using (var packageFile = TestPackages.GetPackageWithPackageTypes())
+            {
+                var zip = TestPackages.GetZip(packageFile);
+
+                using (PackageArchiveReader reader = new PackageArchiveReader(zip))
+                {
+                    // Act
+                    var actual = reader.GetPackageTypes();
+
+                    // Assert
+                    Assert.Equal(2, actual.Count);
+                    Assert.Equal("foo", actual[0].Name);
+                    Assert.Equal(new Version(0, 0), actual[0].Version);
+                    Assert.Equal("bar", actual[1].Name);
+                    Assert.Equal(new Version(2, 0, 0), actual[1].Version);
                 }
             }
         }


### PR DESCRIPTION
This is another step in the episodic story of implementing Package Type: https://github.com/NuGet/Home/issues/2476.

**Done with this PR:**
1. When packing, read package type(s) specified in the input project.json and the input .nuspec. These result in package type in the output .nuspec.
2. Design change from potentially multiple `<packageType>` elements under `<metadata>` to a single parent `<packageTypes>` element (which can have 0 or more `<packageType>` children). This is because the .nuspec `<metadata>` element is defined to have `<xs:all>` children elements, meaning that you can only have 0 or 1 of each element. This was the most straightforward change to our XSD.
3. Unify reading `<packageTypes>` element from packing and reading an existing package. In general, we have a problem where there is a lot of duplicated code between `ManifestReader` and `NuspecReader`.

**Next steps are:**
1. Restrict packing to only one `<packageType>` element. This is our plan for phase 1, until there is a need for multiple package types.
2. Allow `<packageType name="DotnetCliTool" />` and `<packageType name="Dependency" />`. When package type name is `DotnetCliTool`, install to the `"tools"` node in the project.json. If no `<packageType>` is specified, the package type is set to `<packageType name="Dependency" />`.

@emgarten @toddm @spadapet @alpaix
