### PR TITLE
Fixed tests failure on Mac in r3.4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,12 @@
 # Project K
 project.lock.json
 artifacts/
-**/.vs/
 
+# VSCode
+**/.vs/
+**/.vscode/
+
+cli/
 **/nupkgs/*.nupkg
 packages/
 .nuget/nuget.exe

--- a/build.sh
+++ b/build.sh
@@ -22,11 +22,6 @@ fi
 
 dnvm use 1.0.0-rc1-update1 -runtime coreclr
 
-# init the repo
-
-git submodule init
-git submodule update
-
 # clear caches
 if [ "$CLEAR_CACHE" == "1" ]
 then
@@ -38,7 +33,7 @@ then
 fi
 
 # restore packages
-dnu restore
+dnu restore src/NuGet.Core
 dnu restore test/NuGet.Core.Tests
 
 # run tests
@@ -53,20 +48,20 @@ do
         echo "Skipping tests in $testProject because they hang"
         continue
     fi
-	
-	if grep -q dnxcore50 "$testProject"; then
+
+    if grep -q dnxcore50 "$testProject"; then
          echo "Running tests in $testProject on CoreCLR"
-		 
-		 dnvm use 1.0.0-rc1-update1 -runtime coreclr
-		 dnx --project $testProject test -parallel none
-		 
-		 if [ $? -ne 0 ]; then
-			echo "$testProject FAILED on CoreCLR"
-			RESULTCODE=1
-		 fi		 
-	else
+
+         dnvm use 1.0.0-rc1-update1 -runtime coreclr
+         dnx --project $testProject test -parallel none -diagnostics -verbose
+
+         if [ $? -ne 0 ]; then
+            echo "$testProject FAILED on CoreCLR"
+            RESULTCODE=1
+         fi
+    else
          echo "Skipping the tests in $testProject on CoreCLR"
-	fi	
+    fi
 done
 
 exit $RESULTCODE

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -22,11 +22,6 @@ fi
 
 dnvm use 1.0.0-rc1-update1 -runtime coreclr
 
-# init the repo
-
-git submodule init
-git submodule update
-
 # clear caches
 if [ "$CLEAR_CACHE" == "1" ]
 then
@@ -38,7 +33,7 @@ then
 fi
 
 # restore packages
-dnu restore
+dnu restore src/NuGet.Core
 dnu restore test/NuGet.Core.FuncTests
 
 # run tests
@@ -46,17 +41,17 @@ for testProject in `find test/NuGet.Core.FuncTests -type f -name project.json`
 do
 	if grep -q dnxcore50 "$testProject"; then
          echo "Running tests in $testProject on CoreCLR"
-		 
+
 		 dnvm use 1.0.0-rc1-update1 -runtime coreclr
 		 dnx --project $testProject test -parallel none
-		 
+
 		 if [ $? -ne 0 ]; then
 			echo "$testProject FAILED on CoreCLR"
 			RESULTCODE=1
-		 fi		 
+		 fi
 	else
          echo "Skipping the tests in $testProject on CoreCLR"
-	fi	
+	fi
 done
 
 exit $RESULTCODE

--- a/src/NuGet.Core/NuGet.Common/project.json
+++ b/src/NuGet.Core/NuGet.Common/project.json
@@ -18,7 +18,7 @@
             "System.IO.FileSystem": "4.0.0-beta-23109",
             "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
             "System.Linq": "4.0.0-beta-23109",
-            "System.Runtime.Extensions": "4.0.10-beta-23109",
+            "System.Runtime.Extensions": "4.0.11-beta-*",
             "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23826",
             "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
             "System.Text.RegularExpressions": "4.0.10-beta-23109",

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -33,7 +33,7 @@
     },
     "dnxcore50": {
       "dependencies": {
-        "System.Runtime.Extensions": "4.0.10-beta-23109",
+        "System.Runtime.Extensions": "4.0.11-beta-*",
         "System.Collections": "4.0.10-beta-23109",
         "System.Collections.Concurrent": "4.0.10-beta-23109",
         "System.Diagnostics.Debug": "4.0.10-beta-23109",

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -20,8 +20,8 @@
         "System.ObjectModel": "4.0.10-beta-23109",
         "System.IO.FileSystem": "4.0.0-beta-23109",
         "System.Linq": "4.0.0-beta-23109",
-        "System.Runtime": "4.0.20-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109"
+        "System.Runtime": "4.0.21-beta-*",
+        "System.Runtime.Extensions": "4.0.11-beta-*"
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Frameworks/project.json
+++ b/src/NuGet.Core/NuGet.Frameworks/project.json
@@ -21,8 +21,8 @@
     "net45": {},
     "dnxcore50": {
       "dependencies": {
-        "System.Runtime": "4.0.20-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109",
+        "System.Runtime": "4.0.21-beta-*",
+        "System.Runtime.Extensions": "4.0.11-beta-*",
         "System.Collections": "4.0.10-beta-23109",
         "System.Collections.Concurrent": "4.0.10-beta-23109",
         "System.Diagnostics.Tools": "4.0.0-beta-23109",

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -17,7 +17,7 @@
     "net45": {},
     "dnxcore50": {
       "dependencies": {
-        "System.Runtime": "4.0.20-*",
+        "System.Runtime": "4.0.21-beta-*",
         "System.Collections.Concurrent": "4.0.10-*"
       }
     }

--- a/src/NuGet.Core/NuGet.Logging/project.json
+++ b/src/NuGet.Core/NuGet.Logging/project.json
@@ -20,7 +20,7 @@
     "net45": {},
     "dnxcore50": {
       "dependencies": {
-        "System.Runtime": "4.0.20-beta-23109",
+        "System.Runtime": "4.0.21-beta-*",
         "System.Collections.Concurrent": "4.0.10-beta-23109"
       }
     }

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -40,7 +40,7 @@
         "System.IO.Compression": "4.0.0-beta-23109",
         "System.IO.FileSystem": "4.0.0-beta-23109",
         "System.Xml.XDocument": "4.0.10-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109",
+        "System.Runtime.Extensions": "4.0.11-beta-*",
         "System.Reflection.Extensions": "4.0.0-beta-23109",
         "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23225"
       }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -18,7 +18,7 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "System.Runtime": "4.0.20-beta-23109",
+        "System.Runtime": "4.0.21-beta-*",
         "System.Net.Http": "4.0.0-beta-23109",
         "System.Net.Primitives": "4.0.10-beta-23109"
       }

--- a/src/NuGet.Core/NuGet.Shared/project.json
+++ b/src/NuGet.Core/NuGet.Shared/project.json
@@ -17,7 +17,7 @@
             "System.IO.Compression": "4.0.0-beta-23109",
             "System.IO.FileSystem": "4.0.0-beta-23109",
             "System.IO.FileSystem.Primitives": "4.0.0-beta-23109",
-            "System.Runtime.Extensions": "4.0.10-beta-23109",
+            "System.Runtime.Extensions": "4.0.11-beta-*",
             "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23826",
             "System.Security.Cryptography.Cng": "4.0.0-beta-23516",
             "System.Threading": "4.0.10-beta-23109",

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -18,7 +18,7 @@
         "System.Net.Http": "4.0.0-beta-23109",
         "System.Net.Sockets": "4.1.0-beta-23516",
         "System.Linq": "4.0.0-beta-23109",
-        "System.Runtime": "4.0.20-beta-2310"
+        "System.Runtime": "4.0.21-beta-*"
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Test.Utility/ConditionalFactAttribute.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/ConditionalFactAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace NuGet.Test.Utility
+{
+    public class ConditionalFactAttribute : FactAttribute
+    {
+        public ConditionalFactAttribute(params Type[] executionConditionTypes)
+        {
+            var condition = executionConditionTypes
+                .Select(t => Activator.CreateInstance(t))
+                .Cast<TestExecutionCondition>()
+                .FirstOrDefault(c => c.ShouldSkip);
+
+            if (condition != null)
+            {
+                Skip = condition.SkipReason;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/MacOSRuntimeCondition.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/MacOSRuntimeCondition.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+
+namespace NuGet.Test.Utility
+{
+    public class MacOSRuntimeCondition : TestExecutionCondition
+    {
+        public override bool ShouldSkip => RuntimeEnvironmentHelper.IsMacOSX;
+
+        public override string SkipReason => "Test is skipped on Mac OS X";
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/TestExecutionCondition.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestExecutionCondition.cs
@@ -1,0 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Test.Utility
+{
+    public abstract class TestExecutionCondition
+    {
+        public abstract bool ShouldSkip { get; }
+        public abstract string SkipReason { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -8,12 +8,14 @@
   },
   "dependencies": {
     "xunit": "2.1.0",
+    "NuGet.Common": "3.4.5-*",
     "NuGet.Packaging": "3.4.5-*"
   },
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.IO.Compression": ""
+        "System.IO.Compression": "",
+        "System.Runtime": ""
       }
     },
     "dnxcore50": {
@@ -21,9 +23,11 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "System.IO.Compression.ZipFile": "4.0.0-beta-23109",
-        "System.IO.FileSystem": "4.0.0-beta-23109",
-        "System.Diagnostics.Process": "4.0.0-beta-23109"
+        "System.Collections": "4.0.10-beta-*",
+        "System.Diagnostics.Process": "4.0.0-beta-*",
+        "System.IO.Compression.ZipFile": "4.0.0-beta-*",
+        "System.IO.FileSystem": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*"
       }
     }
   }

--- a/src/NuGet.Core/NuGet.Versioning/project.json
+++ b/src/NuGet.Core/NuGet.Versioning/project.json
@@ -29,7 +29,7 @@
         "System.Linq": "4.0.0-beta-23109",
         "System.Resources.ResourceManager": "4.0.0-beta-23109",
         "System.Reflection": "4.0.10-beta-23109",
-        "System.Runtime.Extensions": "4.0.10-beta-23109"
+        "System.Runtime.Extensions": "4.0.11-beta-*"
       }
     }
   }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using Xunit;
+
+// XUnit runner configuration: Disable parallel tests
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
+    "Newtonsoft.Json": "8.0.3",
     "NuGet.Protocol.Core.v3": "3.4.5-*",
     "NuGet.Protocol.Test.Utility": "1.0.0-*",
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-rc1-build204",
     "NuGet.Test.Utility": "3.4.5-*",
     "NuGet.Test.Server": "3.4.5-*",
-    "Newtonsoft.Json": "8.0.3"
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204"
   },
   "commands": {
     "test": "xunit.runner.dnx"
@@ -21,8 +21,8 @@
       "imports": [ "portable-net45+win8" ],
       "dependencies": {
         "moq.netcore": "4.4.0-beta8",
-        "System.Collections": "4.0.10-beta-23109",
-        "System.Net.Requests": "4.0.11-beta-23516"
+        "System.Collections": "4.0.10-beta-*",
+        "System.Net.Requests": "4.0.11-beta-*"
       }
     }
   }


### PR DESCRIPTION
DNX xunit test runner crashed on MacOS when executing Assert.ThrowsAsync.
As a workaround for v3.4.xxx only these tests were skipped.

Also,
- Added conditional fact attribute (Implementation was borrowed from  Roslyn repo).
- Added Mac OS X test execution condition to efficiently skip tests on  Mac.
- NetworkProtocolUtilityTests theory was refactored into separate tests.
  (Another reason to keep test logic simple and to avoid conditional assers)
- Test script was optimized by removing redundant restore projects in NuGet.Clients
- Disabled test parallelization in NuGet.Common.Tests
- Upgraded System.Runtime to 4.0.21

//cc @rrelyea @emgarten @joelverhagen @yishaigalatzer 
