### PR TITLE
project.json build directory

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -98,6 +98,7 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.Logger = logger;
                     packArgs.Arguments = arguments.Values;
                     packArgs.Path = PackCommandRunner.GetInputFile(packArgs);
+                    packArgs.OutputDirectory = outputDirectory.Value();
 
                     // Set the current directory if the files being packed are in a different directory
                     PackCommandRunner.SetupCurrentDirectory(packArgs);
@@ -127,7 +128,6 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.MsBuildDirectory = new Lazy<string>(() => string.Empty);
                     packArgs.NoDefaultExcludes = noDefaultExcludes.HasValue();
                     packArgs.NoPackageAnalysis = noPackageAnalysis.HasValue();
-                    packArgs.OutputDirectory = outputDirectory.Value();
 
                     if (properties.HasValue())
                     {

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -194,7 +194,7 @@ namespace NuGet.Commands
             string targetPath = files.FirstOrDefault();
             if (targetPath == null)
             {
-                targetPath = Path.Combine(_packArgs.BasePath, "bin", configuration, builder.Id, ".dll");
+                targetPath = Path.Combine(_packArgs.BasePath, "bin", configuration, builder.Id + ".dll");
             }
 
             NuGetFramework targetFramework = NuGetFramework.AnyFramework;

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -158,6 +158,7 @@ namespace NuGet.Commands
                 UseShellExecute = false,
                 FileName = dotnetLocation,
                 Arguments = $"build {properties}",
+                WorkingDirectory = _packArgs.BasePath,
                 RedirectStandardOutput = false,
                 RedirectStandardError = false
             };


### PR DESCRIPTION
Changing the project.json build directory to use the basePath instead of the output directory. dotnet pack separates the two so this matches their behavior.  Also, this improves the way the output dlls are found to fix a case found with testing with dotnet pack.

@emgarten 
