### PR TITLE
update CLI, NetCoreApp & CoreFX 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ curl -o cli/dotnet-install.sh https://raw.githubusercontent.com/dotnet/cli/rel/1
 
 # Run install.sh
 chmod +x cli/dotnet-install.sh
-cli/dotnet-install.sh -i cli -c beta -v 1.0.0-preview1-002702
+cli/dotnet-install.sh -i cli -c preview -v 1.0.0-preview2-002911
 
 # Display current version
 DOTNET="$(pwd)/cli/dotnet"

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -166,7 +166,7 @@ Function Install-DotnetCLI {
 
     wget 'https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1' -OutFile 'cli/dotnet-install.ps1'
 
-    & cli/dotnet-install.ps1 -Channel beta -i $CLIRoot -Version 1.0.0-preview1-002702
+    & cli/dotnet-install.ps1 -Channel preview -i $CLIRoot -Version 1.0.0-preview2-002911
 
     if (-not (Test-Path $DotNetExe)) {
         Error-Log "Unable to find dotnet.exe. The CLI install may have failed." -Fatal

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -21,7 +21,7 @@ curl -o cli/dotnet-install.sh https://raw.githubusercontent.com/dotnet/cli/rel/1
 
 # Run install.sh
 chmod +x cli/dotnet-install.sh
-cli/dotnet-install.sh -i cli -c beta -v 1.0.0-preview1-002702
+cli/dotnet-install.sh -i cli -c preview -v 1.0.0-preview2-002911
 
 # Display current version
 DOTNET="$(pwd)/cli/dotnet"

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -50,7 +50,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -51,7 +51,7 @@
         "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -28,7 +28,7 @@
     "NuGet.Commands": {
       "target": "project"
     },
-    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027"
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24128-00"
   },
   "commands": {
     "NuGet.CommandLine.XPlat": "NuGet.CommandLine.XPlat"
@@ -48,7 +48,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-24027",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -73,8 +73,8 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Xml.XDocument": "4.0.11-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Xml.XDocument": "4.0.11-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -35,10 +35,10 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-24027",
-        "System.Diagnostics.Process": "4.1.0-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Security.Cryptography.Algorithms": "4.2.0-rc3-24128-00",
+        "System.Diagnostics.Process": "4.1.0-rc3-24128-00",
+        "System.Threading.Thread": "4.0.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -46,8 +46,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Xml.XDocument": "4.0.11-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Xml.XDocument": "4.0.11-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -28,8 +28,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.ObjectModel": "4.0.12-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.ObjectModel": "4.0.12-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -51,7 +51,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -44,7 +44,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -42,7 +42,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -36,7 +36,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -36,7 +36,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -44,8 +44,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Xml.XDocument": "4.0.11-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Xml.XDocument": "4.0.11-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -50,8 +50,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.IO.Compression": "4.1.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.IO.Compression": "4.1.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -40,9 +40,9 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Dynamic.Runtime": "4.0.11-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Dynamic.Runtime": "4.0.11-rc3-24128-00",
+        "System.Threading.Thread": "4.0.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -49,8 +49,8 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Net.Http": "4.0.1-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Net.Http": "4.1.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -58,8 +58,8 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Dynamic.Runtime": "4.0.11-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.Dynamic.Runtime": "4.0.11-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -38,7 +38,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -33,7 +33,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -40,7 +40,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -44,9 +44,9 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.ObjectModel": "4.0.12-rc2-24027",
-        "System.Dynamic.Runtime": "4.0.11-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.ObjectModel": "4.0.12-rc3-24128-00",
+        "System.Dynamic.Runtime": "4.0.11-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -32,7 +32,7 @@
     },
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "imports": [
         "dotnet5.6",

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -41,9 +41,9 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.IO.Compression.ZipFile": "4.0.1-rc2-24027",
-        "System.Diagnostics.Process": "4.1.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "System.IO.Compression.ZipFile": "4.0.1-rc3-24128-00",
+        "System.Diagnostics.Process": "4.1.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -32,7 +32,7 @@
     },
     "netstandard1.0": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0-rc3-24128-00"
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -39,7 +39,7 @@
         "System.Diagnostics.Process": "4.1.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "imports": [

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -36,7 +36,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "System.Diagnostics.Process": "4.1.0-rc2-24027",
+        "System.Diagnostics.Process": "4.1.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -9,6 +10,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NuGet.XPlat.FuncTest")]
 [assembly: AssemblyTrademark("")]
+// XUnit runner configuration: Disable parallel tests  
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)] 
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -24,7 +24,7 @@
         "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/project.json
@@ -19,9 +19,9 @@
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+        "System.Threading.Tasks.Parallel": "4.0.1-rc3-24128-00",
+        "System.Threading.Thread": "4.0.0-rc3-24128-00",
+        "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -21,8 +21,8 @@
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-24027",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+        "System.Threading.Tasks.Parallel": "4.0.1-rc3-24128-00",
+        "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -25,7 +25,7 @@
         "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -22,7 +22,7 @@
         "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/project.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+        "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Core.Test/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -22,7 +22,7 @@
         "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/project.json
@@ -19,7 +19,7 @@
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+        "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/project.json
@@ -20,7 +20,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -28,7 +28,7 @@
         "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -25,7 +25,7 @@
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+        "System.Diagnostics.TraceSource": "4.0.0-rc3-24128-00",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0-rc2-3002339"

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/project.json
@@ -17,7 +17,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Synchronization.Test/project.json
@@ -27,7 +27,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/project.json
@@ -16,7 +16,7 @@
         "dotnet-test-xunit": "1.0.0-rc2-173361-36",
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002339"
+          "version": "1.0.0-rc3-004338"
         }
       },
       "buildOptions": {


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/2879

Here are the matching shared framework and CLI builds to also consume at the same time: 
• CoreCLR/CoreFX/WCF – rc3-24128-00
• Microsoft.NetCore.App – 1.0.0-rc3-004338
• CLI – 1.0.0-preview2-002911

Due to one particular test that was failing on Linux, we had to disable parallel execution of functional tests for linux and mac.

// @alpaix @joelverhagen @rrelyea 
