### PR TITLE
Adding serviceable flag to the pack commandline.xplat options so that dotnet pack can use it.

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -66,6 +66,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.OutputDirectory_Description,
                     CommandOptionType.SingleValue);
 
+                var serviceable = pack.Option(
+                    "--serviceable",
+                    Strings.Serviceable_Description,
+                    CommandOptionType.NoValue);
+
                 var suffix = pack.Option(
                     "--suffix <suffix>",
                     Strings.Suffix_Description,
@@ -141,6 +146,7 @@ namespace NuGet.CommandLine.XPlat
                         }
                     }
 
+                    packArgs.Serviceable = serviceable.HasValue();
                     packArgs.Suffix = suffix.Value();
                     packArgs.Symbols = symbols.HasValue();
                     if (versionOption.HasValue())

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -555,7 +555,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Set the internal serviceable flag in the package.
+        ///    Looks up a localized string similar to Sets the nuspec serviceable element to true..
         /// </summary>
         public static string Serviceable_Description {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -555,6 +555,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Set the internal serviceable flag in the package.
+        /// </summary>
+        public static string Serviceable_Description {
+            get {
+                return ResourceManager.GetString("Serviceable_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Specifies the server URL.
         /// </summary>
         public static string Source_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -303,6 +303,6 @@
     <value>{0} Version: {1}</value>
   </data>
   <data name="Serviceable_Description" xml:space="preserve">
-    <value>Set the internal serviceable flag in the package</value>
+    <value>Sets the nuspec serviceable element to true.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -302,4 +302,7 @@
   <data name="OutputNuGetVersion" xml:space="preserve">
     <value>{0} Version: {1}</value>
   </data>
+  <data name="Serviceable_Description" xml:space="preserve">
+    <value>Set the internal serviceable flag in the package</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/PackArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackArgs.cs
@@ -26,6 +26,7 @@ namespace NuGet.Commands
         public bool NoPackageAnalysis { get; set; }
         public string OutputDirectory { get; set; }
         public string Path { get; set; }
+        public bool Serviceable { get; set; }
         public string Suffix { get; set; }
         public bool Symbols { get; set; }
         public bool Tool { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -699,6 +699,11 @@ namespace NuGet.Commands
                 builder.Version = new NuGetVersion($"{version}-{_packArgs.Suffix}");
             }
 
+            if (_packArgs.Serviceable)
+            {
+                builder.Serviceable = true;
+            }
+
             if (_packArgs.MinClientVersion != null)
             {
                 builder.MinClientVersion = _packArgs.MinClientVersion;


### PR DESCRIPTION
dotnet pack now supports --serviceable, so the nuget.commandline.xplat must support the same for it to replace it.

@emgarten 
