### PR TITLE
Init.ps1 optimizations

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -36,6 +36,7 @@ namespace NuGet.PackageManagement
     public class NuGetPackageManager
     {
         private IReadOnlyList<SourceRepository> _globalPackageFolderRepositories;
+
         private ISourceRepositoryProvider SourceRepositoryProvider { get; }
 
         private ISolutionManager SolutionManager { get; }
@@ -173,12 +174,15 @@ namespace NuGet.PackageManagement
 
         private void InitializePackagesFolderInfo(string packagesFolderPath, bool excludeVersion = false)
         {
+            // FileSystemPackagesConfig supports id.version formats, if the version is excluded use the normal v2 format
+            var feedType = excludeVersion ? FeedType.FileSystemV2 : FeedType.FileSystemPackagesConfig;
+
             PackagesFolderNuGetProject = new FolderNuGetProject(packagesFolderPath, excludeVersion);
             // Capturing it locally is important since it allows for the instance to cache packages for the lifetime
             // of the closure \ NuGetPackageManager.
             PackagesFolderSourceRepository = SourceRepositoryProvider.CreateRepository(
                 new PackageSource(packagesFolderPath),
-                FeedType.FileSystemV2);
+                feedType);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -10,8 +10,9 @@ namespace NuGet.Packaging
 {
     public class PackagePathResolver
     {
-        private readonly bool _useSideBySidePaths;
         private readonly string _rootDirectory;
+
+        public bool UseSideBySidePaths { get; }
 
         public PackagePathResolver(string rootDirectory, bool useSideBySidePaths = true)
         {
@@ -22,7 +23,7 @@ namespace NuGet.Packaging
                     nameof(rootDirectory));
             }
             _rootDirectory = rootDirectory;
-            _useSideBySidePaths = useSideBySidePaths;
+            UseSideBySidePaths = useSideBySidePaths;
         }
 
         protected internal string Root
@@ -74,7 +75,7 @@ namespace NuGet.Packaging
 
             builder.Append(packageIdentity.Id.ToLowerInvariant());
 
-            if (_useSideBySidePaths)
+            if (UseSideBySidePaths)
             {
                 builder.Append('.');
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/FeedType.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/FeedType.cs
@@ -33,9 +33,14 @@
         FileSystemUnzipped = 1 << 4,
 
         /// <summary>
+        /// Packages.config packages folder format
+        /// </summary>
+        FileSystemPackagesConfig = 1 << 5,
+
+        /// <summary>
         /// Undetermined folder type. Occurs when the folder is empty
         /// or does not exist yet.
         /// </summary>
-        FileSystemUnknown = 1 << 5
+        FileSystemUnknown = 1 << 10
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/FactoryExtensionsV3.cs
@@ -60,6 +60,7 @@ namespace NuGet.Protocol
             yield return new Lazy<INuGetResourceProvider>(() => new FindLocalPackagesResourceUnzippedProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new FindLocalPackagesResourceV2Provider());
             yield return new Lazy<INuGetResourceProvider>(() => new FindLocalPackagesResourceV3Provider());
+            yield return new Lazy<INuGetResourceProvider>(() => new FindLocalPackagesResourcePackagesConfigProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new LocalAutoCompleteResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new LocalDependencyInfoResourceProvider());
             yield return new Lazy<INuGetResourceProvider>(() => new LocalDownloadResourceProvider());

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourcePackagesConfig.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourcePackagesConfig.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// Packages.config packages folder reader
+    /// </summary>
+    public class FindLocalPackagesResourcePackagesConfig : FindLocalPackagesResource
+    {
+        public FindLocalPackagesResourcePackagesConfig(string root)
+        {
+            Root = root;
+        }
+
+        public override IEnumerable<LocalPackageInfo> FindPackagesById(string id, ILogger logger, CancellationToken token)
+        {
+            var packages = LocalFolderUtility.GetPackagesConfigFolderPackages(Root, id, logger);
+
+            // Filter out any duplicates that may appear in the folder multiple times.
+            return LocalFolderUtility.GetDistinctPackages(packages);
+        }
+
+        public override LocalPackageInfo GetPackage(Uri path, ILogger logger, CancellationToken token)
+        {
+            return LocalFolderUtility.GetPackage(path, logger);
+        }
+
+        public override LocalPackageInfo GetPackage(PackageIdentity identity, ILogger logger, CancellationToken token)
+        {
+            return LocalFolderUtility.GetPackagesConfigFolderPackage(Root, identity, logger);
+        }
+
+        public override IEnumerable<LocalPackageInfo> GetPackages(ILogger logger, CancellationToken token)
+        {
+            var packages = LocalFolderUtility.GetPackagesConfigFolderPackages(Root, logger);
+
+            // Filter out any duplicates that may appear in the folder multiple times.
+            return LocalFolderUtility.GetDistinctPackages(packages);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourcePackagesConfigProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourcePackagesConfigProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    public class FindLocalPackagesResourcePackagesConfigProvider : ResourceProvider
+    {
+        public FindLocalPackagesResourcePackagesConfigProvider()
+            : base(typeof(FindLocalPackagesResource), nameof(FindLocalPackagesResourcePackagesConfigProvider), NuGetResourceProviderPositions.Last)
+        {
+        }
+
+        public override async Task<Tuple<bool, INuGetResource>> TryCreate(SourceRepository source, CancellationToken token)
+        {
+            FindLocalPackagesResource curResource = null;
+            var feedType = await source.GetFeedType(token);
+
+            if (feedType == FeedType.FileSystemPackagesConfig)
+            {
+                curResource = new FindLocalPackagesResourcePackagesConfig(source.PackageSource.Source);
+            }
+
+            return new Tuple<bool, INuGetResource>(curResource != null, curResource);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestPackageUtility.cs
@@ -344,6 +344,46 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
+        /// Create a packagets.config folder of nupkgs
+        /// </summary>
+        public static void CreateFolderFeedPackagesConfig(string root, params PackageIdentity[] packages)
+        {
+            var contexts = packages.Select(p => new SimpleTestPackageContext(p)).ToArray();
+
+            CreateFolderFeedPackagesConfig(root, contexts);
+        }
+
+        /// <summary>
+        /// Create a packagets.config folder of nupkgs
+        /// </summary>
+        public static void CreateFolderFeedPackagesConfig(string root, params SimpleTestPackageContext[] contexts)
+        {
+            using (var tempRoot = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                CreatePackages(tempRoot, contexts);
+
+                CreateFolderFeedPackagesConfig(root, Directory.GetFiles(tempRoot));
+            }
+        }
+
+        /// <summary>
+        /// Create a packagets.config folder of nupkgs
+        /// </summary>
+        public static void CreateFolderFeedPackagesConfig(string root, params string[] nupkgPaths)
+        {
+            var resolver = new PackagePathResolver(root);
+            var context = new PackageExtractionContext(NullLogger.Instance);
+
+            foreach (var path in nupkgPaths)
+            {
+                using (var stream = File.OpenRead(path))
+                {
+                    PackageExtractor.ExtractPackage(stream, resolver, context, CancellationToken.None);
+                }
+            }
+        }
+
+        /// <summary>
         /// Create packages with PackageBuilder, this includes OPC support.
         /// </summary>
         public static void CreateOPCPackage(SimpleTestPackageContext package, string repositoryPath)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -175,7 +175,11 @@ namespace NuGet.CommandLine.Test
                 string[] args2 = new string[]
                 {
                     "install",
-                    packagesConfig
+                    packagesConfig,
+                    "-OutputDirectory",
+                    "outputDir",
+                    "-Source",
+                    repositoryPath
                 };
 
                 var r1 = CommandRunner.Run(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
@@ -37,17 +37,19 @@ namespace NuGet.Protocol.Core.v3.Tests
         [Fact]
         public async Task FindLocalPackagesResource_GetPackagesBasic()
         {
+            using (var rootPackagesConfig = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootUnzip = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV3 = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV2 = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var testLogger = new TestLogger();
-                await CreateFeeds(rootV2, rootV3, rootUnzip, PackageSet1);
+                await CreateFeeds(rootV2, rootV3, rootUnzip, rootPackagesConfig, PackageSet1);
                 var expected = new HashSet<PackageIdentity>(PackageSet1);
 
                 var resources = new FindLocalPackagesResource[]
                 {
+                    new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
                     new FindLocalPackagesResourceV3(rootV3)
@@ -78,6 +80,8 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 var resources = new FindLocalPackagesResource[]
                 {
+                    new FindLocalPackagesResourcePackagesConfig(doesNotExist),
+                    new FindLocalPackagesResourcePackagesConfig(emptyDir),
                     new FindLocalPackagesResourceUnzipped(doesNotExist),
                     new FindLocalPackagesResourceV2(doesNotExist),
                     new FindLocalPackagesResourceV3(doesNotExist),
@@ -104,13 +108,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         [Fact]
         public async Task FindLocalPackagesResource_FindPackagesByIdBasic()
         {
+            using (var rootPackagesConfig = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootUnzip = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV3 = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV2 = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var testLogger = new TestLogger();
-                await CreateFeeds(rootV2, rootV3, rootUnzip, PackageSet1);
+                await CreateFeeds(rootV2, rootV3, rootUnzip, rootPackagesConfig, PackageSet1);
                 var expected = new HashSet<PackageIdentity>(new[] 
                 {
                     PackageA1,
@@ -122,6 +127,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 var resources = new FindLocalPackagesResource[]
                 {
+                    new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
                     new FindLocalPackagesResourceV3(rootV3)
@@ -144,13 +150,14 @@ namespace NuGet.Protocol.Core.v3.Tests
         [Fact]
         public async Task FindLocalPackagesResource_GetPackageBasic()
         {
+            using (var rootPackagesConfig = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootUnzip = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV3 = TestFileSystemUtility.CreateRandomTestFolder())
             using (var rootV2 = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var testLogger = new TestLogger();
-                await CreateFeeds(rootV2, rootV3, rootUnzip, PackageSet1);
+                await CreateFeeds(rootV2, rootV3, rootUnzip, rootPackagesConfig, PackageSet1);
                 var expected = new HashSet<PackageIdentity>(new[]
                 {
                     PackageA1,
@@ -162,6 +169,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 var resources = new FindLocalPackagesResource[]
                 {
+                    new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
                     new FindLocalPackagesResourceV3(rootV3)
@@ -180,13 +188,14 @@ namespace NuGet.Protocol.Core.v3.Tests
             }
         }
 
-        private async Task CreateFeeds(string rootV2, string rootV3, string rootUnzip, params PackageIdentity[] packages)
+        private async Task CreateFeeds(string rootV2, string rootV3, string rootUnzip, string rootPackagesConfig, params PackageIdentity[] packages)
         {
             foreach (var package in packages)
             {
                 SimpleTestPackageUtility.CreateFolderFeedV2(rootV2, package);
                 await SimpleTestPackageUtility.CreateFolderFeedV3(rootV3, package);
                 SimpleTestPackageUtility.CreateFolderFeedUnzip(rootUnzip, package);
+                SimpleTestPackageUtility.CreateFolderFeedPackagesConfig(rootPackagesConfig, package);
             }
         }
     }


### PR DESCRIPTION
This fix adds a packages.config packages folder reader that matches the SharedPackageRepository from nuget.core.dll. Previously the packages folder was treated as a v2 folder which meant scanning for a package was done on every sub folder. The new reader narrows searches down to just the possible folders it could reside in, and attempts the expected path first.

The primary fix here is to reduce the amount of work done when the powershell console opens and when a solution is opened. Packages will now have their dependencies resolved once instead of for each project. Previously packages would be read for each project regardless of it had already been done.

Perf results: For a solution with 10 projects and the same 500 packages in each of their packages.config files. 
Current dev branch: 132 seconds
With this fix: 10 seconds

https://github.com/NuGet/Home/issues/2956

//cc @zhili1208 @rrelyea @joelverhagen @jainaashish @drewgil @rohit21agrawal 
