### PR TITLE
Avoid logging total time elapsed for tab command since it will remove the intellisense

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/TabExpansionCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/TabExpansionCommand.cs
@@ -11,6 +11,17 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
     [Cmdlet("TabExpansion", "Package")]
     public class TabExpansionCommand : FindPackageCommand
     {
+        /// <summary>
+        /// logging time disabled for tab command
+        /// </summary>
+        protected override bool IsLoggingTimeDisabled
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         [Parameter]
         public SwitchParameter ExcludeVersionInfo { get; set; }
 

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -88,11 +88,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// </summary>
         protected NuGetPackageManager PackageManager
         {
-            get { return new NuGetPackageManager(
-                _sourceRepositoryProvider,
-                ConfigSettings,
-                VsSolutionManager,
-                _deleteOnRestartManager); }
+            get
+            {
+                return new NuGetPackageManager(
+                    _sourceRepositoryProvider,
+                    ConfigSettings,
+                    VsSolutionManager,
+                    _deleteOnRestartManager);
+            }
         }
 
         /// <summary>
@@ -193,6 +196,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             get { return this; }
         }
 
+        /// <summary>
+        /// Determine if needs to log total time elapsed or not
+        /// </summary>
+        protected virtual bool IsLoggingTimeDisabled { get; }
+
         #endregion Properties
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to display friendly message to the console.")]
@@ -218,7 +226,12 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             }
 
             stopWatch.Stop();
-            LogCore(ProjectManagement.MessageLevel.Info, string.Format(CultureInfo.CurrentCulture, Resources.Cmdlet_TotalTime, stopWatch.Elapsed));
+
+            // Log total time elapsed except for Tab command
+            if (!IsLoggingTimeDisabled)
+            {
+                LogCore(ProjectManagement.MessageLevel.Info, string.Format(CultureInfo.CurrentCulture, Resources.Cmdlet_TotalTime, stopWatch.Elapsed));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Avoid logging total time elapsed for tab command since it will remove the intellisense

Fix https://github.com/NuGet/Home/issues/2853
