### PR TITLE
Add support for specifying additional metadata via AssemblyMetadataAttribute

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadata.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Pack/AssemblyMetadata.cs
@@ -1,16 +1,30 @@
 ﻿using NuGet.Versioning;
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.CommandLine
 {
     [Serializable]
     public class AssemblyMetadata
     {
+        public AssemblyMetadata(Dictionary<string, string> properties = null)
+        {
+            Properties = properties ??
+                // Just like parameter replacements, these are also case insensitive, for consistency.
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
         public string Name { get; set; }
         public string Version { get; set; }
         public string Title { get; set; }
         public string Description { get; set; }
         public string Company { get; set; }
         public string Copyright { get; set; }
+
+        /// <summary>
+        /// Supports extra metadata properties specified for an assembly 
+        /// using AssemblyMetadataAttribute.
+        /// </summary>
+        public Dictionary<string, string> Properties { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine
     using NuGet.Packaging.Core;
 
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
-    public class ProjectFactory : MSBuildUser, IProjectFactory
+    public class ProjectFactory : MSBuildUser, IProjectFactory, IPropertyProvider
     {
         // Its type is Microsoft.Build.Evaluation.Project
         private dynamic _project;
@@ -250,6 +250,19 @@ namespace NuGet.CommandLine
             }
 
             var projectAuthor = InitializeProperties(builder);
+
+            // Only override properties from assembly extracted metadata if they haven't 
+            // been specified also at construction time for the factory (that is, 
+            // console properties always take precedence.
+            foreach (var key in builder.Properties.Keys)
+            {
+                if (!_properties.ContainsKey(key) &&
+                    !ProjectProperties.ContainsKey(key))
+                {
+                    _properties.Add(key, builder.Properties[key]);
+                }
+            }
+
             Manifest manifest = null;
 
             // If there is a project.json file, load that and skip any nuspec that may exist
@@ -314,7 +327,17 @@ namespace NuGet.CommandLine
             // Set the properties that were resolved from the assembly/project so they can be
             // resolved by name if the nuspec contains tokens
             _properties.Clear();
-            _properties.Add("Id", metadata.Id);
+
+            // Allow Id to be overriden by cmd line properties
+            if (ProjectProperties.ContainsKey("Id"))
+            {
+                _properties.Add("Id", ProjectProperties["Id"]);
+            }
+            else
+            {
+                _properties.Add("Id", metadata.Id);
+            }
+
             _properties.Add("Version", metadata.Version.ToString());
 
             if (!String.IsNullOrEmpty(metadata.Title))
@@ -343,7 +366,8 @@ namespace NuGet.CommandLine
         public string GetPropertyValue(string propertyName)
         {
             string value;
-            if (!_properties.TryGetValue(propertyName, out value))
+            if (!_properties.TryGetValue(propertyName, out value) &&
+                !ProjectProperties.TryGetValue(propertyName, out value))
             {
                 dynamic property = _project.GetProperty(propertyName);
                 if (property != null)
@@ -353,6 +377,11 @@ namespace NuGet.CommandLine
             }
 
             return value;
+        }
+
+        dynamic IPropertyProvider.GetPropertyValue(string propertyName)
+        {
+            return GetPropertyValue(propertyName);
         }
 
         private void BuildProject()
@@ -551,7 +580,7 @@ namespace NuGet.CommandLine
 
                 string fullPath = item.GetMetadataValue("FullPath");
                 if (!string.IsNullOrEmpty(fullPath) &&
-                    !NuspecFileExists(fullPath) && 
+                    !NuspecFileExists(fullPath) &&
                     !File.Exists(ProjectJsonPathUtilities.GetProjectConfigPath(Path.GetDirectoryName(fullPath), Path.GetFileName(fullPath))) &&
                     alreadyAppliedProjects.GetLoadedProjects(fullPath).Count == 0)
                 {
@@ -935,12 +964,12 @@ namespace NuGet.CommandLine
         private void AddDependencies(Dictionary<String, Tuple<PackageArchiveReader, PackageDependency>> packagesAndDependencies)
         {
             Dictionary<string, object> props = new Dictionary<string, object>();
-            
+
             foreach (var property in _project.Properties)
             {
                 props.Add(property.Name, property.EvaluatedValue);
             }
-            
+
             if (!props.ContainsKey(ProjectManagement.NuGetProjectMetadataKeys.TargetFramework))
             {
                 props.Add(ProjectManagement.NuGetProjectMetadataKeys.TargetFramework, new NuGetFramework(TargetFramework.Identifier, TargetFramework.Version, TargetFramework.Profile));

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -67,6 +67,8 @@ namespace NuGet.Packaging
             Authors = new HashSet<string>();
             Owners = new HashSet<string>();
             Tags = new HashSet<string>();
+            // Just like parameter replacements, these are also case insensitive, for consistency.
+            Properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         public string Id
@@ -154,6 +156,16 @@ namespace NuGet.Packaging
         }
 
         public ISet<string> Tags
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Exposes the additional properties extracted by the metadata 
+        /// extractor or received from the command line.
+        /// </summary>
+        public Dictionary<string, string> Properties
         {
             get;
             private set;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Properties/AssemblyInfo.cs
@@ -9,3 +9,8 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("33294bb8-5144-4363-b02c-332f6d94c1c1")]
+
+// Exercises the new metadata-driven manifest authoring
+[assembly: AssemblyMetadata("owner", "Outercurve")]
+[assembly: AssemblyInformationalVersion("3.3.0")]
+[assembly: AssemblyCopyright(".NET Foundation")]


### PR DESCRIPTION
Currently the only way to augment the $replacement$ tokens is by passing
additional values from the command line.

Just like for other assembly-level attributes, it's very convenient to be
able to specify these additional key-value pairs using the AssemblyMetadataAttribute.
The command line arguments should always take precedence to those assembly
attributes, so that behavior was added too. Also, the package Id seemed an
important property to be able to override also both as an AssemblyMetadataAttribute
and a cmd line paramenter, so that was added too. Maybe it should be done for
all manifest properties?

Fixes NuGet/Home#2851
