### PR TITLE
Re-enable NuGetServer functional tests

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -108,52 +108,33 @@ namespace NuGet.Commands
 
         private List<SourceRepository> GetEffectiveSourcesCore(ISettings settings)
         {
-            // Take the passed in sources
-            var packageSources = new HashSet<string>(Sources, StringComparer.Ordinal);
             var sourceObjects = new Dictionary<string, PackageSource>(StringComparer.Ordinal);
+            var packageSourceProvider = new PackageSourceProvider(settings);
+            var packageSourcesFromProvider = packageSourceProvider.LoadPackageSources();
+            var useNugetConfigSources = (Sources.Count == 0);
 
-            var packageSourceProvider = new Lazy<PackageSourceProvider>(() 
-                => new PackageSourceProvider(settings));
-
-            // If no sources were passed in use the NuGet.Config sources
-            if (packageSources.Count < 1)
+            // Always use passed-in sources and fallback sources
+            foreach (var sourceUri in Enumerable.Concat(Sources, FallbackSources))
             {
-                // Add enabled sources
-                foreach (var source in packageSourceProvider.Value.LoadPackageSources())
-                {
-                    if (source.IsEnabled)
-                    {
-                        sourceObjects[source.Source] = source;
-                    }
-                }
-
-                var enabledSources = sourceObjects.Values
-                    .Select(source => source.Source)
-                    .Distinct(StringComparer.Ordinal)
-                    .ToList();
-
-                packageSources.UnionWith(enabledSources);
+                sourceObjects[sourceUri] = new PackageSource(sourceUri);
             }
 
-            // Always add fallback sources
-            packageSources.UnionWith(FallbackSources);
+            // Use PackageSource objects from the provider when possible (since those will have credentials from nuget.config)
+            foreach (var source in packageSourcesFromProvider)
+            {
+                if (source.IsEnabled && (useNugetConfigSources || sourceObjects.ContainsKey(source.Source)))
+                {
+                    sourceObjects[source.Source] = source;
+                }
+            }
 
             if (CachingSourceProvider == null)
             {
                 // Create a shared caching provider if one does not exist already
-                CachingSourceProvider = new CachingSourceProvider(packageSourceProvider.Value);
+                CachingSourceProvider = new CachingSourceProvider(packageSourceProvider);
             }
 
-            return packageSources.Select(sourceUri =>
-            {
-                PackageSource source;
-                if (!sourceObjects.TryGetValue(sourceUri, out source))
-                {
-                    source = new PackageSource(sourceUri);
-                }
-
-                return CachingSourceProvider.CreateRepository(source);
-            }).ToList();
+            return sourceObjects.Select(entry => CachingSourceProvider.CreateRepository(entry.Value)).ToList();
         }
 
         public void ApplyStandardProperties(RestoreRequest request)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/CachingSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/CachingSourceProvider.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol
 
         // There should only be one instance of the source repository for each package source.
         private readonly ConcurrentDictionary<string, SourceRepository> _cachedSources
-            = new ConcurrentDictionary<string, SourceRepository>(StringComparer.OrdinalIgnoreCase);
+            = new ConcurrentDictionary<string, SourceRepository>(StringComparer.Ordinal);
 
         public CachingSourceProvider(IPackageSourceProvider packageSourceProvider)
         {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
@@ -12,7 +12,7 @@ namespace NuGet.Protocol.FuncTest
     public class FindPackageByIdResourceTests
     {
         [Theory]
-        //[InlineData(TestServers.NuGetServer)]
+        [InlineData(TestServers.NuGetServer)]
         [InlineData(TestServers.ProGet)]
         [InlineData(TestServers.Klondike)]
         [InlineData(TestServers.Artifactory)]
@@ -35,7 +35,7 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Theory]
-        //[InlineData(TestServers.NuGetServer)]
+        [InlineData(TestServers.NuGetServer)]
         [InlineData(TestServers.ProGet)]
         [InlineData(TestServers.Klondike)]
         [InlineData(TestServers.Artifactory)]
@@ -58,7 +58,7 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Theory]
-        //[InlineData(TestServers.NuGetServer)]
+        [InlineData(TestServers.NuGetServer)]
         [InlineData(TestServers.ProGet)]
         [InlineData(TestServers.Klondike)]
         [InlineData(TestServers.Artifactory)]
@@ -81,7 +81,7 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Theory]
-        //[InlineData(TestServers.NuGetServer, "NuGetServer")]
+        [InlineData(TestServers.NuGetServer, "NuGetServer")]
         [InlineData(TestServers.Vsts,"Vsts")]
         public async Task FindPackageByIdResource_Credential(string packageSource, string feedName)
         {
@@ -105,7 +105,7 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Theory]
-        //[InlineData(TestServers.NuGetServer, "NuGetServer")]
+        [InlineData(TestServers.NuGetServer, "NuGetServer")]
         [InlineData(TestServers.Vsts, "Vsts")]
         public async Task FindPackageByIdResource_CredentialNoDependencyVersion(string packageSource, string feedName)
         {
@@ -129,7 +129,7 @@ namespace NuGet.Protocol.FuncTest
         }
 
         [Theory]
-        //[InlineData(TestServers.NuGetServer, "NuGetServer")]
+        [InlineData(TestServers.NuGetServer, "NuGetServer")]
         [InlineData(TestServers.Vsts, "Vsts")]
         public async Task FindPackageByIdResource_CredentialNormalizedVersion(string packageSource, string feedName)
         {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/BasicLoggingTests.cs
@@ -177,6 +177,7 @@ namespace NuGet.XPlat.FuncTest
             Assert.Equal(0, exitCode);
         }
 
+        [Fact]
         public void BasicLogging_RestoreConfigFile_ExitCode()
         {
             // Arrange

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatRestoreTests.cs
@@ -17,14 +17,14 @@ namespace NuGet.XPlat.FuncTest
         [InlineData(TestServers.Klondike, false)]
         [InlineData(TestServers.MyGet, false)]
         [InlineData(TestServers.Nexus, false)]
-        //[InlineData(TestServers.NuGetServer, false)]
+        [InlineData(TestServers.NuGetServer, false)]
         [InlineData(TestServers.ProGet, false)]
         // Try with config file in a different directory
         [InlineData(TestServers.Artifactory, true)]
         [InlineData(TestServers.Klondike, true)]
         [InlineData(TestServers.MyGet, true)]
         [InlineData(TestServers.Nexus, true)]
-        //[InlineData(TestServers.NuGetServer, true)]
+        [InlineData(TestServers.NuGetServer, true)]
         [InlineData(TestServers.ProGet, true)]
         public void RestoreFromServerSucceeds(string sourceUri, bool configInDifferentDirectory)
         {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/2769

The credentials from NuGet.Server are in the nuget.config file for these XPlat functional tests, but the credentials aren't used. This is due to a bug found during the code review of this PR: https://github.com/NuGet/NuGet.Client/pull/586

GetEffectiveSourcesCore should use the PackageSources from the PackageSourceProvider whenever possible. Those will contain the credentials from nuget.config files.

@emgarten @alpaix @zhili1208 
