### PR TITLE
Enable Get-Package and IVsPackageMetadata.PackagePath on .NET Core projects

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -63,7 +63,6 @@ namespace NuGet.VisualStudio
                         foreach (var project in _solutionManager.GetNuGetProjects())
                         {
                             var installedPackages = await project.GetInstalledPackagesAsync(CancellationToken.None);
-                            var buildIntegratedProject = project as BuildIntegratedNuGetProject;
 
                             foreach (var package in installedPackages)
                             {
@@ -76,7 +75,7 @@ namespace NuGet.VisualStudio
 
                                 // find packages using the solution level packages folder
                                 string installPath;
-                                if (buildIntegratedProject != null)
+                                if (project is INuGetIntegratedProject)
                                 {
                                     installPath = BuildIntegratedProjectUtility.GetPackagePathFromGlobalSource(
                                         effectiveGlobalPackagesFolder,

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellInstalledPackage.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellInstalledPackage.cs
@@ -3,11 +3,9 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement.UI;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Versioning;
@@ -25,21 +23,31 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// <summary>
         /// Get the view of installed packages. Use for Get-Package command.
         /// </summary>
-        internal static List<PowerShellInstalledPackage> GetPowerShellPackageView(Dictionary<NuGetProject, IEnumerable<Packaging.PackageReference>> dictionary,
-                                                                                  ISolutionManager SolutionManager, Configuration.ISettings settings)
+        internal static List<PowerShellInstalledPackage> GetPowerShellPackageView(
+            Dictionary<NuGetProject, IEnumerable<PackageReference>> dictionary,
+            ISolutionManager SolutionManager,
+            Configuration.ISettings settings)
         {
             var views = new List<PowerShellInstalledPackage>();
 
             foreach (var entry in dictionary)
             {
                 var nugetProject = entry.Key;
+                var projectName = entry.Key.GetMetadata<string>(NuGetProjectMetadataKeys.Name);
 
-                string packageFolder = null;
                 FolderNuGetProject packageFolderProject = null;
+                VersionFolderPathResolver pathResolver = null;
 
-                if (nugetProject is BuildIntegratedNuGetProject)
+                // Build a project-specific strategy for resolving a package .nupkg path.
+                if (nugetProject is INuGetIntegratedProject) // This is technically incorrect for DNX projects,
+                                                             // however since that experience is deprecated we don't
+                                                             // care.
                 {
-                    packageFolder = BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(SolutionManager.SolutionDirectory, settings);
+                    var packageFolder = BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
+                        SolutionManager.SolutionDirectory,
+                        settings);
+
+                    pathResolver = new VersionFolderPathResolver(packageFolder);
                 }
                 else
                 {
@@ -51,34 +59,42 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     }
                 }
 
-                // entry.Value is an empty list if no packages are installed
+                // entry.Value is an empty list if no packages are installed.
                 foreach (var package in entry.Value)
                 {
                     string installPackagePath = null;
                     string licenseUrl = null;
 
-                    if (packageFolder != null)
+                    // Try to get the path to the package .nupkg on disk.
+                    if (pathResolver != null)
                     {
-                        var defaultPackagePathResolver = new VersionFolderPathResolver(packageFolder);
-                        installPackagePath = defaultPackagePathResolver.GetPackageFilePath(package.PackageIdentity.Id, package.PackageIdentity.Version);
+                        installPackagePath = pathResolver.GetPackageFilePath(
+                            package.PackageIdentity.Id,
+                            package.PackageIdentity.Version);
                     }
                     else if (packageFolderProject != null)
                     {
                         installPackagePath = packageFolderProject.GetInstalledPackageFilePath(package.PackageIdentity);
                     }
 
+                    // Try to read out the license URL.
                     using (var reader = GetPackageReader(installPackagePath))
+                    using (var nuspecStream = reader?.GetNuspec())
                     {
-                        var nuspecReader = new NuspecReader(reader.GetNuspec());
-                        licenseUrl = nuspecReader.GetLicenseUrl();
+                        if (nuspecStream != null)
+                        {
+                            var nuspecReader = new NuspecReader(nuspecStream);
+                            licenseUrl = nuspecReader.GetLicenseUrl();
+                        }
                     }
 
-
-                    var view = new PowerShellInstalledPackage()
+                    var view = new PowerShellInstalledPackage
                     {
                         Id = package.PackageIdentity.Id,
-                        AsyncLazyVersions = new AsyncLazy<IEnumerable<NuGetVersion>>(() => Task.FromResult<IEnumerable<NuGetVersion>>(new[] { package.PackageIdentity.Version }), NuGetUIThreadHelper.JoinableTaskFactory),
-                        ProjectName = entry.Key.GetMetadata<string>(NuGetProjectMetadataKeys.Name),
+                        AsyncLazyVersions = new AsyncLazy<IEnumerable<NuGetVersion>>(
+                            () => Task.FromResult<IEnumerable<NuGetVersion>>(new[] { package.PackageIdentity.Version }),
+                            NuGetUIThreadHelper.JoinableTaskFactory),
+                        ProjectName = projectName,
                         LicenseUrl = licenseUrl
                     };
 
@@ -91,9 +107,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         private static PackageReaderBase GetPackageReader(string installPath)
         {
+            if (installPath == null)
+            {
+                return null;
+            }
+
             var nupkg = new FileInfo(installPath);
 
-            if (nupkg?.Exists == true)
+            if (nupkg.Exists)
             {
                 return new PackageArchiveReader(nupkg.OpenRead());
             }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellPackage.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellPackage.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement.UI;
 using NuGet.Versioning;
@@ -45,7 +44,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         public AsyncLazy<IEnumerable<NuGetVersion>> AsyncLazyVersions { get; set; }
 
-        public SemanticVersion Version
+        public NuGet.SemanticVersion Version
         {
             get
             {
@@ -53,8 +52,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
                 if (nVersion != null)
                 {
-                    SemanticVersion sVersion;
-                    SemanticVersion.TryParse(nVersion.ToNormalizedString(), out sVersion);
+                    NuGet.SemanticVersion sVersion;
+                    NuGet.SemanticVersion.TryParse(nVersion.ToNormalizedString(), out sVersion);
                     return sVersion;
                 }
 

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageManagement.PowerShellCmdlets.csproj
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageManagement.PowerShellCmdlets.csproj
@@ -109,6 +109,10 @@
       <Project>{306cddfa-ff0b-4299-930c-9ec6c9308160}</Project>
       <Name>PackageManagement.VisualStudio</Name>
     </ProjectReference>
+    <ProjectReference Include="..\VisualStudio\VisualStudio.csproj">
+      <Project>{e5556bc6-a7fd-4d8e-8a7d-7648df1d7471}</Project>
+      <Name>VisualStudio</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\build\common.targets" />

--- a/src/NuGet.Clients/VisualStudio/LegacyTypes/SemanticVersion.cs
+++ b/src/NuGet.Clients/VisualStudio/LegacyTypes/SemanticVersion.cs
@@ -1,21 +1,71 @@
 ﻿using System;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace NuGet
 {
+#pragma warning disable 1591
     /// <summary>
-    /// Legacy
+    /// This is the legacy implementation of the semantic version class. NuGet 2.x implemented this
+    /// under the <code>NuGet</code> namespace. In NuGet 3.x, we moved <code>SemanticVersion</code>
+    /// to <code>NuGet.Versioning.SemanticVersion</code>. We exposed multiple public APIs that have
+    /// the type <code>NuGet.SemanticVersion</code>. Therefore, we still need to have a semantic
+    /// version class implemented at the old location.
     /// </summary>
     [Serializable]
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
-        private readonly string _versionString;
+        private const RegexOptions _flags = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
+        private static readonly Regex _semanticVersionRegex = new Regex(@"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
+        private static readonly Regex _strictSemanticVersionRegex = new Regex(@"^(?<Version>\d+(\.\d+){2})(?<Release>-[a-z][0-9a-z-]*)?$", _flags);
+        private readonly string _originalString;
+        private string _normalizedVersionString;
 
-        /// <summary>
-        /// Legacy
-        /// </summary>
         public SemanticVersion(string version)
+            : this(Parse(version))
         {
-            _versionString = version;
+            // The constructor normalizes the version string so that it we do not need to normalize it every time we need to operate on it. 
+            // The original string represents the original form in which the version is represented to be used when printing.
+            _originalString = version;
+        }
+
+        public SemanticVersion(int major, int minor, int build, int revision)
+            : this(new Version(major, minor, build, revision))
+        {
+        }
+
+        public SemanticVersion(int major, int minor, int build, string specialVersion)
+            : this(new Version(major, minor, build), specialVersion)
+        {
+        }
+
+        public SemanticVersion(Version version)
+            : this(version, String.Empty)
+        {
+        }
+
+        public SemanticVersion(Version version, string specialVersion)
+            : this(version, specialVersion, null)
+        {
+        }
+
+        private SemanticVersion(Version version, string specialVersion, string originalString)
+        {
+            if (version == null)
+            {
+                throw new ArgumentNullException("version");
+            }
+            Version = NormalizeVersionValue(version);
+            SpecialVersion = specialVersion ?? String.Empty;
+            _originalString = String.IsNullOrEmpty(originalString) ? version.ToString() + (!String.IsNullOrEmpty(specialVersion) ? '-' + specialVersion : null) : originalString;
+        }
+
+        internal SemanticVersion(SemanticVersion semVer)
+        {
+            _originalString = semVer.ToString();
+            Version = semVer.Version;
+            SpecialVersion = semVer.SpecialVersion;
         }
 
         /// <summary>
@@ -36,12 +86,47 @@ namespace NuGet
             private set;
         }
 
-        /// <summary>
-        /// Legacy
-        /// </summary>
         public string[] GetOriginalVersionComponents()
         {
-            throw new NotSupportedException();
+            if (!String.IsNullOrEmpty(_originalString))
+            {
+                string original;
+
+                // search the start of the SpecialVersion part, if any
+                int dashIndex = _originalString.IndexOf('-');
+                if (dashIndex != -1)
+                {
+                    // remove the SpecialVersion part
+                    original = _originalString.Substring(0, dashIndex);
+                }
+                else
+                {
+                    original = _originalString;
+                }
+
+                return SplitAndPadVersionString(original);
+            }
+            else
+            {
+                return SplitAndPadVersionString(Version.ToString());
+            }
+        }
+
+        private static string[] SplitAndPadVersionString(string version)
+        {
+            string[] a = version.Split('.');
+            if (a.Length == 4)
+            {
+                return a;
+            }
+            else
+            {
+                // if 'a' has less than 4 elements, we pad the '0' at the end 
+                // to make it 4.
+                var b = new string[4] { "0", "0", "0", "0" };
+                Array.Copy(a, 0, b, 0, a.Length);
+                return b;
+            }
         }
 
         /// <summary>
@@ -49,7 +134,17 @@ namespace NuGet
         /// </summary>
         public static SemanticVersion Parse(string version)
         {
-            throw new NotSupportedException();
+            if (String.IsNullOrEmpty(version))
+            {
+                throw new ArgumentException("Value cannot be null or an empty string.", "version");
+            }
+
+            SemanticVersion semVer;
+            if (!TryParse(version, out semVer))
+            {
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, "'{0}' is not a valid version string.", version), "version");
+            }
+            return semVer;
         }
 
         /// <summary>
@@ -57,7 +152,7 @@ namespace NuGet
         /// </summary>
         public static bool TryParse(string version, out SemanticVersion value)
         {
-            throw new NotSupportedException();
+            return TryParseInternal(version, _semanticVersionRegex, out value);
         }
 
         /// <summary>
@@ -65,7 +160,26 @@ namespace NuGet
         /// </summary>
         public static bool TryParseStrict(string version, out SemanticVersion value)
         {
-            throw new NotSupportedException();
+            return TryParseInternal(version, _strictSemanticVersionRegex, out value);
+        }
+
+        private static bool TryParseInternal(string version, Regex regex, out SemanticVersion semVer)
+        {
+            semVer = null;
+            if (String.IsNullOrEmpty(version))
+            {
+                return false;
+            }
+
+            var match = regex.Match(version.Trim());
+            Version versionValue;
+            if (!match.Success || !Version.TryParse(match.Groups["Version"].Value, out versionValue))
+            {
+                return false;
+            }
+
+            semVer = new SemanticVersion(NormalizeVersionValue(versionValue), match.Groups["Release"].Value.TrimStart('-'), version.Replace(" ", ""));
+            return true;
         }
 
         /// <summary>
@@ -74,23 +188,109 @@ namespace NuGet
         /// <returns>An instance of SemanticVersion if it parses correctly, null otherwise.</returns>
         public static SemanticVersion ParseOptionalVersion(string version)
         {
-            throw new NotSupportedException();
+            SemanticVersion semVer;
+            TryParse(version, out semVer);
+            return semVer;
         }
 
-        /// <summary>
-        /// Legacy
-        /// </summary>
+        private static Version NormalizeVersionValue(Version version)
+        {
+            return new Version(version.Major,
+                               version.Minor,
+                               Math.Max(version.Build, 0),
+                               Math.Max(version.Revision, 0));
+        }
+
         public int CompareTo(object obj)
         {
-            throw new NotSupportedException();
+            if (Object.ReferenceEquals(obj, null))
+            {
+                return 1;
+            }
+            SemanticVersion other = obj as SemanticVersion;
+            if (other == null)
+            {
+                throw new ArgumentException("obj");
+            }
+            return CompareTo(other);
         }
 
-        /// <summary>
-        /// Legacy
-        /// </summary>
         public int CompareTo(SemanticVersion other)
         {
-            throw new NotSupportedException();
+            if (Object.ReferenceEquals(other, null))
+            {
+                return 1;
+            }
+
+            int result = Version.CompareTo(other.Version);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            bool empty = String.IsNullOrEmpty(SpecialVersion);
+            bool otherEmpty = String.IsNullOrEmpty(other.SpecialVersion);
+            if (empty && otherEmpty)
+            {
+                return 0;
+            }
+            else if (empty)
+            {
+                return 1;
+            }
+            else if (otherEmpty)
+            {
+                return -1;
+            }
+            return StringComparer.OrdinalIgnoreCase.Compare(SpecialVersion, other.SpecialVersion);
+        }
+
+        public static bool operator ==(SemanticVersion version1, SemanticVersion version2)
+        {
+            if (Object.ReferenceEquals(version1, null))
+            {
+                return Object.ReferenceEquals(version2, null);
+            }
+            return version1.Equals(version2);
+        }
+
+        public static bool operator !=(SemanticVersion version1, SemanticVersion version2)
+        {
+            return !(version1 == version2);
+        }
+
+        public static bool operator <(SemanticVersion version1, SemanticVersion version2)
+        {
+            if (version1 == null)
+            {
+                throw new ArgumentNullException("version1");
+            }
+            return version1.CompareTo(version2) < 0;
+        }
+
+        public static bool operator <=(SemanticVersion version1, SemanticVersion version2)
+        {
+            return (version1 == version2) || (version1 < version2);
+        }
+
+        public static bool operator >(SemanticVersion version1, SemanticVersion version2)
+        {
+            if (version1 == null)
+            {
+                throw new ArgumentNullException("version1");
+            }
+            return version2 < version1;
+        }
+
+        public static bool operator >=(SemanticVersion version1, SemanticVersion version2)
+        {
+            return (version1 == version2) || (version1 > version2);
+        }
+
+        public override string ToString()
+        {
+            return _originalString;
         }
 
         /// <summary>
@@ -102,23 +302,57 @@ namespace NuGet
         /// <returns>The normalized string representation.</returns>
         public string ToNormalizedString()
         {
-            return _versionString;
+            if (_normalizedVersionString == null)
+            {
+                var builder = new StringBuilder();
+                builder
+                    .Append(Version.Major)
+                    .Append('.')
+                    .Append(Version.Minor)
+                    .Append('.')
+                    .Append(Math.Max(0, Version.Build));
+
+                if (Version.Revision > 0)
+                {
+                    builder.Append('.')
+                           .Append(Version.Revision);
+                }
+
+                if (!string.IsNullOrEmpty(SpecialVersion))
+                {
+                    builder.Append('-')
+                           .Append(SpecialVersion);
+                }
+
+                _normalizedVersionString = builder.ToString();
+            }
+
+            return _normalizedVersionString;
         }
 
-        /// <summary>
-        /// Legacy
-        /// </summary>
-        public override string ToString()
-        {
-            return _versionString;
-        }
-
-        /// <summary>
-        /// Legacy
-        /// </summary>
         public bool Equals(SemanticVersion other)
         {
-            throw new NotSupportedException();
+            return !Object.ReferenceEquals(null, other) &&
+                   Version.Equals(other.Version) &&
+                   SpecialVersion.Equals(other.SpecialVersion, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj)
+        {
+            SemanticVersion semVer = obj as SemanticVersion;
+            return !Object.ReferenceEquals(null, semVer) && Equals(semVer);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = Version.GetHashCode();
+            if (SpecialVersion != null)
+            {
+                hashCode = hashCode * 4567 + SpecialVersion.GetHashCode();
+            }
+
+            return hashCode;
         }
     }
+#pragma warning restore 1591
 }


### PR DESCRIPTION
1. Enable `Get-Package` and `IVsPackageMetadata.PackagePath` on .NET Core projects
2. Port over the `SemanticVersion` implementation. This is necessary so that `Get-Project` does not change contract.

This is the change to `dev` for https://github.com/NuGet/Home/issues/2932 and https://github.com/NuGet/Home/issues/2933.

/cc @emgarten @zhili1208 @rohit21agrawal @alpaix @rrelyea
