### PR TITLE
Setting right TFM when running nuget.exe update for native or js projects

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -14,6 +14,8 @@ namespace NuGet.Common
     public class MSBuildProjectSystem : MSBuildUser, IMSBuildNuGetProjectSystem
     {
         private const string TargetName = "EnsureNuGetPackageBuildImports";
+        private const string JSProjectExt = ".jsproj";
+        private const string VCXProjextExt = ".vcxproj";
         private readonly string _projectDirectory;
 
         public MSBuildProjectSystem(
@@ -46,16 +48,60 @@ namespace NuGet.Common
         {
             get
             {
-                string moniker = GetPropertyValue("TargetFrameworkMoniker");
+                // this is required to get the right TFM for native or js projects since TargetFrameworkMoniker
+                // property won't give the accurate value for these kind of projects
+                string moniker = GetTargetFrameworkString();
+
                 if (String.IsNullOrEmpty(moniker))
                 {
                     return null;
                 }
-                return NuGetFramework.Parse(moniker);
+
+                var framework = NuGetFramework.Parse(moniker);
+
+                // further parse framework for .net core 4.5.1 or 4.5 and get compatible framework instance
+                return MSBuildNuGetProjectSystemUtility.GetCompatibleFramework(framework);
             }
         }
 
         private dynamic Project { get; }
+
+        private string GetTargetFrameworkString()
+        {
+            var extension = GetPropertyValue("ProjectExt");
+
+            // Check for JS project
+            if (StringComparer.OrdinalIgnoreCase.Equals(JSProjectExt, extension))
+            {
+                // JavaScript apps do not have a TargetFrameworkMoniker property set.
+                // We read the TargetPlatformIdentifier and TargetPlatformVersion instead
+                var platformIdentifier = GetPropertyValue("TargetPlatformIdentifier");
+                var platformVersion = GetPropertyValue("TargetPlatformVersion");
+
+                // use the default values for JS if they were not given
+                if (string.IsNullOrEmpty(platformVersion))
+                {
+                    platformVersion = "0.0";
+                }
+
+                if (string.IsNullOrEmpty(platformIdentifier))
+                {
+                    platformIdentifier = "Windows";
+                }
+
+                return string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}", platformIdentifier, platformVersion);
+            }
+
+            // Check for C++ project
+            if (StringComparer.OrdinalIgnoreCase.Equals(VCXProjextExt, extension))
+            {
+                // The C++ project does not have a TargetFrameworkMoniker property set. 
+                // We hard-code the return value to Native.
+                return ProjectManagement.Constants.NativeTFM;
+            }
+
+            return GetPropertyValue("TargetFrameworkMoniker");
+        }
 
         public void AddBindingRedirects()
         {
@@ -134,7 +180,7 @@ namespace NuGet.Common
                 var assemblyName = AssemblyName.GetAssemblyName(fullPath);
                 assemblyFileName = assemblyName.FullName;
             }
-            catch(Exception)
+            catch (Exception)
             {
                 //ignore exception if we weren't able to get assembly strong name, we'll still use assembly file name to add reference
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -600,19 +600,9 @@ namespace NuGet.PackageManagement.VisualStudio
             if (!String.IsNullOrEmpty(targetFrameworkMoniker))
             {
                 var framework = NuGetFramework.Parse(targetFrameworkMoniker);
-                //if the framework is .net core 4.5.1 return windows 8.1
-                if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
-                    && framework.Version.Equals(Version.Parse("4.5.1.0")))
-                {
-                    return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, Version.Parse("8.1"), framework.Profile);
-                }
-                //if the framework is .net core 4.5 return 8.0
-                if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
-                    && framework.Version.Equals(Version.Parse("4.5.0.0")))
-                {
-                    return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows, Version.Parse("8.0"), framework.Profile);
-                }
-                return NuGetFramework.Parse(targetFrameworkMoniker);
+
+                // further parse framework for .net core 4.5.1 or 4.5 and get compatible framework instance
+               return MSBuildNuGetProjectSystemUtility.GetCompatibleFramework(framework);
             }
 
             return NuGetFramework.UnsupportedFramework;
@@ -660,7 +650,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // The C++ project does not have a TargetFrameworkMoniker property set. 
                 // We hard-code the return value to Native.
-                return "Native, Version=0.0";
+                return Constants.NativeTFM;
             }
 
             string targetFramework = GetPropertyValue<string>(envDTEProject, "TargetFrameworkMoniker");

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/Constants.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/Constants.cs
@@ -34,5 +34,7 @@ namespace NuGet.ProjectManagement
             = new ReadOnlyCollection<string>(new[] { ".dll", ".exe", ".winmd" });
 
         public const string ResourceAssemblyExtension = ".resources.dll";
+
+        public static readonly string NativeTFM = "Native, Version=0.0";
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -14,7 +14,7 @@ using NuGet.Packaging.Core;
 
 namespace NuGet.ProjectManagement
 {
-    internal static class MSBuildNuGetProjectSystemUtility
+    public static class MSBuildNuGetProjectSystemUtility
     {
         internal static FrameworkSpecificGroup GetMostCompatibleGroup(NuGetFramework projectTargetFramework,
             IEnumerable<FrameworkSpecificGroup> itemGroups)
@@ -34,6 +34,36 @@ namespace NuGet.ProjectManagement
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Parse existing nuget framework for .net core 4.5.1 or 4.5 and return compatible framework instance
+        /// </summary>
+        /// <param name="framework"></param>
+        /// <returns></returns>
+        public static NuGetFramework GetCompatibleFramework(NuGetFramework framework)
+        {
+            if (framework == null)
+            {
+                throw new ArgumentNullException("framework");
+            }
+
+            // if the framework is .net core 4.5.1 return windows 8.1
+            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
+                && framework.Version.Equals(Version.Parse("4.5.1.0")))
+            {
+                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
+                       new Version("8.1"), framework.Profile);
+            }
+            // if the framework is .net core 4.5 return 8.0
+            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
+                && framework.Version.Equals(Version.Parse("4.5.0.0")))
+            {
+                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
+                       new Version("8.0"), framework.Profile);
+            }
+
+            return framework;
         }
 
         /// <summary>


### PR DESCRIPTION
Setting right TFM when running nuget.exe update for native or js projects. And using project extension to figure out project type like 'vcxproj' for c++ and 'jsproj' for javascript since msbuild projects don't have Project.Kind property.

Fix https://github.com/NuGet/Home/issues/1291
