### PR TITLE
Adding pack support for outputName in project.json

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -190,13 +190,15 @@ namespace NuGet.Commands
                 }
             }
 
+            var dllName = builder.OutputName == null ? builder.Id : builder.OutputName;
+
             string projectOutputDirectory;
             string configFolderPath = $"\\{builder.Id}\\bin\\{configuration}";
             IEnumerable<string> files = PathResolver.PerformWildcardSearch(_packArgs.BasePath, $"**{configFolderPath}\\");
-            string targetPath = files.FirstOrDefault(f => f.EndsWith(builder.Id + ".dll"));
+            string targetPath = files.FirstOrDefault(f => f.EndsWith(dllName + ".dll"));
             if (targetPath == null)
             {
-                targetPath = Path.Combine(_packArgs.BasePath, "bin", configuration, builder.Id + ".dll");
+                targetPath = Path.Combine(_packArgs.BasePath, "bin", configuration, dllName + ".dll");
 
                 projectOutputDirectory = Path.GetDirectoryName(targetPath);
             }
@@ -372,6 +374,10 @@ namespace NuGet.Commands
             if (spec.Language != null)
             {
                 builder.Language = spec.Language;
+            }
+            if (spec.OutputName != null)
+            {
+                builder.OutputName = spec.OutputName;
             }
 
             foreach (var include in spec.PackInclude)

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -375,9 +375,9 @@ namespace NuGet.Commands
             {
                 builder.Language = spec.Language;
             }
-            if (spec.OutputName != null)
+            if (spec.BuildOptions != null && spec.BuildOptions.OutputName != null)
             {
-                builder.OutputName = spec.OutputName;
+                builder.OutputName = spec.BuildOptions.OutputName;
             }
 
             foreach (var include in spec.PackInclude)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -159,6 +159,12 @@ namespace NuGet.Packaging
             set;
         }
 
+        public string OutputName
+        {
+            get;
+            set;
+        }
+
         public ISet<string> Tags
         {
             get;

--- a/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/BuildOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.ProjectModel
+{
+    public class BuildOptions
+    {
+        public string OutputName { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -114,6 +114,12 @@ namespace NuGet.ProjectModel
             packageSpec.Summary = rawPackageSpec.GetValue<string>("summary");
             packageSpec.ReleaseNotes = rawPackageSpec.GetValue<string>("releaseNotes");
 
+            var buildOptions = rawPackageSpec["buildOptions"] as JObject;
+            if (buildOptions != null)
+            {
+                packageSpec.OutputName = buildOptions.GetValue<string>("outputName");
+            }
+
             var requireLicenseAcceptance = rawPackageSpec["requireLicenseAcceptance"];
 
             if (requireLicenseAcceptance != null)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -117,7 +117,10 @@ namespace NuGet.ProjectModel
             var buildOptions = rawPackageSpec["buildOptions"] as JObject;
             if (buildOptions != null)
             {
-                packageSpec.OutputName = buildOptions.GetValue<string>("outputName");
+                packageSpec.BuildOptions = new BuildOptions()
+                {
+                    OutputName = buildOptions.GetValue<string>("outputName")
+                };
             }
 
             var requireLicenseAcceptance = rawPackageSpec["requireLicenseAcceptance"];

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -76,7 +76,7 @@ namespace NuGet.ProjectModel
 
         public string Language { get; set; }
 
-        public string OutputName { get; set; }
+        public BuildOptions BuildOptions { get; set; }
 
         public string[] Tags { get; set; }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -76,6 +76,8 @@ namespace NuGet.ProjectModel
 
         public string Language { get; set; }
 
+        public string OutputName { get; set; }
+
         public string[] Tags { get; set; }
 
         public IList<string> ContentFiles { get; set; }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -410,7 +410,6 @@ namespace NuGet.CommandLine.Test
                 var path = Path.Combine(workingDirectory, "packageA.1.0.0.nupkg");
                 var package = new OptimizedZipPackage(path);
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
-                Array.Sort(files);
 
                 Assert.Equal(
                     files,
@@ -478,7 +477,6 @@ namespace NuGet.CommandLine.Test
                 var path = Path.Combine(workingDirectory, Path.GetFileName(workingDirectory) + ".1.0.0.nupkg");
                 var package = new OptimizedZipPackage(path);
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
-                Array.Sort(files);
 
                 Assert.Equal(
                     files,
@@ -3138,7 +3136,6 @@ stuff \n <<".Replace("\r\n", "\n");
                 var path = Path.Combine(workingDirectory, Path.GetFileName(workingDirectory) + ".1.0.0.nupkg");
                 var package = new OptimizedZipPackage(path);
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
-                Array.Sort(files);
 
                 Assert.Equal(
                     files,
@@ -3212,12 +3209,14 @@ stuff \n <<".Replace("\r\n", "\n");
         {
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var testFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
-                string id = Path.GetFileName(workingDirectory);
+                var id = "packageId";
+                var workingDirectory = Path.Combine(testFolder, id);
                 string dllName = "myDllName";
 
+                Directory.CreateDirectory(id);
                 Util.CreateFile(
                     Path.Combine(workingDirectory, "someDirName", id, "bin/Debug/netcoreapp1.0"),
                     dllName + ".dll",
@@ -3262,7 +3261,6 @@ stuff \n <<".Replace("\r\n", "\n");
                 var path = Path.Combine(workingDirectory, Path.GetFileName(workingDirectory) + ".1.0.0.nupkg");
                 var package = new OptimizedZipPackage(path);
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
-                Array.Sort(files);
 
                 Assert.Equal(
                     files,

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -3207,6 +3207,75 @@ stuff \n <<".Replace("\r\n", "\n");
             }
         }
 
+        [Fact]
+        public void PackCommand_PackJsonCorrectLibPathInNupkgWithOutputName()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                string id = Path.GetFileName(workingDirectory);
+                string dllName = "myDllName";
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "someDirName", id, "bin/Debug/netcoreapp1.0"),
+                    dllName + ".dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    Path.Combine(workingDirectory, "someDirName", id, "bin/Debug/netcoreapp1.0/win7-x64"),
+                    dllName + ".dll",
+                    string.Empty);
+
+                Util.CreateFile(
+                    workingDirectory,
+                    "project.json",
+                @"{
+  ""version"": ""1.0.0"",
+  ""title"": ""packageA"",
+  ""authors"": [ ""test"" ],
+  ""owners"": [ ""test"" ],
+  ""requireLicenseAcceptance"": ""false"",
+  ""description"": ""Description"",
+  ""buildOptions"": {
+    ""outputName"": """ + dllName + @""",
+  },
+  ""copyright"": ""Copyright ©  2013"",
+  ""frameworks"": {
+    ""native"": {
+    },
+    ""uap10.0"": {
+    }
+  }
+}");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    "pack project.json",
+                    waitForExit: true);
+                Assert.Equal(0, r.Item1);
+
+                // Assert
+                var path = Path.Combine(workingDirectory, Path.GetFileName(workingDirectory) + ".1.0.0.nupkg");
+                var package = new OptimizedZipPackage(path);
+                var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
+                Array.Sort(files);
+
+                Assert.Equal(
+                    files,
+                    new string[]
+                    {
+                            @"lib\netcoreapp1.0\" + dllName + ".dll",
+                            @"lib\netcoreapp1.0\win7-x64\" + dllName + ".dll",
+                    });
+
+                Assert.False(r.Item2.Contains("Assembly outside lib folder"));
+            }
+        }
+
         private class PackageDepencyComparer : IEqualityComparer<PackageDependency>
         {
             public bool Equals(PackageDependency x, PackageDependency y)

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -558,5 +558,43 @@ namespace NuGet.ProjectModel.Test
 
             Assert.Contains("The pack options package type must be a string or array of strings in 'project.json'.", actual.Message);
         }
+
+        [Theory]
+        [InlineData("{}", null, true)]
+        [InlineData(@"{
+                        ""buildOptions"": {}
+                      }", null, false)]
+        [InlineData(@"{
+                        ""buildOptions"": {
+                          ""outputName"": ""dllName""
+                        }
+                      }", "dllName", false)]
+        [InlineData(@"{
+                        ""buildOptions"": {
+                          ""outputName"": ""dllName2"",
+                          ""emitEntryPoint"": true
+                        }
+                      }", "dllName2", false)]
+        [InlineData(@"{
+                        ""buildOptions"": {
+                          ""outputName"": null
+                        }
+                      }", null, false)]
+        public void PackageSpecReader_BuildOptions(string json, string expectedValue, bool nullBuildOptions)
+        {
+            // Arrange & Act
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            if (nullBuildOptions)
+            {
+                Assert.Null(actual.BuildOptions);
+            }
+            else
+            {
+                Assert.NotNull(actual.BuildOptions);
+                Assert.Equal(expectedValue, actual.BuildOptions.OutputName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adding support for outputName so that packing a project.json file is able to find the right dll.

@joelverhagen
