### PR TITLE
Fixing pack basepath use for relative paths and when it's not specified

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -85,6 +85,7 @@ namespace NuGet.CommandLine
             packArgs.Logger = Console;
             packArgs.Arguments = Arguments;
             packArgs.OutputDirectory = OutputDirectory;
+            packArgs.BasePath = BasePath;
 
             // The directory that contains msbuild
             packArgs.MsBuildDirectory = new Lazy<string>(() => MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console));
@@ -109,7 +110,6 @@ namespace NuGet.CommandLine
                 }
             }
 
-            packArgs.BasePath = BasePath;
             packArgs.Build = Build;
             packArgs.Exclude = Exclude;
             packArgs.ExcludeEmptyDirectories = ExcludeEmptyDirectories;


### PR DESCRIPTION
Found issue while testing with dotnet pack.  Added tests to cover the cases.

@joelverhagen 
