### PR TITLE
Fixed E2E tests

### DIFF
--- a/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
+++ b/src/NuGet.Core/NuGet.Common/ActivityCorrelationContext.cs
@@ -18,8 +18,10 @@ namespace NuGet.Common
     /// </summary>
 #if !IS_CORECLR
     [Serializable]
-#endif
+    public class ActivityCorrelationContext : MarshalByRefObject, IDisposable
+#else
     public class ActivityCorrelationContext : IDisposable
+#endif
     {
 #if IS_CORECLR
         private static readonly AsyncLocal<ActivityCorrelationContext> _instance = new AsyncLocal<ActivityCorrelationContext>();


### PR DESCRIPTION
by making ActivityCorrelationContext inherit MarshalByRefObject.

Fixes https://github.com/NuGet/Home/issues/2784

With this fix I was able to run E2E tests locally:

> Ran 423 Tests and/or Test cases, 386 Passed, 25 Failed, 12 Skipped. See 'X:\nuget.Client\test\EndToEnd\bin\fc3f\Results.html' or 'X:\nuget.Client\test\EndToEnd\bin\fc3f\TestResults.txt' for more details.

**Following 37 failed tests need immediate attention**

> Failed TabExpansionForInstallPackageSortByDownloadCountDescending 1329 Response status code does not indicate success: 404 (Not Found). 
> Failed TabExpansionForInstallPackageShowSuggestionsForPackageIdWithFilter 8243 Response status code does not indicate success: 404 (Not Found). 
> Failed TabExpansionForInstallPackageSupportsVersion 8243 Response status code does not indicate success: 404 (Not Found). 
> Failed TabExpansionForInstallPackageShowSuggestionsForPackageId 8243 Response status code does not indicate success: 404 (Not Found). 
> Failed UpdatePackageThrowsIfMinClientVersionIsNotSatisfied 1944 Expected <The 'kitty 2.0.0' package requires NuGet client version '5.0.0.1' or above, but the current NuGet version is '3.5.0'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget> but got <The 'kitty 2.0.0' package requires NuGet client version '5.0.0.1' or above, but the current NuGet version is '3.5.0-zlocal-48595'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget>. At update.ps1: line 1498 
> Failed InstallPackageThrowsIfMinClientVersionIsNotSatisfied 2388 Expected <The 'kitty 1.0.0' package requires NuGet client version '5.0.0' or above, but the current NuGet version is '3.5.0'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget> but got <The 'kitty 1.0.0' package requires NuGet client version '5.0.0' or above, but the current NuGet version is '3.5.0-zlocal-48595'. To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget>. At install.ps1: line 2288 
> Skipped ProjectKPackageActionsWhatIf 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUpdateMVCPackagePrerelease 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped GetProjectForDNXClassLibrary 670 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUpdatePackageReinstall 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKInstallPackage 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUninstallPackage 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUpdateNonExistentPackage 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUpdateAllPackages 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKInstallNonExistentPackage 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKInstallMultiplePackages 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Skipped ProjectKUninstallNonExistentPackage 192 Exception calling "NewProject" with "5" argument(s): "The system cannot find the file specified. (Exception from HRESULT: 0x80070002)" 
> Failed PackFromProjectWithDevelopmentDependencySet 192 Exception calling "NewProject" with "5" argument(s): "The project file 'C:\Users\alpanov\AppData\Local\Temp\hmdfchwo.c1j\Temp\EmptyMvcWebApplicationProjectTemplatev4.0.csaspx_5f5f.csproj' cannot be opened.
> 
> There is a missing project subtype.
> Subtype: '{E3E379DF-F4C6-4180-9B81-6769533ABE47}' is unsupported by this installation." 
> Skipped InstallPackageThrowsIfThereIsNoCompatibleContentFiles 822 Exception calling "NewProject" with "5" argument(s): "The method or operation is not implemented." 
> Failed ProjectRetargeting-ShowWarningOnCleanBuild 1584 Exception calling "CleanSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ClearErrorUponCleanProject 1565 Exception calling "CleanSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedLockFileIsCreatedOnBuild 225 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedProjectClosureWithLegacyProjects 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedParentProjectsStayLockedOnBuild 2408 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ClearWarningUponCleanProject 1584 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed AddingBindingRedirectAfterUpdate 4544 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedMixedLegacyProjectsPackagesFolderOnly 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ClearWarningUponCloseSolution 1584 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedMixedLegacyProjectsProjectJsonOnly 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedTransitiveProjectJsonRestores 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ClearErrorAndWarningRetargetBackToOriginalFramework 1584 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedMixedLegacyProjects 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed BuildIntegratedProjectClosure 1207 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed InstallPackageWithScriptAddImportFile 1978 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ConvertBuildErrorToBuildWarningUponBuild 1584 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed InstallingSatellitePackageToWebsiteCopiesResourcesToBin 1601 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))" 
> Failed ProjectRetargeting-ClearWarningUponPackageReinstallationAndBuild 1584 Exception calling "BuildSolution" with "0" argument(s): "The parameter is incorrect. (Exception from HRESULT: 0x80070057 (E_INVALIDARG))"

//cc @emgarten @rrelyea 
