### PR TITLE
Preserve package author intended case in the lock file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -353,7 +353,6 @@ namespace NuGet.Commands
                         package: package,
                         targetGraph: graph,
                         defaultPackagePathResolver: new VersionFolderPathResolver(_localRepository.RepositoryRoot),
-                        correctedPackageName: libraryId.Name,
                         dependencyType: LibraryIncludeFlags.All);
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -40,7 +40,7 @@ namespace NuGet.Commands
             lockFile.Version = _lockFileVersion;
 
             var resolver = new VersionFolderPathResolver(repository.RepositoryRoot);
-            var previousLibraries = previousLockFile?.Libraries.ToDictionary(l => Tuple.Create<string, NuGetVersion>(l.Name, l.Version));
+            var previousLibraries = previousLockFile?.Libraries.ToDictionary(l => Tuple.Create(l.Name, l.Version));
 
             // Use empty string as the key of dependencies shared by all frameworks
             lockFile.ProjectFileDependencyGroups.Add(new ProjectFileDependencyGroup(
@@ -135,8 +135,7 @@ namespace NuGet.Commands
                         lockFileLib = CreateLockFileLibrary(
                             packageInfo,
                             sha512,
-                            path,
-                            correctedPackageName: library.Name);
+                            path);
                     }
                     else if (Path.DirectorySeparatorChar != LockFile.DirectorySeparatorChar)
                     {
@@ -266,7 +265,6 @@ namespace NuGet.Commands
                             packageInfo,
                             targetGraph,
                             resolver,
-                            correctedPackageName: library.Name,
                             dependencyType: includeFlags,
                             targetFrameworkOverride: null,
                             dependencies: graphItem.Data.Dependencies);
@@ -283,7 +281,6 @@ namespace NuGet.Commands
                                 packageInfo,
                                 targetGraph,
                                 resolver,
-                                correctedPackageName: library.Name,
                                 targetFrameworkOverride: nonFallbackFramework,
                                 dependencyType: includeFlags,
                                 dependencies: graphItem.Data.Dependencies);
@@ -351,14 +348,11 @@ namespace NuGet.Commands
             }
         }
 
-        private static LockFileLibrary CreateLockFileLibrary(LocalPackageInfo package, string sha512, string path, string correctedPackageName)
+        private static LockFileLibrary CreateLockFileLibrary(LocalPackageInfo package, string sha512, string path)
         {
             var lockFileLib = new LockFileLibrary();
-
-            // package.Id is read from nuspec and it might be in wrong casing.
-            // correctedPackageName should be the package name used by dependency graph and
-            // it has the correct casing that runtime needs during dependency resolution.
-            lockFileLib.Name = correctedPackageName ?? package.Id;
+            
+            lockFileLib.Name = package.Id;
             lockFileLib.Version = package.Version;
             lockFileLib.Type = LibraryType.Package;
             lockFileLib.Sha512 = sha512;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreGraph.cs
@@ -143,12 +143,6 @@ namespace NuGet.Commands
                             return;
                         }
 
-                        if (!string.Equals(node.Item.Data.Match.Library.Name, node.Key.Name, StringComparison.Ordinal))
-                        {
-                            // Fix casing of the library name to be installed
-                            node.Item.Data.Match.Library.Name = node.Key.Name;
-                        }
-
                         // Don't add rejected nodes since we only want to write reduced nodes
                         // to the lock file
                         flattened.Add(node.Item);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -21,7 +21,6 @@ namespace NuGet.Commands
             LocalPackageInfo package,
             RestoreTargetGraph targetGraph,
             VersionFolderPathResolver defaultPackagePathResolver,
-            string correctedPackageName,
             LibraryIncludeFlags dependencyType)
         {
             return CreateLockFileTargetLibrary(
@@ -29,7 +28,6 @@ namespace NuGet.Commands
                 package,
                 targetGraph,
                 defaultPackagePathResolver,
-                correctedPackageName,
                 dependencyType: dependencyType,
                 targetFrameworkOverride: null,
                 dependencies: null);
@@ -40,7 +38,6 @@ namespace NuGet.Commands
             LocalPackageInfo package,
             RestoreTargetGraph targetGraph,
             VersionFolderPathResolver defaultPackagePathResolver,
-            string correctedPackageName,
             LibraryIncludeFlags dependencyType,
             NuGetFramework targetFrameworkOverride,
             IEnumerable<LibraryDependency> dependencies)
@@ -49,11 +46,8 @@ namespace NuGet.Commands
 
             var framework = targetFrameworkOverride ?? targetGraph.Framework;
             var runtimeIdentifier = targetGraph.RuntimeIdentifier;
-
-            // package.Id is read from nuspec and it might be in wrong casing.
-            // correctedPackageName should be the package name used by dependency graph and
-            // it has the correct casing that runtime needs during dependency resolution.
-            lockFileLib.Name = correctedPackageName ?? package.Id;
+            
+            lockFileLib.Name = package.Id;
             lockFileLib.Version = package.Version;
             lockFileLib.Type = LibraryType.Package;
 
@@ -212,8 +206,6 @@ namespace NuGet.Commands
 
                 // Runtime
                 runtimeTargetItems.AddRange(GetRuntimeTargetLockFileItems(
-                    targetGraph,
-                    lockFileLib,
                     contentItems,
                     framework,
                     dependencyType,
@@ -223,8 +215,6 @@ namespace NuGet.Commands
 
                 // Resource
                 runtimeTargetItems.AddRange(GetRuntimeTargetLockFileItems(
-                    targetGraph,
-                    lockFileLib,
                     contentItems,
                     framework,
                     dependencyType,
@@ -234,8 +224,6 @@ namespace NuGet.Commands
 
                 // Native
                 runtimeTargetItems.AddRange(GetRuntimeTargetLockFileItems(
-                    targetGraph,
-                    lockFileLib,
                     contentItems,
                     framework,
                     dependencyType,
@@ -443,7 +431,6 @@ namespace NuGet.Commands
         /// Items that do not contain the primaryKey will be filtered out.
         /// </summary>
         private static List<ContentItemGroup> GetContentGroupsForFramework(
-            LockFileTargetLibrary lockFileLib,
             NuGetFramework framework,
             List<ContentItemGroup> contentGroups,
             string primaryKey)
@@ -502,8 +489,6 @@ namespace NuGet.Commands
         }
 
         private static List<LockFileRuntimeTarget> GetRuntimeTargetLockFileItems(
-            RestoreTargetGraph targetGraph,
-            LockFileTargetLibrary lockFileLib,
             ContentItemCollection contentItems,
             NuGetFramework framework,
             LibraryIncludeFlags dependencyType,
@@ -514,7 +499,6 @@ namespace NuGet.Commands
             var groups = contentItems.FindItemGroups(patternSet).ToList();
 
             var groupsForFramework = GetContentGroupsForFramework(
-                lockFileLib,
                 framework,
                 groups,
                 ManagedCodeConventions.PropertyNames.RuntimeIdentifier);

--- a/src/NuGet.Core/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
@@ -98,10 +98,16 @@ namespace NuGet.DependencyResolver
 
             if (packageVersion != null)
             {
+                // Use the original package identity for the library identity
+                var packageIdentity = await _findPackagesByIdResource.GetOriginalIdentityAsync(
+                    libraryRange.Name,
+                    packageVersion,
+                    cancellationToken);
+
                 return new LibraryIdentity
                 {
-                    Name = libraryRange.Name,
-                    Version = packageVersion,
+                    Name = packageIdentity.Id,
+                    Version = packageIdentity.Version,
                     Type = LibraryType.Package
                 };
             }

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/comparers/PackageIdentityComparer.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/comparers/PackageIdentityComparer.cs
@@ -83,7 +83,7 @@ namespace NuGet.Packaging.Core
 
             var combiner = new HashCodeCombiner();
 
-            combiner.AddObject(obj.Id.ToUpperInvariant());
+            combiner.AddObject(obj.Id, StringComparer.OrdinalIgnoreCase);
             combiner.AddObject(_versionComparer.GetHashCode(obj.Version));
 
             return combiner.CombinedHash;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -36,6 +36,17 @@ namespace NuGet.Protocol
             return Task.FromResult(infos.Select(p => p.Identity.Version));
         }
 
+        public override Task<PackageIdentity> GetOriginalIdentityAsync(string id, NuGetVersion version, CancellationToken token)
+        {
+            var info = GetPackageInfo(id, version);
+            if (info != null)
+            {
+                return Task.FromResult(info.Identity);
+            }
+
+            return Task.FromResult<PackageIdentity>(null);
+        }
+
         public override Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken token)
         {
             var info = GetPackageInfo(id, version);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -49,10 +50,20 @@ namespace NuGet.Protocol
             return result.Select(item => item.Identity.Version);
         }
 
+        public override async Task<PackageIdentity> GetOriginalIdentityAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+        {
+            var packageInfo = await GetPackageInfoAsync(id, version, cancellationToken);
+            if (packageInfo == null)
+            {
+                return null;
+            }
+
+            return packageInfo.Identity;
+        }
+
         public override async Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
-            var packageInfos = await EnsurePackagesAsync(id, cancellationToken);
-            var packageInfo = packageInfos.FirstOrDefault(p => p.Identity.Version == version);
+            var packageInfo = await GetPackageInfoAsync(id, version, cancellationToken);
             if (packageInfo == null)
             {
                 return null;
@@ -68,14 +79,19 @@ namespace NuGet.Protocol
 
         public override async Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
         {
-            var packageInfos = await EnsurePackagesAsync(id, cancellationToken);
-            var packageInfo = packageInfos.FirstOrDefault(p => p.Identity.Version == version);
+            var packageInfo = await GetPackageInfoAsync(id, version, cancellationToken);
             if (packageInfo == null)
             {
                 return null;
             }
 
             return await OpenNupkgStreamAsync(packageInfo, cancellationToken);
+        }
+
+        private async Task<RemoteSourceDependencyInfo> GetPackageInfoAsync(string id, NuGetVersion version, CancellationToken cancellationToken)
+        {
+            var packageInfos = await EnsurePackagesAsync(id, cancellationToken);
+            return packageInfos.FirstOrDefault(p => p.Identity.Version == version);
         }
 
         private Task<IEnumerable<RemoteSourceDependencyInfo>> EnsurePackagesAsync(string id, CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol.Core.Types
@@ -34,6 +35,17 @@ namespace NuGet.Protocol.Core.Types
         public abstract Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, NuGetVersion version, CancellationToken token);
 
         public abstract Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken token);
+
+        /// <summary>
+        /// Gets the original ID and version for a package. This is useful when finding the
+        /// canonical casing for a package ID. Note that the casing of a package ID can vary from
+        /// version to version.
+        /// </summary>
+        /// <param name="id">The package ID. This value is case insensitive.</param>
+        /// <param name="version">The version.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The package identity, with the ID having the case provided by the package author.</returns>
+        public abstract Task<PackageIdentity> GetOriginalIdentityAsync(string id, NuGetVersion version, CancellationToken token);
 
         /// <summary>
         /// Read dependency info from a nuspec.

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -3,13 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -26,6 +21,14 @@ namespace Test.Utility
         }
 
         /// <summary>
+        /// Creates a handler to override url requests to static content
+        /// </summary>
+        public static TestHttpHandlerProvider CreateHttpHandler(Dictionary<string, Func<HttpResponseMessage>> responses)
+        {
+            return new TestHttpHandlerProvider(() => new TestMessageHandler(responses));
+        }
+
+        /// <summary>
         /// Creates a source and injects an http handler to override the normal http calls
         /// </summary>
         public static SourceRepository CreateSource(string sourceUrl, IEnumerable<Lazy<INuGetResourceProvider>> providers, Dictionary<string, string> responses, string errorContent = "")
@@ -34,129 +37,15 @@ namespace Test.Utility
 
             return new SourceRepository(new PackageSource(sourceUrl), providers.Concat(new Lazy<INuGetResourceProvider>[] { handler }));
         }
-    }
 
-    public class TestHttpHandlerProvider : ResourceProvider
-    {
-        private Func<HttpClientHandler> _messageHandlerFactory;
-
-        public TestHttpHandlerProvider(Func<HttpClientHandler> messageHandlerFactory)
-            : base(typeof(HttpHandlerResource), "testhandler", NuGetResourceProviderPositions.First)
+        /// <summary>
+        /// Creates a source and injects an http handler to override the normal http calls
+        /// </summary>
+        public static SourceRepository CreateSource(string sourceUrl, IEnumerable<Lazy<INuGetResourceProvider>> providers, Dictionary<string, Func<HttpResponseMessage>> responses)
         {
-            _messageHandlerFactory = messageHandlerFactory;
-        }
+            var handler = new Lazy<INuGetResourceProvider>(() => CreateHttpHandler(responses));
 
-        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
-        {
-            var result = new Tuple<bool, INuGetResource>(true, new TestHttpHandler(_messageHandlerFactory()));
-            return Task.FromResult(result);
-        }
-    }
-
-    public class TestHttpHandler : HttpHandlerResource
-    {
-        private HttpClientHandler _messageHandler;
-
-        public TestHttpHandler(HttpClientHandler messageHandler)
-        {
-            _messageHandler = messageHandler;
-        }
-
-        public override HttpClientHandler ClientHandler
-        {
-            get { return _messageHandler; }
-        }
-
-        public override HttpMessageHandler MessageHandler
-        {
-            get
-            {
-                return _messageHandler;
-            }
-        }
-    }
-
-    public class TestMessageHandler : HttpClientHandler
-    {
-        private Dictionary<string, string> _responses;
-        private string _errorContent;
-
-        public TestMessageHandler(Dictionary<string, string> responses, string errorContent)
-        {
-            _responses = responses;
-            _errorContent = errorContent;
-        }
-
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            return SendAsyncPublic(request);
-        }
-
-        public virtual Task<HttpResponseMessage> SendAsyncPublic(HttpRequestMessage request)
-        {
-            var msg = new HttpResponseMessage(HttpStatusCode.OK);
-
-            string source;
-            if (_responses.TryGetValue(request.RequestUri.AbsoluteUri, out source))
-            {
-                // TODO: Make this test infrastructure not a big hack.
-                if (source == null)
-                {
-                    msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-                    msg.Content = new TestContent(_errorContent);
-                }
-                else if (source == string.Empty)
-                {
-                    msg = new HttpResponseMessage(HttpStatusCode.NotFound);
-                    msg.Content = new TestContent(_errorContent);
-                }
-                else if (source == "204")
-                {
-                    msg = new HttpResponseMessage(HttpStatusCode.NoContent);
-                    msg.Content = new TestContent(string.Empty);
-                }
-                else if (source.StartsWith("301 "))
-                {
-                    var url = source.Substring(4);
-                    msg = new HttpResponseMessage(HttpStatusCode.MovedPermanently)
-                    {
-                        RequestMessage = new HttpRequestMessage(HttpMethod.Get, url),
-                        Content = new TestContent(string.Empty)
-                    };
-                }
-                else
-                {
-                    msg.Content = new TestContent(source);
-                }
-            }
-            else
-            {
-                throw new Exception("Unhandled test request: " + request.RequestUri.AbsoluteUri);
-            }
-
-            return Task.FromResult(msg);
-        }
-    }
-
-    public class TestContent : HttpContent
-    {
-        private MemoryStream _stream;
-
-        public TestContent(string s)
-        {
-            _stream = new MemoryStream(Encoding.UTF8.GetBytes(s));
-            _stream.Seek(0, SeekOrigin.Begin);
-        }
-
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            return _stream.CopyToAsync(stream);
-        }
-
-        protected override bool TryComputeLength(out long length)
-        {
-            length = (long)_stream.Length;
-            return true;
+            return new SourceRepository(new PackageSource(sourceUrl), providers.Concat(new Lazy<INuGetResourceProvider>[] { handler }));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpSource.cs
@@ -4,10 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using NuGet.Configuration;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 
 namespace Test.Utility
@@ -32,25 +29,6 @@ namespace Test.Utility
             var handler = new Lazy<INuGetResourceProvider>(() => CreateHttpSource(responses));
 
             return new SourceRepository(new PackageSource(sourceUrl), providers.Concat(new Lazy<INuGetResourceProvider>[] { handler }));
-        }
-    }
-
-    public class TestHttpSourceProvider : ResourceProvider
-    {
-        private Dictionary<string, string> _responses;
-
-        public TestHttpSourceProvider(Dictionary<string, string> responses)
-            : base(typeof(HttpSourceResource), "testhttpsource", NuGetResourceProviderPositions.First)
-        {
-            _responses = responses;
-        }
-
-        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
-        {
-            var httpSource = new TestHttpSource(source.PackageSource, _responses);
-
-            var result = new Tuple<bool, INuGetResource>(true, new HttpSourceResource(httpSource));
-            return Task.FromResult(result);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestContent.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestContent.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Utility
+{
+    public class TestContent : HttpContent
+    {
+        private MemoryStream _stream;
+
+        public TestContent(string s)
+        {
+            _stream = new MemoryStream(Encoding.UTF8.GetBytes(s));
+            _stream.Seek(0, SeekOrigin.Begin);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            return _stream.CopyToAsync(stream);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _stream.Length;
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpHandler.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using NuGet.Protocol.Core.Types;
+
+namespace Test.Utility
+{
+    public class TestHttpHandler : HttpHandlerResource
+    {
+        private HttpClientHandler _messageHandler;
+
+        public TestHttpHandler(HttpClientHandler messageHandler)
+        {
+            _messageHandler = messageHandler;
+        }
+
+        public override HttpClientHandler ClientHandler
+        {
+            get { return _messageHandler; }
+        }
+
+        public override HttpMessageHandler MessageHandler
+        {
+            get
+            {
+                return _messageHandler;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpHandlerProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpHandlerProvider.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace Test.Utility
+{
+    public class TestHttpHandlerProvider : ResourceProvider
+    {
+        private Func<HttpClientHandler> _messageHandlerFactory;
+
+        public TestHttpHandlerProvider(Func<HttpClientHandler> messageHandlerFactory)
+            : base(typeof(HttpHandlerResource), "testhandler", NuGetResourceProviderPositions.First)
+        {
+            _messageHandlerFactory = messageHandlerFactory;
+        }
+
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            var result = new Tuple<bool, INuGetResource>(true, new TestHttpHandler(_messageHandlerFactory()));
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Threading;
+using System.Net.Http;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -16,24 +17,23 @@ namespace Test.Utility
     /// </summary>
     public class TestHttpSource : HttpSource
     {
-        private Dictionary<string, string> _responses;
-
-        public TestHttpSource(PackageSource source, Dictionary<string, string> responses, string errorContent = "")
-            : base(source, () => Task.FromResult<HttpHandlerResource>(
+        public TestHttpSource(PackageSource source, Dictionary<string, string> responses, string errorContent = "") : base(
+            source,
+            () => Task.FromResult<HttpHandlerResource>(
                     new TestHttpHandler(
                         new TestMessageHandler(responses, errorContent))))
         {
-            _responses = responses;
+        }
+
+        public TestHttpSource(PackageSource source, Dictionary<string, Func<HttpResponseMessage>> responses) : base(
+            source,
+            () => Task.FromResult<HttpHandlerResource>(
+                    new TestHttpHandler(new TestMessageHandler(responses))))
+        {
         }
 
         protected override Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
-            string s;
-            if (_responses.TryGetValue(uri, out s) && !string.IsNullOrEmpty(s))
-            {
-                return new MemoryStream(Encoding.UTF8.GetBytes(s));
-            }
-
             return null;
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSourceProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace Test.Utility
+{
+    public class TestHttpSourceProvider : ResourceProvider
+    {
+        private Dictionary<string, string> _responses;
+
+        public TestHttpSourceProvider(Dictionary<string, string> responses)
+            : base(typeof(HttpSourceResource), "testhttpsource", NuGetResourceProviderPositions.First)
+        {
+            _responses = responses;
+        }
+
+        public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            var httpSource = new TestHttpSource(source.PackageSource, _responses);
+
+            var result = new Tuple<bool, INuGetResource>(true, new HttpSourceResource(httpSource));
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestMessageHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestMessageHandler.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Test.Utility
+{
+    public class TestMessageHandler : HttpClientHandler
+    {
+        private Dictionary<string, Func<HttpResponseMessage>> _responses;
+
+        public TestMessageHandler(Dictionary<string, Func<HttpResponseMessage>> responses)
+        {
+            _responses = responses;
+        }
+
+        public TestMessageHandler(Dictionary<string, string> responses, string errorContent)
+        {
+            _responses = GetResponse(responses, errorContent);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return SendAsyncPublic(request);
+        }
+        
+        private Dictionary<string, Func<HttpResponseMessage>> GetResponse(Dictionary<string, string> responses, string errorContent)
+        {
+            return responses.ToDictionary<KeyValuePair<string, string>, string, Func<HttpResponseMessage>>(
+                pair => pair.Key,
+                pair => () => GetResponseMessage(pair.Value, errorContent),
+                responses.Comparer);
+        }
+
+        private HttpResponseMessage GetResponseMessage(string source, string errorContent)
+        {
+            var msg = new HttpResponseMessage(HttpStatusCode.OK);
+
+            if (source == null)
+            {
+                msg = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                msg.Content = new TestContent(errorContent);
+            }
+            else if (source == string.Empty)
+            {
+                msg = new HttpResponseMessage(HttpStatusCode.NotFound);
+                msg.Content = new TestContent(errorContent);
+            }
+            else if (source == "204")
+            {
+                msg = new HttpResponseMessage(HttpStatusCode.NoContent);
+                msg.Content = new TestContent(string.Empty);
+            }
+            else if (source.StartsWith("301 "))
+            {
+                var url = source.Substring(4);
+                msg = new HttpResponseMessage(HttpStatusCode.MovedPermanently)
+                {
+                    RequestMessage = new HttpRequestMessage(HttpMethod.Get, url),
+                    Content = new TestContent(string.Empty)
+                };
+            }
+            else
+            {
+                msg.Content = new TestContent(source);
+            }
+
+            return msg;
+        }
+        
+        public virtual Task<HttpResponseMessage> SendAsyncPublic(HttpRequestMessage request)
+        {
+            Func<HttpResponseMessage> getResponse;
+            if (_responses.TryGetValue(request.RequestUri.AbsoluteUri, out getResponse))
+            {
+                return Task.FromResult(getResponse());
+            }
+            else
+            {
+                throw new Exception("Unhandled test request: " + request.RequestUri.AbsoluteUri);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class HttpFileSystemBasedFindPackageByIdResourceTests
+    {
+        [Fact]
+        public async Task HttpFileSystemBasedFindPackageById_GetOriginalIdentity()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var source = "http://testsource.com/v3-with-flat-container/index.json";
+                var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "DeepEqual", "1.4.0.1-rc");
+                var packageBytes = File.ReadAllBytes(package.FullName);
+
+                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                {
+                    {
+                        source,
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(JsonData.IndexWithFlatContainer)
+                        }
+                    },
+                    {
+                        "https://api.nuget.org/v3-flatcontainer/deepequal/index.json",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(JsonData.DeepEqualFlatContainerIndex)
+                        }
+                    },
+                    {
+                        "https://api.nuget.org/v3-flatcontainer/deepequal/1.4.0.1-rc/deepequal.1.4.0.1-rc.nupkg",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new ByteArrayContent(packageBytes)
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                resource.Logger = NullLogger.Instance;
+                resource.CacheContext = new SourceCacheContext();
+
+                // Act
+                var identity = await resource.GetOriginalIdentityAsync(
+                    "DEEPEQUAL",
+                    new NuGetVersion("1.4.0.1-RC"),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.IsType<HttpFileSystemBasedFindPackageByIdResource>(resource);
+                Assert.Equal("DeepEqual", identity.Id);
+                Assert.Equal("1.4.0.1-rc", identity.Version.ToNormalizedString());
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/JsonData.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/JsonData.cs
@@ -5,9 +5,9 @@ namespace NuGet.Protocol.Tests
 {
     public static class JsonData
     {
-        #region Index
+        #region IndexWithoutFlatContainer
 
-        public const string Index = @"{
+        public const string IndexWithoutFlatContainer = @"{
  ""version"": ""3.0.0-beta.1"",
  ""resources"": [
   {
@@ -126,6 +126,164 @@ namespace NuGet.Protocol.Tests
  ""@context"": {
   ""@vocab"": ""https://schema.nuget.org/services#""
  }
+}";
+
+        #endregion
+
+        #region IndexWithFlatContainer
+
+        public const string IndexWithFlatContainer = @"{
+ ""version"": ""3.0.0-beta.1"",
+ ""resources"": [
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/query"",
+   ""@type"": ""SearchQueryService""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/query"",
+   ""@type"": ""SearchQueryService""
+  },
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService""
+  },
+  {
+   ""@id"": ""https://api-search.nuget.org/"",
+   ""@type"": ""SearchGalleryQueryService""
+  },  
+  {
+   ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
+   ""@type"": ""MetricsService""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v3/registration0/"",
+   ""@type"": ""RegistrationsBaseUrl""
+  },
+  {
+    ""@id"": ""https://api.nuget.org/v3-flatcontainer/"",
+    ""@type"": ""PackageBaseAddress/3.0.0"",
+    ""comment"": ""Base URL of Azure storage where NuGet package registration info for DNX is stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}.{version-lower}.nupkg""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v2"",
+   ""@type"": ""LegacyGallery""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v2"",
+   ""@type"": ""LegacyGallery/2.0.0""
+  },
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/query"",
+   ""@type"": ""SearchQueryService/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/query"",
+   ""@type"": ""SearchQueryService/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api-search.nuget.org/"",
+   ""@type"": ""SearchGalleryQueryService/3.0.0-rc""
+  },  
+  {
+   ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
+   ""@type"": ""MetricsService/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v3/registration0/"",
+   ""@type"": ""RegistrationsBaseUrl/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://www.nuget.org/packages/{id}/{version}/ReportAbuse"",
+   ""@type"": ""ReportAbuseUriTemplate/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v3/registration0/{id-lower}/index.json"",
+   ""@type"": ""PackageDisplayMetadataUriTemplate/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v3/registration0/{id-lower}/{version-lower}.json"",
+   ""@type"": ""PackageVersionDisplayMetadataUriTemplate/3.0.0-rc""
+  },
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/query"",
+   ""@type"": ""SearchQueryService/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/query"",
+   ""@type"": ""SearchQueryService/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://api-v3search-0.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://api-v3search-1.nuget.org/autocomplete"",
+   ""@type"": ""SearchAutocompleteService/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://api-search.nuget.org/"",
+   ""@type"": ""SearchGalleryQueryService/3.0.0-beta""
+  },  
+  {
+   ""@id"": ""https://api-metrics.nuget.org/DownloadEvent"",
+   ""@type"": ""MetricsService/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://api.nuget.org/v3/registration0/"",
+   ""@type"": ""RegistrationsBaseUrl/3.0.0-beta""
+  },
+  {
+   ""@id"": ""https://www.nuget.org/packages/{id}/{version}/ReportAbuse"",
+   ""@type"": ""ReportAbuseUriTemplate/3.0.0-beta""
+  },
+  {
+    ""@id"": ""https://api.nuget.org/v3/stats0/totals.json"",
+    ""@type"": ""TotalStats/3.0.0-rc""
+  }
+ ],
+ ""@context"": {
+  ""@vocab"": ""https://schema.nuget.org/services#""
+ }
+}";
+
+        #endregion
+
+        #region DeepEqual flatcontainer index
+
+        public const string DeepEqualFlatContainerIndex = @"{
+  ""versions"": [
+    ""0.1.0"",
+    ""0.2.0"",
+    ""0.3.0"",
+    ""0.4.0"",
+    ""0.5.0"",
+    ""0.6.0"",
+    ""0.7.0"",
+    ""0.8.0"",
+    ""0.9.0"",
+    ""0.10.0"",
+    ""0.11.0"",
+    ""0.12.0"",
+    ""1.0.0"",
+    ""1.1.0"",
+    ""1.1.1"",
+    ""1.2.0"",
+    ""1.3.0"",
+    ""1.4.0"",
+    ""1.4.0.1-rc""
+  ]
 }";
 
         #endregion

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataClientTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataClientTests.cs
@@ -22,7 +22,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
@@ -45,7 +45,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
@@ -66,7 +66,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
@@ -86,7 +86,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/microsoft.owin/index.json", JsonData.MicrosoftOwinRegistration);
             responses.Add("https://api.nuget.org/v3/registration0/owin/index.json", null);
             // Owin is not added
@@ -107,7 +107,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/microsoft.owin/index.json", JsonData.MicrosoftOwinRegistration);
             responses.Add("https://api.nuget.org/v3/registration0/owin/index.json", "");
             // Owin is not added
@@ -127,7 +127,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/microsoft.owin/index.json", JsonData.MicrosoftOwinRegistration);
             responses.Add("https://api.nuget.org/v3/registration0/owin/index.json", "");
             // Owin is not added
@@ -149,7 +149,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/unlistedpackagea/index.json", JsonData.UnlistedPackageARegistration);
             responses.Add("https://api.nuget.org/v3/registration0/unlistedpackageb/index.json", JsonData.UnlistedPackageBRegistration);
 
@@ -173,7 +173,7 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
             var responses = new Dictionary<string, string>();
-            responses.Add("http://testsource.com/v3/index.json", JsonData.Index);
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
             responses.Add("https://api.nuget.org/v3/registration0/unlistedpackagea/index.json", JsonData.UnlistedPackageARegistration);
             responses.Add("https://api.nuget.org/v3/registration0/unlistedpackageb/index.json", JsonData.UnlistedPackageBRegistration);
             responses.Add("https://api.nuget.org/v3/registration0/unlistedpackagec/index.json", JsonData.UnlistedPackageCRegistration);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -1,9 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 
@@ -32,6 +39,114 @@ namespace NuGet.Protocol.Tests
             // Assert
             // Verify no items returned, and no exceptions were thrown above
             Assert.Equal(0, versions.Count());
+        }
+
+        [Fact]
+        public async Task RemoteV2FindPackageById_GetOriginalIdentity_IdInResponse()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var serviceAddress = TestUtility.CreateServiceAddress();
+                var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "xunit", "2.2.0-beta1-build3239");
+                var packageBytes = File.ReadAllBytes(package.FullName);
+
+                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                {
+                    {
+                        serviceAddress,
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(string.Empty)
+                        }
+                    },
+                    {
+                        serviceAddress + "FindPackagesById()?id='XUNIT'",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()))
+                        }
+                    },
+                    {
+                        "https://www.nuget.org/api/v2/package/xunit/2.2.0-beta1-build3239",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new ByteArrayContent(packageBytes)
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                resource.Logger = NullLogger.Instance;
+                resource.CacheContext = new SourceCacheContext();
+
+                // Act
+                var identity = await resource.GetOriginalIdentityAsync(
+                    "XUNIT",
+                    new NuGetVersion("2.2.0-BETA1-build3239"),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
+                Assert.Equal("xunit", identity.Id);
+                Assert.Equal("2.2.0-beta1-build3239", identity.Version.ToNormalizedString());
+            }
+        }
+
+        [Fact]
+        public async Task RemoteV2FindPackageById_GetOriginalIdentity_IdNotInResponse()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var serviceAddress = TestUtility.CreateServiceAddress();
+                var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "WindowsAzure.Storage", "6.2.2-preview");
+                var packageBytes = File.ReadAllBytes(package.FullName);
+
+                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                {
+                    {
+                        serviceAddress,
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(string.Empty)
+                        }
+                    },
+                    {
+                        serviceAddress + "FindPackagesById()?id='WINDOWSAZURE.STORAGE'",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()))
+                        }
+                    },
+                    {
+                        "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.2-preview",
+                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new ByteArrayContent(packageBytes)
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                resource.Logger = NullLogger.Instance;
+                resource.CacheContext = new SourceCacheContext();
+
+                // Act
+                var identity = await resource.GetOriginalIdentityAsync(
+                    "WINDOWSAZURE.STORAGE",
+                    new NuGetVersion("6.2.2-PREVIEW"),
+                    CancellationToken.None);
+
+                // Assert
+                Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
+                Assert.Equal("WindowsAzure.Storage", identity.Id);
+                Assert.Equal("6.2.2-preview", identity.Version.ToNormalizedString());
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV3FindPackageByIdResourceTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class RemoteV3FindPackageByIdResourceTests
+    {
+        [Fact]
+        public async Task RemoteV3FindPackageById_GetOriginalIdentity_IdInResponse()
+        {
+            // Arrange
+            var responses = new Dictionary<string, string>();
+            responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
+            responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+
+            // Act
+            var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var identity = await resource.GetOriginalIdentityAsync(
+                "DEEPEQUAL",
+                new NuGetVersion("1.4.0.1-RC"),
+                CancellationToken.None);
+
+            // Assert
+            Assert.IsType<RemoteV3FindPackageByIdResource>(resource);
+            Assert.Equal("DeepEqual", identity.Id);
+            Assert.Equal("1.4.0.1-rc", identity.Version.ToNormalizedString());
+        }
+    }
+}


### PR DESCRIPTION
1. Add `GetOriginalIdentityAsync` to `FindPackageByIdResource` and use in restore.
2. Update test HTTP handler to allow stubbing the entire HttpResponseMessage.

We are already doing this for the case of versions (e.g. `1.2.0-BETA` could be corrected to `1.2.0-beta`). Since the lock file will have the correct case, so will the .deps file.

Addresses https://github.com/NuGet/Home/issues/2882.

@emgarten @alpaix @yishaigalatzer @rrelyea 
