### PR TITLE
Add additional registry key to ensure .tt templates are executed without prompting

### DIFF
--- a/scripts/e2etests/SetupFunctionalTests.ps1
+++ b/scripts/e2etests/SetupFunctionalTests.ps1
@@ -14,11 +14,19 @@ function EnableWindowsDeveloperMode()
 
 function DisableTextTemplateSecurityWarning([string]$VSVersion)
 {
-    $textTemplatingSecurityWarningRegistryKey = Join-Path "HKCU:\SOFTWARE\Microsoft\VisualStudio" $VSVersion
-    $textTemplatingSecurityWarningRegistryKey = Join-Path $textTemplatingSecurityWarningRegistryKey `
-    "ApplicationPrivateSettings\Microsoft\VisualStudio\TextTemplating\VSHost\OrchestratorOptionsAutomation"
+    $registryKey = Join-Path "HKCU:\SOFTWARE\Microsoft\VisualStudio" $VSVersion
+    $registryKey = Join-Path $registryKey "ApplicationPrivateSettings\Microsoft\VisualStudio\TextTemplating\VSHost\OrchestratorOptionsAutomation"
 
-    $success = SetRegistryKey $textTemplatingSecurityWarningRegistryKey "ShowWarningDialog" 1*System.Boolean*False
+    $success = SetRegistryKey $registryKey "ShowWarningDialog" 1*System.Boolean*False
+    if (!($success))
+    {
+        exit 1
+    }
+
+    $registryKey = Join-Path "HKCU:\SOFTWARE\Microsoft\VisualStudio" $VSVersion
+    $registryKey = Join-Path $registryKey "DSLTools"
+
+    $success = SetRegistryKey $registryKey "ShowWarningDialog" 1*System.Boolean*False
     if (!($success))
     {
         exit 1


### PR DESCRIPTION
Looks like the registry key for .tt templates in NuGet files is different than the one in `Tools -> Options -> Text Templating -> Show Security Message`.

This is one reason the tests were hanging.

@emgarten @zhili1208 
