### PR TITLE
Observe package type during install, only allowing DotnetCliTool in .NET Core

### DIFF
--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25402.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PackageManagement.VisualStudio", "src\NuGet.Clients\PackageManagement.VisualStudio\PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject
@@ -103,6 +103,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StandaloneConsole", "src\NuGet.Clients\StandaloneConsole\StandaloneConsole.csproj", "{1CC223A4-B9F7-4D32-B502-6F85F1CF3218}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.UI.Test", "test\NuGet.Clients.Tests\NuGet.PackageManagement.UI.Test\NuGet.PackageManagement.UI.Test.csproj", "{6157BF46-D371-4126-A7F1-ED6E23F77ACD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio.Test", "test\NuGet.Clients.Tests\NuGet.PackageManagement.VisualStudio.Test\NuGet.PackageManagement.VisualStudio.Test.csproj", "{9EA84487-C70C-420C-9674-75CF19F43757}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -402,6 +404,16 @@ Global
 		{6157BF46-D371-4126-A7F1-ED6E23F77ACD}.Mono Release|Any CPU.Build.0 = Release|Any CPU
 		{6157BF46-D371-4126-A7F1-ED6E23F77ACD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6157BF46-D371-4126-A7F1-ED6E23F77ACD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Coverage|Any CPU.ActiveCfg = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Coverage|Any CPU.Build.0 = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Mono Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Mono Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Mono Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Mono Release|Any CPU.Build.0 = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EA84487-C70C-420C-9674-75CF19F43757}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -422,5 +434,6 @@ Global
 		{114FD278-477D-4292-82AA-7F8A5FC0BA08} = {390F8FBC-5FFC-4E61-B5D2-6EB39E66E2D2}
 		{1CC223A4-B9F7-4D32-B502-6F85F1CF3218} = {390F8FBC-5FFC-4E61-B5D2-6EB39E66E2D2}
 		{6157BF46-D371-4126-A7F1-ED6E23F77ACD} = {25E91311-400E-47A6-A844-733D604E662A}
+		{9EA84487-C70C-420C-9674-75CF19F43757} = {25E91311-400E-47A6-A844-733D604E662A}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,18 +75,31 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentException(ProjectManagement.Strings.PackageStreamShouldBeSeekable);
             }
 
-            nuGetProjectContext.Log(ProjectManagement.MessageLevel.Info, Strings.InstallingPackage, packageIdentity);
+            nuGetProjectContext.Log(MessageLevel.Info, Strings.InstallingPackage, packageIdentity);
 
             packageStream.Seek(0, SeekOrigin.Begin);
-            var packageSupportedFrameworks = GetSupportedFrameworks(packageStream);
-            var projectFrameworks = _project.GetSupportedFrameworksAsync(token)
-                .Result
-                .Select(f => NuGetFramework.Parse(f.FullName));
+            
+            // Get additional information from the package that the INuGetPackageManager can act on.
+            IEnumerable<NuGetFramework> supportedFrameworks;
+            IEnumerable<PackageType> packageTypes;
+            using (var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
+            {
+                supportedFrameworks = packageReader.GetSupportedFrameworks();
+                packageTypes = packageReader.GetPackageTypes();
+            }
 
             var args = new Dictionary<string, object>();
-            args["Frameworks"] = projectFrameworks.Where(
-                projectFramework =>
-                    IsCompatible(projectFramework, packageSupportedFrameworks)).ToArray();
+
+            args["Frameworks"] = _project
+                .GetSupportedFrameworksAsync(token)
+                .Result
+                .Select(f => NuGetFramework.Parse(f.FullName))
+                .Where(projectFramework => IsCompatible(projectFramework, supportedFrameworks))
+                .ToArray();
+
+            args["PackageTypes"] = packageTypes
+                .ToArray();
+
             await _project.InstallPackageAsync(
                 new NuGetPackageMoniker
                 {
@@ -98,20 +110,13 @@ namespace NuGet.PackageManagement.VisualStudio
                 logger: null,
                 progress: null,
                 cancellationToken: token);
-            return true;
-        }
 
-        private static IEnumerable<NuGetFramework> GetSupportedFrameworks(Stream packageStream)
-        {
-            using (var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true))
-            {
-                return packageReader.GetSupportedFrameworks();
-            }
+            return true;
         }
 
         public override async Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
-            nuGetProjectContext.Log(ProjectManagement.MessageLevel.Info, Strings.UninstallingPackage, packageIdentity);
+            nuGetProjectContext.Log(MessageLevel.Info, Strings.UninstallingPackage, packageIdentity);
 
             var args = new Dictionary<string, object>();
             await _project.UninstallPackageAsync(
@@ -127,9 +132,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
-        public override async Task<IEnumerable<Packaging.PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
+        public override async Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
         {
-            var result = new List<Packaging.PackageReference>();
+            var result = new List<PackageReference>();
             foreach (object item in await _project.GetInstalledPackagesAsync(token))
             {
                 PackageIdentity identity = null;
@@ -151,7 +156,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     }
                 }
 
-                result.Add(new Packaging.PackageReference(
+                result.Add(new PackageReference(
                     identity,
                     targetFramework: null));
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/IInstallationCompatibility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IInstallationCompatibility.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Validates the compatibility of a installed packages for the given project type. This
+    /// component should be used after packages have been downloaded to disk but have not yet
+    /// been installed to the project. If an installed package is not compatibile with the given
+    /// project, an exception is thrown. The checks performed by this class are based on 
+    /// package minimum client versions and package types.
+    /// </summary>
+    public interface IInstallationCompatibility
+    {
+        /// <summary>
+        /// Validates the compatibility of a multiple installed packages for the given project type.
+        /// </summary>
+        /// <param name="nuGetProject">
+        /// The NuGet project. The type of the NuGet project determines the sorts or validations that are done.
+        /// </param>
+        /// <param name="pathContext">The path context used to find the installed packages.</param>
+        /// <param name="nuGetProjectActions">The project actions.</param>
+        /// <param name="restoreResult">The restore result generated during installation.</param>
+        void EnsurePackageCompatibility(
+           NuGetProject nuGetProject,
+           INuGetPathContext pathContext,
+           IEnumerable<NuGetProjectAction> nuGetProjectActions,
+           RestoreResult restoreResult);
+
+        /// <summary>
+        /// Validates the compatibility of a single downloaded package.
+        /// </summary>
+        /// <param name="nuGetProject">
+        /// The NuGet project. The type of the NuGet project determines the sorts or validations that are done.
+        /// </param>
+        /// <param name="packageIdentity">The identity of that package contained in the download result.</param>
+        /// <param name="resourceResult">The downloaded package.</param>
+        void EnsurePackageCompatibility(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            DownloadResourceResult resourceResult);
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/InstallationCompatibility.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement
+{
+    public class InstallationCompatibility : IInstallationCompatibility
+    {
+        private static InstallationCompatibility _instance;
+
+        public static InstallationCompatibility Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new InstallationCompatibility();
+                }
+
+                return _instance;
+            }
+        }
+
+        public void EnsurePackageCompatibility(
+            NuGetProject nuGetProject,
+            INuGetPathContext pathContext,
+            IEnumerable<NuGetProjectAction> nuGetProjectActions,
+            RestoreResult restoreResult)
+        {
+            // Find all of the installed package identities.
+            var requestedPackageIds = new HashSet<string>(
+                nuGetProjectActions
+                    .Where(action => action.NuGetProjectActionType == NuGetProjectActionType.Install)
+                    .Select(action => action.PackageIdentity.Id),
+                StringComparer.OrdinalIgnoreCase);
+
+            var installedIdentities = restoreResult
+                .RestoreGraphs
+                .SelectMany(graph => graph.Flattened)
+                .Where(result => result.Key.Type == LibraryType.Package)
+                .Select(result => new PackageIdentity(result.Key.Name, result.Key.Version))
+                .Distinct()
+                .Where(identity => requestedPackageIds.Contains(identity.Id));
+
+            // Read the .nuspec on disk and ensure package compatibility.
+            var resolver = new FallbackPackagePathResolver(pathContext);
+            foreach (var identity in installedIdentities)
+            {
+                var packageInfo = resolver.GetPackageInfo(
+                    identity.Id,
+                    identity.Version);
+
+                if (packageInfo != null)
+                {
+                    var manifestPath = packageInfo.PathResolver.GetManifestFilePath(
+                        identity.Id,
+                        identity.Version);
+                    var nuspecReader = new NuspecReader(manifestPath);
+
+                    EnsurePackageCompatibility(
+                        nuGetProject,
+                        identity,
+                        nuspecReader);
+                }
+            }
+        }
+
+        public void EnsurePackageCompatibility(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            DownloadResourceResult resourceResult)
+        {
+            NuspecReader nuspecReader;
+            if (resourceResult.PackageReader != null)
+            {
+                nuspecReader = resourceResult.PackageReader.NuspecReader;
+            }
+            else
+            {
+                using (var packageReader = new PackageArchiveReader(resourceResult.PackageStream, leaveStreamOpen: true))
+                {
+                    nuspecReader = packageReader.NuspecReader;
+                }
+            }
+
+            EnsurePackageCompatibility(
+                nuGetProject,
+                packageIdentity,
+                nuspecReader);
+        }
+
+        private static void EnsurePackageCompatibility(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            NuspecReader nuspecReader)
+        {
+            // Validate that the current version of NuGet satisfies the minVersion attribute specified in the .nuspec
+            MinClientVersionUtility.VerifyMinClientVersion(nuspecReader);
+
+            // Validate the package type. There must be zero package types or exactly one package
+            // type that is one of the recognized package types.
+            var packageTypes = nuspecReader.GetPackageTypes();
+            var identityString = $"{packageIdentity.Id} {packageIdentity.Version.ToNormalizedString()}";
+            
+            if (packageTypes.Count > 1)
+            {
+                throw new PackagingException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.MultiplePackageTypesNotSupported,
+                    identityString));
+            }
+            else if (packageTypes.Count == 1)
+            {
+                var packageType = packageTypes[0];
+                var packageTypeString = packageType.Name;
+                if (packageType.Version != PackageType.EmptyVersion)
+                {
+                    packageTypeString += " " + packageType.Version;
+                }
+
+                var projectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
+
+                if (packageType == PackageType.Legacy || // Added for "quirks mode", but not yet fully implemented.
+                    packageType == PackageType.Dependency) // A package explicitly stated as a dependency.
+                {
+                    // These types are always acceptable.
+                }
+                else if (nuGetProject is ProjectKNuGetProjectBase &&
+                         packageType == PackageType.DotnetCliTool)
+                {
+                    // ProjectKNuGetProjectBase projects are .NET Core (both "dotnet" and "dnx").
+                    // .NET CLI tools are support for "dotnet" projects. The projects eventually
+                    // call into INuGetPackageManager, which is not implemented by NuGet. This code
+                    // will make the decision of how to install the .NET CLI tool package.
+                }
+                else
+                {
+                    throw new PackagingException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.UnsupportedPackageType,
+                        identityString,
+                        packageTypeString,
+                        projectName));
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -213,6 +213,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; has multiple package types, which is not supported..
+        /// </summary>
+        public static string MultiplePackageTypesNotSupported {
+            get {
+                return ResourceManager.GetString("MultiplePackageTypesNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Already referencing a newer version of &apos;{0}&apos;...
         /// </summary>
         public static string NewerVersionAlreadyReferenced {
@@ -569,6 +578,15 @@ namespace NuGet.PackageManagement {
         public static string UnsupportedPackageFeature {
             get {
                 return ResourceManager.GetString("UnsupportedPackageFeature", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; has a package type &apos;{1}&apos; that is not supported by project &apos;{2}&apos;. .
+        /// </summary>
+        public static string UnsupportedPackageType {
+            get {
+                return ResourceManager.GetString("UnsupportedPackageType", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -294,4 +294,14 @@
   <data name="FoundPackageInPackagesFolder" xml:space="preserve">
     <value>Found package '{0} {1}' in '{2}'.</value>
   </data>
+  <data name="MultiplePackageTypesNotSupported" xml:space="preserve">
+    <value>Package '{0}' has multiple package types, which is not supported.</value>
+    <comment>{0} is replaced with the package identity.</comment>
+  </data>
+  <data name="UnsupportedPackageType" xml:space="preserve">
+    <value>Package '{0}' has a package type '{1}' that is not supported by project '{2}'.</value>
+    <comment>{0} is the package identity.
+{1} is the unsupported package type.
+{2} is the project name.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageType.cs
@@ -38,6 +38,26 @@ namespace NuGet.Packaging.Core
             return Equals(obj as PackageType);
         }
 
+        public static bool operator ==(PackageType a, PackageType b)
+        {
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+            
+            if (((object)a == null) || ((object)b == null))
+            {
+                return false;
+            }
+
+            return a.Equals(b);
+        }
+
+        public static bool operator !=(PackageType a, PackageType b)
+        {
+            return !(a == b);
+        }
+
         public bool Equals(PackageType other)
         {
             if (other == null)

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageContext.cs
@@ -40,6 +40,7 @@ namespace NuGet.Test.Utility
         public string Exclude { get; set; } = string.Empty;
         public List<KeyValuePair<string, byte[]>> Files { get; set; } = new List<KeyValuePair<string, byte[]>>();
         public XDocument Nuspec { get; set; }
+        public List<PackageType> PackageTypes { get; set; } = new List<PackageType>();
 
         /// <summary>
         /// runtime.json

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -164,6 +164,25 @@ namespace NuGet.Test.Utility
                     }
                 }
 
+                if (packageContext.PackageTypes.Any())
+                {
+                    var metadata = xml.Element("package").Element("metadata");
+                    var packageTypes = new XElement("packageTypes");
+                    metadata.Add(packageTypes);
+
+                    foreach (var packageType in packageContext.PackageTypes)
+                    {
+                        var packageTypeElement = new XElement("packageType");
+                        packageTypeElement.Add(new XAttribute("name", packageType.Name));
+                        if (packageType.Version != PackageType.EmptyVersion)
+                        {
+                            packageTypeElement.Add(new XAttribute("version", packageType.Version));
+                        }
+
+                        packageTypes.Add(packageTypeElement);
+                    }
+                }
+
                 zip.AddEntry($"{id}.nuspec", xml.ToString(), Encoding.UTF8);
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\..\Build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9EA84487-C70C-420C-9674-75CF19F43757}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.PackageManagement.VisualStudio.Test</RootNamespace>
+    <AssemblyName>NuGet.PackageManagement.VisualStudio.Test</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <CodeAnalysisRuleSet>..\..\..\NuGet.ruleset</CodeAnalysisRuleSet>
+    <PackagesDirectory>$(UserProfile)\.nuget\packages</PackagesDirectory>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <ResolveNuGetPackages>true</ResolveNuGetPackages>
+    <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>$(DefineConstants);TRACE;DEBUG;CODE_ANALYSIS</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProjectKNuGetProjectTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\PackageManagement.VisualStudio\PackageManagement.VisualStudio.csproj">
+      <Project>{306cddfa-ff0b-4299-930c-9ec6c9308160}</Project>
+      <Name>PackageManagement.VisualStudio</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="$(VisualStudioVersion)=='14.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.14.1.127-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(VisualStudioVersion)=='15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.183-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\..\build\common.targets" />
+  <Import Project="..\..\..\build\sign.targets" />
+  <Import Project="..\..\..\build\test.targets" />
+</Project>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Interop;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class ProjectKNuGetProjectTests
+    {
+        [Fact]
+        public async Task ProjectKNuGetProject_WithPackageTypes_InstallPackageAsync()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(testDirectory);
+                using (var download = tc.InitializePackage())
+                {
+                    // Act
+                    var result = await tc.Target.InstallPackageAsync(
+                        tc.PackageIdentity,
+                        download,
+                        tc.ProjectContext.Object,
+                        CancellationToken.None);
+
+                    // Assert
+                    Assert.True(result);
+                    tc.PackageManager.Verify(
+                        x => x.InstallPackageAsync(
+                            It.Is<INuGetPackageMoniker>(y =>
+                                y.Id == tc.PackageIdentity.Id &&
+                                y.Version == tc.PackageIdentity.Version.ToNormalizedString()),
+                            It.Is<IReadOnlyDictionary<string, object>>(y =>
+                                y.ContainsKey("PackageTypes") &&
+                                Enumerable.SequenceEqual((IEnumerable<PackageType>)y["PackageTypes"], tc.PackageTypes)),
+                            It.IsAny<TextWriter>(),
+                            It.IsAny<IProgress<INuGetPackageInstallProgress>>(),
+                            It.IsAny<CancellationToken>()),
+                        Times.Once);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ProjectKNuGetProject_WithFrameworks_InstallPackageAsync()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(testDirectory);
+                using (var download = tc.InitializePackage())
+                {
+                    // Act
+                    var result = await tc.Target.InstallPackageAsync(
+                        tc.PackageIdentity,
+                        download,
+                        tc.ProjectContext.Object,
+                        CancellationToken.None);
+
+                    // Assert
+                    Assert.True(result);
+                    tc.PackageManager.Verify(
+                        x => x.InstallPackageAsync(
+                            It.Is<INuGetPackageMoniker>(y =>
+                                y.Id == tc.PackageIdentity.Id &&
+                                y.Version == tc.PackageIdentity.Version.ToNormalizedString()),
+                            It.Is<IReadOnlyDictionary<string, object>>(y =>
+                                y.ContainsKey("Frameworks") &&
+                                Enumerable.SequenceEqual(
+                                    (IEnumerable<NuGetFramework>)y["Frameworks"], tc.SupportedFrameworks)),
+                            It.IsAny<TextWriter>(),
+                            It.IsAny<IProgress<INuGetPackageInstallProgress>>(),
+                            It.IsAny<CancellationToken>()),
+                        Times.Once);
+                }
+            }
+        }
+
+        private class TestContext
+        {
+            public TestContext(TestDirectory testDirectory)
+            {
+                // Dependencies
+                TestDirectory = testDirectory;
+                PackageManager = new Mock<INuGetPackageManager>();
+                ProjectContext = new Mock<INuGetProjectContext>();
+                var projectName = "ProjectName";
+                var uniqueName = "UniqueName";
+                PackageIdentity = new PackageIdentity("PackageA", new NuGetVersion("1.0.0-beta"));
+                PackageTypes = new List<PackageType>
+                {
+                    new PackageType("Foo", Version.Parse("1.0.0")),
+                    new PackageType("Bar", Version.Parse("2.0"))
+                };
+                SupportedFrameworks = new List<NuGetFramework>
+                {
+                    new NuGetFramework("net40"),
+                    new NuGetFramework("netcoreapp1.0")
+                };
+
+                // Setup
+                PackageManager
+                    .Setup(x => x.GetSupportedFrameworksAsync(It.IsAny<CancellationToken>()))
+                    .Returns(() => Task.FromResult<IReadOnlyCollection<FrameworkName>>(
+                        SupportedFrameworks.Select(f => new FrameworkName(f.DotNetFrameworkName)).ToList()));
+                
+                Target = new ProjectKNuGetProject(
+                    PackageManager.Object,
+                    projectName,
+                    uniqueName);
+            }
+
+            public TestDirectory TestDirectory { get; }
+            public Mock<INuGetPackageManager> PackageManager { get; }
+            public Mock<INuGetProjectContext> ProjectContext { get; }
+            public PackageIdentity PackageIdentity { get; }
+            public ProjectKNuGetProject Target { get; }
+            public List<PackageType> PackageTypes { get; }
+            public List<NuGetFramework> SupportedFrameworks { get; }
+
+            public DownloadResourceResult InitializePackage()
+            {
+                var context = new SimpleTestPackageContext(PackageIdentity);
+                context.PackageTypes.Clear();
+                context.PackageTypes.AddRange(PackageTypes);
+
+                var package = SimpleTestPackageUtility.CreateFullPackage(
+                    TestDirectory,
+                    context);
+
+                return new DownloadResourceResult(package.OpenRead());
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NuGet.PackageManagement.VisualStudio.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("9ea84487-c70c-420c-9674-75cf19f43757")]

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "dependencies": {
+    "Moq": "4.2.1507.118",
+    "Test.Utility": "3.5.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.visualstudio": "2.1.0"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -1,0 +1,455 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Moq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class InstallationCompatibilityTests
+    {
+        [Fact]
+        public void InstallationCompatibility_WithLowerMinClientVersion_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.MinClientVersion = new NuGetVersion("10.0.0");
+            var result = new DownloadResourceResult(Stream.Null, tc.PackageReader.Object);
+
+            // Act & Assert
+            var ex = Assert.Throws<MinClientVersionException>(() =>
+                 tc.Target.EnsurePackageCompatibility(
+                    tc.NuGetProject,
+                    tc.PackageIdentityA,
+                    result));
+
+            Assert.Equal(
+                "The 'PackageA 1.0.0' package requires NuGet client version '10.0.0' or above, " +
+                $"but the current NuGet version is '{MinClientVersionUtility.GetNuGetClientVersion()}'. " +
+                "To upgrade NuGet, please go to http://docs.nuget.org/consume/installing-nuget",
+                ex.Message);
+
+            tc.PackageReader.Verify(x => x.GetMinClientVersion(), Times.Never);
+            tc.PackageReader.Verify(x => x.GetPackageTypes(), Times.Never);
+            tc.NuspecReader.Verify(x => x.GetMinClientVersion(), Times.AtLeastOnce);
+            tc.NuspecReader.Verify(x => x.GetPackageTypes(), Times.Never);
+        }
+
+        [Fact]
+        public async Task InstallationCompatibility_WithValidProjectActions_Succeeds()
+        {
+            // Arrange
+            using (var userPackageFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(userPackageFolder);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    userPackageFolder,
+                    PackageSaveMode.Defaultv3,
+                    new[]
+                    {
+                        new SimpleTestPackageContext(tc.PackageIdentityA)
+                        {
+                            PackageTypes = { PackageType.DotnetCliTool }
+                        },
+                        new SimpleTestPackageContext(tc.PackageIdentityB) // Not inspected, because this package is
+                                                                          // being uninstalled, not installed.
+                        {
+                            PackageTypes = { tc.InvalidPackageType }
+                        },
+                        new SimpleTestPackageContext(tc.PackageIdentityC)
+                        {
+                            PackageTypes = { PackageType.Dependency }
+                        },
+                    });
+
+                // Act & Assert
+                tc.Target.EnsurePackageCompatibility(
+                    tc.ProjectKProject,
+                    tc.NuGetPathContext.Object,
+                    new NuGetProjectAction[]
+                    {
+                        NuGetProjectAction.CreateInstallProjectAction(tc.PackageIdentityA, tc.SourceRepository),
+                        NuGetProjectAction.CreateUninstallProjectAction(tc.PackageIdentityB),
+                        NuGetProjectAction.CreateInstallProjectAction(tc.PackageIdentityC, tc.SourceRepository)
+                    },
+                    tc.GetRestoreResult(new[]
+                    {
+                        tc.PackageIdentityA,
+                        tc.PackageIdentityB,
+                        tc.PackageIdentityC
+                    }));
+            }
+        }
+
+        [Fact]
+        public async Task InstallationCompatibility_WithInvalidProjectActions_Fails()
+        {
+            // Arrange
+            using (var userPackageFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(userPackageFolder);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    userPackageFolder,
+                    PackageSaveMode.Defaultv3,
+                    new[]
+                    {
+                        new SimpleTestPackageContext(tc.PackageIdentityA)
+                        {
+                            PackageTypes = { tc.InvalidPackageType }
+                        }
+                    });
+
+                // Act & Assert
+                var ex = Assert.Throws<PackagingException>(() =>
+                    tc.Target.EnsurePackageCompatibility(
+                        tc.ProjectKProject,
+                        tc.NuGetPathContext.Object,
+                        new NuGetProjectAction[]
+                        {
+                            NuGetProjectAction.CreateInstallProjectAction(tc.PackageIdentityA, tc.SourceRepository)
+                        },
+                        tc.GetRestoreResult(new[] { tc.PackageIdentityA })));
+
+                Assert.Equal(
+                    "Package 'PackageA 1.0.0' has a package type 'Invalid 1.2' that is not supported by project 'TestProjectKNuGetProject'.",
+                    ex.Message);
+            }
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WithInvalidType_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(tc.InvalidPackageType);
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.NuGetProject,
+                "Package 'PackageA 1.0.0' has a package type 'Invalid 1.2' that is not supported by project 'TestNuGetProject'.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WithInvalidTypeAndEmptyVersion_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(new PackageType("Invalid", PackageType.EmptyVersion));
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.NuGetProject,
+                "Package 'PackageA 1.0.0' has a package type 'Invalid' that is not supported by project 'TestNuGetProject'.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WitMultipleTypes_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Legacy);
+            tc.PackageTypes.Add(PackageType.Dependency);
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.NuGetProject,
+                "Package 'PackageA 1.0.0' has multiple package types, which is not supported.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WithDotnetCliToolType_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.DotnetCliTool);
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.NuGetProject,
+                "Package 'PackageA 1.0.0' has a package type 'DotnetCliTool' that is not supported by project 'TestNuGetProject'.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WithLegacyType_Succeeds()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Legacy);
+
+            // Act & Assert
+            tc.VerifySuccess(tc.NuGetProject);
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithNuGetProject_WithDependency_Succeeds()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Dependency);
+
+            // Act & Assert
+            tc.VerifySuccess(tc.NuGetProject);
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithProjectKProject_WithInvalidType_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(tc.InvalidPackageType);
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.ProjectKProject,
+                "Package 'PackageA 1.0.0' has a package type 'Invalid 1.2' that is not supported by project 'TestProjectKNuGetProject'.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithProjectKProject_WithMultipleTypes_Fails()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Legacy);
+            tc.PackageTypes.Add(PackageType.Dependency);
+
+            // Act & Assert
+            tc.VerifyFailure(
+                tc.ProjectKProject,
+                "Package 'PackageA 1.0.0' has multiple package types, which is not supported.");
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithProjectKProject_WithDotnetCliToolType_Succeeds()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.DotnetCliTool);
+
+            // Act & Assert
+            tc.VerifySuccess(tc.ProjectKProject);
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithProjectKProject_WithLegacyType_Succeeds()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Legacy);
+
+            // Act & Assert
+            tc.VerifySuccess(tc.ProjectKProject);
+        }
+
+        [Fact]
+        public void InstallationCompatibility_WithProjectKProject_WithDependency_Succeeds()
+        {
+            // Arrange
+            var tc = new TestContext();
+            tc.PackageTypes.Add(PackageType.Dependency);
+
+            // Act & Assert
+            tc.VerifySuccess(tc.ProjectKProject);
+        }
+
+        private class TestContext
+        {
+            public TestContext(string userPackageFolder = null)
+            {
+                // Dependencies
+                SourceRepository = new SourceRepository(new PackageSource("http://example/index.json"), Enumerable.Empty <INuGetResourceProvider>());
+
+                PackageIdentityA = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0"));
+                PackageIdentityB = new PackageIdentity("PackageB", NuGetVersion.Parse("1.0.0"));
+                PackageIdentityC = new PackageIdentity("PackageC", NuGetVersion.Parse("1.0.0"));
+                PackageTypes = new List<PackageType>();
+                MinClientVersion = new NuGetVersion(2, 0, 0);
+
+                InvalidPackageType = new PackageType("Invalid", new Version(1, 2));
+
+                NuGetProject = new TestNuGetProject(new List<PackageReference>());
+                ProjectKProject = new TestProjectKNuGetProject();
+
+                NuGetPathContext = new Mock<INuGetPathContext>();
+
+                NuspecReader = new Mock<NuspecReader>(new XDocument());
+
+                PackageReader = new Mock<PackageReaderBase>(
+                    new FrameworkNameProvider(new[] { DefaultFrameworkMappings.Instance },
+                    new[] { DefaultPortableFrameworkMappings.Instance }))
+                {
+                    CallBase = true
+                };
+
+                // Setup
+                NuGetPathContext
+                    .Setup(x => x.UserPackageFolder)
+                    .Returns(userPackageFolder);
+                NuGetPathContext
+                    .Setup(x => x.FallbackPackageFolders)
+                    .Returns(new string[0]);
+
+                NuspecReader
+                    .Setup(p => p.GetIdentity())
+                    .Returns(() => PackageIdentityA);
+                NuspecReader
+                    .Setup(p => p.GetMinClientVersion())
+                    .Returns(() => MinClientVersion);
+                NuspecReader
+                    .Setup(p => p.GetPackageTypes())
+                    .Returns(() => PackageTypes);
+
+                PackageReader
+                    .Setup(p => p.GetIdentity())
+                    .Returns(() => PackageIdentityA);
+                PackageReader
+                    .Setup(p => p.GetMinClientVersion())
+                    .Returns(() => MinClientVersion);
+                PackageReader
+                    .Setup(p => p.GetPackageTypes())
+                    .Returns(() => PackageTypes);
+
+                PackageReader
+                    .Setup(p => p.NuspecReader)
+                    .Returns(() => NuspecReader.Object);
+
+                Target = new InstallationCompatibility();
+            }
+
+            public SourceRepository SourceRepository { get; }
+            public PackageIdentity PackageIdentityA { get; }
+            public PackageIdentity PackageIdentityB { get; }
+            public PackageIdentity PackageIdentityC { get; }
+            public List<PackageType> PackageTypes { get; }
+            public NuGetVersion MinClientVersion { get; set; }
+            public TestNuGetProject NuGetProject { get; }
+            public TestProjectKNuGetProject ProjectKProject { get; }
+            public Mock<INuGetPathContext> NuGetPathContext { get; }
+            public Mock<PackageReaderBase> PackageReader { get; }
+            public Mock<NuspecReader> NuspecReader { get; }
+            public InstallationCompatibility Target { get; }
+            public PackageType InvalidPackageType { get; }
+
+            public void VerifyFailure(
+                NuGetProject nugetProject,
+                string expected)
+            {
+                // Arrange
+                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object);
+
+                // Act & Assert
+                var ex = Assert.Throws<PackagingException>(() =>
+                     Target.EnsurePackageCompatibility(
+                        nugetProject,
+                        PackageIdentityA,
+                        result));
+
+                Assert.Equal(expected, ex.Message);
+                PackageReader.Verify(x => x.GetMinClientVersion(), Times.Never);
+                PackageReader.Verify(x => x.GetPackageTypes(), Times.Never);
+                NuspecReader.Verify(x => x.GetMinClientVersion(), Times.Once);
+                NuspecReader.Verify(x => x.GetPackageTypes(), Times.Once);
+            }
+
+            public void VerifySuccess(NuGetProject nugetProject)
+            {
+                // Arrange
+                var result = new DownloadResourceResult(Stream.Null, PackageReader.Object);
+
+                // Act & Assert
+                Target.EnsurePackageCompatibility(
+                    nugetProject,
+                    PackageIdentityA,
+                    result);
+
+                PackageReader.Verify(x => x.GetMinClientVersion(), Times.Never);
+                PackageReader.Verify(x => x.GetPackageTypes(), Times.Never);
+                NuspecReader.Verify(x => x.GetMinClientVersion(), Times.Once);
+                NuspecReader.Verify(x => x.GetPackageTypes(), Times.Once);
+            }
+
+            public RestoreResult GetRestoreResult(IEnumerable<PackageIdentity> identities)
+            {
+                var node = new GraphNode<RemoteResolveResult>(new LibraryRange("project", LibraryDependencyTarget.All))
+                {
+                    Item = new GraphItem<RemoteResolveResult>(
+                        new LibraryIdentity(
+                            "project",
+                            new NuGetVersion("1.0.0"),
+                            LibraryType.Project))
+                    {
+                        Data = new RemoteResolveResult
+                        {
+                            Match = new RemoteMatch
+                            {
+                                Provider = null
+                            }
+                        }
+                    }
+                };
+
+                foreach (var identity in identities)
+                {
+                    var dependencyNode = new GraphNode<RemoteResolveResult>(
+                        new LibraryRange(
+                            identity.Id,
+                            new VersionRange(identity.Version),
+                            LibraryDependencyTarget.All))
+                    {
+                        Item = new GraphItem<RemoteResolveResult>(
+                            new LibraryIdentity(
+                                identity.Id,
+                                identity.Version,
+                                LibraryType.Package))
+                        {
+                            Data = new RemoteResolveResult
+                            {
+                                Match = new RemoteMatch
+                                {
+                                    Provider = null
+                                }
+                            }
+                        }
+                    };
+
+                    dependencyNode.OuterNode = node;
+                    node.InnerNodes.Add(dependencyNode);
+                }
+
+                var graph = RestoreTargetGraph.Create(
+                    false,
+                    new[] { node },
+                    new RemoteWalkContext(),
+                    NullLogger.Instance,
+                    FrameworkConstants.CommonFrameworks.NetStandard10);
+
+                return new RestoreResult(
+                    true,
+                    new[] { graph },
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -1,15 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Moq;
-using NuGet.Frameworks;
-using NuGet.PackageManagement;
-using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.Protocol.Core.Types;
-using NuGet.Resolver;
-using NuGet.Test.Utility;
-using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18,6 +9,18 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Moq;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using Strings = NuGet.ProjectManagement.Strings;
@@ -161,6 +164,9 @@ namespace NuGet.Test
                     deleteOnRestartManager);
                 var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(testSolutionManager, testSettings);
 
+                var installationCompatibility = new Mock<IInstallationCompatibility>();
+                nuGetPackageManager.InstallationCompatibility = installationCompatibility.Object;
+
                 var msBuildNuGetProject = testSolutionManager.AddNewMSBuildProject();
                 var msBuildNuGetProjectSystem = msBuildNuGetProject.MSBuildNuGetProjectSystem as TestMSBuildNuGetProjectSystem;
                 var packagesConfigPath = msBuildNuGetProject.PackagesConfigNuGetProject.FullPath;
@@ -181,11 +187,27 @@ namespace NuGet.Test
                 // Assert
                 // Check that the packages.config file exists after the installation
                 Assert.True(File.Exists(packagesConfigPath));
+
                 // Check the number of packages and packages returned by PackagesConfigProject after the installation
                 packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
                 Assert.Equal(1, packagesInPackagesConfig.Count);
                 Assert.Equal(packageIdentity, packagesInPackagesConfig[0].PackageIdentity);
                 Assert.Equal(msBuildNuGetProject.MSBuildNuGetProjectSystem.TargetFramework, packagesInPackagesConfig[0].TargetFramework);
+
+                // Ensure that installation compatibility was checked.
+                installationCompatibility.Verify(
+                    x => x.EnsurePackageCompatibility(
+                        msBuildNuGetProject,
+                        packageIdentity,
+                        It.IsAny<DownloadResourceResult>()),
+                    Times.Once);
+                installationCompatibility.Verify(
+                    x => x.EnsurePackageCompatibility(
+                        It.IsAny<NuGetProject>(),
+                        It.IsAny<INuGetPathContext>(),
+                        It.IsAny<IEnumerable<NuGetProjectAction>>(),
+                        It.IsAny<RestoreResult>()),
+                    Times.Never);
             }
         }
 
@@ -4441,42 +4463,6 @@ namespace NuGet.Test
             }
         }
 
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_FailsIfThePackageTypeIsManaged()
-        {
-            await VerifyFailureForPackageTypes(new[] { new PackageType("Managed", new Version(2, 0)) });
-        }
-
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_FailsIfThePackageTypeIsUnexpected()
-        {
-            await VerifyFailureForPackageTypes(new[] { new PackageType("Fake", new Version(1, 2)) });
-        }
-
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_FailsIfThePackageTypeIsDotnetCliTool()
-        {
-            await VerifyFailureForPackageTypes(new[] { PackageType.DotnetCliTool });
-        }
-
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_FailsIfThePackageTypeIsDependency()
-        {
-            await VerifyFailureForPackageTypes(new[] { PackageType.Dependency });
-        }
-
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_FailsIfMultiplePackageTypes()
-        {
-            await VerifyFailureForPackageTypes(new[] { PackageType.Legacy, PackageType.Legacy });
-        }
-
-        [Fact]
-        public async Task ExecuteNuGetProjectActionsAsync_SucceedsIfThePackageTypeIsLegacy()
-        {
-            await VerifySuccessForPackageTypes(new[] { PackageType.Legacy });
-        }
-
         // [Fact]
         public async Task TestPacManUpdatePackagePreservePackagesConfigAttributes()
         {
@@ -4687,141 +4673,6 @@ namespace NuGet.Test
             var packageDependency = packageInfo.Dependencies.Single();
             Assert.Equal("b", packageDependency.Id);
             Assert.Equal(bVersionRange.ToString(), packageDependency.VersionRange.ToString());
-        }
-
-        private static async Task VerifyFailureForPackageTypes(IReadOnlyList<PackageType> packageTypes)
-        {
-            // Arrange
-            var packageSource = new Configuration.PackageSource("some source");
-            var packageSourceProvider = new TestPackageSourceProvider(new[] { packageSource });
-            var sourceRepositoryProvider = new SourceRepositoryProvider(
-                packageSourceProvider,
-                new[] { new Lazy<INuGetResourceProvider>(() => new TestDownloadResourceProvider(packageTypes)) });
-            var testSettings = Configuration.NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
-            {
-                var deleteOnRestartManager = new TestDeleteOnRestartManager();
-                var nugetProject = new TestNuGetProject(new Packaging.PackageReference[0]);
-
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    testSettings,
-                    testSolutionManager,
-                    deleteOnRestartManager);
-                var identity = new PackageIdentity("ManagedCodeConventions", NuGetVersion.Parse("1.0.0"));
-                var actions = new[] { NuGetProjectAction.CreateInstallProjectAction(identity, sourceRepositoryProvider.CreateRepository(packageSource)) };
-
-                // Act and Assert
-                var ex = await Assert.ThrowsAsync<MinClientVersionException>(() =>
-                    nuGetPackageManager.ExecuteNuGetProjectActionsAsync(
-                        nugetProject,
-                        actions,
-                        new TestNuGetProjectContext(),
-                        default(CancellationToken)));
-                Assert.Equal("Package 'ManagedCodeConventions 1.0.0' uses features that are not supported by the current version of NuGet. " +
-                    "To upgrade NuGet, see http://docs.nuget.org/consume/installing-nuget.", ex.Message);
-            }
-        }
-
-        private static async Task VerifySuccessForPackageTypes(IReadOnlyList<PackageType> packageTypes)
-        {
-            // Arrange
-            var packageSource = new Configuration.PackageSource("some source");
-            var packageSourceProvider = new TestPackageSourceProvider(new[] { packageSource });
-            var sourceRepositoryProvider = new SourceRepositoryProvider(
-                packageSourceProvider,
-                new[] { new Lazy<INuGetResourceProvider>(() => new TestDownloadResourceProvider(packageTypes)) });
-            var testSettings = Configuration.NullSettings.Instance;
-            using (var testSolutionManager = new TestSolutionManager(true))
-            {
-                var deleteOnRestartManager = new TestDeleteOnRestartManager();
-                var nugetProject = new TestNuGetProject(new Packaging.PackageReference[0]);
-
-                var nuGetPackageManager = new NuGetPackageManager(
-                    sourceRepositoryProvider,
-                    testSettings,
-                    testSolutionManager,
-                    deleteOnRestartManager);
-                var identity = new PackageIdentity("ManagedCodeConventions", NuGetVersion.Parse("1.0.0"));
-                var actions = new[] { NuGetProjectAction.CreateInstallProjectAction(identity, sourceRepositoryProvider.CreateRepository(packageSource)) };
-
-                // Act
-                await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(
-                        nugetProject,
-                        actions,
-                        new TestNuGetProjectContext(),
-                        default(CancellationToken));
-
-                // No exception should be thrown.
-            }
-        }
-
-        private class TestDownloadResourceProvider : ResourceProvider
-        {
-            private readonly IReadOnlyList<PackageType> _packageTypes;
-
-            public TestDownloadResourceProvider(IReadOnlyList<PackageType> packageTypes)
-                : base(typeof(DownloadResource))
-            {
-                _packageTypes = packageTypes;
-            }
-
-            public override Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
-            {
-                INuGetResource resource = new TestDownloadResource(_packageTypes);
-                return Task.FromResult(Tuple.Create(true, resource));
-            }
-        }
-
-        private class TestDownloadResource : DownloadResource
-        {
-            private readonly IReadOnlyList<PackageType> _packageTypes;
-
-            public TestDownloadResource(IReadOnlyList<PackageType> _packageTypes)
-            {
-                this._packageTypes = _packageTypes;
-            }
-
-            public override Task<DownloadResourceResult> GetDownloadResourceResultAsync(
-                PackageIdentity identity,
-                Configuration.ISettings settings,
-                Common.ILogger logger,
-                CancellationToken token)
-            {
-                var nuspecReader = new Mock<NuspecReader>(new XDocument());
-                var packageReader = new Mock<PackageReaderBase>(
-                    new FrameworkNameProvider(new[] { DefaultFrameworkMappings.Instance },
-                    new[] { DefaultPortableFrameworkMappings.Instance }))
-                {
-                    CallBase = true
-                };
-
-                packageReader
-                    .Setup(p => p.GetIdentity())
-                    .Returns(new PackageIdentity("ManagedCodeConventions", NuGetVersion.Parse("1.0.0")));
-                packageReader
-                    .Setup(p => p.GetMinClientVersion())
-                    .Returns(new NuGetVersion(2, 0, 0));
-                packageReader
-                    .Setup(p => p.GetPackageTypes())
-                    .Returns(_packageTypes);
-
-                nuspecReader
-                    .Setup(p => p.GetIdentity())
-                    .Returns(new PackageIdentity("ManagedCodeConventions", NuGetVersion.Parse("1.0.0")));
-                nuspecReader
-                    .Setup(p => p.GetMinClientVersion())
-                    .Returns(new NuGetVersion(2, 0, 0));
-                nuspecReader
-                    .Setup(p => p.GetPackageTypes())
-                    .Returns(_packageTypes);
-
-                packageReader
-                    .Setup(p => p.NuspecReader)
-                    .Returns(nuspecReader.Object);
-
-                return Task.FromResult(new DownloadResourceResult(Stream.Null, packageReader.Object));
-            }
         }
 
         private SourceRepositoryProvider CreateSource(List<SourcePackageDependencyInfo> packages)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestProjectKNuGetProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestProjectKNuGetProject.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Test
+{
+    internal class TestProjectKNuGetProject : ProjectKNuGetProjectBase
+    {
+        public TestProjectKNuGetProject()
+        {
+            InternalMetadata.AddRange(CreateMetadata());
+        }
+        
+        private static Dictionary<string, object> CreateMetadata()
+        {
+            return new Dictionary<string, object>
+            {
+                { NuGetProjectMetadataKeys.Name, nameof(TestProjectKNuGetProject) },
+                { NuGetProjectMetadataKeys.TargetFramework, NuGetFramework.Parse("net45") },
+            };
+        }
+
+        public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
+        {
+            return Task.FromResult<IEnumerable<PackageReference>>(new PackageReference[0]);
+        }
+
+        public override Task<bool> InstallPackageAsync(
+            PackageIdentity packageIdentity,
+            DownloadResourceResult downloadResourceResult,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token)
+        {
+            return Task.FromResult(true);
+        }
+
+        public override Task<bool> UninstallPackageAsync(
+            PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
1. Observe package type on install. This means that .NET Core projects now allow `Dependency` and `DotnetCliTool` packages. Every other package type now allows `Dependency` (but not `DotnetCliTool`).
2. Move installation compatibility validation to a new `InstallationCompatibility` class, which is tested on its own.

This PR completes https://github.com/NuGet/Home/issues/2476. There is additional work owned by @abpiskunov to install `DotnetCliTool` packages to the `"tools"` node instead of the `"dependencies"` node.

I have built a bunch of packages with a variety of package types. You can play with them on this source:
https://www.myget.org/F/jver-packagetype/api/v3/index.json

@emgarten @rohit21agrawal @yishaigalatzer @abpiskunov

Here's what the error looks like:
![packagetypeinstallation](https://cloud.githubusercontent.com/assets/94054/16050529/e06727fc-3210-11e6-941d-5178b2200b73.png)
