### PR TITLE
Pass all specific frameworks to INuGetPackageManager (.NET Core tooling)

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
@@ -90,11 +90,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var args = new Dictionary<string, object>();
 
-            args["Frameworks"] = _project
-                .GetSupportedFrameworksAsync(token)
-                .Result
-                .Select(f => NuGetFramework.Parse(f.FullName))
-                .Where(projectFramework => IsCompatible(projectFramework, supportedFrameworks))
+            args["Frameworks"] = supportedFrameworks
+                .Where(f => f.IsSpecificFramework)
                 .ToArray();
 
             args["PackageTypes"] = packageTypes

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
@@ -80,7 +80,12 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                             It.Is<IReadOnlyDictionary<string, object>>(y =>
                                 y.ContainsKey("Frameworks") &&
                                 Enumerable.SequenceEqual(
-                                    (IEnumerable<NuGetFramework>)y["Frameworks"], tc.SupportedFrameworks)),
+                                    (IEnumerable<NuGetFramework>)y["Frameworks"],
+                                    new[]
+                                    {
+                                        NuGetFramework.Parse("net45"),
+                                        NuGetFramework.Parse("netstandard1.0")
+                                    })),
                             It.IsAny<TextWriter>(),
                             It.IsAny<IProgress<INuGetPackageInstallProgress>>(),
                             It.IsAny<CancellationToken>()),


### PR DESCRIPTION
Worked with @abpiskunov on this one. Now that we expose `IVsFrameworkCompatibility`, we can pass all of the package frameworks to the .NET Core tooling. This allows tooling to do so the same compatibility check that we were doing before (and is removed in this PR) _in addition_ to taking `"imports"` into account. NuGet code does not have access to imports via the via `INuGetPackageManager` interface.

/cc @emgarten @abpiskunov @yishaigalatzer 
