### PR TITLE
Display exception when there is a failure finding projects in update command

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -151,13 +151,13 @@ namespace NuGet.CommandLine
                 }
                 catch (Exception e)
                 {
-                    if (Console.Verbosity == NuGet.Verbosity.Detailed)
+                    if (Console.Verbosity == Verbosity.Detailed || ExceptionLogger.Instance.ShowStack)
                     {
                         Console.WriteWarning(e.ToString());
                     }
                     else
                     {
-                        Console.WriteWarning(e.Message);
+                        Console.WriteWarning(ExceptionUtilities.DisplayMessage(e));
                     }
                 }
             }
@@ -169,9 +169,16 @@ namespace NuGet.CommandLine
             {
                 return GetMSBuildProject(path, projectContext);
             }
-            catch (CommandLineException)
+            catch (CommandLineException e)
             {
-
+                if (Console.Verbosity == Verbosity.Detailed || ExceptionLogger.Instance.ShowStack)
+                {
+                    Console.WriteWarning(e.ToString());
+                }
+                else
+                {
+                    Console.WriteWarning(ExceptionUtilities.DisplayMessage(e));
+                }
             }
 
             return null;


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2418.

When zero or 2+ project files are found associated with (i.e. in the same directory as) a package.config, the update command silently ignores that package.config. This change is to log a warning message.

@jainaashish @alpaix @emgarten 
