### PR TITLE
Passing a version suffix into the dotnet build when building a project.json file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -151,6 +151,11 @@ namespace NuGet.Commands
                 properties += $" -b \"{basePath}\"";
             }
 
+            if (!string.IsNullOrEmpty(_packArgs.Suffix))
+            {
+                properties += $" --version-suffix {_packArgs.Suffix}";
+            }
+
             string dotnetLocation = NuGetEnvironment.GetDotNetLocation();
 
             var processStartInfo = new ProcessStartInfo


### PR DESCRIPTION
Testing of dotnet pack calling nuget pack found we were missing this feature.  If the suffix isn't passed into the dotnet build, then it doesn't end up using it in the dll version.

@emgarten @joelverhagen 
