### PR TITLE
Add basic push tests in NuGet.XPlat.FuncTest

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -43,7 +43,22 @@ namespace NuGet.Commands
 
         public static async Task<PackageUpdateResource> GetPackageUpdateResource(IPackageSourceProvider sourceProvider, string source)
         {
-            var packageSource = new PackageSource(source);
+            // Use a loaded PackageSource if possible since it contains credential info
+            PackageSource packageSource = null;
+            foreach (var loadedPackageSource in sourceProvider.LoadPackageSources())
+            {
+                if (loadedPackageSource.IsEnabled && source == loadedPackageSource.Source)
+                {
+                    packageSource = loadedPackageSource;
+                    break;
+                }
+            }
+
+            if (packageSource == null)
+            {
+                packageSource = new PackageSource(source);
+            }
+
             var sourceRepositoryProvider = new CachingSourceProvider(sourceProvider);
             var sourceRepository = sourceRepositoryProvider.CreateRepository(packageSource);
 

--- a/src/NuGet.Core/NuGet.Test.Utility/TestFileSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TestFileSystemUtility.cs
@@ -58,5 +58,26 @@ namespace NuGet.Test.Utility
                 throw new InvalidOperationException("Trying to delete the root test folder in a test");
             }
         }
+
+        private class ResetDirectory : IDisposable
+        {
+            public string OldPath { get; set; }
+
+            void IDisposable.Dispose()
+            {
+                Directory.SetCurrentDirectory(OldPath);
+            }
+        }
+
+        public static IDisposable SetCurrentDirectory(string path)
+        {
+            string oldPath = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(path);
+
+            return new ResetDirectory()
+            {
+                OldPath = oldPath
+            };
+        }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatPushTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NuGet.CommandLine.XPlat;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XPlatPushTests
+    {
+        [Theory]
+        [InlineData(TestServers.MyGet, nameof(TestServers.MyGet), false)]
+        [InlineData(TestServers.ProGet, nameof(TestServers.ProGet), false)]
+        [InlineData(TestServers.Nexus, nameof(TestServers.Nexus), true)]
+        // [InlineData(TestServers.Klondike, nameof(TestServers.Klondike), false)] // 500 Internal Server Error pushing
+        // [InlineData(TestServers.NuGetServer, nameof(TestServers.NuGetServer), false)] // 500 - missing manifest?
+        public async Task PushToServerSucceeds(string sourceUri, string feedName, bool mustDeleteFirst)
+        {
+            // Arrange
+            using (var packageDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (TestFileSystemUtility.SetCurrentDirectory(packageDir))
+            {
+                var packageId = "XPlatPushTests.PushToServerSucceeds";
+                var packageVersion = "1.0.0";
+                var packageFile = await TestPackages.GetRuntimePackageAsync(packageDir, packageId, packageVersion);
+                var configFile = XPlatTestUtils.CopyFuncTestConfig(packageDir);
+                var log = new TestCommandOutputLogger();
+
+                var apiKey = XPlatTestUtils.ReadApiKey(feedName);
+                Assert.False(string.IsNullOrEmpty(apiKey));
+
+                if (mustDeleteFirst)
+                {
+                    DeletePackageBeforePush(packageId, packageVersion, sourceUri, apiKey);
+                }
+
+                var pushArgs = new List<string>()
+                {
+                    "push",
+                    packageFile.FullName,
+                    "--source",
+                    sourceUri,
+                    "--api-key",
+                    apiKey
+                };
+
+                // Act
+                int exitCode = Program.MainInternal(pushArgs.ToArray(), log);
+
+                // Assert
+                Assert.Equal(string.Empty, log.ShowErrors());
+                Assert.Equal(0, exitCode);
+                Assert.Contains($"PUT {sourceUri}", log.ShowMessages());
+                Assert.Contains("Your package was pushed.", log.ShowMessages());
+            }
+        }
+
+        /// <summary>
+        /// This is called when the package must be deleted before being pushed. It's ok if this
+        /// fails, maybe the package was never pushed.
+        /// </summary>
+        private static void DeletePackageBeforePush(string packageId, string packageVersion, string sourceUri, string apiKey)
+        {
+            var packageUri = $"{sourceUri}/{packageId}/{packageVersion}";
+            var log = new TestCommandOutputLogger();
+            var args = new List<string>()
+            {
+                "delete",
+                packageId,
+                packageVersion,
+                "--source",
+                sourceUri,
+                "--api-key",
+                apiKey,
+                "--non-interactive"
+            };
+
+            int exitCode = Program.MainInternal(args.ToArray(), log);
+            Assert.InRange(exitCode, 0, 1);
+
+            Assert.Contains($"DELETE {packageUri}", log.ShowMessages());
+
+            if (exitCode == 0)
+            {
+                Assert.Contains($"OK {packageUri}", log.ShowMessages());
+            }
+            else
+            {
+                Assert.Contains($"NotFound {packageUri}", log.ShowMessages());
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -1,4 +1,6 @@
 ﻿using System.IO;
+using System.Xml;
+using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
@@ -48,7 +50,7 @@ namespace NuGet.XPlat.FuncTest
             using (var sw = new StreamWriter(fs))
             using (var writer = new JsonTextWriter(sw))
             {
-                writer.Formatting = Formatting.Indented;
+                writer.Formatting = Newtonsoft.Json.Formatting.Indented;
 
                 var serializer = new JsonSerializer();
                 serializer.Serialize(writer, json);
@@ -65,6 +67,18 @@ namespace NuGet.XPlat.FuncTest
             var destConfigFile = Path.Combine(destinationFolder, "NuGet.Config");
             File.Copy(sourceConfigFile, destConfigFile);
             return destConfigFile;
+        }
+
+        public static string ReadApiKey(string feedName)
+        {
+            string fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            using (Stream configStream = File.OpenRead(Path.Combine(fullPath, "NuGet.Protocol.FuncTest.config")))
+            {
+                var doc = XDocument.Load(XmlReader.Create(configStream));
+                var element = doc.Root.Element(feedName);
+
+                return element?.Element("ApiKey")?.Value;
+            }
         }
     }
 }


### PR DESCRIPTION
This adds an xplat functional test for pushing to a few of our internal test servers.
The API keys for those servers were added to config files that are already updated on each CI agent.

@alpaix @zhili1208 @emgarten 
