### PR TITLE
Don't prompt for credentials on 403 when an API key is sent

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageConfiguration.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageConfiguration.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+
+namespace NuGet.Protocol
+{
+    public class HttpRequestMessageConfiguration
+    {
+        public static readonly HttpRequestMessageConfiguration Default =
+            new HttpRequestMessageConfiguration();
+
+        public HttpRequestMessageConfiguration(
+            ILogger logger = null,
+            bool promptOn403 = true)
+        {
+            Logger = logger ?? NullLogger.Instance;
+            PromptOn403 = promptOn403;
+        }
+
+        public ILogger Logger { get; }
+        public bool PromptOn403 { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageFactory.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRequestMessageFactory.cs
@@ -22,19 +22,12 @@ namespace NuGet.Protocol
         /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
         public static HttpRequestMessage Create(HttpMethod method, string requestUri, ILogger log)
         {
-            if (requestUri == null)
-            {
-                throw new ArgumentNullException(nameof(requestUri));
-            }
-
             if (log == null)
             {
                 throw new ArgumentNullException(nameof(log));
             }
 
-            var request = new HttpRequestMessage(method, requestUri);
-            request.SetLogger(log);
-            return request;
+            return Create(method, requestUri, new HttpRequestMessageConfiguration(log));
         }
 
         /// <summary>
@@ -46,18 +39,67 @@ namespace NuGet.Protocol
         /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
         public static HttpRequestMessage Create(HttpMethod method, Uri requestUri, ILogger log)
         {
-            if (requestUri == null)
-            {
-                throw new ArgumentNullException(nameof(requestUri));
-            }
-
             if (log == null)
             {
                 throw new ArgumentNullException(nameof(log));
             }
 
+            return Create(method, requestUri, new HttpRequestMessageConfiguration(log));
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        /// <param name="method">Desired HTTP verb</param>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="configuration">The request configuration</param>
+        /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
+        public static HttpRequestMessage Create(
+            HttpMethod method,
+            string requestUri,
+            HttpRequestMessageConfiguration configuration)
+        {
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
             var request = new HttpRequestMessage(method, requestUri);
-            request.SetLogger(log);
+            request.SetConfiguration(configuration);
+
+            return request;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        /// <param name="method">Desired HTTP verb</param>
+        /// <param name="requestUri">Request URI</param>
+        /// <param name="configuration">The request configuration</param>
+        /// <returns>Instance of <see cref="HttpRequestMessage"/></returns>
+        public static HttpRequestMessage Create(
+            HttpMethod method,
+            Uri requestUri,
+            HttpRequestMessageConfiguration configuration)
+        {
+            if (requestUri == null)
+            {
+                throw new ArgumentNullException(nameof(requestUri));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            var request = new HttpRequestMessage(method, requestUri);
+            request.SetConfiguration(configuration);
+
             return request;
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyAuthenticationHandler.cs
@@ -57,7 +57,7 @@ namespace NuGet.Protocol
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var logger = request.GetLogger() ?? NullLogger.Instance;
+            var logger = request.GetOrCreateConfiguration().Logger;
 
             while (true)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/StaticHttpHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.Protocol.Core.Types;
 
@@ -23,7 +24,7 @@ namespace Test.Utility
         /// <summary>
         /// Creates a handler to override url requests to static content
         /// </summary>
-        public static TestHttpHandlerProvider CreateHttpHandler(Dictionary<string, Func<HttpResponseMessage>> responses)
+        public static TestHttpHandlerProvider CreateHttpHandler(Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>> responses)
         {
             return new TestHttpHandlerProvider(() => new TestMessageHandler(responses));
         }
@@ -41,7 +42,10 @@ namespace Test.Utility
         /// <summary>
         /// Creates a source and injects an http handler to override the normal http calls
         /// </summary>
-        public static SourceRepository CreateSource(string sourceUrl, IEnumerable<Lazy<INuGetResourceProvider>> providers, Dictionary<string, Func<HttpResponseMessage>> responses)
+        public static SourceRepository CreateSource(
+            string sourceUrl,
+            IEnumerable<Lazy<INuGetResourceProvider>> providers,
+            Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>> responses)
         {
             var handler = new Lazy<INuGetResourceProvider>(() => CreateHttpHandler(responses));
 

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -25,7 +25,7 @@ namespace Test.Utility
         {
         }
 
-        public TestHttpSource(PackageSource source, Dictionary<string, Func<HttpResponseMessage>> responses) : base(
+        public TestHttpSource(PackageSource source, Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>> responses) : base(
             source,
             () => Task.FromResult<HttpHandlerResource>(
                     new TestHttpHandler(new TestMessageHandler(responses))))

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -26,28 +26,28 @@ namespace NuGet.Protocol.Tests
                 var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "DeepEqual", "1.4.0.1-rc");
                 var packageBytes = File.ReadAllBytes(package.FullName);
 
-                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
                 {
                     {
                         source,
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(JsonData.IndexWithFlatContainer)
-                        }
+                        })
                     },
                     {
                         "https://api.nuget.org/v3-flatcontainer/deepequal/index.json",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(JsonData.DeepEqualFlatContainerIndex)
-                        }
+                        })
                     },
                     {
                         "https://api.nuget.org/v3-flatcontainer/deepequal/1.4.0.1-rc/deepequal.1.4.0.1-rc.nupkg",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new ByteArrayContent(packageBytes)
-                        }
+                        })
                     }
                 };
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -51,28 +51,28 @@ namespace NuGet.Protocol.Tests
                 var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "xunit", "2.2.0-beta1-build3239");
                 var packageBytes = File.ReadAllBytes(package.FullName);
 
-                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
                 {
                     {
                         serviceAddress,
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(string.Empty)
-                        }
+                        })
                     },
                     {
                         serviceAddress + "FindPackagesById()?id='XUNIT'",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()))
-                        }
+                        })
                     },
                     {
                         "https://www.nuget.org/api/v2/package/xunit/2.2.0-beta1-build3239",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new ByteArrayContent(packageBytes)
-                        }
+                        })
                     }
                 };
 
@@ -105,28 +105,28 @@ namespace NuGet.Protocol.Tests
                 var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "WindowsAzure.Storage", "6.2.2-preview");
                 var packageBytes = File.ReadAllBytes(package.FullName);
 
-                var responses = new Dictionary<string, Func<HttpResponseMessage>>
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
                 {
                     {
                         serviceAddress,
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(string.Empty)
-                        }
+                        })
                     },
                     {
                         serviceAddress + "FindPackagesById()?id='WINDOWSAZURE.STORAGE'",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()))
-                        }
+                        })
                     },
                     {
                         "https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.2-preview",
-                        () => new HttpResponseMessage(HttpStatusCode.OK)
+                        _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new ByteArrayContent(packageBytes)
-                        }
+                        })
                     }
                 };
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class PackageUpdateResourceTests
+    {
+        private const string ApiKeyHeader = "X-NuGet-ApiKey";
+
+        [Fact]
+        public async Task PackageUpdateResource_IncludesApiKeyWhenDeleting()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var source = "https://www.nuget.org/api/v2";
+                HttpRequestMessage actualRequest = null;
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+                {
+                    {
+                        "https://www.nuget.org/api/v2/DeepEqual/1.4.0.1-rc",
+                        request =>
+                        {
+                            actualRequest = request;
+                            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var apiKey = "SomeApiKey";
+
+                // Act
+                await resource.Delete(
+                    packageId: "DeepEqual",
+                    packageVersion: "1.4.0.1-rc",
+                    getApiKey: _ => apiKey,
+                    confirm: _ => true,
+                    log: NullLogger.Instance);
+
+                // Assert
+                Assert.NotNull(actualRequest);
+                Assert.Equal(HttpMethod.Delete, actualRequest.Method);
+
+                IEnumerable<string> values;
+                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                Assert.Equal(1, values.Count());
+                Assert.Equal(apiKey, values.First());
+
+                Assert.False(
+                    actualRequest.GetOrCreateConfiguration().PromptOn403,
+                    "When the API key is provided, the user should not be prompted on HTTP 403.");
+            }
+        }
+
+        [Fact]
+        public async Task PackageUpdateResource_AllowsNoApiKeyWhenDeleting()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var source = "https://www.nuget.org/api/v2";
+                HttpRequestMessage actualRequest = null;
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+                {
+                    {
+                        "https://www.nuget.org/api/v2/DeepEqual/1.4.0.1-rc",
+                        request =>
+                        {
+                            actualRequest = request;
+                            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var apiKey = string.Empty;
+
+                // Act
+                await resource.Delete(
+                    packageId: "DeepEqual",
+                    packageVersion: "1.4.0.1-rc",
+                    getApiKey: _ => apiKey,
+                    confirm: _ => true,
+                    log: NullLogger.Instance);
+
+                // Assert
+                Assert.NotNull(actualRequest);
+                Assert.Equal(HttpMethod.Delete, actualRequest.Method);
+
+                IEnumerable<string> values;
+                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                Assert.Null(values);
+
+                Assert.True(
+                    actualRequest.GetOrCreateConfiguration().PromptOn403,
+                    "When the API key is not provided, the user should be prompted on HTTP 403.");
+            }
+        }
+
+        [Fact]
+        public async Task PackageUpdateResource_AllowsApiKeyWhenPushing()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var source = "https://www.nuget.org/api/v2";
+                HttpRequestMessage actualRequest = null;
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+                {
+                    {
+                        "https://www.nuget.org/api/v2/",
+                        request =>
+                        {
+                            actualRequest = request;
+                            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var apiKey = "SomeApiKey";
+
+                var packageInfo = SimpleTestPackageUtility.CreateFullPackage(workingDir, "test", "1.0.0");
+
+                // Act
+                await resource.Push(
+                    packagePath: packageInfo.FullName,
+                    symbolsSource: null,
+                    timeoutInSecond: 5,
+                    disableBuffering: false,
+                    getApiKey: _ => apiKey,
+                    log: NullLogger.Instance);
+
+                // Assert
+                Assert.NotNull(actualRequest);
+                Assert.Equal(HttpMethod.Put, actualRequest.Method);
+
+                IEnumerable<string> values;
+                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                Assert.Equal(1, values.Count());
+                Assert.Equal(apiKey, values.First());
+
+                Assert.False(
+                    actualRequest.GetOrCreateConfiguration().PromptOn403,
+                    "When the API key is provided, the user should not be prompted on HTTP 403.");
+            }
+        }
+
+        [Fact]
+        public async Task PackageUpdateResource_AllowsNoApiKeyWhenPushing()
+        {
+            // Arrange
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var source = "https://www.nuget.org/api/v2";
+                HttpRequestMessage actualRequest = null;
+                var responses = new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>
+                {
+                    {
+                        "https://www.nuget.org/api/v2/",
+                        request =>
+                        {
+                            actualRequest = request;
+                            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                        }
+                    }
+                };
+
+                var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+                var resource = await repo.GetResourceAsync<PackageUpdateResource>();
+                var apiKey = string.Empty;
+
+                var packageInfo = SimpleTestPackageUtility.CreateFullPackage(workingDir, "test", "1.0.0");
+
+                // Act
+                await resource.Push(
+                    packagePath: packageInfo.FullName,
+                    symbolsSource: null,
+                    timeoutInSecond: 5,
+                    disableBuffering: false,
+                    getApiKey: _ => apiKey,
+                    log: NullLogger.Instance);
+
+                // Assert
+                Assert.NotNull(actualRequest);
+                Assert.Equal(HttpMethod.Put, actualRequest.Method);
+
+                IEnumerable<string> values;
+                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                Assert.Null(values);
+
+                Assert.True(
+                    actualRequest.GetOrCreateConfiguration().PromptOn403,
+                    "When the API key is not provided, the user should be prompted on HTTP 403.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Don't prompt for credentials on 403 when an API key is sent for package push and delete. This is achieved by introducing an option to `HttpRequestMessage` to `PromptOn403 = false`.
2. Improve in-memory HTTP handler to allow assertions of the incoming `HttpRequestMessage` which is typically instantiated by the product code.

Fixes https://github.com/NuGet/Home/issues/2910.

Note that this change is only for `dev` right now. If this change is approved I will work it for first `3.5.0-beta2` (not as hard) then `3.4.5` (pretty hard since the HTTP stuff has changed a lot).

@alpaix @emgarten @maartenba @yishaigalatzer @rrelyea 
