### PR TITLE
Fixing the relative file path used in pack when the output files are …

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -190,11 +190,19 @@ namespace NuGet.Commands
                 }
             }
 
-            IEnumerable<string> files = PathResolver.PerformWildcardSearch(_packArgs.BasePath, $"**\\{builder.Id}\\bin\\{configuration}\\");
+            string projectOutputDirectory;
+            string configFolderPath = $"\\{builder.Id}\\bin\\{configuration}";
+            IEnumerable<string> files = PathResolver.PerformWildcardSearch(_packArgs.BasePath, $"**{configFolderPath}\\");
             string targetPath = files.FirstOrDefault();
             if (targetPath == null)
             {
                 targetPath = Path.Combine(_packArgs.BasePath, "bin", configuration, builder.Id + ".dll");
+
+                projectOutputDirectory = Path.GetDirectoryName(targetPath);
+            }
+            else
+            {
+                projectOutputDirectory = targetPath.Substring(0, targetPath.IndexOf(configFolderPath) + configFolderPath.Length);
             }
 
             NuGetFramework targetFramework = NuGetFramework.AnyFramework;
@@ -214,8 +222,6 @@ namespace NuGet.Commands
                 // Include pdbs for symbol packages
                 allowedOutputExtensions.Add(".pdb");
             }
-
-            string projectOutputDirectory = Path.GetDirectoryName(targetPath);
 
             string targetFileName = Path.GetFileNameWithoutExtension(targetPath);
 


### PR DESCRIPTION
…dll outputs from a project.json build.

The code finds the dlls under the output directory.  They will be under framework names, and sometimes are in subdirectories depending on the project folder structure.  In some cases, the folder structure made the logic not able to figure out the relative path of the file so it was putting full path folders into the nupkg.

@drewgil 
