### PR TITLE
remove new xmlns uri for serviceable

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -53,12 +53,7 @@ namespace NuGet.Packaging
         /// Added packageTypes element under metadata.
         /// </summary>
         internal const string SchemaVersionV7 = "http://schemas.microsoft.com/packaging/2016/04/nuspec.xsd";
-
-        /// <summary>
-        /// Added serviceble element under metadata.
-        /// </summary>
-        internal const string SchemaVersionV8 = "http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd";
-
+        
         private static readonly string[] VersionToSchemaMappings = new[] {
             SchemaVersionV1,
             SchemaVersionV2,
@@ -66,8 +61,7 @@ namespace NuGet.Packaging
             SchemaVersionV4,
             SchemaVersionV5,
             SchemaVersionV6,
-            SchemaVersionV7,
-            SchemaVersionV8
+            SchemaVersionV7
         };
 
 #if !IS_CORECLR

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
@@ -17,7 +17,6 @@ namespace NuGet.Packaging
         public const int TargetFrameworkSupportForReferencesVersion = 5;
         public const int XdtTransformationVersion = 6;
         public const int PackageTypeVersion = 7;
-        public const int ServiceableVersion = 8;
 
         public static int GetManifestVersion(ManifestMetadata metadata)
         {
@@ -27,11 +26,7 @@ namespace NuGet.Packaging
         private static int GetMaxVersionFromMetadata(ManifestMetadata metadata)
         {
             // Important: always add newer version checks at the top
-            if (metadata.Serviceable)
-            {
-                return ServiceableVersion;
-            }
-
+            
             if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
             {
                 return PackageTypeVersion;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
@@ -368,7 +368,7 @@ namespace NuGet.Packaging.Test
         {
             // Arrange
             string content = @"<?xml version=""1.0""?>
-<package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+<package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata hello=""world"">
     <id>A</id>
     <version>1.0</version>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
@@ -10,30 +10,6 @@ namespace NuGet.Packaging.Test
     public class ManifestVersionUtilityTest
     {
         [Fact]
-        public void GetManifestVersionReturns8IfServiceableIsSet()
-        {
-            // Arrange
-            var metadata = new ManifestMetadata
-            {
-                Id = "Foo",
-                Version = NuGetVersion.Parse("1.0"),
-                Authors = new[] { "A, B" },
-                Description = "Description",
-                Serviceable = true,
-                PackageTypes = new[]
-                {
-                    new PackageType("Bar", new System.Version(2, 0))
-                }
-            };
-
-            // Act
-            var version = ManifestVersionUtility.GetManifestVersion(metadata);
-
-            // Assert
-            Assert.Equal(8, version);
-        }
-
-        [Fact]
         public void GetManifestVersionReturns7IfPackageTypesAreSet()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -531,7 +531,7 @@ namespace NuGet.Packaging.Test
 
                 // Assert
                 Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<package xmlns=""http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd"">
+<package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
     <version>1.0.0</version>


### PR DESCRIPTION
@rrelyea @joelverhagen 
As discussed, this changeset removes the code that added the serviceable element in the new xmlns.
Fixes https://github.com/NuGet/Home/issues/2943
