### PR TITLE
Support importing multiple IVsCredentialProvider implementations

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -225,6 +225,15 @@ namespace NuGet.PackageManagement.UI
             await WaitForCompletionAsync(currentLoader, token);
 
             token.ThrowIfCancellationRequested();
+
+            if (currentLoader == _loader
+                && !loadedItems.Any()
+                && currentLoader.State.LoadingStatus == LoadingStatus.Ready)
+            {
+                UpdatePackageList(currentLoader.GetCurrent(), refresh: false);
+            }
+
+            token.ThrowIfCancellationRequested();
         }
 
         private async Task<IEnumerable<PackageItemListViewModel>> LoadNextPageAsync(IPackageItemLoader currentLoader, CancellationToken token)

--- a/src/NuGet.Clients/VsExtension/Resources.Designer.cs
+++ b/src/NuGet.Clients/VsExtension/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to load credential provider from assembly {0}..
+        /// </summary>
+        internal static string CredentialProviderFailed_ImportedProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_ImportedProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The legacy NuGet credential provider failed to load..
         /// </summary>
         internal static string CredentialProviderFailed_LegacyCredentialProvider {

--- a/src/NuGet.Clients/VsExtension/Resources.resx
+++ b/src/NuGet.Clients/VsExtension/Resources.resx
@@ -231,4 +231,7 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
   <data name="CredentialProviderFailed_DefaultCredentialsCredentialProvider" xml:space="preserve">
     <value>The default credentials credential provider failed to load.</value>
   </data>
+  <data name="CredentialProviderFailed_ImportedProvider" xml:space="preserve">
+    <value>Failed to load credential provider from assembly {0}.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderImporterTests.cs
@@ -111,7 +111,7 @@ namespace NuGet.VsExtension.Test
             _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
             var importer = GetTestableImporter();
             var testableProvider = new TeamSystem.NuGetCredentialProvider.VisualStudioAccountProvider();
-            importer.ImportedProviders = new List<Lazy<IVsCredentialProvider>> { new Lazy<IVsCredentialProvider>( () => testableProvider) };
+            importer.VisualStudioAccountProvider = testableProvider;
 
             // Act
             var results = importer.GetProviders();

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/VsCredentialProviderImporterTests.cs
@@ -1,26 +1,75 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using EnvDTE;
 using Moq;
 using NuGet.VisualStudio;
 using NuGetVSExtension;
+using System;
+using System.Collections.Generic;
+using System.Text;
 using Xunit;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.VsExtension.Test
 {
+    // This namespace declaration is on-purpose, to allow for testing the MEF imported VSTS credential provider without actually importing it.
+    namespace TeamSystem.NuGetCredentialProvider
+    {
+        public class VisualStudioAccountProvider : IVsCredentialProvider
+        {
+            public Task<ICredentials> GetCredentialsAsync(Uri uri, IWebProxy proxy, bool isProxyRequest, bool isRetry, bool nonInteractive, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+
+    internal class FailingCredentialProvider : NonFailingCredentialProvider
+    {
+        public FailingCredentialProvider()
+        {
+            // simulate a failure at contruction time
+            throw new Exception("Exception thrown in constructor of FailingCredentialProvider");
+        }
+    }
+
+    internal class NonFailingCredentialProvider : IVsCredentialProvider
+    {
+        public Task<ICredentials> GetCredentialsAsync(Uri uri, IWebProxy proxy, bool isProxyRequest, bool isRetry, bool nonInteractive, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     public class VsCredentialProviderImporterTests
     {
+        private readonly StringBuilder _testErrorOutput = new StringBuilder();
+        private static readonly VisualStudioAccountProvider _visualStudioAccountProvider = new VisualStudioAccountProvider(null, null);
         private readonly Mock<DTE> _mockDte = new Mock<DTE>();
-        private readonly Func<Credentials.ICredentialProvider> _fallbackProviderFactory = () => new VisualStudioAccountProvider(null, null);
+        private readonly Func<Credentials.ICredentialProvider> _fallbackProviderFactory = () => _visualStudioAccountProvider;
+        private readonly List<string> _errorMessages = new List<string>();
+        private readonly Action<Exception, string> _errorDelegate;
+
+        public VsCredentialProviderImporterTests()
+        {
+            _errorDelegate = (e, s) => _errorMessages.Add(s);
+        }
+
+        private void TestableErrorWriter(string s)
+        {
+            _testErrorOutput.AppendLine(s);
+        }
 
         private VsCredentialProviderImporter GetTestableImporter()
         {
             var importer = new VsCredentialProviderImporter(
                 _mockDte.Object,
                 _fallbackProviderFactory,
-                () => { });
+                _errorDelegate,
+                initializer: () => { });
 
             importer.Version = _mockDte.Object.Version;
 
@@ -35,10 +84,10 @@ namespace NuGet.VsExtension.Test
             var importer = GetTestableImporter();
 
             // Act
-            var result = importer.GetProvider();
+            var results = importer.GetProviders();
 
             // Assert
-            Assert.IsType<VisualStudioAccountProvider>(result);
+            Assert.Contains(_visualStudioAccountProvider, results);
         }
 
         [Fact]
@@ -49,10 +98,10 @@ namespace NuGet.VsExtension.Test
             var importer = GetTestableImporter();
 
             // Act
-            var result = importer.GetProvider();
+            var results = importer.GetProviders();
 
             // Assert
-            Assert.Null(result);
+            Assert.DoesNotContain(_visualStudioAccountProvider, results);
         }
 
         [Fact]
@@ -61,15 +110,14 @@ namespace NuGet.VsExtension.Test
             // Arrange
             _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
             var importer = GetTestableImporter();
-            var provider = new Mock<IVsCredentialProvider>();
-            var testableProvider = provider.Object;
-            importer.ImportedProvider = testableProvider;
+            var testableProvider = new TeamSystem.NuGetCredentialProvider.VisualStudioAccountProvider();
+            importer.ImportedProviders = new List<Lazy<IVsCredentialProvider>> { new Lazy<IVsCredentialProvider>( () => testableProvider) };
 
             // Act
-            var result = importer.GetProvider();
+            var results = importer.GetProviders();
 
             // Assert
-            Assert.IsType<VsCredentialProviderAdapter>(result);
+            Assert.DoesNotContain(_visualStudioAccountProvider, results);
         }
 
         [Fact]
@@ -81,12 +129,61 @@ namespace NuGet.VsExtension.Test
             var importer = new VsCredentialProviderImporter(
                 _mockDte.Object,
                 _fallbackProviderFactory,
+                _errorDelegate,
                 () => { throw exception; });
             importer.Version = _mockDte.Object.Version;
 
             // Act & Assert
-            var actual = Assert.Throws<ArgumentException>(() => importer.GetProvider());
+            var actual = Assert.Throws<ArgumentException>(() => importer.GetProviders());
             Assert.Same(exception, actual);
+        }
+
+        [Fact]
+        public void WhenImportedProviderFailsOnDev14_ThenOtherProvidersAreStillImportedIncludingBuiltInProvider()
+        {
+            // Arrange
+            _mockDte.Setup(x => x.Version).Returns("14.0.247200.00");
+            var importer = GetTestableImporter();
+            var nonFailingProviderFactory = new Lazy<IVsCredentialProvider>(() => new NonFailingCredentialProvider());
+            var failingProviderFactory = new Lazy<IVsCredentialProvider>(() => new FailingCredentialProvider());
+            importer.ImportedProviders = new List<Lazy<IVsCredentialProvider>>
+            {
+                nonFailingProviderFactory,
+                failingProviderFactory
+            };
+
+            // Act
+            var results = importer.GetProviders();
+
+            // Assert
+            // We expect 2 providers:
+            // The non-failing provider, and the built-in provider on dev14
+            Assert.Equal(2, results.Count);
+            Assert.Contains(_visualStudioAccountProvider, results);
+        }
+
+        [Fact]
+        public void WhenImportedProviderFailsOnDev15_ThenOtherProvidersAreStillImportedExcludingBuiltInProvider()
+        {
+            // Arrange
+            _mockDte.Setup(x => x.Version).Returns("15.0.123456.00");
+            var importer = GetTestableImporter();
+            var nonFailingProviderFactory = new Lazy<IVsCredentialProvider>(() => new NonFailingCredentialProvider());
+            var failingProviderFactory = new Lazy<IVsCredentialProvider>(() => new FailingCredentialProvider());
+            importer.ImportedProviders = new List<Lazy<IVsCredentialProvider>>
+            {
+                nonFailingProviderFactory,
+                failingProviderFactory
+            };
+
+            // Act
+            var results = importer.GetProviders();
+
+            // Assert
+            // We expect a single provider:
+            // The non-failing provider, and NO built-in provider on dev15
+            Assert.Equal(1, results.Count);
+            Assert.DoesNotContain(_visualStudioAccountProvider, results);
         }
     }
 }


### PR DESCRIPTION
Fixes NuGet/Home#2909

Verified current tests.
Also tested locally by implementing a custom provider and it was properly picked up.

cc @joelverhagen 
