### PR TITLE
Don't show warning about missing API key for local sources (nuget delete command)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -75,7 +75,7 @@ namespace NuGet.Protocol.Core.Types
         {
             var sourceDisplayName = GetSourceDisplayName(_source);
             var apiKey = getApiKey(_source);
-            if (String.IsNullOrEmpty(apiKey))
+            if (string.IsNullOrEmpty(apiKey) && !IsFileSource())
             {
                 log.LogWarning(string.Format(CultureInfo.CurrentCulture,
                     Strings.NoApiKeyFound,


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2625
