### PR TITLE
Fix package.json deprecation warnings.

### DIFF
--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -2,18 +2,20 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Versioning": {
       "target": "project"
@@ -33,7 +35,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -48,7 +50,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -1,20 +1,22 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "description": "NuGet 3 restore for dotnet CLI, DNX, and UWP",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true,
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20456",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
@@ -31,7 +33,7 @@
   },
   "frameworks": {
     "net46": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -50,7 +52,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -1,10 +1,12 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "description": "Complete commands common to command-line and GUI NuGet clients",
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
@@ -13,18 +15,18 @@
       "CS1573",
       "CS1584",
       "CS1658"
-    ]
+    ],
+    "compile": {
+      "include": [
+        "../../../Shared/*.cs",
+        "../../../submodules/FileSystem/src/Microsoft.Extensions.FileSystemGlobbing/**/*.cs",
+        "../../../submodules/FileSystem/src/Microsoft.AspNet.FileProviders.Abstractions/**/*.cs",
+        "../../../submodules/FileSystem/src/Microsoft.AspNet.FileProviders.Sources/**/*.cs",
+        "../../../submodules/Common/src/Microsoft.Extensions.Primitives/IChangeToken.cs"
+      ],
+      "exclude": "../../../submodules/FileSystem/src/**/AssemblyInfo.cs"
+    }
   },
-  "compile": [
-    "../../../Shared/*.cs",
-    "../../../submodules/FileSystem/src/Microsoft.Extensions.FileSystemGlobbing/**/*.cs",
-    "../../../submodules/FileSystem/src/Microsoft.AspNet.FileProviders.Abstractions/**/*.cs",
-    "../../../submodules/FileSystem/src/Microsoft.AspNet.FileProviders.Sources/**/*.cs",
-    "../../../submodules/Common/src/Microsoft.Extensions.Primitives/IChangeToken.cs"
-  ],
-  "compileExclude": [
-    "../../../submodules/FileSystem/src/**/AssemblyInfo.cs"
-  ],
   "dependencies": {
     "NuGet.Client": {
       "target": "project"
@@ -56,7 +58,7 @@
         "System.Xml": "",
         "System.Xml.Linq": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -72,7 +74,7 @@
         "NETStandard.Library": "1.5.0-rc2-24027",
         "System.Xml.XDocument": "4.0.11-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -2,19 +2,21 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1574"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
@@ -23,7 +25,7 @@
         "System.Core": "",
         "System.IO.Compression": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -36,7 +38,7 @@
         "System.Diagnostics.Process": "4.1.0-rc2-24027",
         "System.Threading.Thread": "4.0.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -5,23 +5,25 @@
   ],
   "description": "NuGet's client configuration settings implementation.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "nuget",
-    "configuration",
-    "nuget.config"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "nuget",
+      "configuration",
+      "nuget.config"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -34,7 +36,7 @@
         "System.Xml": "",
         "System.Xml.Linq": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -45,7 +47,7 @@
         "NETStandard.Library": "1.5.0-rc2-24027",
         "System.Xml.XDocument": "4.0.11-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -2,21 +2,23 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -32,7 +34,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -2,19 +2,21 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1574"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.LibraryModel": {
       "target": "project"
@@ -34,7 +36,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -49,7 +51,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -2,18 +2,20 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Packaging": {
       "target": "project"
@@ -27,7 +29,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -42,7 +44,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -5,9 +5,11 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
@@ -15,14 +17,14 @@
       "CS1574",
       "CS1573"
     ],
-    "languageVersion": "csharp5"
+    "languageVersion": "csharp5",
+    "compile": [
+      "../../../Shared/*.cs"
+    ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "frameworks": {
     "net40-client": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP",
           "IS_NET40_CLIENT"
@@ -30,7 +32,7 @@
       }
     },
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -40,7 +42,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Indexing/project.json
+++ b/src/NuGet.Core/NuGet.Indexing/project.json
@@ -1,30 +1,32 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "description": "NuGet.Indexing Class Library",
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/IdentifierKeywordAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/IdentifierAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/DescriptionAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/DotTokenizer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/TokenizingHelper.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/OwnerAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/VersionAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/CamelCaseFilter.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/TagsAnalyzer.cs",
+      "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/SemanticVersionFilter.cs",
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/NuGetQuery.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/IdentifierKeywordAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/IdentifierAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/DescriptionAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/DotTokenizer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/TokenizingHelper.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/OwnerAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/VersionAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/CamelCaseFilter.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/TagsAnalyzer.cs",
-    "../../../submodules/NuGet.Services.Metadata/src/NuGet.Indexing/SemanticVersionFilter.cs",
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "Lucene.Net": "3.0.3",
     "NuGet.Versioning": {
@@ -36,7 +38,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -2,11 +2,20 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
+    ]
+  },
   "dependencies": {
     "NuGet.Versioning": {
       "target": "project"
@@ -15,16 +24,9 @@
       "target": "project"
     }
   },
-  "compilationOptions": {
-    "warningsAsErrors": true,
-    "xmlDoc": true,
-    "nowarn": [
-      "CS1591"
-    ]
-  },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -39,7 +41,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -1,10 +1,12 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "description": "NuGet Package Management",
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
@@ -12,11 +14,11 @@
       "CS1580",
       "CS1574",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.ProjectManagement": {
       "target": "project"
@@ -36,7 +38,7 @@
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -2,8 +2,10 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "dependencies": {
     "NuGet.Frameworks": {
       "target": "project"
@@ -12,19 +14,19 @@
       "target": "project"
     }
   },
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -39,7 +41,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -5,18 +5,20 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -32,7 +34,7 @@
         "System.Xml.Linq": "",
         "System.IO.Compression": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -48,7 +50,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -5,24 +5,26 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "semver",
-    "semantic versioning"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "semver",
+      "semantic versioning"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1574",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -38,7 +40,7 @@
         "System.Xml.Linq": "",
         "System.IO.Compression": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -54,7 +56,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.ProjectManagement/project.json
+++ b/src/NuGet.Core/NuGet.ProjectManagement/project.json
@@ -1,21 +1,23 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "description": "NuGet Project Management",
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1574",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "Microsoft.Web.Xdt": "2.1.1",
     "NuGet.ProjectModel": {
@@ -27,7 +29,7 @@
       "frameworkAssemblies": {
         "System.ComponentModel.Composition": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -2,28 +2,30 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
     "NuGet.DependencyResolver.Core": {
       "target": "project"
     }
   },
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -40,7 +42,7 @@
         "System.Dynamic.Runtime": "4.0.11-rc2-24027",
         "System.Threading.Thread": "4.0.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -5,22 +5,24 @@
   ],
   "description": "NuGet's protocol-level base types used for connecting to API v2 and API v3 repositories.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "nuget protocol"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "nuget protocol"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -37,7 +39,7 @@
       "frameworkAssemblies": {
         "System.Net.Http": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -53,7 +55,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -5,23 +5,25 @@
   ],
   "description": "NuGet Protocol v2",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "nuget protocol"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "nuget protocol"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1574",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Configuration": {
       "target": "project"
@@ -40,7 +42,7 @@
         "System.Runtime.Serialization": "",
         "WindowsBase": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -5,22 +5,24 @@
   ],
   "description": "NuGet Protocol for 3.1.0 servers",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "nuget protocol"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "nuget protocol"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -41,7 +43,7 @@
         "System.Net.Http.WebRequest": "",
         "System.ServiceModel": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -57,7 +59,7 @@
         "NETStandard.Library": "1.5.0-rc2-24027",
         "System.Dynamic.Runtime": "4.0.11-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -1,18 +1,20 @@
 ﻿{
   "version": "1.0.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Protocol.Core.v3": {
       "target": "project"
@@ -21,7 +23,7 @@
   "frameworks": {
     "net46": {
       "dependencies": {},
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -36,7 +38,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.VisualStudio/project.json
@@ -5,21 +5,23 @@
   ],
   "description": "NuGet Protocol for Visual Studio",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "nuget protocol"
-  ],
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "nuget protocol"
+    ]
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Configuration": {
       "target": "project"
@@ -37,7 +39,7 @@
         "System.ComponentModel.Composition": "",
         "System.Runtime.Serialization": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -2,26 +2,28 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
   "dependencies": {
     "NuGet.Packaging": {
       "target": "project"
     }
   },
-  "compilationOptions": {
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -36,7 +38,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -5,19 +5,21 @@
     "NuGet"
   ],
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1573"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Packaging": {
       "target": "project"
@@ -28,7 +30,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -43,7 +45,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -2,20 +2,22 @@
   "version": "3.5.0-*",
   "description": "NuGet v3 core library.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591",
       "CS1573",
       "CS1572"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "Newtonsoft.Json": "6.0.4",
     "NuGet.Versioning": {
@@ -27,7 +29,7 @@
   },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -44,7 +46,7 @@
         "System.ObjectModel": "4.0.12-rc2-24027",
         "System.Dynamic.Runtime": "4.0.11-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -1,18 +1,20 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -20,7 +22,7 @@
   },
   "frameworks": {
     "net46": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -35,7 +37,7 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -1,18 +1,20 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "xunit": "2.1.0",
     "NuGet.Packaging": {
@@ -24,7 +26,7 @@
       "frameworkAssemblies": {
         "System.IO.Compression": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -41,7 +43,7 @@
         "System.IO.Compression.ZipFile": "4.0.1-rc2-24027",
         "System.Diagnostics.Process": "4.1.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -5,22 +5,24 @@
   ],
   "description": "NuGet's implementation of Semantic Versioning.",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "tags": [
-    "semver",
-    "semantic versioning"
-  ],
-  "compilationOptions": {
-    "warningsAsErrors": true,
-    "xmlDoc": true
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      "semver",
+      "semantic versioning"
+    ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "compile": [
+      "../../../Shared/*.cs"
+    ]
+  },
   "frameworks": {
     "net45": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]
@@ -30,7 +32,7 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24027"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -4,23 +4,25 @@
   "authors": [
     "yigalatz"
   ],
-  "tags": [
-    ""
-  ],
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "tags": [
+      ""
+    ]
+  },
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true,
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "NuGet.Common": {
       "target": "project"
@@ -43,14 +45,14 @@
         "dnxcore50",
         "portable-net45+win8"
       ],
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
       }
     },
     "net46": {
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -1,18 +1,20 @@
 ﻿{
   "version": "3.5.0-*",
   "copyright": "Copyright .NET Foundation. All rights reserved.",
-  "projectUrl": "https://github.com/NuGet/NuGet.Client",
-  "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
-  "compilationOptions": {
+  "packOptions": {
+    "projectUrl": "https://github.com/NuGet/NuGet.Client",
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"
+  },
+  "buildOptions": {
     "warningsAsErrors": true,
     "xmlDoc": true,
     "nowarn": [
       "CS1591"
+    ],
+    "compile": [
+      "../../../Shared/*.cs"
     ]
   },
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
   "dependencies": {
     "xunit": "2.1.0",
     "Microsoft.VisualStudio.ProjectSystem.Interop": "1.0.0-*",
@@ -31,7 +33,7 @@
       "frameworkAssemblies": {
         "System.Runtime.Serialization": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -27,7 +27,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -46,7 +46,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -28,7 +28,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -47,7 +47,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -25,7 +25,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -42,7 +42,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Indexing.Test/project.json
@@ -19,7 +19,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -34,7 +34,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -19,7 +19,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -34,7 +34,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -25,7 +25,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -43,7 +43,7 @@
       "dependencies": {
         "Moq": "4.2.1510.2205"
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/project.json
@@ -18,7 +18,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -23,7 +23,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -37,7 +37,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -31,7 +31,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -48,7 +48,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/project.json
@@ -19,7 +19,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -34,7 +34,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -20,7 +20,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -34,7 +34,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -1,8 +1,10 @@
 ﻿{
   "version": "3.5.0-*",
-  "compile": [
-    "../../../Shared/*.cs"
-  ],
+  "buildOptions": {
+    "compile": [
+      "../../../Shared/*.cs"
+    ]
+  },
   "dependencies": {
     "NuGet.Test.Utility": {
       "target": "project"
@@ -26,7 +28,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -40,7 +42,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -19,7 +19,7 @@
           "version": "1.0.0-rc2-3002339"
         }
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_CORECLR"
         ]
@@ -33,7 +33,7 @@
         "System.Runtime": "",
         "System.Threading.Tasks": ""
       },
-      "compilationOptions": {
+      "buildOptions": {
         "define": [
           "IS_DESKTOP"
         ]


### PR DESCRIPTION
Now that we've moved to dotnet cli preview1 we get a bunch of deprecation warnings with our current `package.json` files. This clears those up.
