### PR TITLE
Updating dotnet cli

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ curl -o cli/install.sh https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/sc
 
 # Run install.sh
 chmod +x cli/install.sh
-cli/install.sh -i cli -c beta -v 1.0.0-rc2-002345
+cli/install.sh -i cli -c beta -v 1.0.0-preview1-002702
 
 # Display current version
 DOTNET="$(pwd)/cli/dotnet"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -21,7 +21,7 @@ curl -o cli/install.sh https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/sc
 
 # Run install.sh
 chmod +x cli/install.sh
-cli/install.sh -i cli -c beta -v 1.0.0-rc2-002345
+cli/install.sh -i cli -c beta -v 1.0.0-preview1-002702
 
 # Display current version
 DOTNET="$(pwd)/cli/dotnet"

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -18,7 +18,7 @@
       ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
         "System.Threading.Thread": "4.0.0-rc2-24027",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -20,7 +20,7 @@
       ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
         "Microsoft.NETCore.App": {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -18,7 +18,7 @@
       ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -18,7 +18,7 @@
       ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -17,7 +17,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -24,7 +24,7 @@
       ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -14,7 +14,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -21,7 +21,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -13,7 +13,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "dotnet-test-xunit": "1.0.0-dev-140469-38",
+        "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"


### PR DESCRIPTION
Updating the CLI we build with to 1.0.0-preview1-002702   This is passing on the CI.  

The main script change here is to remove `--infer-runtimes` which is no longer needed.

//cc @alpaix @joelverhagen @rohit21agrawal @drewgil 
