### PR TITLE
Remove command line tests from Dev15 runs

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -564,10 +564,13 @@ Function Test-ClientsProjects {
         [string]$Configuration = $DefaultConfiguration,
         [string]$MSBuildVersion = $DefaultMSBuildVersion
     )
+    
+    # We don't run command line tests on Dev15 as we don't build a nuget.exe for this version
     $testProjectsLocation = Join-Path $NuGetClientRoot test\NuGet.Clients.Tests
     $testProjects = Get-ChildItem $testProjectsLocation -Recurse -Filter '*.csproj' |
         %{ $_.FullName } |
-        ?{ -not $_.EndsWith('WebAppTest.csproj') }
+        ?{ -not $_.EndsWith('WebAppTest.csproj') -and 
+           -not ($_.EndsWith('NuGet.CommandLine.Test.csproj') -and ($MSBuildVersion -eq '15'))}
 
     $testProjects | Test-ClientProject -Configuration $Configuration -MSBuildVersion $MSBuildVersion
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -1197,7 +1197,9 @@ namespace NuGet.CommandLine.Test
                     slnPath,
                     "-Verbosity",
                     "detailed",
-                    "-DisableParallelProcessing"
+                    "-DisableParallelProcessing",
+                    "MSBuildVersion",
+                    "14"
                 };
 
                 // Act


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2898
Tests now pass for both Dev14 and Dev15 builds. Note that the other two tests called out in this bug description were fixed by a separate change--likely this one: https://github.com/NuGet/NuGet.Client/commit/b325ee6d2e843f9f2c8629ac0ab841a2f4c5f7ea
