### PR TITLE
Fix currently broken end-to-end tests

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/FindPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/FindPackageCommand.cs
@@ -103,7 +103,8 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         private void FindPackagesByPSSearchService()
         {
-            var remotePackages = GetPackagesFromRemoteSource(Id, IncludePrerelease.IsPresent);
+            var errors = new List<string>();
+            var remotePackages = GetPackagesFromRemoteSource(Id, IncludePrerelease.IsPresent, errors.Add);
 
             if (ExactMatch.IsPresent)
             {
@@ -133,6 +134,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             if (view.Any())
             {
                 WriteObject(view, enumerateCollection: true);
+            }
+
+            foreach (var error in errors)
+            {
+                LogCore(ProjectManagement.MessageLevel.Error, error);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following source failed to search for packages: &apos;{0}&apos;{1}{2}.
+        /// </summary>
+        internal static string Cmdlet_FailedToSearchSource {
+            get {
+                return ResourceManager.GetString("Cmdlet_FailedToSearchSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to parse package identities from file {0} with exception: {1}.
         /// </summary>
         internal static string Cmdlet_FailToParsePackages {

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
@@ -252,4 +252,10 @@
   <data name="Cmdlet_TotalTime" xml:space="preserve">
     <value>Time Elapsed: {0}</value>
   </data>
+  <data name="Cmdlet_FailedToSearchSource" xml:space="preserve">
+    <value>The following source failed to search for packages: '{0}'{1}{2}</value>
+    <comment>{0} is the source that failed.
+{1} is a line separator.
+{2} is the exception message.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/MultiSourcePackageFeed.cs
@@ -151,12 +151,24 @@ namespace NuGet.PackageManagement.UI
 
             if (notCompleted.Any())
             {
-                var items = notCompleted
-                        .ToDictionary(kv => kv.Key, kv => GetLoadingStatus(kv.Value.Status));
+                var statuses = notCompleted.ToDictionary(
+                    kv => kv.Key,
+                    kv => GetLoadingStatus(kv.Value.Status));
 
-                foreach (var item in items)
+                foreach (var item in statuses)
                 {
                     aggregated.SourceSearchStatus.Add(item);
+                }
+
+                var exceptions = notCompleted
+                    .Where(kv => kv.Value.Exception != null)
+                    .ToDictionary(
+                        kv => kv.Key,
+                        kv => (Exception) kv.Value.Exception);
+
+                foreach (var item in exceptions)
+                {
+                    aggregated.SourceSearchException.Add(item);
                 }
             }
 

--- a/src/NuGet.Clients/PackageManagement.UI/Models/SearchResult.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/SearchResult.cs
@@ -39,7 +39,9 @@ namespace NuGet.PackageManagement.UI
 
         IEnumerator IEnumerable.GetEnumerator() => Items.GetEnumerator();
 
-        public IDictionary<string, LoadingStatus> SourceSearchStatus { get; set; }
+        public IDictionary<string, LoadingStatus> SourceSearchStatus { get; set; } = new Dictionary<string, LoadingStatus>();
+
+        public IDictionary<string, Exception> SourceSearchException { get; set; } = new Dictionary<string, Exception>();
 
         // total number of unmerged items found
         public int RawItemsCount { get; set; }
@@ -64,8 +66,7 @@ namespace NuGet.PackageManagement.UI
 
         public static SearchResult<T> Empty<T>() => new SearchResult<T>
         {
-            Items = new T[] { },
-            SourceSearchStatus = new Dictionary<string, LoadingStatus> { }
+            Items = new T[] { }
         };
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalPackageSearchResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalPackageSearchResource.cs
@@ -143,7 +143,7 @@ namespace NuGet.Protocol
 
         private static bool IsLocalOrUNC(string currentSource)
         {
-            Uri currentURI = UriUtility.TryCreateSourceUri(currentSource, UriKind.RelativeOrAbsolute);
+            Uri currentURI = UriUtility.TryCreateSourceUri(currentSource, UriKind.Absolute);
             if (currentURI != null)
             {
                 if (currentURI.IsFile || currentURI.IsUnc)

--- a/test/EndToEnd/tests/GetPackageTest.ps1
+++ b/test/EndToEnd/tests/GetPackageTest.ps1
@@ -13,7 +13,7 @@ function Test-GetPackageListsInstalledPackages {
 
     # Act
     Install-Package elmah -Project $p.Name -Version 1.1
-    Install-Package jQuery -Project $p.Name
+    Install-Package jQuery -Project $p.Name -Version 2.2.4
     $packages = Get-Package
 
     # Assert
@@ -119,7 +119,7 @@ function Test-GetPackageAcceptsRelativePathSource2 {
 
 function Test-GetPackageThrowsWhenSourceIsInvalid {
     # Act & Assert
-    Assert-Throws { Get-Package -ListAvailable -source "d:package" } "Invalid URI: A Dos path must be rooted, for example, 'c:\'."
+    Assert-Throws { Get-Package -ListAvailable -source "d:package" } "The following source failed to search for packages: 'd:package'`r`nThe path 'd:package' for the selected source could not be resolved."
 }
 
 function Test-GetPackageForProjectReturnsEmptyProjectIfItHasNoInstalledPackage {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/FeedTypeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/FeedTypeUtilityTests.cs
@@ -46,6 +46,19 @@ namespace NuGet.Protocol.Core.v3.Tests
             Assert.Equal(FeedType.FileSystemUnknown, type);
         }
 
+        [Theory]
+        [InlineData("../foo/packages")]
+        [InlineData(@"..\foo\packages")]
+        [InlineData(@"packages")]
+        public void FeedTypeUtility_VerifyRelativePathIsUnknown(string source)
+        {
+            // Arrange & Act
+            var type = FeedTypeUtility.GetFeedType(new PackageSource(source));
+
+            // Assert
+            Assert.Equal(FeedType.FileSystemUnknown, type);
+        }
+
         [Fact]
         public void FeedTypeUtility_VerifyBadSourceIsUnknown2()
         {


### PR DESCRIPTION
1. Log errors encountered during `Get-Package` and `Find-Package` PMC commands
2. Re-enable support for relative sources in PMC commands
3. Fix currently broken end-to-end tests
   - `GetPackageListsInstalledPackages`
   - `GetPackageAcceptsRelativePathSource`
   - `GetPackageAcceptsRelativePathSource2`
   - `GetPackageThrowsWhenSourceIsInvalid`

Fixes https://github.com/NuGet/Home/issues/2999.

@alpaix @emgarten @zhili1208 @rohit21agrawal @jainaashish 
