### PR TITLE
fixed https://github.com/NuGet/Home/issues/2763

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -433,7 +433,7 @@ namespace NuGet.Configuration
                 curr = curr._next;
             }
 
-            return ApplyEnvironmentTransform(ret);
+            return ret;
         }
 
         private string ApplyEnvironmentTransform(string configValue)
@@ -460,8 +460,6 @@ namespace NuGet.Configuration
                 curr.PopulateValues(section, settingValues, isPath);
                 curr = curr._next;
             }
-
-            settingValues.ForEach(settingValue => settingValue.Value = ApplyEnvironmentTransform(settingValue.Value));
 
             return settingValues.AsReadOnly();
         }
@@ -823,6 +821,7 @@ namespace NuGet.Configuration
 
             // Return the optional value which if not there will be null;
             var value = XElementUtility.GetOptionalAttributeValue(element, ConfigurationConstants.ValueAttribute);
+            value = ApplyEnvironmentTransform(value);
             if (!isPath
                 || String.IsNullOrEmpty(value))
             {
@@ -905,7 +904,7 @@ namespace NuGet.Configuration
                 throw new InvalidDataException(String.Format(CultureInfo.CurrentCulture, Resources.UserSettings_UnableToParseConfigFile, ConfigFilePath));
             }
 
-            var value = valueAttribute.Value;
+            var value = ApplyEnvironmentTransform(valueAttribute.Value);
             var originalValue = valueAttribute.Value;
             Uri uri;
 

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
@@ -31,10 +31,10 @@ namespace NuGet.Configuration.Test
                 Environment.SetEnvironmentVariable("RP_ENV_VAR", "ONE");
 
                 //Act
-                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile, isPath: true);
 
                 //Assert
-                Assert.Equal(settings.GetValue("config", "repositoryPath"), expectedRepositoryPath);
+                Assert.Equal(settings.GetValue("config", "repositoryPath"), Path.Combine(nugetConfigFileFolder,expectedRepositoryPath));
             }
         }
 
@@ -57,7 +57,55 @@ namespace NuGet.Configuration.Test
                 ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
 
                 //Assert
-                var settingsForConfig = settings.GetSettingValues("config");
+                var settingsForConfig = settings.GetSettingValues("config", isPath: true);
+                Assert.Single(settingsForConfig);
+                Assert.Equal(settingsForConfig.Single().Value, Path.Combine(nugetConfigFileFolder, expectedRepositoryPath));
+            }
+        }
+
+        [Fact]
+        public void GetValueEvaluatesEnvironmentVariableWithAbsolutePath()
+        {
+            //Arrange
+            var expectedRepositoryPath = @"C:\log";
+
+            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nugetConfigFile = "NuGet.config";
+                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
+
+                File.WriteAllText(nugetConfigFilePath, DefaultNuGetConfigurationWithEnvironmentVariable);
+
+                Environment.SetEnvironmentVariable("RP_ENV_VAR", @"C:\log");
+
+                //Act
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile, isPath: true);
+
+                //Assert
+                Assert.Equal(settings.GetValue("config", "repositoryPath"), expectedRepositoryPath);
+            }
+        }
+
+        [Fact]
+        public void GetSettingValuesEvaluatesEnvironmentVariableWithAbsolutePath()
+        {
+            //Arrange
+            var expectedRepositoryPath = @"C:\log";
+
+            using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nugetConfigFile = "NuGet.config";
+                var nugetConfigFilePath = Path.Combine(nugetConfigFileFolder, nugetConfigFile);
+
+                File.WriteAllText(nugetConfigFilePath, DefaultNuGetConfigurationWithEnvironmentVariable);
+
+                Environment.SetEnvironmentVariable("RP_ENV_VAR", @"C:\log");
+
+                //Act
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
+
+                //Assert
+                var settingsForConfig = settings.GetSettingValues("config", isPath: true);
                 Assert.Single(settingsForConfig);
                 Assert.Equal(settingsForConfig.Single().Value, expectedRepositoryPath);
             }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/EnvironmentSupportTests.cs
@@ -31,10 +31,10 @@ namespace NuGet.Configuration.Test
                 Environment.SetEnvironmentVariable("RP_ENV_VAR", "ONE");
 
                 //Act
-                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile, isPath: true);
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
 
                 //Assert
-                Assert.Equal(settings.GetValue("config", "repositoryPath"), Path.Combine(nugetConfigFileFolder,expectedRepositoryPath));
+                Assert.Equal(settings.GetValue("config", "repositoryPath", isPath: true), Path.Combine(nugetConfigFileFolder, expectedRepositoryPath));
             }
         }
 
@@ -67,7 +67,7 @@ namespace NuGet.Configuration.Test
         public void GetValueEvaluatesEnvironmentVariableWithAbsolutePath()
         {
             //Arrange
-            var expectedRepositoryPath = @"C:\log";
+            var expectedRepositoryPath = @"C:\log\two";
 
             using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
@@ -79,10 +79,10 @@ namespace NuGet.Configuration.Test
                 Environment.SetEnvironmentVariable("RP_ENV_VAR", @"C:\log");
 
                 //Act
-                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile, isPath: true);
+                ISettings settings = new Settings(nugetConfigFileFolder, nugetConfigFile);
 
                 //Assert
-                Assert.Equal(settings.GetValue("config", "repositoryPath"), expectedRepositoryPath);
+                Assert.Equal(settings.GetValue("config", "repositoryPath", isPath: true), expectedRepositoryPath);
             }
         }
 
@@ -90,7 +90,7 @@ namespace NuGet.Configuration.Test
         public void GetSettingValuesEvaluatesEnvironmentVariableWithAbsolutePath()
         {
             //Arrange
-            var expectedRepositoryPath = @"C:\log";
+            var expectedRepositoryPath = @"C:\log\two";
 
             using (var nugetConfigFileFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2763
Fixed Env variable issue.

The bug is Apply EnvironmentTransform after solving path,  nuget will treat env variable path value as relative path, so the path result will be Path.Combine(Root, value). But if this value is absolute path, then will get path format issue.

The fix is Apply EnvironmentTransform before solving path
