### PR TITLE
Make LibraryIdentity and LibraryRange case-insensitive

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIdentity.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIdentity.cs
@@ -40,7 +40,7 @@ namespace NuGet.LibraryModel
             {
                 return true;
             }
-            return string.Equals(Name, other.Name) &&
+            return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase) &&
                    Equals(Version, other.Version) &&
                    Equals(Type, other.Type);
         }
@@ -54,7 +54,7 @@ namespace NuGet.LibraryModel
         {
             unchecked
             {
-                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^
+                return ((Name != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Name) : 0) * 397) ^
                        (Version != null ? Version.GetHashCode() : 0) ^
                        (Type != null ? Type.GetHashCode() : 0);
             }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -134,7 +134,7 @@ namespace NuGet.LibraryModel
             }
 
             return TypeConstraint == other.TypeConstraint
-                && string.Equals(Name, other.Name)
+                && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                 && Equals(VersionRange, other.VersionRange);
         }
 
@@ -147,7 +147,7 @@ namespace NuGet.LibraryModel
         {
             unchecked
             {
-                return ((Name != null ? Name.GetHashCode() : 0) * 397) ^
+                return ((Name != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Name) : 0) * 397) ^
                        (VersionRange != null ? VersionRange.GetHashCode() : 0) ^
                        TypeConstraint.GetHashCode();
             }

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryIdentityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryIdentityTests.cs
@@ -1,0 +1,64 @@
+﻿using NuGet.Versioning;
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
+
+namespace NuGet.LibraryModel.Tests
+{
+    public class LibraryIdentityTests
+    {
+        [Theory]
+        [InlineData("packageA", "packageA", true)] // same
+        [InlineData("packageA", "PackageA", true)] // same except different case
+        [InlineData("packageA", "packageB", false)] // different
+        [InlineData("packageA", "packageA ", false)] // different
+        public void LibraryIdentity_Equals_Name(string nameA, string nameB, bool expected)
+        {
+            // Arrange
+            var version = new NuGetVersion("1.0.0");
+            var identityA = new LibraryIdentity(nameA, version, LibraryType.Package);
+            var identityB = new LibraryIdentity(nameB, version, LibraryType.Package);
+
+            // Act
+            var actual = identityA.Equals(identityB);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("1.0.0-beta", "1.0.0-beta", true)] // same
+        [InlineData("1.0.0-beta", "1.0.0-BETA", true)] // same except different case
+        [InlineData("1.0.0-beta", "2.0.0-beta", false)] // different
+        public void LibraryIdentity_Equals_Version(string versionA, string versionB, bool expected)
+        {
+            // Arrange
+            var identityA = new LibraryIdentity("packageA", new NuGetVersion(versionA), LibraryType.Package);
+            var identityB = new LibraryIdentity("packageA", new NuGetVersion(versionB), LibraryType.Package);
+
+            // Act
+            var actual = identityA.Equals(identityB);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("package", "package", true)] // same
+        [InlineData("package", "PACKAGE", true)] // same except different case
+        [InlineData("package", "assembly", false)] // different
+        public void LibraryIdentity_Equals_LibraryType(string typeA, string typeB, bool expected)
+        {
+            // Arrange
+            var version = new NuGetVersion("1.0.0");
+            var identityA = new LibraryIdentity("packageA", version, LibraryType.Parse(typeA));
+            var identityB = new LibraryIdentity("packageA", version, LibraryType.Parse(typeB));
+
+            // Act
+            var actual = identityA.Equals(identityB);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.LibraryModel.Tests/LibraryRangeTests.cs
@@ -5,7 +5,6 @@ namespace NuGet.LibraryModel.Tests
 {
     public class LibraryRangeTests
     {
-
         [Theory]
         [InlineData("1.0.0", "packageA >= 1.0.0")]
         [InlineData("1.0.0-*", "packageA >= 1.0.0-*")]
@@ -27,6 +26,62 @@ namespace NuGet.LibraryModel.Tests
 
             // Act and Assert
             Assert.Equal(expected, range.ToLockFileDependencyGroupString());
+        }
+
+        [Theory]
+        [InlineData("packageA", "packageA", true)] // same
+        [InlineData("packageA", "PackageA", true)] // same except different case
+        [InlineData("packageA", "packageB", false)] // different
+        [InlineData("packageA", "packageA ", false)] // different
+        public void LibraryRange_Equals_Name(string nameA, string nameB, bool expected)
+        {
+            // Arrange
+            var rangeA = new LibraryRange(nameA, LibraryDependencyTarget.All);
+            var rangeB = new LibraryRange(nameB, LibraryDependencyTarget.All);
+
+            // Act
+            var actual = rangeA.Equals(rangeB);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("1.0.0-beta", "1.0.0-beta", true)] // same
+        [InlineData("1.0.0-beta", "1.0.0-BETA", true)] // same except different case
+        [InlineData("1.0.0-beta", "2.0.0-beta", false)] // different
+        public void LibraryRange_Equals_Version(string versionA, string versionB, bool expected)
+        {
+            // Arrange
+            var rangeA = new LibraryRange("packageA", VersionRange.Parse(versionA), LibraryDependencyTarget.All);
+            var rangeB = new LibraryRange("packageA", VersionRange.Parse(versionB), LibraryDependencyTarget.All);
+
+            // Act
+            var actual = rangeA.Equals(rangeB);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(LibraryDependencyTarget.Package, LibraryDependencyTarget.Package, true)] // same
+        [InlineData(LibraryDependencyTarget.Package, LibraryDependencyTarget.All, false)] // subset
+        [InlineData(LibraryDependencyTarget.Package, LibraryDependencyTarget.Assembly, false)] // different
+        public void LibraryRange_Equals_TypeConstraint(
+            LibraryDependencyTarget typeConstraintA,
+            LibraryDependencyTarget typeConstraintB,
+            bool expected)
+        {
+            // Arrange
+            var version = VersionRange.Parse("1.0.0");
+            var rangeA = new LibraryRange("packageA", version, typeConstraintA);
+            var rangeB = new LibraryRange("packageA", version, typeConstraintB);
+
+            // Act
+            var actual = rangeA.Equals(rangeB);
+
+            // Assert
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
1. Make the `Name` property in `LibraryIdentity` and `LibraryRange` case insensitive.
2. Add functional test to verify the related issue.

Throughout the graph operations, the `LibraryIdentity` name is stored in various case-insensitive structures (e.g. in [`GraphOperations.cs`](https://github.com/NuGet/NuGet.Client/blob/ecab2955a3aed1eea6f0fcccfe696a9fb46eab60/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs#L155)). However this general approach of case-insensitive names does not extend to the `Tracker.Entry` type, which uses a hashset keyed off of the `LibraryIdentity`. This change takes care of that gap.

Fixes https://github.com/NuGet/Home/issues/2901.

@emgarten @alpaix @yishaigalatzer @rrelyea 
