### PR TITLE
Taking out slash trimming in pack for src of files

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestReader.cs
@@ -317,7 +317,7 @@ namespace NuGet.Packaging
                 files.AddRange(srcElement.Value.Trim(';').Split(';').Select(s => 
                     new ManifestFile
                     {
-                        Source = s.SafeTrim().TrimStart(slashes),
+                        Source = s.SafeTrim(),
                         Target = target,
                         Exclude = exclude
                     }));

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -710,7 +710,7 @@ namespace NuGet.Packaging
 
         private static void CreatePart(ZipArchive package, string path, Stream sourceStream)
         {
-            if (PackageHelper.IsNuspec(path) || ProjectJsonPathUtilities.IsProjectConfig(path))
+            if (PackageHelper.IsNuspec(path))
             {
                 return;
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -58,7 +58,7 @@ namespace NuGet.CommandLine.Test
   </metadata>
   <files>
     <file src=""contentFiles/any/any/image.jpg"" target=""\Content\image.jpg"" />
-    <file src=""/contentFiles/any/any/image2.jpg"" target=""Content\other\image2.jpg"" />
+    <file src=""contentFiles/any/any/image2.jpg"" target=""Content\other\image2.jpg"" />
   </files>
 </package>");
 


### PR DESCRIPTION
This was breaking full path files in Unix.  Fixes https://github.com/NuGet/Home/issues/2914

Also taking out suppression of including project.json from the output package since it's not necessary and was causing problems for @ericstj.

@joelverhagen
