### PR TITLE
accessibility improvements for package manager UI

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Automation/FilterLabelAutomationPeer.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Automation/FilterLabelAutomationPeer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+
+namespace NuGet.PackageManagement.UI.Automation
+{
+    public class FilterLabelAutomationPeer : ButtonAutomationPeer
+    {
+        private FilterLabel _filterLabel;
+        public FilterLabelAutomationPeer(Button button, FilterLabel owner) : base(button)
+        {
+            _filterLabel = owner;
+        }
+
+        protected override string GetNameCore()
+        {
+            return _filterLabel.Text;
+        }
+
+        protected override string GetClassNameCore()
+        {
+            return _filterLabel.GetType().Name;
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
@@ -61,12 +61,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="UIAutomationProvider" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Actions\UIActionEngine.cs" />
     <Compile Include="Actions\ProjectContext.cs" />
     <Compile Include="Actions\UpdatePreviewResult.cs" />
+    <Compile Include="Automation\FilterLabelAutomationPeer.cs" />
     <Compile Include="Common\ErrorFloodGate.cs" />
     <Compile Include="Common\IOptionsPageActivator.cs" />
     <Compile Include="Common\NuGetEvent.cs" />

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
@@ -1242,6 +1242,24 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Refresh.
+        /// </summary>
+        public static string ToolTip_Refresh {
+            get {
+                return ResourceManager.GetString("ToolTip_Refresh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings.
+        /// </summary>
+        public static string ToolTip_Settings {
+            get {
+                return ResourceManager.GetString("ToolTip_Settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Uninstall this package..
         /// </summary>
         public static string ToolTip_UninstallButton {

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.resx
@@ -551,4 +551,10 @@ Packages installed into Website projects will not be restored during build. Cons
   <data name="Operation_TotalTime" xml:space="preserve">
     <value>Time Elapsed: {0}</value>
   </data>
+  <data name="ToolTip_Refresh" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="ToolTip_Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -19,7 +19,7 @@
       <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
     </Grid.RowDefinitions>
-    <Button
+    <Button x:Name="_labelButton"
       Grid.Row="0"
       Click="ButtonClicked">
       <Button.Template>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/FilterLabel.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/FilterLabel.xaml.cs
@@ -4,8 +4,11 @@
 using System;
 using System.Globalization;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using NuGet.PackageManagement.UI.Automation;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -122,6 +125,11 @@ namespace NuGet.PackageManagement.UI
                     TextBlock.ForegroundProperty,
                     Brushes.UIText);
             }
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new FilterLabelAutomationPeer(_labelButton, this);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageItemControl.xaml
@@ -277,6 +277,7 @@
                       Command="{x:Static nuget:Commands.UninstallPackageCommand}"
                       CommandParameter="{Binding}"
                       Visibility="Hidden"
+                      AutomationProperties.Name="{x:Static nuget:Resources.Button_Uninstall}"
                       ToolTip="{x:Static nuget:Resources.ToolTip_UninstallButton}">
                       <nuget:UninstallButton
                         Width="16"
@@ -291,6 +292,7 @@
                       Style="{StaticResource buttonStyle}"
                       Command="{x:Static nuget:Commands.InstallPackageCommand}"
                       CommandParameter="{Binding}"
+                      AutomationProperties.Name="{x:Static nuget:Resources.Button_Install}"
                       Visibility="Hidden">
                       <Button.ToolTip>
                         <MultiBinding Converter="{StaticResource StringFormatConverter}">
@@ -332,6 +334,7 @@
                       Margin="0,5,0,0"
                       Command="{x:Static nuget:Commands.InstallPackageCommand}"
                       CommandParameter="{Binding}"
+                      AutomationProperties.Name="{x:Static nuget:Resources.Button_Update}"
                       Visibility="Hidden">
                       <Button.ToolTip>
                         <MultiBinding Converter="{StaticResource StringFormatConverter}">

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerTopPanel.xaml
@@ -105,6 +105,8 @@
         Margin="3,0"
         VerticalAlignment="Center"
         Padding="0"
+        ToolTip="{x:Static nuget:Resources.ToolTip_Refresh}"
+        AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_Refresh}"
         Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
         Command="{x:Static nuget:Commands.RestartSearchCommand}">
         <Image
@@ -160,6 +162,8 @@
         AutomationProperties.AutomationId="Button_Settings"
         VerticalAlignment="Center"
         Padding="0"
+        ToolTip="{x:Static nuget:Resources.ToolTip_Settings}"
+        AutomationProperties.Name="{x:Static nuget:Resources.ToolTip_Settings}"
         Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
         Click="_settingsButton_Click">
         <Rectangle


### PR DESCRIPTION
This changeset makes sure that all UIElements have AutomationProperties.Name set on them - since that is the property that is used by accessibility tools like Narrator to read out the elements.
Issue: https://github.com/NuGet/Home/issues/2745
CC: @alpaix @rrelyea @joelverhagen @emgarten @drewgil 
