### PR TITLE
Make --disable-parallel limit the concurrent HTTP requests to 1

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -14,6 +14,7 @@ using NuGet.PackageManagement;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Versioning;
@@ -60,6 +61,11 @@ namespace NuGet.CommandLine
 
         public override Task ExecuteCommandAsync()
         {
+            if (DisableParallelProcessing)
+            {
+                HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
+            }
+
             CalculateEffectivePackageSaveMode();
             CalculateEffectiveSettings();
             string installPath = ResolveInstallPath();

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -50,6 +50,11 @@ namespace NuGet.CommandLine
 
         public override async Task ExecuteCommandAsync()
         {
+            if (DisableParallelProcessing)
+            {
+                HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
+            }
+
             CalculateEffectivePackageSaveMode();
 
             var restoreSummaries = new List<RestoreSummary>();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/RestoreCommand.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using NuGet.Commands;
 using NuGet.Configuration;
@@ -121,6 +122,11 @@ namespace NuGet.CommandLine.XPlat
                             var os = PlatformApis.GetOSName();
                             var defaultRuntimes = RequestRuntimeUtility.GetDefaultRestoreRuntimes(os, runtimeOSname);
                             restoreContext.FallbackRuntimes.UnionWith(defaultRuntimes);
+                        }
+
+                        if (restoreContext.DisableParallel)
+                        {
+                            HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
                         }
 
                         var restoreSummaries = await RestoreRunner.Run(restoreContext);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/DependencyInfo/Utils.cs
@@ -24,13 +24,19 @@ namespace NuGet.Protocol
         }
 
         public async static Task<IEnumerable<JObject>> LoadRanges(
-            HttpSource httpClient,
+            HttpSource httpSource,
             Uri registrationUri,
             VersionRange range,
             ILogger log,
             CancellationToken token)
         {
-            var index = await httpClient.GetJObjectAsync(registrationUri, ignoreNotFounds: true, log: log, token: token);
+            var index = await httpSource.GetJObjectAsync(
+                new HttpSourceRequest(registrationUri, log)
+                {
+                    IgnoreNotFounds = true
+                },
+                log,
+                token);
 
             if (index == null)
             {
@@ -52,11 +58,13 @@ namespace NuGet.Protocol
                     {
                         var rangeUri = item["@id"].ToObject<Uri>();
 
-                        rangeTasks.Add(httpClient.GetJObjectAsync(
-                            rangeUri,
-                            ignoreNotFounds: true,
-                            log: log,
-                            token: token));
+                        rangeTasks.Add(httpSource.GetJObjectAsync(
+                            new HttpSourceRequest(rangeUri, log)
+                            {
+                                IgnoreNotFounds = true
+                            },
+                            log,
+                            token));
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/DownloadTimeoutStreamContent.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/DownloadTimeoutStreamContent.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// A wrapper around <see cref="StreamContent"/> that applies a <see cref="DownloadTimeoutStream"/>
+    /// to the contained stream. When the <see cref="HttpResponseMessage"/> is disposed, this
+    /// content is disposed which in turn disposes the <see cref="DownloadTimeoutStream"/>, which
+    /// disposes the actual network stream.
+    /// </summary>
+    public class DownloadTimeoutStreamContent : StreamContent
+    {
+        public DownloadTimeoutStreamContent(string downloadName, Stream networkStream, TimeSpan timeout)
+            : base(new DownloadTimeoutStream(downloadName, networkStream, timeout))
+        {
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Threading;
 
 namespace NuGet.Protocol
 {
@@ -12,6 +13,8 @@ namespace NuGet.Protocol
     /// </summary>
     public class HttpRetryHandlerRequest
     {
+        public static readonly TimeSpan DefaultDownloadTimeout = TimeSpan.FromSeconds(60);
+
         public HttpRetryHandlerRequest(HttpClient httpClient, Func<HttpRequestMessage> requestFactory)
         {
             HttpClient = httpClient;
@@ -20,6 +23,7 @@ namespace NuGet.Protocol
             MaxTries = 3;
             RequestTimeout = TimeSpan.FromSeconds(100);
             RetryDelay = TimeSpan.FromMilliseconds(200);
+            DownloadTimeout = DefaultDownloadTimeout;
         }
 
         /// <summary>The HTTP client to use for each request attempt.</summary>
@@ -43,5 +47,8 @@ namespace NuGet.Protocol
         /// <summary>How long to wait before trying again after a failed request.</summary>
         /// <summary>This API is intended only for testing purposes and should not be used in product code.</summary>
         public TimeSpan RetryDelay { get; set; }
+
+        /// <summary>The timeout to apply to <see cref="DownloadTimeoutStream"/> instances.</summary>
+        public TimeSpan DownloadTimeout { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCachedRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCachedRequest.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// A cached HTTP request handled by <see cref="HttpSource"/>.
+    /// </summary>
+    public class HttpSourceCachedRequest
+    {
+        public HttpSourceCachedRequest(string uri, string cacheKey, HttpSourceCacheContext cacheContext)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            if (cacheKey == null)
+            {
+                throw new ArgumentNullException(nameof(cacheKey));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            Uri = uri;
+            CacheKey = cacheKey;
+            CacheContext = cacheContext;
+        }
+
+        /// <summary>
+        /// The URI to request with <code>GET</code>.
+        /// </summary>
+        public string Uri { get; }
+
+        /// <summary>
+        /// The cache key to use when fetching and storing the response from the HTTP cache. This
+        /// cache key is scoped to the NuGet source. That is to say that each NuGet source has its
+        /// own independent HTTP cache.
+        /// </summary>
+        public string CacheKey { get; }
+
+        /// <summary>
+        /// The cache context.
+        /// </summary>
+        public HttpSourceCacheContext CacheContext { get; }
+
+        /// <summary>
+        /// The header values to apply when building the <see cref="HttpRequestMessage"/>.
+        /// </summary>
+        public IList<MediaTypeWithQualityHeaderValue> AcceptHeaderValues { get; } = new List<MediaTypeWithQualityHeaderValue>();
+
+        /// <summary>
+        /// When processing the <see cref="HttpResponseMessage"/>, this flag allows
+        /// <code>404 Not Found</code> to be interpreted as a null response. This value defaults
+        /// to <code>false</code>.
+        /// </summary>
+        public bool IgnoreNotFounds { get; set; }
+
+        /// <summary>
+        /// A method used to validate the response stream. This method should not
+        /// dispose the stream and should throw an exception when the content is invalid.
+        /// </summary>
+        public Action<Stream> EnsureValidContents { get; set; }
+
+        /// <summary>
+        /// The timeout to use when fetching the <see cref="HttpResponseMessage"/>. Since
+        /// <see cref="HttpSource"/> only uses <see cref="HttpCompletionOption.ResponseHeadersRead"/>,
+        /// this means that we wait this amount of time for only the HTTP headers to be returned.
+        /// Downloading the response body is not included in this timeout.
+        /// </summary>
+        public TimeSpan RequestTimeout { get; set; } = HttpSourceRequest.DefaultRequestTimeout;
+
+        /// <summary>The timeout to apply to <see cref="DownloadTimeoutStream"/> instances.</summary>
+        public TimeSpan DownloadTimeout { get; set; } = HttpRetryHandlerRequest.DefaultDownloadTimeout;
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceRequest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using NuGet.Common;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// A non-cached HTTP request handled by <see cref="HttpSource"/>.
+    /// </summary>
+    public class HttpSourceRequest
+    {
+        public static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(100);
+
+        public HttpSourceRequest(string uri, ILogger log)
+            : this(() => HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log))
+        {
+        }
+
+        public HttpSourceRequest(Uri uri, ILogger log)
+            : this(() => HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log))
+        {
+        }
+
+        public HttpSourceRequest(Func<HttpRequestMessage> requestFactory)
+        {
+            if (requestFactory == null)
+            {
+                throw new ArgumentNullException(nameof(requestFactory));
+            }
+            
+            RequestFactory = requestFactory;
+        }
+        
+        /// <summary>
+        /// A factory that can be called repeatedly to build the HTTP request message.
+        /// </summary>
+        public Func<HttpRequestMessage> RequestFactory { get; }
+
+        /// <summary>
+        /// When processing the <see cref="HttpResponseMessage"/>, this flag allows
+        /// <code>404 Not Found</code> to be interpreted as a null response. This value defaults
+        /// to <code>false</code>.
+        /// </summary>
+        public bool IgnoreNotFounds { get; set; }
+
+        /// <summary>
+        /// The timeout to use when fetching the <see cref="HttpResponseMessage"/>. Since
+        /// <see cref="HttpSource"/> only uses <see cref="HttpCompletionOption.ResponseHeadersRead"/>,
+        /// this means that we wait this amount of time for only the HTTP headers to be returned.
+        /// Downloading the response body is not included in this timeout.
+        /// </summary>
+        public TimeSpan RequestTimeout { get; set; } = DefaultRequestTimeout;
+
+        /// <summary>The timeout to apply to <see cref="DownloadTimeoutStream"/> instances.</summary>
+        public TimeSpan DownloadTimeout { get; set; } = HttpRetryHandlerRequest.DefaultDownloadTimeout;
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResourceProvider.cs
@@ -17,6 +17,11 @@ namespace NuGet.Protocol
         private readonly ConcurrentDictionary<PackageSource, HttpSourceResource> _cache
             = new ConcurrentDictionary<PackageSource, HttpSourceResource>();
 
+        /// <summary>
+        /// The throttle to apply to all <see cref="HttpSource"/> HTTP requests.
+        /// </summary>
+        public static IThrottle Throttle { get; set; }
+
         public HttpSourceResourceProvider()
             : base(typeof(HttpSourceResource),
                   nameof(HttpSourceResource),
@@ -30,10 +35,13 @@ namespace NuGet.Protocol
 
             HttpSourceResource curResource = null;
 
+            var throttle = Throttle ?? NullThrottle.Instance;
+
             if (source.PackageSource.IsHttp)
             {
-                curResource = _cache.GetOrAdd(source.PackageSource, 
-                    (packageSource) => new HttpSourceResource(HttpSource.Create(source)));
+                curResource = _cache.GetOrAdd(
+                    source.PackageSource, 
+                    packageSource => new HttpSourceResource(HttpSource.Create(source, throttle)));
             }
 
             return Task.FromResult(new Tuple<bool, INuGetResource>(curResource != null, curResource));

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
@@ -7,7 +7,6 @@ namespace NuGet.Protocol
     {
         NotFound,
         NoContent,
-        OpenedFromDisk,
-        OpenedFromNetwork
+        OpenedFromDisk
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IThrottle.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/IThrottle.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// An interface used for throttling operations. For example, suppose the application needs to
+    /// limit the concurrency of HTTP operations. Before executing each HTTP operation, the
+    /// <see cref="WaitAsync"/> would be executed. After the HTTP operation has been completed, the
+    /// application should call <see cref="Release"/>. The implementation of <see cref="WaitAsync"/>
+    /// should only allow the application to continue if there is an appropriate number of concurrent
+    /// callers. The primary implementation of this interface simply wraps a <see cref="SemaphoreSlim"/>.
+    /// </summary>
+    public interface IThrottle
+    {
+        /// <summary>
+        /// Waits until an appropriate level of concurrency has been reached before allowing the
+        /// caller to continue.
+        /// </summary>
+        Task WaitAsync();
+
+        /// <summary>
+        /// Signals that the throttled operation has been completed and other threads can being
+        /// their own throttled operation.
+        /// </summary>
+        void Release();
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/NullThrottle.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/NullThrottle.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// An throttle implementation that allows any level of concurrency. That is, the
+    /// <see cref="WaitAsync"/> and <see cref="Release"/> methods do nothing.
+    /// </summary>
+    public class NullThrottle : IThrottle
+    {
+        private static readonly Task _completedTask = Task.FromResult(true);
+        private static readonly NullThrottle _instance = new NullThrottle();
+
+        public static NullThrottle Instance
+        {
+            get
+            {
+                return _instance;
+            }
+        }
+
+        public Task WaitAsync()
+        {
+            return _completedTask;
+        }
+
+        public void Release()
+        {
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/SemaphoreSlimThrottle.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/SemaphoreSlimThrottle.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public class SemaphoreSlimThrottle : IThrottle
+    {
+        private readonly SemaphoreSlim _semaphore;
+
+        public SemaphoreSlimThrottle(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public async Task WaitAsync()
+        {
+            await _semaphore.WaitAsync();
+        }
+
+        public void Release()
+        {
+            _semaphore.Release();
+        }
+
+        public static SemaphoreSlimThrottle CreateBinarySemaphore()
+        {
+            return new SemaphoreSlimThrottle(new SemaphoreSlim(1));
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -77,9 +77,8 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             return await _httpSource.ProcessStreamAsync(
-                   uri: apiEndpointUri,
-                   ignoreNotFounds: false,
-                   processAsync: stream =>
+                   new HttpSourceRequest(apiEndpointUri, logger),
+                   stream =>
                    {
                        using (var reader = new StreamReader(stream))
                        using (var jsonReader = new JsonTextReader(reader))
@@ -89,8 +88,8 @@ namespace NuGet.Protocol
                            return Task.FromResult(json);
                        }
                    },
-                   log: logger,
-                   token: token);
+                   logger,
+                   token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -101,7 +101,7 @@ namespace NuGet.Protocol
             try
             {
                 lastRequestUri = await client.ProcessResponseAsync(
-                    () => HttpRequestMessageFactory.Create(HttpMethod.Get, url, log),
+                    new HttpSourceRequest(() => HttpRequestMessageFactory.Create(HttpMethod.Get, url, log)),
                     response =>
                     {
                         if (response.RequestMessage == null)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -432,20 +432,20 @@ namespace NuGet.Protocol
             CancellationToken token)
         {
             return await _httpSource.ProcessResponseAsync(
-                () =>
-                {
-                    var request = HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log);
-                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
-                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
-                    return request;
-                },
+                new HttpSourceRequest(
+                    () =>
+                    {
+                        var request = HttpRequestMessageFactory.Create(HttpMethod.Get, uri, log);
+                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
+                        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml"));
+                        return request;
+                    }),
                 async response =>
                 {
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
                         var networkStream = await response.Content.ReadAsStreamAsync();
-                        var timeoutStream = new DownloadTimeoutStream(uri, networkStream, _httpSource.DownloadTimeout);
-                        return LoadXml(timeoutStream);
+                        return LoadXml(networkStream);
                     }
                     else if (ignoreNotFounds && response.StatusCode == HttpStatusCode.NotFound)
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ServiceIndexResourceV3Provider.cs
@@ -120,13 +120,15 @@ namespace NuGet.Protocol
                 try
                 {
                     using (var sourceResponse = await client.GetAsync(
-                        url,
-                        "service_index",
-                        cacheContext,
+                        new HttpSourceCachedRequest(
+                            url,
+                            "service_index",
+                            cacheContext)
+                        {
+                            EnsureValidContents = stream => HttpStreamValidation.ValidateJObject(url, stream)
+                        },
                         log,
-                        ignoreNotFounds: false,
-                        ensureValidContents: stream => HttpStreamValidation.ValidateJObject(url, stream),
-                        cancellationToken: token))
+                        token))
                     {
                         return ConsumeServiceIndexStream(sourceResponse.Stream, utcNow);
                     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -175,13 +175,15 @@ namespace NuGet.Protocol
                 try
                 {
                     using (var data = await _httpSource.GetAsync(
-                        package.ContentUri,
-                        "nupkg_" + package.Identity.Id + "." + package.Identity.Version.ToNormalizedString(),
-                        CreateCacheContext(retry),
+                        new HttpSourceCachedRequest(
+                            package.ContentUri,
+                            "nupkg_" + package.Identity.Id + "." + package.Identity.Version.ToNormalizedString(),
+                            CreateCacheContext(retry))
+                        {
+                            EnsureValidContents = stream => HttpStreamValidation.ValidateNupkg(package.ContentUri, stream)
+                        },
                         Logger,
-                        ignoreNotFounds: false,
-                        ensureValidContents: stream => HttpStreamValidation.ValidateNupkg(package.ContentUri, stream),
-                        cancellationToken: cancellationToken))
+                        cancellationToken))
                     {
                         return new NupkgEntry
                         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
@@ -50,10 +50,9 @@ namespace NuGet.Protocol
 
             var queryUri = queryUrl.Uri;
             var results = await _client.GetJObjectAsync(
-                uri: queryUri,
-                ignoreNotFounds: false,
-                log: Common.NullLogger.Instance,
-                token: token);
+                new HttpSourceRequest(queryUri, Common.NullLogger.Instance),
+                Common.NullLogger.Instance,
+                token);
             token.ThrowIfCancellationRequested();
             if (results == null)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
@@ -82,10 +82,9 @@ namespace NuGet.Protocol
                     try
                     {
                         searchJson = await _client.GetJObjectAsync(
-                            uri: queryUrl.Uri,
-                            ignoreNotFounds: false,
-                            log: log,
-                            token: cancellationToken);
+                            new HttpSourceRequest(queryUrl.Uri, log),
+                            log,
+                            cancellationToken);
                     }
                     catch when (i < _searchEndpoints.Length - 1)
                     {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/DownloadTimeoutStream.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Protocol;
 
 namespace NuGet.Protocol
 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
@@ -40,9 +40,11 @@ namespace NuGet.Protocol
                 try
                 {
                     return await client.ProcessStreamAsync(
-                        uri: uri,
-                        ignoreNotFounds: true,
-                        processAsync: async packageStream =>
+                        new HttpSourceRequest(uri, logger)
+                        {
+                            IgnoreNotFounds = true
+                        },
+                        async packageStream =>
                         {
                             if (packageStream == null)
                             {
@@ -56,8 +58,8 @@ namespace NuGet.Protocol
                                 logger,
                                 token);
                         },
-                        log: logger,
-                        token: token);
+                        logger,
+                        token);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -21,14 +21,16 @@ namespace Test.Utility
             source,
             () => Task.FromResult<HttpHandlerResource>(
                     new TestHttpHandler(
-                        new TestMessageHandler(responses, errorContent))))
+                        new TestMessageHandler(responses, errorContent))),
+            NullThrottle.Instance)
         {
         }
 
         public TestHttpSource(PackageSource source, Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>> responses) : base(
             source,
             () => Task.FromResult<HttpHandlerResource>(
-                    new TestHttpHandler(new TestMessageHandler(responses))))
+                    new TestHttpHandler(new TestMessageHandler(responses))),
+            NullThrottle.Instance)
         {
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NetworkCallCountTest.cs
@@ -568,8 +568,7 @@ namespace NuGet.CommandLine.Test
                     "restore",
                     slnPath,
                     "-Verbosity",
-                    "detailed",
-                    "-DisableParallelProcessing"
+                    "detailed"
                 };
 
                 var task = Task.Run(() =>
@@ -660,8 +659,7 @@ namespace NuGet.CommandLine.Test
                     "restore",
                     slnPath,
                     "-Verbosity",
-                    "detailed",
-                    "-DisableParallelProcessing"
+                    "detailed"
                 };
 
                 var task = Task.Run(() =>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/SemaphoreSlimThrottleTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/SemaphoreSlimThrottleTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class SemaphoreSlimThrottleTests
+    {
+        [Fact]
+        public async Task SemaphoreSlimThrottle_RespectsInnerSemaphore()
+        {
+            // Arrange
+            var semaphoreSlim = new SemaphoreSlim(2);
+            var target = new SemaphoreSlimThrottle(semaphoreSlim);
+
+            // Act
+            await target.WaitAsync();
+            var countA = semaphoreSlim.CurrentCount;
+            await target.WaitAsync();
+            var countB = semaphoreSlim.CurrentCount;
+            target.Release();
+            var countC = semaphoreSlim.CurrentCount;
+            target.Release();
+            var countD = semaphoreSlim.CurrentCount;
+
+            // Assert
+            Assert.Equal(1, countA);
+            Assert.Equal(0, countB);
+            Assert.Equal(1, countC);
+            Assert.Equal(2, countD);
+        }
+
+        [Fact]
+        public async Task SemaphoreSlimThrottle_CreateBinarySemaphore_HasInitialCountOfOne()
+        {
+            // Arrange
+            var target = SemaphoreSlimThrottle.CreateBinarySemaphore();
+            await target.WaitAsync();
+
+            // Act
+            var task = Task.Run(target.WaitAsync);
+            var acquiredBeforeRelease = task.Wait(TimeSpan.FromMilliseconds(10));
+            target.Release();
+            var acquiredAfterRelease = task.Wait(TimeSpan.FromSeconds(10));
+
+            // Assert
+            Assert.False(acquiredBeforeRelease, "The binary semaphore should only allow a count of one.");
+            Assert.True(acquiredAfterRelease, "The binary semaphore should have released back to a count of one.");
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/DownloadTimeoutStreamTests.cs
@@ -18,7 +18,10 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange & Act & Assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
-                new DownloadTimeoutStream(null, new MemoryStream(), TimeSpan.Zero));
+                new DownloadTimeoutStream(
+                    downloadName: null,
+                    networkStream: new MemoryStream(),
+                    timeout: TimeSpan.Zero));
             Assert.Equal("downloadName", exception.ParamName);
         }
         
@@ -27,7 +30,11 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange & Act & Assert
             var exception = Assert.Throws<ArgumentNullException>(() =>
-                new DownloadTimeoutStream("downloadName", null, TimeSpan.Zero));
+                new DownloadTimeoutStream(
+                    downloadName: "downloadName",
+                    networkStream: null,
+                    timeout: TimeSpan.Zero));
+
             Assert.Equal("networkStream", exception.ParamName);
         }
         
@@ -90,7 +97,10 @@ namespace NuGet.Protocol.Tests
             {
                 OnRead = (buffer, offset, count) => { throw expected; } 
             };
-            var timeoutStream = new DownloadTimeoutStream("download", slowStream, TimeSpan.FromSeconds(1));
+            var timeoutStream = new DownloadTimeoutStream(
+                "download",
+                slowStream,
+                TimeSpan.FromSeconds(1));
             
             // Act & Assert
             var actual = await Assert.ThrowsAsync<IOException>(() =>


### PR DESCRIPTION
1. Add an `IThrottle` mechanism to `HttpSource` which, if provided, limits the concurrency of HTTP. This can eventually be used for arbitrary degree of concurrency.
2. Clean up the `HttpSource` methods by adding `HttpSourceRequest` and `HttpSourceCachedRequest`. As we add parameters to `HttpSource` we can keep the method signatures small and just add properties to these new request types.
3. Move `DownloadTimeoutStream` injection down to `HttpRetryHandler` so higher levels don't need to duplicate initialization.

Provides a workaround for suspected contention issues in https://github.com/NuGet/Home/issues/2945.

@emgarten @alpaix @yishaigalatzer 
