### PR TITLE
Add CommitHash tag to assembly metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ mergelog.txt
 
 # Build results
 
+# Generated source files
+*.generated.cs
+
 # Roslyn cache directories
 **/*.ide/
 

--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -130,6 +130,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{DE23D0
 		Shared\TypeInfo.cs = Shared\TypeInfo.cs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UpdateAssemblyInfo", "UpdateAssemblyInfo", "{C5A8448A-2255-4B5C-9367-515CC010F4F1}"
+	ProjectSection(SolutionItems) = preProject
+		Shared\UpdateAssemblyInfo\project.json = Shared\UpdateAssemblyInfo\project.json
+		Shared\UpdateAssemblyInfo\UpdateAssemblyInfo.cs = Shared\UpdateAssemblyInfo\UpdateAssemblyInfo.cs
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -406,5 +412,6 @@ Global
 		{1A94F70B-1AB6-4638-931A-4AB0EBEF7EC1} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{626E0086-1375-4ABE-A0F8-412786D315FA} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{2034C981-C938-4F0F-8F3B-528B83CB8F7D} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
+		{C5A8448A-2255-4B5C-9367-515CC010F4F1} = {DE23D071-162F-47A3-BC68-42E4A354835C}
 	EndGlobalSection
 EndGlobal

--- a/Shared/UpdateAssemblyInfo/UpdateAssemblyInfo.cs
+++ b/Shared/UpdateAssemblyInfo/UpdateAssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Diagnostics;
 using System.IO;
 
@@ -35,7 +38,7 @@ namespace NuGet.Shared
 
         private static string GetGitCommitHash()
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo("git.exe") { RedirectStandardOutput = true, Arguments = "rev-parse HEAD" };
+            ProcessStartInfo startInfo = new ProcessStartInfo("git") { RedirectStandardOutput = true, Arguments = "rev-parse HEAD" };
             var process = new Process { StartInfo = startInfo };
             process.Start();
             process.WaitForExit();

--- a/Shared/UpdateAssemblyInfo/UpdateAssemblyInfo.cs
+++ b/Shared/UpdateAssemblyInfo/UpdateAssemblyInfo.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace NuGet.Shared
+{
+    public class UpdateAssemblyInfo
+    {
+        private const string assemblyInfoFileName = "CommonAssemblyInfo.generated.cs";
+
+        public static void Main(string[] args)
+        {
+            // Write out git commit hash to a generated assembly info file
+            var assemblyInfoText = GetAssemblyInfoFileText();
+            var assemblyInfoFullFileName = Path.GetFullPath(Path.Combine("..", assemblyInfoFileName));
+
+            // We don't want to re-write the file if the commit hash has not change (since that will trigger all projects being dirty).
+            var existingText = File.Exists(assemblyInfoFullFileName) ? File.ReadAllText(assemblyInfoFullFileName) : "";
+            if (existingText != assemblyInfoText)
+            {
+                Console.WriteLine($"Writing new content for '{assemblyInfoFileName}':\n{assemblyInfoText}");
+                File.WriteAllText(assemblyInfoFullFileName, assemblyInfoText);
+            }
+            else
+            {
+                Console.WriteLine($"Content of '{assemblyInfoFileName}' has not changed.");
+            }
+        }
+
+        private static string GetAssemblyInfoFileText()
+        {
+            var commitHash = GetGitCommitHash();
+            return $"#if !IS_NET40_CLIENT\n[assembly: System.Reflection.AssemblyMetadata(\"CommitHash\", \"{commitHash}\")]\n#endif";
+        }
+
+        private static string GetGitCommitHash()
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo("git.exe") { RedirectStandardOutput = true, Arguments = "rev-parse HEAD" };
+            var process = new Process { StartInfo = startInfo };
+            process.Start();
+            process.WaitForExit();
+            return process.StandardOutput.ReadToEnd().Trim();
+        }
+    }
+}

--- a/Shared/UpdateAssemblyInfo/project.json
+++ b/Shared/UpdateAssemblyInfo/project.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-3002702"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -410,6 +410,13 @@ Function Build-CoreProjects {
         Restore-XProjects $XProjectsLocation -Fast:$Fast
     }
 
+    Trace-Log "Updating shared assembly info for xprojs"
+    cd Shared\UpdateAssemblyInfo
+    & $DotNetExe restore 
+    & $DotNetExe run
+    cd ..\..
+    Trace-Log "Finished updating shared assembly info"
+
     $xprojects = Find-XProjects $XProjectsLocation
     $xprojects | Invoke-DotnetPack -config $Configuration -label $ReleaseLabel -build $BuildNumber -out $Artifacts
 


### PR DESCRIPTION
@emgarten - this is one possible approach to including the `CommitHash` assembly metadata. The benefit is it is pretty simple to do without any major changes to our build process. One issue is that it will cause incremental builds to be slower, as projects will have to be rebuilt whenever the local current commit changes. Should we have a command line switch to turn this off? Should it default to being turned off when building for debug?
