### PR TITLE
Log warnings returned by the server

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpResponseMessageExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpResponseMessageExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using NuGet.Common;
+
+namespace NuGet.Protocol
+{
+    public static class HttpResponseMessageExtensions
+    {
+        public static void LogServerWarning(this HttpResponseMessage response, ILogger log)
+        {
+            if (log == null)
+            {
+                throw new ArgumentNullException(nameof(log));
+            }
+
+            if (response == null)
+            {
+                throw new ArgumentNullException(nameof(response));
+            }
+
+            if (response.Headers.Contains(ProtocolConstants.ServerWarningHeader))
+            {
+                foreach (var warning in response.Headers.GetValues(ProtocolConstants.ServerWarningHeader))
+                {
+                    log.LogWarning(warning);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/ProtocolConstants.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/ProtocolConstants.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Protocol
+{
+    public static class ProtocolConstants
+    {
+        public static readonly string ApiKeyHeader = "X-NuGet-ApiKey";
+        public static readonly string ServerWarningHeader = "X-NuGet-Warning";
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpHandlerResourceV3Provider.cs
@@ -48,7 +48,7 @@ namespace NuGet.Protocol
             };
 
             // HTTP handler pipeline can be injected here, around the client handler
-            HttpMessageHandler messageHandler = clientHandler;
+            HttpMessageHandler messageHandler = new ServerWarningLogHandler(clientHandler);
 
             if (proxy != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -271,6 +271,8 @@ namespace NuGet.Protocol
             try
             {
                 response = await RetryHandler.SendAsync(request, log, cancellationToken);
+				
+                response.LogServerWarning(log);
             }
             catch
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -271,8 +270,6 @@ namespace NuGet.Protocol
             try
             {
                 response = await RetryHandler.SendAsync(request, log, cancellationToken);
-				
-                response.LogServerWarning(log);
             }
             catch
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ServerWarningLogHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ServerWarningLogHandler.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public class ServerWarningLogHandler
+        : DelegatingHandler
+    {
+        public ServerWarningLogHandler(HttpClientHandler clientHandler)
+            : base(clientHandler)
+        {
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var configuration = request.GetOrCreateConfiguration();
+
+            var response = await base.SendAsync(request, cancellationToken);
+
+            response.LogServerWarning(configuration.Logger);
+
+            return response;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -21,7 +24,6 @@ namespace NuGet.Protocol.Core.Types
     public class PackageUpdateResource : INuGetResource
     {
         private const string ServiceEndpoint = "/api/v2/package";
-        private const string ApiKeyHeader = "X-NuGet-ApiKey";
 
         private HttpSource _httpSource;
         private string _source;
@@ -277,6 +279,8 @@ namespace NuGet.Protocol.Core.Types
                 response =>
                 {
                     response.EnsureSuccessStatusCode();
+                    response.LogServerWarning(logger);
+
                     return Task.FromResult(0);
                 },
                 logger,
@@ -313,7 +317,7 @@ namespace NuGet.Protocol.Core.Types
 
             if (hasApiKey)
             {
-                request.Headers.Add(ApiKeyHeader, apiKey);
+                request.Headers.Add(ProtocolConstants.ApiKeyHeader, apiKey);
             }
 
             return request;
@@ -396,7 +400,7 @@ namespace NuGet.Protocol.Core.Types
 
                         if (hasApiKey)
                         {
-                            request.Headers.Add(ApiKeyHeader, apiKey);
+                            request.Headers.Add(ProtocolConstants.ApiKeyHeader, apiKey);
                         }
 
                         return request;
@@ -404,6 +408,8 @@ namespace NuGet.Protocol.Core.Types
                 response =>
                 {
                     response.EnsureSuccessStatusCode();
+                    response.LogServerWarning(logger);
+
                     return Task.FromResult(0);
                 },
                 logger,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -279,7 +279,6 @@ namespace NuGet.Protocol.Core.Types
                 response =>
                 {
                     response.EnsureSuccessStatusCode();
-                    response.LogServerWarning(logger);
 
                     return Task.FromResult(0);
                 },
@@ -408,7 +407,6 @@ namespace NuGet.Protocol.Core.Types
                 response =>
                 {
                     response.EnsureSuccessStatusCode();
-                    response.LogServerWarning(logger);
 
                     return Task.FromResult(0);
                 },

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -1,10 +1,22 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using Xunit.Abstractions;
 
 namespace NuGet.Test.Utility
 {
     public class TestLogger : Common.ILogger
     {
+        private readonly ITestOutputHelper _output;
+
+        public TestLogger()
+        {
+        }
+
+        public TestLogger(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         /// <summary>
         /// Logged messages
         /// </summary>
@@ -76,6 +88,7 @@ namespace NuGet.Test.Utility
         {
             // NOTE(anurse): Uncomment this to help when debugging tests
             //Console.WriteLine($"{level}: {data}");
+            _output?.WriteLine($"{level}: {data}");
         }
 
         public void Clear()

--- a/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Concurrent;
 using Xunit.Abstractions;
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using NuGet.Common;
+using NuGet.Protocol;
 
 namespace NuGet.CommandLine.Test
 {
@@ -54,6 +55,8 @@ namespace NuGet.CommandLine.Test
             Put = new RouteTable(BasePath);
             Delete = new RouteTable(BasePath);
         }
+
+        private List<string> ServerWarnings { get; } = new List<string>();
 
         /// <summary>
         /// Starts the mock server.
@@ -303,6 +306,11 @@ namespace NuGet.CommandLine.Test
                         {
                             response.StatusCode = (int)r;
                         }
+
+                        foreach (var warning in ServerWarnings)
+                        {
+                            response.Headers.Add(ProtocolConstants.ServerWarningHeader, warning);
+                        }
                     }
                     else
                     {
@@ -415,6 +423,22 @@ namespace NuGet.CommandLine.Test
         {
             XDocument doc = new XDocument(ToODataEntryXElement(package));
             return doc.ToString();
+        }
+
+        public void AddServerWarnings(string[] messages)
+        {
+            if (messages == null)
+            {
+                return;
+            }
+
+            foreach (var message in messages)
+            {
+                if (!string.IsNullOrEmpty(message))
+                {
+                    ServerWarnings.Add(message);
+                }
+            }
         }
 
         public void Dispose()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -295,6 +295,49 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Theory]
+        [MemberData(nameof(ServerWarningData))]
+        public void PushCommand_LogsServerWarningsWhenPresent(string firstServerWarning, string secondServerWarning)
+        {
+            var serverWarnings = new[] { firstServerWarning, secondServerWarning };
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Arrange
+            using (var packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+                using (var server = new MockServer())
+                {
+                    server.Get.Add("/push", r => "OK");
+                    server.Put.Add("/push", r => HttpStatusCode.Created);
+
+                    server.AddServerWarnings(serverWarnings);
+
+                    server.Start();
+
+                    // Act
+                    string[] args = new string[]
+                    {"push", packageFileName, "-Source", server.Uri + "push", "-Apikey", "token"};
+                    var result = CommandRunner.Run(
+                        nugetexe,
+                        Directory.GetCurrentDirectory(),
+                        string.Join(" ", args),
+                        true);
+                    server.Stop();
+
+                    // Assert
+                    var output = result.Item2;
+                    foreach (var serverWarning in serverWarnings)
+                    {
+                        if (!string.IsNullOrEmpty(serverWarning))
+                        {
+                            Assert.Contains(serverWarning, output);
+                        }
+                    }
+                }
+            }
+        }
+
         [Fact]
         public void PushCommand_PushToServerNoSymbols()
         {
@@ -2022,6 +2065,19 @@ namespace NuGet.CommandLine.Test
             public static readonly string ProviderNotApplicableCode = "1";
             public static readonly string FailCode = "2";
 
+        }
+
+        public static IEnumerable<string[]> ServerWarningData
+        {
+            get
+            {
+                return new[]
+                {
+                    new string[] { null, null },
+                    new string[] { "Single server warning message", null},
+                    new string[] { "First of two server warning messages", "Second of two server warning messages"}
+                };
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -303,7 +303,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             // Arrange
-            using (var packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var packageDirectory = TestDirectory.Create())
             {
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 using (var server = new MockServer())
@@ -316,7 +316,7 @@ namespace NuGet.CommandLine.Test
                     server.Start();
 
                     // Act
-                    string[] args = new string[]
+                    var args = new string[]
                     {"push", packageFileName, "-Source", server.Uri + "push", "-Apikey", "token"};
                     var result = CommandRunner.Run(
                         nugetexe,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
@@ -101,7 +101,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(HttpMethod.Delete, actualRequest.Method);
 
                 IEnumerable<string> values;
-                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                actualRequest.Headers.TryGetValues(ProtocolConstants.ApiKeyHeader, out values);
                 Assert.Null(values);
 
                 Assert.True(
@@ -151,7 +151,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(HttpMethod.Put, actualRequest.Method);
 
                 IEnumerable<string> values;
-                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                actualRequest.Headers.TryGetValues(ProtocolConstants.ApiKeyHeader, out values);
                 Assert.Equal(1, values.Count());
                 Assert.Equal(apiKey, values.First());
 
@@ -202,7 +202,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(HttpMethod.Put, actualRequest.Method);
 
                 IEnumerable<string> values;
-                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                actualRequest.Headers.TryGetValues(ProtocolConstants.ApiKeyHeader, out values);
                 Assert.Null(values);
 
                 Assert.True(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
@@ -17,8 +17,6 @@ namespace NuGet.Protocol.Tests
 {
     public class PackageUpdateResourceTests
     {
-        private const string ApiKeyHeader = "X-NuGet-ApiKey";
-
         [Fact]
         public async Task PackageUpdateResource_IncludesApiKeyWhenDeleting()
         {
@@ -56,7 +54,7 @@ namespace NuGet.Protocol.Tests
                 Assert.Equal(HttpMethod.Delete, actualRequest.Method);
 
                 IEnumerable<string> values;
-                actualRequest.Headers.TryGetValues(ApiKeyHeader, out values);
+                actualRequest.Headers.TryGetValues(ProtocolConstants.ApiKeyHeader, out values);
                 Assert.Equal(1, values.Count());
                 Assert.Equal(apiKey, values.First());
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/HttpHeaderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/HttpHeaderUtilityTests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Core.v3.Tests.Utility
         [Fact]
         public void LogsServerWarningWhenNuGetWarningHeaderPresent()
         {
-            var testLogger = new TestLogger();
+            var testLogger = new TestLogger(_output);
             var response = new HttpResponseMessage();
             response.Headers.Add(ProtocolConstants.ServerWarningHeader, "test");
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/HttpHeaderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/HttpHeaderUtilityTests.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net.Http;
+using NuGet.Test.Utility;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGet.Protocol.Core.v3.Tests.Utility
+{
+    public class HttpResponseMessageExtensionsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public HttpResponseMessageExtensionsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void LogsServerWarningWhenNuGetWarningHeaderPresent()
+        {
+            var testLogger = new TestLogger();
+            var response = new HttpResponseMessage();
+            response.Headers.Add(ProtocolConstants.ServerWarningHeader, "test");
+
+            response.LogServerWarning(testLogger);
+
+            Assert.Equal(1, testLogger.Warnings);
+
+            string warning;
+            Assert.True(testLogger.Messages.TryDequeue(out warning));
+            Assert.Equal("test", warning);
+        }
+    }
+}


### PR DESCRIPTION
Fixes NuGet/Home#2934

cc @maartenba @rrelyea @yishaigalatzer 

No server to test against yet, but intercepted some requests using fiddler and added the header in the response. Example below:

![image](https://cloud.githubusercontent.com/assets/880728/15927309/233633da-2e41-11e6-8a2d-191a4c750d51.png)
