### PR TITLE
Fixes for pack

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -200,9 +200,12 @@ namespace NuGet.CommandLine
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to continue regardless of any error we encounter extracting metadata.")]
-        public PackageBuilder CreateBuilder(string basePath)
+        public PackageBuilder CreateBuilder(string basePath, NuGetVersion version, string suffix, bool buildIfNeeded)
         {
-            BuildProject();
+            if (buildIfNeeded)
+            {
+                BuildProject();
+            }
 
             if (!string.IsNullOrEmpty(TargetPath))
             {
@@ -253,7 +256,7 @@ namespace NuGet.CommandLine
             Manifest manifest = null;
 
             // If there is a project.json file, load that and skip any nuspec that may exist
-            if (!PackCommandRunner.ProcessProjectJsonFile(builder, basePath, builder.Id, GetPropertyValue))
+            if (!PackCommandRunner.ProcessProjectJsonFile(builder, basePath, builder.Id, version, suffix, GetPropertyValue))
             {
                 // If the package contains a nuspec file then use it for metadata
                 manifest = ProcessNuspec(builder, basePath);
@@ -671,7 +674,7 @@ namespace NuGet.CommandLine
 
         private bool ProcessJsonFile(PackageBuilder builder, string basePath, string id)
         {
-            return PackCommandRunner.ProcessProjectJsonFile(builder, basePath, id, GetPropertyValue);
+            return PackCommandRunner.ProcessProjectJsonFile(builder, basePath, id, null, null, GetPropertyValue);
         }
 
         // Creates a package dependency from the given project, which has a corresponding

--- a/src/NuGet.Core/NuGet.Commands/IProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/IProjectFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using NuGet.Packaging;
+using NuGet.Versioning;
 
 namespace NuGet.Commands
 {
@@ -8,6 +9,6 @@ namespace NuGet.Commands
     {
         Dictionary<string, string> GetProjectProperties();
         void SetIncludeSymbols(bool includeSymbols);
-        PackageBuilder CreateBuilder(string basePath);
+        PackageBuilder CreateBuilder(string basePath, NuGetVersion version, string suffix, bool buildIfNeeded);
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -68,6 +68,7 @@ namespace NuGet.Common
                 // regex wildcard adjustments for Windows-style file systems
                 pattern = pattern
                     .Replace("/", @"\\") // On Windows, / is treated the same as \.
+                    .Replace(@"\.\*\*", @"\.[^\\.]*") // .** should not match on ../file or ./file but will match .file
                     .Replace(@"\*\*\\", ".*") //For recursive wildcards \**\, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator


### PR DESCRIPTION
Make it only build once instead of twice when building symbols.
Use the correct version when passing a version or suffix to pack when a version is in the project.json file.
Allow ....\files to get included in the pack. This was causing dlls to not get included when the output directory started with .....

@emgarten @spadapet @joelverhagen 
