### PR TITLE
Add support for serviceable element in nuspec file

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core/NuspecCoreReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuspecCoreReaderBase.cs
@@ -109,6 +109,14 @@ namespace NuGet.Packaging.Core
         }
 
         /// <summary>
+        /// Returns if the package is serviceable.
+        /// </summary>
+        public virtual bool IsServiceable()
+        {
+            return NuspecUtility.IsServiceable(MetadataNode);
+        }
+
+        /// <summary>
         /// The developmentDependency attribute
         /// </summary>
         public virtual bool GetDevelopmentDependency()

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuspecUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuspecUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using NuGet.Packaging;
 
 namespace NuGet.Packaging.Core
 {
@@ -19,6 +20,7 @@ namespace NuGet.Packaging.Core
         public static readonly string PackageType = "packageType";
         public static readonly string PackageTypeName = "name";
         public static readonly string PackageTypeVersion = "version";
+        public static readonly string Serviceable = "serviceable";
 
         /// <summary>
         /// Gets the package types from a .nuspec metadata XML element.
@@ -89,6 +91,26 @@ namespace NuGet.Packaging.Core
             }
 
             return packageTypes;
+        }
+
+        /// <summary>
+        /// Gets the value of serviceable element from a .nuspec metadata XML element.
+        /// </summary>
+        /// <param name="metadataNode">The metadata XML element.</param>
+        /// <returns>
+        /// true if the serviceable element is set in the .nuspec file as true, else false.
+        /// </returns>
+        public static bool IsServiceable(XElement metadataNode)
+        {
+            var metadataNamespace = metadataNode.GetDefaultNamespace().NamespaceName;
+            var element = metadataNode.Elements(XName.Get(Serviceable, metadataNamespace)).FirstOrDefault();
+            if (element == null)
+            {
+                return false;
+            }
+
+            string value = element.Value ?? element.Value.Trim();
+            return System.Xml.XmlConvert.ToBoolean(value);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/IPackageMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/IPackageMetadata.cs
@@ -26,6 +26,7 @@ namespace NuGet.Packaging
         string ReleaseNotes { get; }
         string Language { get; }
         string Tags { get; }
+        bool Serviceable { get; }
         string Copyright { get; }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestMetadata.cs
@@ -38,6 +38,7 @@ namespace NuGet.Packaging
             Authors = copy.Authors;
             Owners = copy.Owners;
             Tags = string.IsNullOrEmpty(copy.Tags) ? null : copy.Tags.Trim();
+            Serviceable = copy.Serviceable;
             _licenseUrl = copy.LicenseUrl?.OriginalString;
             _projectUrl = copy.ProjectUrl?.OriginalString;
             _iconUrl = copy.IconUrl?.OriginalString;
@@ -166,6 +167,8 @@ namespace NuGet.Packaging
         public string Language { get; set; }
 
         public string Tags { get; set; }
+
+        public bool Serviceable { get; set; }
 
         private IEnumerable<PackageDependencyGroup> _dependencyGroups = new List<PackageDependencyGroup>();
         public IEnumerable<PackageDependencyGroup> DependencyGroups

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -121,6 +121,9 @@ namespace NuGet.Packaging
                 case "tags":
                     manifestMetadata.Tags = value;
                     break;
+                case "serviceable":
+                    manifestMetadata.Serviceable = XmlConvert.ToBoolean(value);
+                    break;
                 case "dependencies":
                     manifestMetadata.DependencyGroups = ReadDependencyGroups(element);
                     break;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -54,6 +54,11 @@ namespace NuGet.Packaging
         /// </summary>
         internal const string SchemaVersionV7 = "http://schemas.microsoft.com/packaging/2016/04/nuspec.xsd";
 
+        /// <summary>
+        /// Added serviceble element under metadata.
+        /// </summary>
+        internal const string SchemaVersionV8 = "http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd";
+
         private static readonly string[] VersionToSchemaMappings = new[] {
             SchemaVersionV1,
             SchemaVersionV2,
@@ -61,7 +66,8 @@ namespace NuGet.Packaging
             SchemaVersionV4,
             SchemaVersionV5,
             SchemaVersionV6,
-            SchemaVersionV7
+            SchemaVersionV7,
+            SchemaVersionV8
         };
 
 #if !IS_CORECLR

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
@@ -17,6 +17,7 @@ namespace NuGet.Packaging
         public const int TargetFrameworkSupportForReferencesVersion = 5;
         public const int XdtTransformationVersion = 6;
         public const int PackageTypeVersion = 7;
+        public const int ServiceableVersion = 8;
 
         public static int GetManifestVersion(ManifestMetadata metadata)
         {
@@ -25,7 +26,17 @@ namespace NuGet.Packaging
 
         private static int GetMaxVersionFromMetadata(ManifestMetadata metadata)
         {
-            // Important: check for version 5 before version 4
+            // Important: always add newer version checks at the top
+            if (metadata.Serviceable)
+            {
+                return ServiceableVersion;
+            }
+
+            if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
+            {
+                return PackageTypeVersion;
+            }
+
             bool referencesHasTargetFramework =
               metadata.PackageAssemblyReferences != null &&
               metadata.PackageAssemblyReferences.Any(r => r.TargetFramework != null && r.TargetFramework.IsSpecificFramework);
@@ -46,11 +57,6 @@ namespace NuGet.Packaging
             if (metadata.Version != null && metadata.Version.IsPrerelease)
             {
                 return SemverVersion;
-            }
-
-            if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
-            {
-                return PackageTypeVersion;
             }
 
             return DefaultVersion;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -123,6 +123,12 @@ namespace NuGet.Packaging
             set;
         }
 
+        public bool Serviceable
+        {
+            get;
+            set;
+        }
+
         public bool DevelopmentDependency
         {
             get;
@@ -494,6 +500,7 @@ namespace NuGet.Packaging
             ProjectUrl = metadata.ProjectUrl;
             RequireLicenseAcceptance = metadata.RequireLicenseAcceptance;
             DevelopmentDependency = metadata.DevelopmentDependency;
+            Serviceable = metadata.Serviceable;
             Description = metadata.Description;
             Summary = metadata.Summary;
             ReleaseNotes = metadata.ReleaseNotes;

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -51,7 +51,11 @@ namespace NuGet.Packaging.Xml
             AddElementIfNotNull(elem, ns, "copyright", metadata.Copyright);
             AddElementIfNotNull(elem, ns, "language", metadata.Language);
             AddElementIfNotNull(elem, ns, "tags", metadata.Tags);
-            
+            if (metadata.Serviceable)
+            {
+                elem.Add(new XElement(ns + "serviceable", metadata.Serviceable));
+            }
+
             if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
             {
                 elem.Add(GetXElementFromManifestPackageTypes(ns, metadata.PackageTypes));

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -171,6 +171,11 @@ namespace NuGet.Packaging
             return NuspecReader.GetFrameworkReferenceGroups();
         }
 
+        public bool IsServiceable()
+        {
+            return NuspecReader.IsServiceable();
+        }
+
         public IEnumerable<FrameworkSpecificGroup> GetBuildItems()
         {
             var id = GetIdentity().Id;

--- a/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
+++ b/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd
@@ -63,6 +63,7 @@
                             <xs:element name="copyright" maxOccurs="1" minOccurs="0" type="xs:string" />
                             <xs:element name="language" maxOccurs="1" minOccurs="0" type="xs:string" default="en-US" />
                             <xs:element name="tags" maxOccurs="1" minOccurs="0" type="xs:string" />
+                            <xs:element name="serviceable" maxOccurs="1" minOccurs="0" type="xs:boolean" />
                             <xs:element name="packageTypes" maxOccurs="1" minOccurs="0">
                                 <xs:complexType>
                                     <xs:sequence>

--- a/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestPackages.cs
@@ -240,6 +240,29 @@ namespace NuGet.Test.Utility
             return file;
         }
 
+        public static TempFile GetServiceablePackage()
+        {
+            var file = new TempFile();
+
+            using (var zip = new ZipArchive(File.Create(file), ZipArchiveMode.Create))
+            {
+                zip.AddEntry("lib/net40/test40.dll", ZeroContent);
+
+                zip.AddEntry("packageA.nuspec", @"<?xml version=""1.0"" encoding=""utf-8""?>
+                            <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+                              <metadata>
+                                <id>packageA</id>
+                                <version>2.0.3</version>
+                                <authors>Author1, author2</authors>
+                                <description>Sample description</description>
+                                <serviceable>true</serviceable>
+                              </metadata>
+                            </package>", Encoding.UTF8);
+            }
+
+            return file;
+        }
+
         public static TempFile GetLegacyTestPackageMinClient(string minClientVersion)
         {
             var file = new TempFile();

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
@@ -200,6 +200,7 @@ namespace NuGet.Packaging.Test
                 dependencies: new[] { new PackageDependency("Test", VersionRange.Parse("1.2.0")) },
                 assemblyReference: new[] { new FrameworkAssemblyReference("System.Data", new[] { NuGetFramework.Parse("4.0") }) },
                 references: references,
+                serviceable: true,
                 packageTypes: new[]
                 {
                     new PackageType("foo", new Version(2, 0, 0)),
@@ -221,6 +222,7 @@ namespace NuGet.Packaging.Test
                 Copyright = "Copyright 2012",
                 Language = "fr-FR",
                 Tags = "Test Unit",
+                Serviceable = true,
                 DependencyGroups = new[]
                                     {
                                         new PackageDependencyGroup(
@@ -358,6 +360,41 @@ namespace NuGet.Packaging.Test
             Assert.Equal(new[] { "Luan" }, manifest.Metadata.Authors);
             Assert.False(manifest.Metadata.RequireLicenseAcceptance);
             Assert.True(manifest.Metadata.DevelopmentDependency);
+            Assert.Equal("Descriptions", manifest.Metadata.Description);
+        }
+
+        [Fact]
+        public void ReadServiceable()
+        {
+            // Arrange
+            string content = @"<?xml version=""1.0""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+  <metadata hello=""world"">
+    <id>A</id>
+    <version>1.0</version>
+    <authors>Luan</authors>
+    <owners>Luan</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <developmentDependency>true</developmentDependency>
+    <description>Descriptions</description>
+    <serviceable>true</serviceable>
+    <extra>This element is not defined in schema.</extra>
+  </metadata>
+  <clark>meko</clark>
+  <files>
+      <file src=""my.txt"" destination=""outdir"" />
+  </files>
+</package>";
+            // Act
+            var manifest = Manifest.ReadFrom(content.AsStream(), validateSchema: false);
+
+            // Assert
+            Assert.Equal("A", manifest.Metadata.Id);
+            Assert.Equal(NuGetVersion.Parse("1.0"), manifest.Metadata.Version);
+            Assert.Equal(new[] { "Luan" }, manifest.Metadata.Authors);
+            Assert.False(manifest.Metadata.RequireLicenseAcceptance);
+            Assert.True(manifest.Metadata.DevelopmentDependency);
+            Assert.True(manifest.Metadata.Serviceable);
             Assert.Equal("Descriptions", manifest.Metadata.Description);
         }
 
@@ -689,6 +726,7 @@ namespace NuGet.Packaging.Test
             Assert.Equal(expected.Metadata.DevelopmentDependency, actual.Metadata.DevelopmentDependency);
             Assert.Equal(expected.Metadata.Summary, actual.Metadata.Summary);
             Assert.Equal(expected.Metadata.Tags, actual.Metadata.Tags);
+            Assert.Equal(expected.Metadata.Serviceable, actual.Metadata.Serviceable);
             Assert.Equal(expected.Metadata.MinClientVersion, actual.Metadata.MinClientVersion);
 
             if (expected.Metadata.DependencyGroups != null)
@@ -814,6 +852,7 @@ namespace NuGet.Packaging.Test
                                             string iconUrl = null,
                                             bool? requiresLicenseAcceptance = null,
                                             bool? developmentDependency = null,
+                                            bool serviceable = false,
                                             string description = "Test description",
                                             string summary = null,
                                             string releaseNotes = null,
@@ -885,6 +924,10 @@ namespace NuGet.Packaging.Test
             if (tags != null)
             {
                 metadata.Add(new XElement("tags", tags));
+            }
+            if (serviceable)
+            {
+                metadata.Add(new XElement("serviceable", true));
             }
             if (dependencies != null)
             {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
@@ -10,6 +10,30 @@ namespace NuGet.Packaging.Test
     public class ManifestVersionUtilityTest
     {
         [Fact]
+        public void GetManifestVersionReturns8IfServiceableIsSet()
+        {
+            // Arrange
+            var metadata = new ManifestMetadata
+            {
+                Id = "Foo",
+                Version = NuGetVersion.Parse("1.0"),
+                Authors = new[] { "A, B" },
+                Description = "Description",
+                Serviceable = true,
+                PackageTypes = new[]
+                {
+                    new PackageType("Bar", new System.Version(2, 0))
+                }
+            };
+
+            // Act
+            var version = ManifestVersionUtility.GetManifestVersion(metadata);
+
+            // Assert
+            Assert.Equal(8, version);
+        }
+
+        [Fact]
         public void GetManifestVersionReturns7IfPackageTypesAreSet()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -242,6 +242,19 @@ namespace NuGet.Packaging.Test
                   </metadata>
                 </package>";
 
+        private const string ServiceablePackageTypesElement = @"<?xml version=""1.0""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+                  <metadata>
+                    <id>packageA</id>
+                    <version>1.0.1-alpha</version>
+                    <title>Package A</title>
+                    <authors>ownera, ownerb</authors>
+                    <owners>ownera, ownerb</owners>
+                    <description>package A description.</description>
+                    <serviceable>true</serviceable>
+                  </metadata>
+                </package>";
+
         [Fact]
         public void NuspecReaderTests_NamespaceOnMetadata()
         {
@@ -479,6 +492,19 @@ namespace NuGet.Packaging.Test
 
             // Assert
             Assert.Equal(0, actual.Count);
+        }
+
+        [Fact]
+        public void NuspecReaderTests_ServiceablePackage()
+        {
+            // Arrange
+            var reader = GetReader(ServiceablePackageTypesElement);
+
+            // Act
+            var actual = reader.IsServiceable();
+
+            // Assert
+            Assert.True(actual);
         }
 
         private static NuspecReader GetReader(string nuspec)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -505,6 +505,47 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void CreatePackageWithServiceableElement()
+        {
+            // Arrange
+            PackageBuilder builder = new PackageBuilder()
+            {
+                Id = "A",
+                Version = NuGetVersion.Parse("1.0"),
+                Description = "Description",
+                Authors = { "testAuthor" },
+                Serviceable = true,
+                Files =
+                {
+                    CreatePackageFile("content" + Path.DirectorySeparatorChar + "winrt53" + Path.DirectorySeparatorChar + "one.txt")
+                }
+            };
+
+            using (var ms = new MemoryStream())
+            {
+                builder.Save(ms);
+
+                ms.Seek(0, SeekOrigin.Begin);
+
+                var manifestStream = GetManifestStream(ms);
+
+                // Assert
+                Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+  <metadata>
+    <id>A</id>
+    <version>1.0.0</version>
+    <authors>testAuthor</authors>
+    <owners>testAuthor</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Description</description>
+    <serviceable>true</serviceable>
+  </metadata>
+</package>", manifestStream.ReadToEnd());
+            }
+        }
+
+        [Fact]
         public void CreatePackageWithPackageTypes()
         {
             // Arrange
@@ -1742,6 +1783,7 @@ Description is required.");
     <language>en-US</language>
     <licenseUrl>http://somesite/somelicense.txt</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <serviceable>true</serviceable>
     <copyright>2010</copyright>
     <packageTypes>
         <packageType name=""foo"" />
@@ -1769,7 +1811,7 @@ Description is required.");
             Assert.Equal("This is the Description (With, Comma-Separated, Words, in Parentheses).", builder.Description);
             Assert.Equal(new Uri("http://somesite/somelicense.txt"), builder.LicenseUrl);
             Assert.True(builder.RequireLicenseAcceptance);
-
+            Assert.True(builder.Serviceable);
             Assert.Equal(2, builder.PackageTypes.Count);
             Assert.Equal("foo", builder.PackageTypes.ElementAt(0).Name);
             Assert.Equal(new Version(0, 0), builder.PackageTypes.ElementAt(0).Version);

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -472,6 +472,25 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
+        public void PackageReader_Serviceable()
+        {
+            // Arrange
+            using (var packageFile = TestPackages.GetServiceablePackage())
+            {
+                var zip = TestPackages.GetZip(packageFile);
+
+                using (PackageArchiveReader reader = new PackageArchiveReader(zip))
+                {
+                    // Act
+                    var actual = reader.IsServiceable();
+
+                    // Assert
+                    Assert.True(actual);
+                }
+            }
+        }
+
+        [Fact]
         public void PackageReader_PackageTypes()
         {
             // Arrange


### PR DESCRIPTION
Issue : https://github.com/NuGet/Home/issues/2870

This feature adds < serviceable > element to nuspec xml schema, and makes the necessary changes to the reader and writer so that if the element is set as true nuget pack persists that information in the nuspec file it writes.

CC: @rrelyea @alpaix @emgarten @joelverhagen 
