### PR TITLE
Batches project event processing when updating lock file

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -31,6 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
     public class BuildIntegratedProjectSystem : BuildIntegratedNuGetProject
     {
         private IScriptExecutor _scriptExecutor;
+        private IVsProjectBuildSystem _buildSystem;
 
         public BuildIntegratedProjectSystem(
             string jsonConfigPath,
@@ -60,6 +61,29 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 return _scriptExecutor;
             }
+        }
+
+        public IVsProjectBuildSystem ProjectBuildSystem
+        {
+            get
+            {
+                if (_buildSystem == null)
+                {
+                    _buildSystem = EnvDTEProjectUtility.GetVsProjectBuildSystem(EnvDTEProject);
+                }
+
+                return _buildSystem;
+            }
+        }
+
+        public override void BeginProcessing()
+        {
+            ProjectBuildSystem?.StartBatchEdit();
+        }
+
+        public override void EndProcessing()
+        {
+            ProjectBuildSystem?.EndBatchEdit();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -30,7 +30,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string BinDir = "bin";
         private const string NuGetImportStamp = "NuGetPackageImportStamp";
         private IVsProjectBuildSystem _buildSystem;
-        private bool _buildSystemFetched;
 
         public VSMSBuildNuGetProjectSystem(EnvDTEProject envDTEProject, INuGetProjectContext nuGetProjectContext)
         {
@@ -71,10 +70,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                if (!_buildSystemFetched)
+                if (_buildSystem == null)
                 {
                     _buildSystem = EnvDTEProjectUtility.GetVsProjectBuildSystem(EnvDTEProject);
-                    _buildSystemFetched = true;
                 }
 
                 return _buildSystem;

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1991,8 +1991,10 @@ namespace NuGet.PackageManagement
                 }
 
                 // Write out the lock file
+                buildIntegratedProject.BeginProcessing();
                 var logger = new ProjectContextLogger(nuGetProjectContext);
                 await restoreResult.CommitAsync(logger, token);
+                buildIntegratedProject.EndProcessing();
 
                 // Write out a message for each action
                 foreach (var action in nuGetProjectActions)

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -234,6 +234,16 @@ namespace NuGet.ProjectManagement.Projects
             return Task.FromResult(false);
         }
 
+        public virtual void BeginProcessing()
+        {
+            // Intentional no-op
+        }
+
+        public virtual void EndProcessing()
+        {
+            // Intentional no-op
+        }
+
         private async Task<JObject> GetJsonAsync()
         {
             try


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2878 -- suspends project event processing in project.json projects during lock file write, which stops file watcher in VS firing events on changes before all changes written.
