### PR TITLE
Adding support for native-txm folder

### DIFF
--- a/src/NuGet.Core/NuGet.Client/AnyFramework.cs
+++ b/src/NuGet.Core/NuGet.Client/AnyFramework.cs
@@ -1,0 +1,19 @@
+﻿using NuGet.Frameworks;
+
+namespace NuGet.Client
+{
+    /// <summary>
+    /// An internal NuGetFramework marker for ManagedCodeConventions.
+    /// Most conventions disallow the string 'any' as a txm, so to allow
+    /// it for conventions with no txm in the path we use this special type.
+    /// </summary>
+    internal class AnyFramework : NuGetFramework
+    {
+        internal static AnyFramework Instance { get; } = new AnyFramework();
+
+        private AnyFramework()
+            : base(NuGetFramework.AnyFramework)
+        {
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -138,6 +138,12 @@ namespace NuGet.Client
                 {
                     return true;
                 }
+                else if (Object.Equals(AnyFramework.AnyFramework, availableFrameworkName))
+                {
+                    // If the convention does not contain a TxM it will use AnyFramework, this is
+                    // always compatible with other frameworks.
+                    return true;
+                }
                 else if (criteriaFrameworkName.IsAny
                          || availableFrameworkName.IsAny)
                 {
@@ -329,12 +335,20 @@ namespace NuGet.Client
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                         {
-                            "runtimes/{rid}/native/{any?}",
+                            "runtimes/{rid}/native-txm/{tfm}/{any?}",
+                            new PatternDefinition("runtimes/{rid}/native/{any?}", defaults: new Dictionary<string, object>
+                            {
+                                { "tfm", AnyFramework.Instance }
+                            }),
                             "native/{any?}",
                         },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "runtimes/{rid}/native/{any}",
+                        "runtimes/{rid}/native-txm/{tfm}/{any}",
+                        new PatternDefinition("runtimes/{rid}/native/{any}", defaults: new Dictionary<string, object>
+                        {
+                            { "tfm", AnyFramework.Instance }
+                        }),
                         "native/{any}",
                     });
 
@@ -358,7 +372,7 @@ namespace NuGet.Client
                         "build/{tfm}/{msbuild?}",
                         new PatternDefinition("build/{msbuild?}", defaults: new Dictionary<string, object>
                         {
-                            { "tfm", NuGetFramework.AnyFramework }
+                            { "tfm", AnyFramework.Instance }
                         })
                     },
                     pathPatterns: new PatternDefinition[]
@@ -366,7 +380,7 @@ namespace NuGet.Client
                         "build/{tfm}/{msbuild}",
                         new PatternDefinition("build/{msbuild}", defaults: new Dictionary<string, object>
                         {
-                            { "tfm", NuGetFramework.AnyFramework }
+                            { "tfm", AnyFramework.Instance }
                         })
                     });
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -174,16 +174,12 @@ namespace NuGet.Commands
             lockFileLib.ResourceAssemblies.AddRange(resourceGroup);
 
             // Native
-            var nativeCriteria = targetGraph.Conventions.Criteria.ForRuntime(targetGraph.RuntimeIdentifier);
-
-            var nativeGroup = contentItems.FindBestItemGroup(
-                nativeCriteria,
+            var nativeGroup = GetLockFileItems(
+                orderedCriteria,
+                contentItems,
                 targetGraph.Conventions.Patterns.NativeLibraries);
 
-            if (nativeGroup != null)
-            {
-                lockFileLib.NativeLibraries = nativeGroup.Items.Select(p => new LockFileItem(p.Path)).ToList();
-            }
+            lockFileLib.ResourceAssemblies.AddRange(nativeGroup);
 
             // content v2 items
             var contentFileGroups = contentItems.FindItemGroups(targetGraph.Conventions.Patterns.ContentFiles);

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelNativeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelNativeTests.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+using Xunit;
+
+namespace NuGet.Client.Test
+{
+    public class ContentModelNativeTests
+    {
+        [Theory]
+        [InlineData("win7-x64", "runtimes/win7-x64/native/a.dll")]
+        [InlineData("win7-x86", "runtimes/win7/native/a.dll")]
+        [InlineData("win7", "runtimes/win7/native/a.dll")]
+        [InlineData("linux", "runtimes/linux/native/a.dll")]
+        public void ContentModel_NativeRIDFolder_ForRuntime(string rid, string expected)
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7-x64/native/a.dll",
+                "runtimes/win7/native/a.dll",
+                "runtimes/linux/native/a.dll",
+                "runtimes/any/native/a.dll",
+            });
+
+            var criteria = conventions.Criteria.ForRuntime(rid);
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.NativeLibraries);
+
+            var result = string.Join("|", group.Items.Select(item => item.Path).OrderBy(s => s));
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+
+        [Theory]
+        [InlineData("win7-x64", "runtimes/win7-x64/native/a.dll")]
+        [InlineData("win7-x86", "runtimes/win7/native/a.dll")]
+        [InlineData("win7", "runtimes/win7/native/a.dll")]
+        [InlineData("linux", "runtimes/linux/native/a.dll")]
+        public void ContentModel_NativeRIDFolder_ForFrameworkAndRuntime(string rid, string expected)
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7-x64/native/a.dll",
+                "runtimes/win7/native/a.dll",
+                "runtimes/linux/native/a.dll",
+                "runtimes/any/native/a.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("netcore50"), rid);
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.NativeLibraries);
+
+            var result = string.Join("|", group.Items.Select(item => item.Path).OrderBy(s => s));
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ContentModel_NativeSubFoldersAllowed()
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7-x64/native/sub/a.dll"
+            });
+
+            var criteria1 = conventions.Criteria.ForRuntime("win7-x64");
+
+            // Act
+            var group1 = collection.FindBestItemGroup(criteria1, conventions.Patterns.NativeLibraries);
+
+            var result1 = string.Join("|", group1.Items.Select(item => item.Path).OrderBy(s => s));
+
+            // Assert
+            Assert.Equal("runtimes/win7-x64/native/sub/a.dll", result1);
+        }
+
+        [Fact]
+        public void ContentModel_FavorNativeTxMOverNative()
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7/native-txm/win81/a.dll",
+                "runtimes/win7/native-txm/win8/a.dll",
+                "runtimes/win7/native/a.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("uap10.0"), "win7-x64");
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.NativeLibraries);
+
+            var result = string.Join("|", group.Items.Select(item => item.Path).OrderBy(s => s));
+
+            // Assert
+            Assert.Equal("runtimes/win7/native-txm/win81/a.dll", result);
+        }
+
+        [Fact]
+        public void ContentModel_NoNativeTxMMatchesFallbackToNative()
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7/native-txm/win81/a.dll",
+                "runtimes/win7/native-txm/win8/a.dll",
+                "runtimes/win7/native/a.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("net46"), "win7-x64");
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.NativeLibraries);
+
+            var result = string.Join("|", group.Items.Select(item => item.Path).OrderBy(s => s));
+
+            // Assert
+            Assert.Equal("runtimes/win7/native/a.dll", result);
+        }
+
+        [Fact]
+        public void ContentModel_NoRidMatchReturnsNothing()
+        {
+            // Arrange
+            var runtimeGraph = new RuntimeGraph(
+                    new List<RuntimeDescription>() {
+                        new RuntimeDescription("any"),
+                        new RuntimeDescription("win7", new[] { "any" }),
+                        new RuntimeDescription("win7-x64", new[] { "any", "win7" }),
+                        new RuntimeDescription("win7-x86", new[] { "any", "win7" })},
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netcore50.app") });
+
+            var conventions = new ManagedCodeConventions(runtimeGraph);
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/win7/native-txm/win81/a.dll",
+                "runtimes/win7/native-txm/win8/a.dll",
+                "runtimes/win7/native/a.dll",
+            });
+
+            var criteria = conventions.Criteria.ForFrameworkAndRuntime(NuGetFramework.Parse("win8"), "linux");
+
+            // Act
+            var group = collection.FindBestItemGroup(criteria, conventions.Patterns.NativeLibraries);
+
+            // Assert
+            Assert.Null(group);
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for /runtimes/{rid}/native-txm/{tfm}/    Nupkgs can use this to specify a native dependency that pivots on both framework and rid.

https://github.com/NuGet/Home/issues/2782

//cc @alpaix @zhili1208 @rohit21agrawal @rrelyea @ericstj @davidfowl 
