### PR TITLE
Build dev14 after dev15 so that EndToEnd artifacts are dev14

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -107,6 +107,15 @@ Invoke-BuildStep 'Building NuGet.Core projects' {
     -skip:$SkipXProj `
     -ev +BuildErrors
 
+## Building the Dev15 Tooling solution
+Invoke-BuildStep 'Building NuGet.Clients projects - Dev15 dependencies' {
+        param($Configuration, $ReleaseLabel, $BuildNumber, $SkipRestore, $Fast)
+        Build-ClientsProjects $Configuration $ReleaseLabel $BuildNumber -MSBuildVersion "15" -SkipRestore:$SkipRestore -Fast:$Fast
+    } `
+    -args $Configuration, $ReleaseLabel, $BuildNumber, $SkipRestore, $Fast `
+    -skip:$SkipDev15 `
+    -ev +BuildErrors
+
 ## Building the Dev14 Tooling solution
 Invoke-BuildStep 'Building NuGet.Clients projects - Dev14 dependencies' {
         param($Configuration, $ReleaseLabel, $BuildNumber, $SkipRestore, $Fast)
@@ -125,15 +134,6 @@ Invoke-BuildStep 'Merging NuGet.exe' {
     -skip:($SkipILMerge -or $Fast -or $SkipDev14) `
     -ev +BuildErrors
 
-## Building the Dev15 Tooling solution
-Invoke-BuildStep 'Building NuGet.Clients projects - Dev15 dependencies' {
-        param($Configuration, $ReleaseLabel, $BuildNumber, $SkipRestore, $Fast)
-        Build-ClientsProjects $Configuration $ReleaseLabel $BuildNumber -MSBuildVersion "15" -SkipRestore:$SkipRestore -Fast:$Fast
-    } `
-    -args $Configuration, $ReleaseLabel, $BuildNumber, $SkipRestore, $Fast `
-    -skip:$SkipDev15 `
-    -ev +BuildErrors
-
 Invoke-BuildStep 'Running NuGet.Core tests' {
         param($SkipRestore, $Fast)
         Test-CoreProjects -SkipRestore:$SkipRestore -Fast:$Fast -Configuration $Configuration
@@ -142,20 +142,20 @@ Invoke-BuildStep 'Running NuGet.Core tests' {
     -skip:(-not $RunTests) `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Running NuGet.Clients tests - Dev14 dependencies' {
-        param($Configuration)
-        Test-ClientsProjects -Configuration:$Configuration -MSBuildVersion "14"
-    } `
-    -args $Configuration `
-    -skip:((-not $RunTests) -or $SkipDev14) `
-    -ev +BuildErrors
-
 Invoke-BuildStep 'Running NuGet.Clients tests - Dev15 dependencies' {
         param($Configuration)
         Test-ClientsProjects -Configuration $Configuration -MSBuildVersion "15"
     } `
     -args $Configuration `
     -skip:((-not $RunTests) -or $SkipDev15) `
+    -ev +BuildErrors
+
+Invoke-BuildStep 'Running NuGet.Clients tests - Dev14 dependencies' {
+        param($Configuration)
+        Test-ClientsProjects -Configuration:$Configuration -MSBuildVersion "14"
+    } `
+    -args $Configuration `
+    -skip:((-not $RunTests) -or $SkipDev14) `
     -ev +BuildErrors
 
 Trace-Log ('-' * 60)


### PR DESCRIPTION
As part of our CI, we build an `EndToEnd.zip` archive which is dropped on the E2E test machine. This `EndToEnd.zip` includes a little test `API.Test.dll`. Since the dev15 build is happening second, the `API.Test.dll` included in the .zip file is built for dev15, which doesn't work on the end E2E machine (which is testing dev14 right now).

@emgarten @drewgil 
