### PR TITLE
Set Accept-Language header on HTTP requests

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/V2Utilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/V2Utilities.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Net;
-using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -357,6 +357,13 @@ namespace NuGet.Protocol
             // Set user agent
             UserAgent.SetUserAgent(httpClient);
 
+            // Set accept-language header
+            string acceptLanguage = CultureInfo.CurrentUICulture.ToString();
+            if (!string.IsNullOrEmpty(acceptLanguage))
+            {
+                httpClient.DefaultRequestHeaders.AcceptLanguage.ParseAdd(acceptLanguage);
+            }
+
             return httpClient;
         }
 


### PR DESCRIPTION
(relates to https://github.com/NuGet/Home/issues/2934)

The server currently has no information about the client locale. This PR adds the Accept-Language header to outgoing HTTP requests so that the server can optionally return localized error and warning messages.

Design is based on how UserAgent is added to the request. Simplified version would be to just add the current UI culture instead of having a separate class.

@rrelyea @yishaigalatzer @emgarten @joelverhagen 
