### PR TITLE
Don't throw if nothing to do when restoring.

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -72,10 +72,11 @@ namespace NuGet.CommandLine
             var hasProjectJsonFiles = restoreInputs.RestoreV3Context.Inputs.Any();
             if (!hasPackagesConfigFiles && !hasProjectJsonFiles)
             {
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    LocalizedResourceManager.GetString("RestoreCommandNoPackagesConfigOrProjectJson"));
-                throw new CommandLineException(message);
+
+                Console.LogMinimal(LocalizedResourceManager.GetString(restoreInputs.RestoringWithSolutionFile
+                        ? "SolutionRestoreCommandNoPackagesConfigOrProjectJson"
+                        : "ProjectRestoreCommandNoPackagesConfigOrProjectJson"));
+                return;
             }
 
             // packages.config

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -8845,6 +8845,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nothing to do. This project does not specify any packages for NuGet to restore..
+        /// </summary>
+        public static string ProjectRestoreCommandNoPackagesConfigOrProjectJson {
+            get {
+                return ResourceManager.GetString("ProjectRestoreCommandNoPackagesConfigOrProjectJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is no default source, please specify a source..
         /// </summary>
         public static string PushCommandNoSourceError {
@@ -9849,15 +9858,6 @@ namespace NuGet.CommandLine {
         public static string RestoreCommandFileNotFound_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandFileNotFound_trk", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to restore. The project does not contain a project.json or packages.config file..
-        /// </summary>
-        public static string RestoreCommandNoPackagesConfigOrProjectJson {
-            get {
-                return ResourceManager.GetString("RestoreCommandNoPackagesConfigOrProjectJson", resourceCulture);
             }
         }
         
@@ -11014,6 +11014,15 @@ namespace NuGet.CommandLine {
         public static string SettingsCredentials_UsingSavedCredentials {
             get {
                 return ResourceManager.GetString("SettingsCredentials_UsingSavedCredentials", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nothing to do. None of the projects in this solution specify any packages for NuGet to restore..
+        /// </summary>
+        public static string SolutionRestoreCommandNoPackagesConfigOrProjectJson {
+            get {
+                return ResourceManager.GetString("SolutionRestoreCommandNoPackagesConfigOrProjectJson", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -494,8 +494,11 @@
     <value>Restoring NuGet packages...
 To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck '{0}'.</value>
   </data>
-  <data name="RestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
-   <value>Unable to restore. The project does not contain a project.json or packages.config file.</value>
+  <data name="ProjectRestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
+   <value>Nothing to do. This project does not specify any packages for NuGet to restore.</value>
+ </data>
+  <data name="SolutionRestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
+   <value>Nothing to do. None of the projects in this solution specify any packages for NuGet to restore.</value>
  </data>
   <data name="Error_CannotGetGetAllProjectFileNamesMethod" xml:space="preserve">
     <value>Cannot get the GetAllProjectFileNamesMethod from type  Mono.XBuild.CommandLine.SolutionParser.</value>


### PR DESCRIPTION
If you restore a solution or a project without a `packages.config` or `project.json`, display an informational message rather than throwing. Also, make the message appropriate to the context (solution vs project).

Working on some tests currently. Wanted to get this out for PR since it is a P0.

See NuGet/Home#2766
