### PR TITLE
Taking out code that sets the basepath to the project directory if the argument is not passed in.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -98,10 +98,6 @@ namespace NuGet.CommandLine
 
             Console.WriteLine(LocalizedResourceManager.GetString("PackageCommandAttemptingToBuildPackage"), Path.GetFileName(packArgs.Path));
 
-            // If the BasePath is not specified, use the directory of the input file (nuspec / proj) file
-            BasePath = String.IsNullOrEmpty(BasePath) ? Path.GetDirectoryName(Path.GetFullPath(packArgs.Path)) : BasePath;
-            BasePath = BasePath.TrimEnd(Path.DirectorySeparatorChar);
-
             if (!String.IsNullOrEmpty(MinClientVersion))
             {
                 if (!System.Version.TryParse(MinClientVersion, out _minClientVersionValue))

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -105,16 +105,12 @@ namespace NuGet.CommandLine.XPlat
                     packArgs.Arguments = arguments.Values;
                     packArgs.Path = PackCommandRunner.GetInputFile(packArgs);
                     packArgs.OutputDirectory = outputDirectory.Value();
+                    packArgs.BasePath = basePath.Value();
 
                     // Set the current directory if the files being packed are in a different directory
                     PackCommandRunner.SetupCurrentDirectory(packArgs);
 
                     logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.PackageCommandAttemptingToBuildPackage, Path.GetFileName(packArgs.Path)));
-
-                    if (basePath.HasValue())
-                    {
-                        packArgs.BasePath = basePath.Value();
-                    }
 
                     packArgs.Build = build.HasValue();
                     packArgs.Exclude = exclude.Values;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -111,9 +111,10 @@ namespace NuGet.CommandLine.XPlat
 
                     logger.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.PackageCommandAttemptingToBuildPackage, Path.GetFileName(packArgs.Path)));
 
-                    // If the BasePath is not specified, use the directory of the input file (nuspec / proj) file
-                    packArgs.BasePath = !basePath.HasValue() ? Path.GetDirectoryName(Path.GetFullPath(packArgs.Path)) : basePath.Value();
-                    packArgs.BasePath = packArgs.BasePath.TrimEnd(Path.DirectorySeparatorChar);
+                    if (basePath.HasValue())
+                    {
+                        packArgs.BasePath = basePath.Value();
+                    }
 
                     packArgs.Build = build.HasValue();
                     packArgs.Exclude = exclude.Values;


### PR DESCRIPTION
Taking out code that sets the basepath to the project directory if the argument is not passed in.

It was causing problems with dotnet pack.  The code wasn't actually doing anything for NuGet.exe but it does end up setting a basepath in xplat that shouldn't be set.

@joelverhagen 
