### PR TITLE
Remove redundant define constant in PackageManagement.VisualStudio pr…

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
@@ -18,12 +18,6 @@
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '14.0'">
-    <DefineConstants>$(DefineConstants);VS14</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(VisualStudioVersion)' == '15.0'">
-    <DefineConstants>$(DefineConstants);VS15</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
@@ -41,13 +41,11 @@ namespace NuGet.PackageManagement.VisualStudio
                         Strings.DTE_ProjectUnsupported, EnvDTEProjectUtility.GetName(envDTEProject)));
             }
 
-#if VS14
             if (EnvDTEProjectUtility.SupportsINuGetProjectSystem(envDTEProject))
             {
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.CurrentCulture, Strings.DTE_ProjectUnsupported, typeof(IMSBuildNuGetProjectSystem).FullName));
             }
-#endif
 
             var guids = VsHierarchyUtility.GetProjectTypeGuids(envDTEProject);
             if (guids.Contains(NuGetVSConstants.CppProjectTypeGuid)) // Got a cpp project


### PR DESCRIPTION
…oject. We no longer target versions below Dev14.
