### PR TITLE
Reduce packages assemblies access to the facade only

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
@@ -202,24 +202,6 @@
       <Name>VisualStudio.Facade</Name>
     </ProjectReference>
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VisualStudioVersion)=='14.0'">
-      <ItemGroup>
-        <ProjectReference Include="..\VisualStudio14.Packages\VisualStudio14.Packages.csproj">
-          <Project>{A3AB10FD-0E3E-426B-B3D9-B5BF34E5D190}</Project>
-          <Name>VisualStudio14.Packages</Name>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(VisualStudioVersion)=='15.0'">
-      <ItemGroup>
-        <ProjectReference Include="..\VisualStudio15.Packages\VisualStudio15.Packages.csproj">
-          <Project>{868ACCBA-B981-440D-9C98-2A235E1E861A}</Project>
-          <Name>VisualStudio15.Packages</Name>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\sign.targets" />

--- a/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
+++ b/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
@@ -100,24 +100,12 @@
     <None Include="NuGet.VisualStudio.nuspec" />
     <None Include="project.json" />
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VisualStudioVersion)=='14.0'">
-      <ItemGroup>
-        <ProjectReference Include="..\VisualStudio14.Packages\VisualStudio14.Packages.csproj">
-          <Project>{A3AB10FD-0E3E-426B-B3D9-B5BF34E5D190}</Project>
-          <Name>VisualStudio14.Packages</Name>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(VisualStudioVersion)=='15.0'">
-      <ItemGroup>
-        <ProjectReference Include="..\VisualStudio15.Packages\VisualStudio15.Packages.csproj">
-          <Project>{868ACCBA-B981-440D-9C98-2A235E1E861A}</Project>
-          <Name>VisualStudio15.Packages</Name>
-        </ProjectReference>
-      </ItemGroup>
-    </When>
-  </Choose>
+  <ItemGroup>
+    <ProjectReference Include="..\VisualStudio.Facade\VisualStudio.Facade.csproj">
+      <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
+      <Name>VisualStudio.Facade</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />
   <Import Project="..\..\..\build\sign.targets" />


### PR DESCRIPTION
In other words, VisualStudio.Facade is the only project with a reference to VisualStudio14.Packages and VisualStudio15.Packages, making it a true facade. A simple one, but a more correct implementation. This will open the way for moving more dependencies upstream as we get time, hopefully resulting in fewer version conflict warnings.
