### PR TITLE
Cleanup unused code from NuGet.CommandLine

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -92,7 +92,6 @@ namespace NuGet.CommandLine
             {
                 try
                 {
-                    var xDocument = XDocument.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -92,7 +92,8 @@ namespace NuGet.CommandLine
             {
                 try
                 {
-                    var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
+                    var xDocument = XDocument.Load(projectConfigFilePath);
+                    var reader = new PackagesConfigReader(xDocument);
                     return reader.GetPackages(allowDuplicatePackageIds);
                 }
                 catch (XmlException ex)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -26,8 +26,6 @@ namespace NuGet.CommandLine
         UsageExampleResourceName = "InstallCommandUsageExamples")]
     public class InstallCommand : DownloadCommandBase
     {
-        private static readonly object _satelliteLock = new object();
-
         [Option(typeof(NuGetCommand), "InstallCommandOutputDirDescription")]
         public string OutputDirectory { get; set; }
 
@@ -45,11 +43,6 @@ namespace NuGet.CommandLine
 
         [Option(typeof(NuGetCommand), "InstallCommandSolutionDirectory")]
         public string SolutionDirectory { get; set; }
-
-        private bool AllowMultipleVersions
-        {
-            get { return !ExcludeVersion; }
-        }
 
         [ImportingConstructor]
         public InstallCommand()

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -30,7 +30,6 @@ namespace NuGet.CommandLine
         private dynamic _project;
 
         private Common.ILogger _logger;
-        private Configuration.ISettings _settings;
         private bool _usingJsonFile;
 
         // Files we want to always exclude from the resulting package
@@ -111,7 +110,6 @@ namespace NuGet.CommandLine
             _project = project;
             ProjectProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             AddSolutionDir();
-            _settings = null;
 
             // Get the target framework of the project
             string targetFrameworkMoniker = _project.GetPropertyValue("TargetFrameworkMoniker");
@@ -139,21 +137,6 @@ namespace NuGet.CommandLine
                     break;
                 }
             }                
-        }
-
-        private Configuration.ISettings DefaultSettings
-        {
-            get
-            {
-                if (null == _settings)
-                {
-                    _settings = Configuration.Settings.LoadDefaultSettings(
-                        _project.DirectoryPath,
-                        null,
-                        MachineWideSettings);
-                }
-                return _settings;
-            }
         }
 
         private string TargetPath
@@ -410,29 +393,6 @@ namespace NuGet.CommandLine
             }
 
             TargetPath = ResolveTargetPath();
-        }
-
-        private object CreateLoggers()
-        {
-            var consoleLoggerType = _msbuildAssembly.GetType(
-                "Microsoft.Build.Logging.ConsoleLogger",
-                throwOnError: true);
-            var consoleLogger = Activator.CreateInstance(
-                consoleLoggerType);
-            var verbosityProperty = consoleLoggerType.GetProperty("Verbosity");
-            verbosityProperty.SetMethod.Invoke(consoleLogger, new object[] { Microsoft.Build.Framework.LoggerVerbosity.Quiet });
-
-            var iloggerType = _frameworkAssembly.GetType(
-                "Microsoft.Build.Framework.ILogger",
-                throwOnError: true);
-            var loggerList = typeof(List<>)
-                .MakeGenericType(iloggerType)
-                .GetConstructor(Type.EmptyTypes)
-                .Invoke(null);
-            var addMethod = loggerList.GetType().GetMethod("Add");
-            addMethod.Invoke(loggerList, new[] { consoleLogger });
-
-            return loggerList;
         }
 
         private string ResolveTargetPath()

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -29,9 +29,7 @@ namespace NuGet.CommandLine
         public override async Task ExecuteCommandAsync()
         {
             string packagePath = Arguments[0];
-            string sourcePath = Source;
             string apiKeyValue = ApiKey;
-            int timeoutSeconds = Timeout;
 
             if (string.IsNullOrEmpty(apiKeyValue) && Arguments.Count > 1)
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -39,8 +39,6 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
         public string MSBuildVersion { get; set; }
 
-        private static readonly int MaxDegreesOfConcurrency = Environment.ProcessorCount;
-
         [ImportingConstructor]
         public RestoreCommand()
             : base(MachineCache.Default)
@@ -589,40 +587,6 @@ namespace NuGet.CommandLine
                         || string.Equals(lastFourCharacters, "proj", StringComparison.OrdinalIgnoreCase));
             }
             return false;
-        }
-
-        /// <summary>
-        /// Gets the solution file, in full path format. If <paramref name="solutionFileOrDirectory"/> is a file,
-        /// that file is returned. Otherwise, searches for a *.sln file in
-        /// directory <paramref name="solutionFileOrDirectory"/>. If exactly one sln file is found,
-        /// that file is returned. If multiple sln files are found, an exception is thrown.
-        /// If no sln files are found, returns null.
-        /// </summary>
-        /// <param name="solutionFileOrDirectory">The solution file or directory to search for solution files.</param>
-        /// <returns>The full path of the solution file. Or null if no solution file can be found.</returns>
-        private string GetSolutionFile(string solutionFileOrDirectory)
-        {
-            //Check if the string passed is a file
-            //If it is a file, then check if it a solution or project file
-            //For other file types and directories it will fall out of these checks and fail later for invalid inputs
-            if (File.Exists(solutionFileOrDirectory) && IsSolutionOrProjectFile(solutionFileOrDirectory))
-            {
-                return Path.GetFullPath(solutionFileOrDirectory);
-            }
-
-            // look for solution files
-            var slnFiles = Directory.GetFiles(solutionFileOrDirectory, "*.sln");
-            if (slnFiles.Length > 1)
-            {
-                throw new InvalidOperationException(LocalizedResourceManager.GetString("Error_MultipleSolutions"));
-            }
-
-            if (slnFiles.Length == 1)
-            {
-                return Path.GetFullPath(slnFiles[0]);
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/SetApiKeyCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/SetApiKeyCommand.cs
@@ -41,14 +41,14 @@ namespace NuGet.CommandLine
                 source = SourceProvider.ResolveAndValidateSource(Source);
             }
 
-            SettingsUtility.SetEncryptedValue(Settings, CommandLineUtility.ApiKeysSectionName, source, apiKey);
+            SettingsUtility.SetEncryptedValue(Settings, ConfigurationConstants.ApiKeys, source, apiKey);
 
             string sourceName = CommandLineUtility.GetSourceDisplayName(source);
 
             // Setup the symbol server key
             if (setSymbolServerKey)
             {
-                SettingsUtility.SetEncryptedValue(Settings, CommandLineUtility.ApiKeysSectionName, NuGetConstants.DefaultSymbolServerUrl, apiKey);
+                SettingsUtility.SetEncryptedValue(Settings, ConfigurationConstants.ApiKeys, NuGetConstants.DefaultSymbolServerUrl, apiKey);
                 Console.WriteLine(LocalizedResourceManager.GetString("SetApiKeyCommandDefaultApiKeysSaved"),
                                   apiKey,
                                   sourceName,
@@ -57,15 +57,6 @@ namespace NuGet.CommandLine
             else
             {
                 Console.WriteLine(LocalizedResourceManager.GetString("SetApiKeyCommandApiKeySaved"), apiKey, sourceName);
-            }
-        }
-
-        private void ValidateSource(string source)
-        {
-            Uri result;
-            if (!Uri.TryCreate(source, UriKind.Absolute, out result))
-            {
-                throw new CommandLineException(LocalizedResourceManager.GetString("InvalidSource"), source);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/CommandLineUtility.cs
@@ -9,14 +9,6 @@ namespace NuGet
 {
     public static class CommandLineUtility
     {
-        public readonly static string ApiKeysSectionName = "apikeys";
-
-        public static string GetApiKey(ISettings settings, string source)
-        {
-            var value = settings.GetDecryptedValue(CommandLineUtility.ApiKeysSectionName, source);
-            return value;
-        }
-
         public static void ValidateSource(string source)
         {
             Uri result;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ExitCodeException.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ExitCodeException.cs
@@ -6,7 +6,6 @@ namespace NuGet.CommandLine
     public class ExitCodeException : CommandLineException
     {
         public ExitCodeException(int exitCode)
-            : base()
         {
             ExitCode = exitCode;
         }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Solution.cs
@@ -114,17 +114,5 @@ namespace NuGet.Common
             }
             this.Projects = projects;
         }
-
-        private static Type GetSolutionParserType(Assembly msbuildAssembly)
-        {
-            var solutionParserType = msbuildAssembly.GetType("Microsoft.Build.Construction.SolutionParser");
-
-            if (solutionParserType == null)
-            {
-                throw new CommandLineException(LocalizedResourceManager.GetString("Error_CannotLoadTypeSolutionParser"));
-            }
-
-            return solutionParserType;
-        }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/MSBuildCachedRequestProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MSBuildCachedRequestProvider.cs
@@ -49,9 +49,7 @@ namespace NuGet.CommandLine
             string inputPath,
             RestoreArgs restoreContext)
         {
-            var paths = new List<string>();
             var requests = new List<RestoreSummaryRequest>();
-            var rootPath = Path.GetDirectoryName(inputPath);
 
             var entryPoints = _projectProvider.GetEntryPoints();
 


### PR DESCRIPTION
Removed some unused code from NuGet.CommandLine. Mostly those are private methods that are not used. Verified using UTs.

@emgarten, @yishaigalatzer 
