### PR TITLE
Credential service test fix

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageExtensions.cs
@@ -1,13 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Net.Http;
+using NuGet.Common;
 
 namespace NuGet.Protocol
 {
     internal static class HttpRequestMessageExtensions
     {
+        public static readonly string NuGetLoggerKey = "NuGet_Logger";
+
         /// <summary>
         /// Clones an <see cref="HttpRequestMessage" /> request.
         /// </summary>
@@ -32,6 +36,52 @@ namespace NuGet.Protocol
             }
 
             return clone;
+        }
+
+        /// <summary>
+        /// Retrieves a logger instance attached to the given request as custom property.
+        /// </summary>
+        /// <param name="request">Request message</param>
+        /// <returns>Logger instance if exists, or null otherwise.</returns>
+        public static ILogger GetLogger(this HttpRequestMessage request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            return request.GetProperty<ILogger>(NuGetLoggerKey);
+        }
+
+        /// <summary>
+        /// Attaches a logger instance to the given request message as custom property.
+        /// </summary>
+        /// <param name="request">A request message</param>
+        /// <param name="logger">A logger instance</param>
+        public static void SetLogger(this HttpRequestMessage request, ILogger logger)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            request.Properties[NuGetLoggerKey] = logger;
+        }
+
+        private static T GetProperty<T>(this HttpRequestMessage request, string key)
+        {
+            object result;
+            if (request.Properties.TryGetValue(key, out result) && result is T)
+            {
+                return (T)result;
+            }
+
+            return default(T);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageFactory.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using NuGet.Common;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// Factory class containing methods facilitating creation of <see cref="HttpRequestMessage"/> 
+    /// with additional custom parameters.
+    /// </summary>
+    public static class HttpRequestMessageFactory
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        /// <param name="method">Desired HTTP verb</param>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="log">Logger instance to be attached</param>
+        /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
+        public static HttpRequestMessage Create(HttpMethod method, string requestUri, ILogger log)
+        {
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+
+            var request = new HttpRequestMessage(method, requestUri);
+            request.SetLogger(log);
+            return request;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        /// <param name="method">Desired HTTP verb</param>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="log">Logger instance to be attached</param>
+        /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
+        public static HttpRequestMessage Create(HttpMethod method, Uri requestUri, ILogger log)
+        {
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+
+            var request = new HttpRequestMessage(method, requestUri);
+            request.SetLogger(log);
+            return request;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandler.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Protocol;
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
-using Strings = NuGet.Protocol.Strings;
 
 namespace NuGet.Protocol
 {
@@ -88,7 +87,7 @@ namespace NuGet.Protocol
         /// </summary>
         public async Task<HttpSourceResult> GetAsync(
             string uri,
-            MediaTypeWithQualityHeaderValue[] accept,
+            MediaTypeWithQualityHeaderValue[] acceptHeaderValues,
             string cacheKey,
             HttpSourceCacheContext cacheContext,
             ILogger log,
@@ -134,11 +133,13 @@ namespace NuGet.Protocol
 
                     Func<HttpRequestMessage> requestFactory = () =>
                     {
-                        var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                        foreach (var a in accept)
+                        var request = HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log);
+
+                        foreach (var acceptHeaderValue in acceptHeaderValues)
                         {
-                            request.Headers.Accept.Add(a);
+                            request.Headers.Accept.Add(acceptHeaderValue);
                         }
+
                         return request;
                     };
 
@@ -255,7 +256,7 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             Func<Task<HttpResponseMessage>> request = () => SendWithRetrySupportAsync(
-                () => new HttpRequestMessage(HttpMethod.Get, uri),
+                () => HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log),
                 DefaultRequestTimeout,
                 log,
                 token);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -102,7 +101,7 @@ namespace NuGet.Protocol
             try
             {
                 lastRequestUri = await client.ProcessResponseAsync(
-                    () => new HttpRequestMessage(HttpMethod.Get, url),
+                    () => HttpRequestMessageFactory.Create(HttpMethod.Get, url, log),
                     response =>
                     {
                         if (response.RequestMessage == null)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -138,7 +138,7 @@ namespace NuGet.Protocol
                 UriUtility.UrlEncodeOdataParameter(package.Version.ToNormalizedString()));
 
             // Try to find the package directly
-            // Set max count to -1, get all packages 
+            // Set max count to -1, get all packages
             var packages = await QueryV2Feed(
                 uri,
                 package.Id,
@@ -404,7 +404,7 @@ namespace NuGet.Protocol
                     // Request the next url in parallel to parsing the current page
                     if (!string.IsNullOrEmpty(nextUri) && uri != nextUri)
                     {
-                        // a bug on the server side causes the same next link to be returned 
+                        // a bug on the server side causes the same next link to be returned
                         // for every page. To avoid falling into an infinite loop we must
                         // keep track here.
                         uri = nextUri;
@@ -434,7 +434,7 @@ namespace NuGet.Protocol
             return await _httpSource.ProcessResponseAsync(
                 () =>
                 {
-                    var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                    var request = HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log);
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
                     request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
                     return request;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -246,8 +246,8 @@ namespace NuGet.Protocol.Core.Types
         // Indicates whether the specified source is a file source, such as: \\a\b, c:\temp, etc.
         private bool IsFileSource()
         {
-            //we leverage the detection already done at resource provider level. 
-            //that for file system, the "httpSource" is null. 
+            //we leverage the detection already done at resource provider level.
+            //that for file system, the "httpSource" is null.
             return _httpSource == null;
         }
 
@@ -261,7 +261,7 @@ namespace NuGet.Protocol.Core.Types
             CancellationToken token)
         {
             await _httpSource.ProcessResponseAsync(
-                () => CreateRequest(source, pathToPackage, apiKey),
+                () => CreateRequest(source, pathToPackage, apiKey, logger),
                 requestTimeout,
                 response =>
                 {
@@ -274,16 +274,17 @@ namespace NuGet.Protocol.Core.Types
 
         private HttpRequestMessage CreateRequest(string source,
             string pathToPackage,
-            string apiKey)
+            string apiKey,
+            ILogger log)
         {
             var fileStream = new FileStream(pathToPackage, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var request = new HttpRequestMessage(HttpMethod.Put, GetServiceEndpointUrl(source, string.Empty));
+            var request = HttpRequestMessageFactory.Create(HttpMethod.Put, GetServiceEndpointUrl(source, string.Empty), log);
             var content = new MultipartFormDataContent();
 
             var packageContent = new StreamContent(fileStream);
             packageContent.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
             //"package" and "package.nupkg" are random names for content deserializing
-            //not tied to actual package name.  
+            //not tied to actual package name.
             content.Add(packageContent, "package", "package.nupkg");
             request.Content = content;
 
@@ -360,7 +361,7 @@ namespace NuGet.Protocol.Core.Types
                 {
                     // Review: Do these values need to be encoded in any way?
                     var url = String.Join("/", packageId, packageVersion);
-                    var request = new HttpRequestMessage(HttpMethod.Delete, GetServiceEndpointUrl(source, url));
+                    var request = HttpRequestMessageFactory.Create(HttpMethod.Delete, GetServiceEndpointUrl(source, url), logger);
                     if (!string.IsNullOrEmpty(apiKey))
                     {
                         request.Headers.Add(ApiKeyHeader, apiKey);
@@ -471,7 +472,7 @@ namespace NuGet.Protocol.Core.Types
                 if (Directory.GetFiles(idDirectory, "*.nupkg").Any() ||
                     Directory.GetFiles(idDirectory, "*.nuspec").Any())
                 {
-                    // ~/Foo/Foo.1.0.0.nupkg (LocalPackageRepository with PackageSaveModes.Nupkg) or 
+                    // ~/Foo/Foo.1.0.0.nupkg (LocalPackageRepository with PackageSaveModes.Nupkg) or
                     // ~/Foo/Foo.1.0.0.nuspec (LocalPackageRepository with PackageSaveMode.Nuspec)
                     return true;
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1084,8 +1084,8 @@ $@"<?xml version='1.0' encoding='utf-8'?>
 
                         // Assert
                         Assert.Equal(1, r1.Item1);
-
-                        Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Item3);
+                        Assert.Contains("Response status code does not indicate success: 401 (Unauthorized).", r1.Item3);
+                        Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Item2);
 
                         // No requests hit server, since abort during credential acquisition
                         // and no fallback to console provider
@@ -1165,7 +1165,8 @@ $@"<?xml version='1.0' encoding='utf-8'?>
 
                         // Assert
                         Assert.Equal(1, r1.Item1);
-                        Assert.Contains($"Credential plugin {pluginPath} timed out", r1.Item3);
+                        Assert.Contains("Response status code does not indicate success: 401 (Unauthorized).", r1.Item3);
+                        Assert.Contains($"Credential plugin {pluginPath} timed out", r1.Item2);
                         // ensure the process was killed
                         Assert.Equal(0, System.Diagnostics.Process.GetProcessesByName(Path.GetFileNameWithoutExtension(pluginPath)).Length);
                         // No requests hit server, since abort during credential acquisition


### PR DESCRIPTION
Due to recent changes in HttpSource authentication handlers maintain their
own retry cycle that is separate from the retry handler's one.
Whenever CredentialService throws the exception being caught by the retry
handler it is considered as retryable. Therefore the retry handler retries
the same request 3 times independendly.
As a result push timeout test failed on external nuget.exe runtime timeout.

To fix that I granted authentication handlers a role to interpret
CredentialService originated exceptions and act accordingly. Meaning now
when such error occurs the handler will write error message to log and
return 401/407 without retrying.

To enable writing to log I added a HttpRequestMessage property containing
logger instance. This property is populated by a request factory(ies).

//cc @rrelyea @joelverhagen @rohit21agrawal 
