### PR TITLE
Adding batch processing start/end for install/uninstall packages to improve performance

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -261,12 +261,12 @@ namespace NuGet.PackageManagement
         /// and <paramref name="nuGetProjectContext" /> are used in the process.
         /// </summary>
         public async Task<IEnumerable<NuGetProjectAction>> PreviewInstallPackageAsync(
-            NuGetProject nuGetProject, 
+            NuGetProject nuGetProject,
             string packageId,
-            ResolutionContext resolutionContext, 
+            ResolutionContext resolutionContext,
             INuGetProjectContext nuGetProjectContext,
-            IEnumerable<SourceRepository> primarySources, 
-            IEnumerable<SourceRepository> secondarySources, 
+            IEnumerable<SourceRepository> primarySources,
+            IEnumerable<SourceRepository> secondarySources,
             CancellationToken token)
         {
             if (nuGetProject == null)
@@ -779,7 +779,7 @@ namespace NuGet.PackageManagement
                 }
 
                 // Remove packages that do not meet the constraints specified in the UpdateConstrainst
-                prunedAvailablePackages = PrunePackageTree.PruneByUpdateConstraints(prunedAvailablePackages, projectInstalledPackageReferences, resolutionContext.VersionConstraints);                
+                prunedAvailablePackages = PrunePackageTree.PruneByUpdateConstraints(prunedAvailablePackages, projectInstalledPackageReferences, resolutionContext.VersionConstraints);
 
                 // Remove all but the highest packages that are of the same Id as a specified packageId
                 if (packageId != null)
@@ -1626,6 +1626,11 @@ namespace NuGet.PackageManagement
                             logger);
                     }
 
+                    if (msbuildProject != null)
+                    {
+                        msbuildProject.MSBuildNuGetProjectSystem.BeginProcessing();
+                    }
+
                     foreach (var nuGetProjectAction in actionsList)
                     {
                         executedNuGetProjectActions.Push(nuGetProjectAction);
@@ -1703,6 +1708,11 @@ namespace NuGet.PackageManagement
                         }
 
                         downloadTokenSource.Dispose();
+                    }
+
+                    if (msbuildProject != null)
+                    {
+                        msbuildProject.MSBuildNuGetProjectSystem.EndProcessing();
                     }
                 }
 


### PR DESCRIPTION
Adding batch processing start/end for install/uninstall packages for ms build projects which improved performance by ~25%

Fix https://github.com/NuGet/Home/issues/2903

Below numbers are taken while updating 35 packages across 6 different types of projects in a solution:
Without batch  With batch processing
92 seconds     66 seconds
87 seconds     67 seconds
87 seconds     58 seconds
91 seconds     60 seconds
89 seconds     64 seconds
