### PR TITLE
Fixing pack error "value cannot be null" when no sln file exists

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -926,7 +926,15 @@ namespace NuGet.CommandLine
             var references = packagesProject.GetInstalledPackagesAsync(CancellationToken.None).Result;
 
             var solutionDir = GetSolutionDir();
-            var packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDir, ReadSettings(solutionDir));
+            string packagesFolderPath;
+            if (solutionDir == null)
+            {
+                packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(_project.DirectoryPath, ReadSettings(_project.DirectoryPath));
+            }
+            else
+            {
+                packagesFolderPath = PackagesFolderPathUtility.GetPackagesFolderPath(solutionDir, ReadSettings(solutionDir));
+            }
             var sourceRepository = Repository.Factory.GetCoreV3(packagesFolderPath).GetResource<FindPackageByIdResource>();
 
             // Collect all packages


### PR DESCRIPTION
The check for the location of the packages folder using the solution folder fails if no sln file exists.  The code now uses the project folder in the call to determine the packages folder in that case.

@joelverhagen @emgarten @spadapet 
