### PR TITLE
Adding pack support for packOptions files in project.json.

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -395,7 +395,7 @@ namespace NuGet.Commands
             if (spec.PackOptions != null)
             {
                 PackCommandRunner runner = new PackCommandRunner(new PackArgs() { BasePath = basePath }, null);
-                if (spec.PackOptions?.IncludeExcludeFiles != null)
+                if (spec.PackOptions.IncludeExcludeFiles != null)
                 {
                     string fullExclude;
                     string filesExclude;
@@ -420,7 +420,7 @@ namespace NuGet.Commands
                     }
                 }
 
-                if (spec.PackOptions?.Mappings != null)
+                if (spec.PackOptions.Mappings != null)
                 {
                     foreach (var map in spec.PackOptions.Mappings)
                     {
@@ -929,6 +929,9 @@ namespace NuGet.Commands
                 {
                     if (builder.Version == null)
                     {
+                        // If the version is null, the user will get an error later saying that a version
+                        // is required. Specifying a version here just keeps it from throwing until
+                        // it gets to the better error message. It won't actually get used.
                         version = "1.0.0";
                     }
                     else

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -394,7 +394,6 @@ namespace NuGet.Commands
 
             if (spec.PackOptions != null)
             {
-                PackCommandRunner runner = new PackCommandRunner(new PackArgs() { BasePath = basePath }, null);
                 if (spec.PackOptions.IncludeExcludeFiles != null)
                 {
                     string fullExclude;
@@ -413,7 +412,7 @@ namespace NuGet.Commands
                     {
                         foreach (var includeFile in spec.PackOptions.IncludeExcludeFiles.IncludeFiles)
                         {
-                            var resolvedPath = runner.ResolvePath(new PhysicalPackageFile() { SourcePath = includeFile });
+                            var resolvedPath = ResolvePath(new PhysicalPackageFile() { SourcePath = includeFile }, basePath);
 
                             builder.AddFiles(basePath, includeFile, resolvedPath, filesExclude);
                         }
@@ -813,6 +812,13 @@ namespace NuGet.Commands
 
         private string ResolvePath(IPackageFile packageFile)
         {
+            var basePath = string.IsNullOrEmpty(_packArgs.BasePath) ? _packArgs.CurrentDirectory : _packArgs.BasePath;
+
+            return ResolvePath(packageFile, basePath);
+        }
+
+        private static string ResolvePath(IPackageFile packageFile, string basePath)
+        {
             var physicalPackageFile = packageFile as PhysicalPackageFile;
 
             // For PhysicalPackageFiles, we want to filter by SourcePaths, the path on disk. The Path value maps to the TargetPath
@@ -824,8 +830,6 @@ namespace NuGet.Commands
             var path = physicalPackageFile.SourcePath;
 
             // Make sure that the basepath has a directory separator
-            var basePath = string.IsNullOrEmpty(_packArgs.BasePath) ? _packArgs.CurrentDirectory : _packArgs.BasePath;
-
             int index = path.IndexOf(PathUtility.EnsureTrailingSlash(basePath), StringComparison.OrdinalIgnoreCase);
             if (index != -1)
             {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -605,7 +605,9 @@ namespace NuGet.Packaging
 
             ExcludeFiles(searchFiles, basePath, exclude);
 
-            if (!PathResolver.IsWildcardSearch(source) && !PathResolver.IsDirectoryPath(source) && !searchFiles.Any())
+            // Don't throw if the exclude is what made this find no files. Adding files from
+            // project.json ends up calling this one file at a time where some may be filtered out.  
+            if (!PathResolver.IsWildcardSearch(source) && !PathResolver.IsDirectoryPath(source) && !searchFiles.Any() && string.IsNullOrEmpty(exclude))
             {
                 throw new FileNotFoundException(
                     String.Format(CultureInfo.CurrentCulture, NuGetResources.PackageAuthoring_FileNotFound, source));

--- a/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/IncludeExcludeFiles.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace NuGet.ProjectModel
+{
+    public class IncludeExcludeFiles
+    {
+        public IReadOnlyList<string> Include { get; set; }
+        public IReadOnlyList<string> Exclude { get; set; }
+        public IReadOnlyList<string> IncludeFiles { get; set; }
+        public IReadOnlyList<string> ExcludeFiles { get; set; }
+
+        public bool HandleIncludeExcludeFiles(JObject jsonObject)
+        {
+            var rawInclude = jsonObject["include"];
+            var rawExclude = jsonObject["exclude"];
+            var rawIncludeFiles = jsonObject["includeFiles"];
+            var rawExcludeFiles = jsonObject["excludeFiles"];
+
+            IEnumerable<string> include;
+            IEnumerable<string> exclude;
+            IEnumerable<string> includeFiles;
+            IEnumerable<string> excludeFiles;
+            bool foundOne = false;
+            if (rawInclude != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawInclude, out include))
+            {
+                Include = include.ToList();
+                foundOne = true;
+            }
+            if (rawExclude != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawExclude, out exclude))
+            {
+                Exclude = exclude.ToList();
+                foundOne = true;
+            }
+            if (rawIncludeFiles != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawIncludeFiles, out includeFiles))
+            {
+                IncludeFiles = includeFiles.ToList();
+                foundOne = true;
+            }
+            if (rawExcludeFiles != null && JsonPackageSpecReader.TryGetStringEnumerableFromJArray(rawExcludeFiles, out excludeFiles))
+            {
+                ExcludeFiles = excludeFiles.ToList();
+                foundOne = true;
+            }
+
+            return foundOne;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -570,7 +570,7 @@ namespace NuGet.ProjectModel
             return isValid;
         }
 
-        public static bool TryGetStringEnumerableFromJArray(JToken token, out IEnumerable<string> result)
+        internal static bool TryGetStringEnumerableFromJArray(JToken token, out IEnumerable<string> result)
         {
             IEnumerable<string> values;
             if (token == null)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackOptions.cs
@@ -9,5 +9,7 @@ namespace NuGet.ProjectModel
     public class PackOptions
     {
         public IReadOnlyList<PackageType> PackageType { get; set; }
+        public IncludeExcludeFiles IncludeExcludeFiles { get; set; }
+        public Dictionary<string, IncludeExcludeFiles> Mappings { get; set; } = new Dictionary<string, IncludeExcludeFiles>();
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -559,6 +559,98 @@ namespace NuGet.ProjectModel.Test
             Assert.Contains("The pack options package type must be a string or array of strings in 'project.json'.", actual.Message);
         }
 
+        [Fact]
+        public void PackageSpecReader_PackOptions_Files1()
+        {
+            // Arrange & Act
+            string json = @"{
+                        ""packOptions"": {
+                          ""files"": {
+                            ""include"": ""file1"",
+                            ""exclude"": ""file2"",
+                            ""includeFiles"": ""file3"",
+                            ""excludeFiles"": ""file4"",
+                            ""mappings"": {
+                              ""dest/path"": ""./src/path""
+                            }
+                          }
+                        }
+                      }";
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            Assert.NotNull(actual.PackOptions);
+            Assert.Equal(1, actual.PackOptions.IncludeExcludeFiles.Include.Count);
+            Assert.Equal(1, actual.PackOptions.IncludeExcludeFiles.Exclude.Count);
+            Assert.Equal(1, actual.PackOptions.IncludeExcludeFiles.IncludeFiles.Count);
+            Assert.Equal(1, actual.PackOptions.IncludeExcludeFiles.ExcludeFiles.Count);
+            Assert.Equal("file1", actual.PackOptions.IncludeExcludeFiles.Include.First());
+            Assert.Equal("file2", actual.PackOptions.IncludeExcludeFiles.Exclude.First());
+            Assert.Equal("file3", actual.PackOptions.IncludeExcludeFiles.IncludeFiles.First());
+            Assert.Equal("file4", actual.PackOptions.IncludeExcludeFiles.ExcludeFiles.First());
+            Assert.NotNull(actual.PackOptions.Mappings);
+            Assert.Equal(1, actual.PackOptions.Mappings.Count());
+            Assert.Equal("dest/path", actual.PackOptions.Mappings.First().Key);
+            Assert.Equal(1, actual.PackOptions.Mappings.First().Value.Include.Count());
+            Assert.Null(actual.PackOptions.Mappings.First().Value.Exclude);
+            Assert.Null(actual.PackOptions.Mappings.First().Value.IncludeFiles);
+            Assert.Null(actual.PackOptions.Mappings.First().Value.ExcludeFiles);
+            Assert.Equal("./src/path", actual.PackOptions.Mappings.First().Value.Include.First());
+        }
+
+        [Fact]
+        public void PackageSpecReader_PackOptions_Files2()
+        {
+            // Arrange & Act
+            string json = @"{
+                        ""packOptions"": {
+                          ""files"": {
+                            ""include"": [""file1a"", ""file1b""],
+                            ""exclude"": [""file2a"", ""file2b""],
+                            ""includeFiles"": [""file3a"", ""file3b""],
+                            ""excludeFiles"": [""file4a"", ""file4b""],
+                            ""mappings"": {
+                              ""dest/path1"": [""./src/path1"", ""./src/path2""],
+                              ""dest/path2"": {
+                                ""includeFiles"": [""map1a"", ""map1b""],
+                              },
+                            }
+                          }
+                        }
+                      }";
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            Assert.NotNull(actual.PackOptions);
+            Assert.Equal(2, actual.PackOptions.IncludeExcludeFiles.Include.Count);
+            Assert.Equal(2, actual.PackOptions.IncludeExcludeFiles.Exclude.Count);
+            Assert.Equal(2, actual.PackOptions.IncludeExcludeFiles.IncludeFiles.Count);
+            Assert.Equal(2, actual.PackOptions.IncludeExcludeFiles.ExcludeFiles.Count);
+            Assert.Equal("file1a", actual.PackOptions.IncludeExcludeFiles.Include.First());
+            Assert.Equal("file2a", actual.PackOptions.IncludeExcludeFiles.Exclude.First());
+            Assert.Equal("file3a", actual.PackOptions.IncludeExcludeFiles.IncludeFiles.First());
+            Assert.Equal("file4a", actual.PackOptions.IncludeExcludeFiles.ExcludeFiles.First());
+            Assert.Equal("file1b", actual.PackOptions.IncludeExcludeFiles.Include.Last());
+            Assert.Equal("file2b", actual.PackOptions.IncludeExcludeFiles.Exclude.Last());
+            Assert.Equal("file3b", actual.PackOptions.IncludeExcludeFiles.IncludeFiles.Last());
+            Assert.Equal("file4b", actual.PackOptions.IncludeExcludeFiles.ExcludeFiles.Last());
+            Assert.NotNull(actual.PackOptions.Mappings);
+            Assert.Equal(2, actual.PackOptions.Mappings.Count());
+            Assert.Equal("dest/path1", actual.PackOptions.Mappings.First().Key);
+            Assert.Equal("dest/path2", actual.PackOptions.Mappings.Last().Key);
+            Assert.Equal(2, actual.PackOptions.Mappings.First().Value.Include.Count());
+            Assert.Null(actual.PackOptions.Mappings.First().Value.Exclude);
+            Assert.Null(actual.PackOptions.Mappings.First().Value.IncludeFiles);
+            Assert.Null(actual.PackOptions.Mappings.First().Value.ExcludeFiles);
+            Assert.Equal("./src/path1", actual.PackOptions.Mappings.First().Value.Include.First());
+            Assert.Equal("./src/path2", actual.PackOptions.Mappings.First().Value.Include.Last());
+            Assert.Null(actual.PackOptions.Mappings.Last().Value.Include);
+            Assert.Null(actual.PackOptions.Mappings.Last().Value.Exclude);
+            Assert.Null(actual.PackOptions.Mappings.Last().Value.ExcludeFiles);
+            Assert.Equal("map1a", actual.PackOptions.Mappings.Last().Value.IncludeFiles.First());
+            Assert.Equal("map1b", actual.PackOptions.Mappings.Last().Value.IncludeFiles.Last());
+        }
+
         [Theory]
         [InlineData("{}", null, true)]
         [InlineData(@"{


### PR DESCRIPTION
The files property of project.json includes support for glob includes and excludes as well as arrays of include and exclude files, plus mappings to map them to different target directories.

This is required to get dotnet pack to continue supporting existing features when it switches to using NuGet pack.

@joelverhagen @emgarten 
