### PR TITLE
LockFile.Equals fix for version 1 format

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -770,8 +770,8 @@ namespace NuGet.Commands
             }
 
             // Remove tools
-            lockFile.Tools = null;
-            lockFile.ProjectFileToolGroups = null;
+            lockFile.Tools.Clear();
+            lockFile.ProjectFileToolGroups.Clear();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -184,15 +184,19 @@ namespace NuGet.ProjectModel
             json[TargetsProperty] = WriteObject(lockFile.Targets, WriteTarget);
             json[LibrariesProperty] = WriteObject(lockFile.Libraries, WriteLibrary);
             json[ProjectFileDependencyGroupsProperty] = WriteObject(lockFile.ProjectFileDependencyGroups, WriteProjectFileDependencyGroup);
-            
-            if (lockFile.Tools != null)
+
+            // Avoid writing out the tools section for v1 lock files
+            if (lockFile.Version >= 2)
             {
-                json[ToolsProperty] = WriteObject(lockFile.Tools, WriteTarget);
-            }
-            
-            if (lockFile.ProjectFileToolGroups != null)
-            {
-                json[ProjectFileToolGroupsProperty] = WriteObject(lockFile.ProjectFileToolGroups, WriteProjectFileDependencyGroup);
+                if (lockFile.Tools != null)
+                {
+                    json[ToolsProperty] = WriteObject(lockFile.Tools, WriteTarget);
+                }
+
+                if (lockFile.ProjectFileToolGroups != null)
+                {
+                    json[ProjectFileToolGroupsProperty] = WriteObject(lockFile.ProjectFileToolGroups, WriteProjectFileDependencyGroup);
+                }
             }
 
             if (lockFile.PackageFolders?.Any() == true)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
@@ -912,6 +912,9 @@ namespace NuGet.Commands.Test
                 Assert.True(result.Success);
                 Assert.Equal(0, lockFile.Libraries.Count);
                 Assert.Equal(0, lockFile.Targets[0].Libraries.Count);
+
+                // Verify round tripping for v1 with p2ps
+                Assert.Equal(result.LockFile, lockFile);
             }
         }
     }


### PR DESCRIPTION
This is a small change to skip writing the tool sections of the lock file by looking at the version instead of by nulling out the values.

Null was used before to avoid writing the json property out, but that causes issues with LockFile.Equals since files read in default to an empty list instead of null for safety. During the equals compare null != empty list, so the file is written to disk. This fix seems like the safest way to make up for this until we drop the v1 format.

https://github.com/NuGet/Home/issues/2817

//cc @joelverhagen @zhili1208 @alpaix 
