### PR TITLE
Using suffix for snapshot value in pack for project.json

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -296,7 +296,7 @@ namespace NuGet.Commands
 
         private static void LoadProjectJsonFile(PackageBuilder builder, string path, string basePath, string id, Stream stream, NuGetVersion version, string suffix, Func<string, string> propertyProvider)
         {
-            PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(stream, id, path);
+            PackageSpec spec = JsonPackageSpecReader.GetPackageSpec(stream, id, path, suffix);
 
             if (id == null)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildProjectReferenceProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildProjectReferenceProvider.cs
@@ -191,7 +191,7 @@ namespace NuGet.Commands
             {
                 if (File.Exists(path))
                 {
-                    result = JsonPackageSpecReader.GetPackageSpec(projectName, path);
+                    result = JsonPackageSpecReader.GetPackageSpec(projectName, path, string.Empty);
                 }
 
                 _projectJsonCache.Add(path, result);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
@@ -76,7 +76,7 @@ namespace NuGet.Commands
                 restoreContext.CacheContext,
                 restoreContext.Log);
 
-            var project = JsonPackageSpecReader.GetPackageSpec(file.Directory.Name, file.FullName);
+            var project = JsonPackageSpecReader.GetPackageSpec(file.Directory.Name, file.FullName, string.Empty);
 
             var request = new RestoreRequest(
                 project,

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1891,7 +1891,8 @@ namespace NuGet.PackageManagement
                     var originalPackageSpec = JsonPackageSpecReader.GetPackageSpec(
                         rawPackageSpec.ToString(),
                         buildIntegratedProject.ProjectName,
-                        buildIntegratedProject.JsonConfigPath);
+                        buildIntegratedProject.JsonConfigPath,
+                        string.Empty);
 
                     var originalRestoreResult = await BuildIntegratedRestoreUtility.RestoreAsync(
                         buildIntegratedProject,
@@ -1919,7 +1920,8 @@ namespace NuGet.PackageManagement
                 // Create a package spec from the modified json
                 var packageSpec = JsonPackageSpecReader.GetPackageSpec(rawPackageSpec.ToString(),
                     buildIntegratedProject.ProjectName,
-                    buildIntegratedProject.JsonConfigPath);
+                    buildIntegratedProject.JsonConfigPath,
+                    string.Empty);
 
 
                 // Restore based on the modified package spec. This operation does not write the lock file to disk.

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -202,7 +202,7 @@ namespace NuGet.ProjectManagement.Projects
         {
             get
             {
-                return JsonPackageSpecReader.GetPackageSpec(ProjectName, JsonConfigPath);
+                return JsonPackageSpecReader.GetPackageSpec(ProjectName, JsonConfigPath, string.Empty);
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedProjectReferenceContext.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedProjectReferenceContext.cs
@@ -89,7 +89,8 @@ namespace NuGet.ProjectManagement
                 // Read the spec and add it to the cache
                 spec = JsonPackageSpecReader.GetPackageSpec(
                     projectName,
-                    projectJsonPath);
+                    projectJsonPath,
+                    string.Empty);
 
                 SpecCache.Add(projectJsonPath, spec);
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/ExternalProjectReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ExternalProjectReference.cs
@@ -77,7 +77,7 @@ namespace NuGet.ProjectModel
             {
                 if (_packageSpec == null && PackageSpecPath != null && PackageSpecProjectName != null)
                 {
-                    _packageSpec = JsonPackageSpecReader.GetPackageSpec(PackageSpecProjectName, PackageSpecPath);
+                    _packageSpec = JsonPackageSpecReader.GetPackageSpec(PackageSpecProjectName, PackageSpecPath, string.Empty);
                 }
 
                 return _packageSpec;

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -27,7 +27,8 @@ namespace NuGet.ProjectModel
         /// </summary>
         /// <param name="name">project name</param>
         /// <param name="packageSpecPath">file path</param>
-        public static PackageSpec GetPackageSpec(string name, string packageSpecPath, string snapshotValue = "")
+        /// <param name="snapshotValue">snapshot suffix value</param>
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath, string snapshotValue)
         {
             using (var stream = new FileStream(packageSpecPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
@@ -41,7 +42,7 @@ namespace NuGet.ProjectModel
             return GetPackageSpec(ms, name, packageSpecPath, snapshotValue);
         }
 
-        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue = "")
+        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue)
         {
             // Load the raw JSON into the package spec object
             var reader = new JsonTextReader(new StreamReader(stream));
@@ -158,7 +159,6 @@ namespace NuGet.ProjectModel
                 packageSpec.Dependencies,
                 rawPackageSpec,
                 "dependencies",
-                snapshotValue,
                 isGacOrFrameworkReference: false);
 
             packageSpec.Tools = ReadTools(packageSpec, rawPackageSpec).ToList();
@@ -234,7 +234,6 @@ namespace NuGet.ProjectModel
             IList<LibraryDependency> results,
             JObject settings,
             string propertyName,
-            string snapshotValue,
             bool isGacOrFrameworkReference)
         {
             var dependencies = settings[propertyName] as JObject;
@@ -350,18 +349,6 @@ namespace NuGet.ProjectModel
 
                     if (!string.IsNullOrEmpty(dependencyVersionValue))
                     {
-                        if (dependencyVersionValue.Contains("-*"))
-                        {
-                            if (string.IsNullOrEmpty(snapshotValue))
-                            {
-                                dependencyVersionValue = dependencyVersionValue.Replace("-*", "");
-                            }
-                            else
-                            {
-                                dependencyVersionValue = dependencyVersionValue.Replace("-*", $"-{snapshotValue}");
-                            }
-                        }
-
                         try
                         {
                             dependencyVersionRange = VersionRange.Parse(dependencyVersionValue);
@@ -613,7 +600,6 @@ namespace NuGet.ProjectModel
                 targetFrameworkInformation.Dependencies,
                 properties,
                 "dependencies",
-                string.Empty,
                 isGacOrFrameworkReference: false);
 
             var frameworkAssemblies = new List<LibraryDependency>();
@@ -622,7 +608,6 @@ namespace NuGet.ProjectModel
                 frameworkAssemblies,
                 properties,
                 "frameworkAssemblies",
-                string.Empty,
                 isGacOrFrameworkReference: true);
 
             frameworkAssemblies.ForEach(d => targetFrameworkInformation.Dependencies.Add(d));

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -158,6 +158,7 @@ namespace NuGet.ProjectModel
                 packageSpec.Dependencies,
                 rawPackageSpec,
                 "dependencies",
+                snapshotValue,
                 isGacOrFrameworkReference: false);
 
             packageSpec.Tools = ReadTools(packageSpec, rawPackageSpec).ToList();
@@ -233,6 +234,7 @@ namespace NuGet.ProjectModel
             IList<LibraryDependency> results,
             JObject settings,
             string propertyName,
+            string snapshotValue,
             bool isGacOrFrameworkReference)
         {
             var dependencies = settings[propertyName] as JObject;
@@ -348,6 +350,11 @@ namespace NuGet.ProjectModel
 
                     if (!string.IsNullOrEmpty(dependencyVersionValue))
                     {
+                        if (dependencyVersionValue.Contains("-*"))
+                        {
+                            dependencyVersionValue = dependencyVersionValue.Replace("-*", $"-{snapshotValue}");
+                        }
+
                         try
                         {
                             dependencyVersionRange = VersionRange.Parse(dependencyVersionValue);
@@ -599,6 +606,7 @@ namespace NuGet.ProjectModel
                 targetFrameworkInformation.Dependencies,
                 properties,
                 "dependencies",
+                string.Empty,
                 isGacOrFrameworkReference: false);
 
             var frameworkAssemblies = new List<LibraryDependency>();
@@ -607,6 +615,7 @@ namespace NuGet.ProjectModel
                 frameworkAssemblies,
                 properties,
                 "frameworkAssemblies",
+                string.Empty,
                 isGacOrFrameworkReference: true);
 
             frameworkAssemblies.ForEach(d => targetFrameworkInformation.Dependencies.Add(d));

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -27,21 +27,21 @@ namespace NuGet.ProjectModel
         /// </summary>
         /// <param name="name">project name</param>
         /// <param name="packageSpecPath">file path</param>
-        public static PackageSpec GetPackageSpec(string name, string packageSpecPath)
+        public static PackageSpec GetPackageSpec(string name, string packageSpecPath, string snapshotValue = "")
         {
             using (var stream = new FileStream(packageSpecPath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                return GetPackageSpec(stream, name, packageSpecPath);
+                return GetPackageSpec(stream, name, packageSpecPath, snapshotValue);
             }
         }
 
-        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath)
+        public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath, string snapshotValue)
         {
             var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
-            return GetPackageSpec(ms, name, packageSpecPath);
+            return GetPackageSpec(ms, name, packageSpecPath, snapshotValue);
         }
 
-        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath)
+        public static PackageSpec GetPackageSpec(Stream stream, string name, string packageSpecPath, string snapshotValue = "")
         {
             // Load the raw JSON into the package spec object
             var reader = new JsonTextReader(new StreamReader(stream));
@@ -78,7 +78,7 @@ namespace NuGet.ProjectModel
             {
                 try
                 {
-                    packageSpec.Version = SpecifySnapshot(version.Value<string>(), snapshotValue: string.Empty);
+                    packageSpec.Version = SpecifySnapshot(version.Value<string>(), snapshotValue: snapshotValue);
                 }
                 catch (Exception ex)
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -352,7 +352,14 @@ namespace NuGet.ProjectModel
                     {
                         if (dependencyVersionValue.Contains("-*"))
                         {
-                            dependencyVersionValue = dependencyVersionValue.Replace("-*", $"-{snapshotValue}");
+                            if (string.IsNullOrEmpty(snapshotValue))
+                            {
+                                dependencyVersionValue = dependencyVersionValue.Replace("-*", "");
+                            }
+                            else
+                            {
+                                dependencyVersionValue = dependencyVersionValue.Replace("-*", $"-{snapshotValue}");
+                            }
                         }
 
                         try

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecResolver.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecResolver.cs
@@ -277,7 +277,7 @@ namespace NuGet.ProjectModel
                                         throw new InvalidOperationException(message, ex);
                                     }
 
-                                    project = JsonPackageSpecReader.GetPackageSpec(stream, Name, FullPath);
+                                    project = JsonPackageSpecReader.GetPackageSpec(stream, Name, FullPath, string.Empty);
                                 }
                                 finally
                                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/XProjUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/XProjUtility.cs
@@ -49,7 +49,7 @@ namespace NuGet.ProjectModel
                 if (File.Exists(jsonPath))
                 {
                     var projectName = Path.GetFileNameWithoutExtension(filePath);
-                    var spec = JsonPackageSpecReader.GetPackageSpec(projectName, jsonPath);
+                    var spec = JsonPackageSpecReader.GetPackageSpec(projectName, jsonPath, string.Empty);
 
                     var resolver = new PackageSpecResolver(spec);
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -33,7 +33,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 // This package has a minclientversion of 9999
                 AddDependency(spec, "TestPackage.MinClientVersion", "1.0.0");
@@ -75,7 +75,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 // This package has a minclientversion of 9999
                 AddDependency(spec, "TestPackage.MinClientVersion", "1.0.0");
@@ -119,7 +119,7 @@ namespace NuGet.Commands.FuncTest
             {
                 sources.Add(new PackageSource(sourceDir));
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 // This package has a minclientversion of 9.9999.0
                 AddDependency(spec, "packageA", "1.0.0");
@@ -173,7 +173,7 @@ namespace NuGet.Commands.FuncTest
             {
                 sources.Add(new PackageSource(emptyDir));
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 // This package has a minclientversion of 9.9999.0
                 AddDependency(spec, "packageA", "1.0.0");
@@ -254,7 +254,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -308,7 +308,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -364,7 +364,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -419,7 +419,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
                 var logger = new TestLogger();
 
                 // Create left over nupkg to simulate a corrupted install
@@ -478,7 +478,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -528,7 +528,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -580,7 +580,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -621,7 +621,7 @@ namespace NuGet.Commands.FuncTest
                 json["frameworks"] = frameworks;
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(json.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(json.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "nEwTonSoft.JSon", "6.0.8");
                 AddDependency(spec, "json-ld.net", "1.0.4");
@@ -672,7 +672,7 @@ namespace NuGet.Commands.FuncTest
                 json["frameworks"] = frameworks;
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(json.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(json.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "nEwTonSoft.JSon", "4.0.1");
                 AddDependency(spec, "dotNetRDF", "1.0.8.3533");
@@ -707,7 +707,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -759,7 +759,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -809,7 +809,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -872,7 +872,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -915,7 +915,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "WebGrease", "1.6.0");
 
@@ -982,7 +982,7 @@ namespace NuGet.Commands.FuncTest
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
@@ -1035,7 +1035,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfigWithNet46.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "Moon.Owin.Localization", "1.3.1");
 
@@ -1077,7 +1077,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -1116,7 +1116,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
@@ -1149,7 +1149,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "owin", "1.0");
 
@@ -1180,7 +1180,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "Newtonsoft.Json", "7.0.0"); // 7.0.0 does not exist so we'll bump up to 7.0.1
 
@@ -1217,7 +1217,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "Newtonsoft.Json", "7.0.1");
 
@@ -1260,7 +1260,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NuGet.Core", "2.8.3");
 
@@ -1308,7 +1308,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath, string.Empty);
 
                 AddDependency(spec, "NotARealPackage.ThisShouldNotExists.DontCreateIt.Seriously.JustDontDoIt.Please", "2.8.3");
 
@@ -1358,7 +1358,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1405,7 +1405,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1450,7 +1450,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1537,7 +1537,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath, string.Empty);
 
                 var lockFileFormat = new LockFileFormat();
                 var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
@@ -1622,7 +1622,7 @@ namespace NuGet.Commands.FuncTest
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath, string.Empty);
 
                 var lockFileFormat = new LockFileFormat();
                 var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
@@ -1670,7 +1670,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1710,7 +1710,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1748,7 +1748,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -1786,7 +1786,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var context = new SourceCacheContext();
@@ -1831,7 +1831,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var context = new SourceCacheContext();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -85,7 +85,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -138,7 +138,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger)
@@ -189,7 +189,7 @@ namespace NuGet.Commands.FuncTest
             }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -230,7 +230,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -281,7 +281,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -345,7 +345,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -412,7 +412,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
@@ -470,7 +470,7 @@ namespace NuGet.Commands.FuncTest
                 }");
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -51,7 +51,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -123,7 +123,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -191,7 +191,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -258,7 +258,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -326,7 +326,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -393,7 +393,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -472,7 +472,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -550,7 +550,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -134,7 +134,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -209,7 +209,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -305,7 +305,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -404,7 +404,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -500,7 +500,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -589,7 +589,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -664,7 +664,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -735,7 +735,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -805,7 +805,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -875,7 +875,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -952,7 +952,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1027,7 +1027,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1105,7 +1105,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1184,7 +1184,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1264,7 +1264,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1345,7 +1345,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1428,7 +1428,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1511,7 +1511,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1588,7 +1588,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1660,7 +1660,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1715,7 +1715,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1872,7 +1872,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 
@@ -1929,7 +1929,7 @@ namespace NuGet.Commands.Test
                 }
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var project1PackagePath = SimpleTestPackageUtility.CreateFullPackage(
                     packageSource.FullName,
@@ -137,8 +137,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(packageBProject.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageBProjectJson, "packageB", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageBProjectJson, "packageB", specPath2, string.Empty);
 
                 var packageAPath = SimpleTestPackageUtility.CreateFullPackage(
                     packageSource.FullName,
@@ -246,9 +246,9 @@ namespace NuGet.Commands.Test
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(packageAProject.FullName, "project.json");
                 var specPath3 = Path.Combine(packageAExternalProject.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2);
-                var spec3 = JsonPackageSpecReader.GetPackageSpec(packageAExternalProjectJson, "packageA", specPath3);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2, string.Empty);
+                var spec3 = JsonPackageSpecReader.GetPackageSpec(packageAExternalProjectJson, "packageA", specPath3, string.Empty);
 
                 var packageAPath = SimpleTestPackageUtility.CreateFullPackage(
                     packageSource.FullName,
@@ -361,8 +361,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(packageAProject.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2, string.Empty);
 
                 var packageAPath = SimpleTestPackageUtility.CreateFullPackage(
                     packageSource.FullName,
@@ -464,8 +464,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(packageAProject.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(packageAProjectJson, "packageA", specPath2, string.Empty);
 
                 var packageAPath = SimpleTestPackageUtility.CreateFullPackage(
                     packageSource.FullName,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -1596,7 +1596,7 @@ namespace NuGet.Commands.Test
             Directory.CreateDirectory(testProject2Dir);
 
             var specPath1 = Path.Combine(testProject1Dir, "project.json");
-            var spec1 = JsonPackageSpecReader.GetPackageSpec(configJson1, "TestProject1", specPath1);
+            var spec1 = JsonPackageSpecReader.GetPackageSpec(configJson1, "TestProject1", specPath1, string.Empty);
 
             using (var writer = new StreamWriter(File.OpenWrite(specPath1)))
             {
@@ -1604,7 +1604,7 @@ namespace NuGet.Commands.Test
             }
 
             var specPath2 = Path.Combine(testProject2Dir, "project.json");
-            var spec2 = JsonPackageSpecReader.GetPackageSpec(configJson2, "TestProject2", specPath2);
+            var spec2 = JsonPackageSpecReader.GetPackageSpec(configJson2, "TestProject2", specPath2, string.Empty);
 
             using (var writer = new StreamWriter(File.OpenWrite(specPath2)))
             {
@@ -1663,21 +1663,21 @@ namespace NuGet.Commands.Test
             Directory.CreateDirectory(testProject3Dir);
 
             var specPath1 = Path.Combine(testProject1Dir, "project.json");
-            var spec1 = JsonPackageSpecReader.GetPackageSpec(configJson1, "TestProject1", specPath1);
+            var spec1 = JsonPackageSpecReader.GetPackageSpec(configJson1, "TestProject1", specPath1, string.Empty);
             using (var writer = new StreamWriter(File.OpenWrite(specPath1)))
             {
                 writer.WriteLine(configJson1);
             }
 
             var specPath2 = Path.Combine(testProject2Dir, "project.json");
-            var spec2 = JsonPackageSpecReader.GetPackageSpec(configJson2, "TestProject2", specPath2);
+            var spec2 = JsonPackageSpecReader.GetPackageSpec(configJson2, "TestProject2", specPath2, string.Empty);
             using (var writer = new StreamWriter(File.OpenWrite(specPath2)))
             {
                 writer.WriteLine(configJson2);
             }
 
             var specPath3 = Path.Combine(testProject3Dir, "project.json");
-            var spec3 = JsonPackageSpecReader.GetPackageSpec(configJson3, "TestProject3", specPath3);
+            var spec3 = JsonPackageSpecReader.GetPackageSpec(configJson3, "TestProject3", specPath3, string.Empty);
             using (var writer = new StreamWriter(File.OpenWrite(specPath3)))
             {
                 writer.WriteLine(configJson3);
@@ -1723,7 +1723,7 @@ namespace NuGet.Commands.Test
             sources.Add(new PackageSource(repository));
 
             var specPath = Path.Combine(testProjectDir, "project.json");
-            var spec = JsonPackageSpecReader.GetPackageSpec(configJson, "TestProject", specPath);
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson, "TestProject", specPath, string.Empty);
 
             var request = new RestoreRequest(spec, sources, packagesDir, logger);
             request.LockFilePath = Path.Combine(testProjectDir, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MinClientVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MinClientVersionTests.cs
@@ -47,7 +47,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
@@ -70,7 +70,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
@@ -64,8 +64,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -150,8 +150,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -256,9 +256,9 @@ namespace NuGet.Commands.Test
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
-                var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
+                var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -360,8 +360,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -437,8 +437,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -518,7 +518,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project3.FullName, "project3.csproj"), string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -625,9 +625,9 @@ namespace NuGet.Commands.Test
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project2", specPath2);
-                var spec3 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project3", specPath3);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project2", specPath2, string.Empty);
+                var spec3 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project3", specPath3, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir, logger);
@@ -762,7 +762,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project3.FullName, "project3.xproj"), string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
@@ -889,7 +889,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project3.FullName, "project3.xproj"), string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
                 var specPath3 = Path.Combine(project3.FullName, "project.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -73,8 +73,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -148,8 +148,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -220,8 +220,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -298,8 +298,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -383,8 +383,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -464,8 +464,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -532,7 +532,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(msbuidPath2, string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -602,7 +602,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -674,8 +674,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -749,8 +749,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -824,8 +824,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -940,9 +940,9 @@ namespace NuGet.Commands.Test
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
-                var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
+                var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1004,7 +1004,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(project1ProjPath, string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 sources.Add(new PackageSource(packageSource.FullName));
 
@@ -1074,7 +1074,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(project1ProjPath, string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 sources.Add(new PackageSource(packageSource.FullName));
 
@@ -1173,8 +1173,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1251,8 +1251,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1313,7 +1313,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project2.FullName, "packages.config"), string.Empty);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1400,8 +1400,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1485,8 +1485,8 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -54,7 +54,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -113,7 +113,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "PROJECT1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "PROJECT1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -179,7 +179,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -248,7 +248,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -317,7 +317,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -386,7 +386,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -448,7 +448,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -509,7 +509,7 @@ namespace NuGet.Commands.Test
                 SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "project1", "1.0.0");
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -572,7 +572,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -626,7 +626,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -1180,7 +1180,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(Project.FullName, "project.json"), ProjectJson);
 
                 var specPath1 = Path.Combine(Project.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(ProjectJson, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(ProjectJson, "project1", specPath1, string.Empty);
                 Request = new RestoreRequest(spec1, Sources, PackagesDir.FullName, Logger);
 
                 Request.LockFilePath = Path.Combine(Project.FullName, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var lockPath = Path.Combine(project1.FullName, "project.lock.json");
@@ -124,7 +124,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(workingDir, "NuGet.Config"), String.Format(configFile, packageSource.FullName));
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var configPath = Path.Combine(workingDir, "NuGet.Config");
 
@@ -209,10 +209,10 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var projPath1 = Path.Combine(project1.FullName, "project1.csproj");
                 var projPath2 = Path.Combine(project2.FullName, "project2.xproj");
@@ -319,10 +319,10 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
+                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2, string.Empty);
 
                 var logger = new TestLogger();
                 var lockPath1 = Path.Combine(project1.FullName, "project.lock.json");
@@ -393,7 +393,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var lockPath1 = Path.Combine(project1.FullName, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
@@ -52,7 +52,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -168,7 +168,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -240,7 +240,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -312,7 +312,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -384,7 +384,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -455,7 +455,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -132,7 +132,7 @@ namespace NuGet.Commands.Test
                 }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -199,7 +199,7 @@ namespace NuGet.Commands.Test
             }".Replace("_FRAMEWORK_", framework));
 
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
-                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
+                var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath, string.Empty);
 
                 var request = new RestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -121,7 +121,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -215,7 +215,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
@@ -306,7 +306,7 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1, string.Empty);
 
                 var logger = new TestLogger();
                 var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyTargetTests.cs
@@ -23,7 +23,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -47,7 +47,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -71,7 +71,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -95,7 +95,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -116,7 +116,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -146,7 +146,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -182,7 +182,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -218,7 +218,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)
@@ -254,7 +254,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
                 var dependency = spec.Dependencies.Single();
             }
             catch (FileFormatException ex)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/ImportFrameworkTest.cs
@@ -24,7 +24,7 @@ namespace NuGet.ProjectModel.Test
                 }");
 
             // Act & Assert
-            var ex = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json"));
+            var ex = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json", string.Empty));
             Assert.Equal("Imports contains an invalid framework: '[  \"dotnet5.3\",  \"portable-net452+win81\",  \"furtureFramework\"]' in 'project.json'.", ex.InnerException.Message);
 
         }
@@ -46,7 +46,7 @@ namespace NuGet.ProjectModel.Test
                 }");
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json", string.Empty);
             var importFramework = spec.TargetFrameworks.First().Imports.ToList();
 
             // Assert
@@ -70,7 +70,7 @@ namespace NuGet.ProjectModel.Test
                 }");
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", "project.json", string.Empty);
             var importFramework = spec.TargetFrameworks.First().Imports.ToList();
             var expectedFramework = NuGetFramework.Parse("dotnet5.3");
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/IncludeFlagTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -47,7 +47,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -71,7 +71,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -98,7 +98,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             var futureFlag = LibraryIncludeFlagUtils.GetFlags(new string[] { "futureFlag" });
@@ -125,7 +125,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -154,7 +154,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -178,7 +178,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -204,7 +204,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -229,7 +229,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -254,7 +254,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -279,7 +279,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -304,7 +304,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -331,7 +331,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -357,7 +357,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -383,7 +383,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -409,7 +409,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert
@@ -433,7 +433,7 @@ namespace NuGet.ProjectModel.Test
 
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var dependency = spec.Dependencies.Single();
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -29,7 +29,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             }
             catch (Exception ex)
             {
@@ -56,7 +56,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var range = spec.Dependencies.Single().LibraryRange.VersionRange;
 
             // Assert
@@ -83,7 +83,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             }
             catch (Exception ex)
             {
@@ -114,7 +114,7 @@ namespace NuGet.ProjectModel.Test
 
             try
             {
-                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+                var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             }
             catch (Exception ex)
             {
@@ -140,7 +140,7 @@ namespace NuGet.ProjectModel.Test
                         }";
 
             // Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             var range = spec.TargetFrameworks.Single().Dependencies.Single().LibraryRange.VersionRange;
 
             // Assert
@@ -159,7 +159,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             
             // Assert
             Assert.Equal(2, actual.Tools.Count);
@@ -187,7 +187,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             Assert.Equal(1, actual.Tools.Count);
@@ -209,7 +209,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act & Assert
-            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty));
             Assert.Contains("Tools must specify a version range.", actual.Message);
         }
 
@@ -226,7 +226,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act & Assert
-            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty));
             Assert.Contains("not a valid version string", actual.Message);
         }
 
@@ -243,7 +243,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act & Assert
-            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty));
             Assert.Contains("not a valid version string", actual.Message);
         }
 
@@ -261,7 +261,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act & Assert
-            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+            var actual = Assert.Throws<FileFormatException>(() => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty));
             Assert.Contains("Imports contains an invalid framework: 'a' in 'project.json'.", actual.Message);
         }
 
@@ -279,7 +279,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             
             // Assert
             Assert.Equal(1, actual.Tools.Count);
@@ -306,7 +306,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             
             // Assert
             Assert.Equal(1, actual.Tools.Count);
@@ -333,7 +333,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
             
             // Assert
             Assert.Equal(1, actual.Tools.Count);
@@ -359,7 +359,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
@@ -387,7 +387,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
@@ -414,7 +414,7 @@ namespace NuGet.ProjectModel.Test
                          }";
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             var dep = actual.Dependencies.FirstOrDefault(d => d.Name.Equals("redist"));
@@ -448,7 +448,7 @@ namespace NuGet.ProjectModel.Test
         public void PackageSpecReader_PackOptions_Default(string json)
         {
             // Arrange & Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -490,7 +490,7 @@ namespace NuGet.ProjectModel.Test
                 .ToArray();
 
             // Act
-            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty);
 
             // Assert
             Assert.NotNull(actual.PackOptions);
@@ -554,7 +554,7 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange & Act & Assert
             var actual = Assert.Throws<FileFormatException>(
-                () => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json"));
+                () => JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json", string.Empty));
 
             Assert.Contains("The pack options package type must be a string or array of strings in 'project.json'.", actual.Message);
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
@@ -96,7 +96,7 @@ namespace NuGet.ProjectModel.Test
         private static void VerifyJsonPackageSpecRoundTrip(string json)
         {
             // Arrange & Act
-            var spec = JsonPackageSpecReader.GetPackageSpec(json, "testName", @"C:\fake\path");
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "testName", @"C:\fake\path", string.Empty);
 
             JObject jsonObject = new JObject();
             JsonPackageSpecWriter.WritePackageSpec(spec, jsonObject);


### PR DESCRIPTION
Making versions in project.json that end in -\* so that the \* gets replaced by the suffix passed into the command-line arguments.
