### PR TITLE
Add support for "nuget.exe push -SymbolsSource XXX -SymbolsApiKey YYY"

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -17,6 +17,12 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandApiKey")]
         public string ApiKey { get; set; }
 
+        [Option(typeof(NuGetCommand), "PushCommandSymbolSourceDescription")]
+        public string SymbolSource { get; set; }
+
+        [Option(typeof(NuGetCommand), "SymbolApiKey")]
+        public string SymbolApiKey { get; set; }
+
         [Option(typeof(NuGetCommand), "PushCommandTimeoutDescription")]
         public int Timeout { get; set; }
 
@@ -44,6 +50,8 @@ namespace NuGet.CommandLine
                     packagePath,
                     Source,
                     apiKeyValue,
+                    SymbolSource,
+                    SymbolApiKey,
                     Timeout,
                     DisableBuffering,
                     NoSymbols,

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -8871,7 +8871,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If a symbols package exists, it will not be pushed to a symbols server..
+        ///   Looks up a localized string similar to If a symbols package exists, it will not be pushed to a symbol server..
         /// </summary>
         internal static string PushCommandNoSymbolsDescription {
             get {
@@ -9002,6 +9002,15 @@ namespace NuGet.CommandLine {
         internal static string PushCommandSourceDescription_trk {
             get {
                 return ResourceManager.GetString("PushCommandSourceDescription_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org..
+        /// </summary>
+        internal static string PushCommandSymbolSourceDescription {
+            get {
+                return ResourceManager.GetString("PushCommandSymbolSourceDescription", resourceCulture);
             }
         }
         
@@ -13095,6 +13104,15 @@ namespace NuGet.CommandLine {
         internal static string SpecCommandUsageSummary_trk {
             get {
                 return ResourceManager.GetString("SpecCommandUsageSummary_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The API key for the symbol server..
+        /// </summary>
+        internal static string SymbolApiKey {
+            get {
+                return ResourceManager.GetString("SymbolApiKey", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -321,6 +321,9 @@ nuget pack foo.nuspec -Version 2.1.0</value>
     <value>Specifies the server URL. If not specified, nuget.org is used unless DefaultPushSource config value is set in the NuGet config file.</value>
     <comment>Please don't localize "DefaultPushSource"</comment>
   </data>
+  <data name="PushCommandSymbolSourceDescription" xml:space="preserve">
+    <value>Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org.</value>
+  </data>
   <data name="PushCommandTimeoutDescription" xml:space="preserve">
     <value>Specifies the timeout for pushing to a server in seconds. Defaults to 300 seconds (5 minutes).</value>
   </data>
@@ -440,6 +443,9 @@ nuget update -Self</value>
   </data>
   <data name="CommandApiKey" xml:space="preserve">
     <value>The API key for the server.</value>
+  </data>
+  <data name="SymbolApiKey" xml:space="preserve">
+    <value>The API key for the symbol server.</value>
   </data>
   <data name="DefaultConfigDescription" xml:space="preserve">
     <value>NuGet's default configuration is obtained by loading %AppData%\NuGet\NuGet.config, then loading any nuget.config or .nuget\nuget.config starting from root of drive and ending in current directory.</value>
@@ -5243,7 +5249,7 @@ nuget update -Self</value>
     <value>Disable buffering when pushing to an HTTP(S) server to decrease memory usage. Note that when this option is enabled, integrated windows authentication might not work.</value>
   </data>
   <data name="PushCommandNoSymbolsDescription" xml:space="preserve">
-    <value>If a symbols package exists, it will not be pushed to a symbols server.</value>
+    <value>If a symbols package exists, it will not be pushed to a symbol server.</value>
   </data>
   <data name="CommandFallbackSourceDescription" xml:space="preserve">
     <value>A list of package sources to use as fallbacks for this command.</value>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PushCommand.cs
@@ -26,6 +26,11 @@ namespace NuGet.CommandLine.XPlat
                     Strings.Source_Description,
                     CommandOptionType.SingleValue);
 
+                var symbolSource = push.Option(
+                    "-ss|--symbol-source <source>",
+                    Strings.SymbolSource_Description,
+                    CommandOptionType.SingleValue);
+
                 var timeout = push.Option(
                     "-t|--timeout <timeout>",
                     Strings.Push_Timeout_Description,
@@ -34,6 +39,11 @@ namespace NuGet.CommandLine.XPlat
                 var apikey = push.Option(
                     "-k|--api-key <apiKey>",
                     Strings.ApiKey_Description,
+                    CommandOptionType.SingleValue);
+
+                var symbolApiKey = push.Option(
+                    "-sk|--symbol-api-key <apiKey>",
+                    Strings.SymbolApiKey_Description,
                     CommandOptionType.SingleValue);
 
                 var disableBuffering = push.Option(
@@ -61,6 +71,8 @@ namespace NuGet.CommandLine.XPlat
                     string packagePath = arguments.Values[0];
                     string sourcePath = source.Value();
                     string apiKeyValue = apikey.Value();
+                    string symbolSourcePath = symbolSource.Value();
+                    string symbolApiKeyValue = symbolApiKey.Value();
                     bool disableBufferingValue = disableBuffering.HasValue();
                     bool noSymbolsValue = noSymbols.HasValue();
                     int timeoutSeconds = 0;
@@ -80,6 +92,8 @@ namespace NuGet.CommandLine.XPlat
                             packagePath,
                             sourcePath,
                             apiKeyValue,
+                            symbolSourcePath,
+                            symbolApiKeyValue,
                             timeoutSeconds,
                             disableBufferingValue,
                             noSymbolsValue,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -591,11 +591,29 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The API key for the symbol server..
+        /// </summary>
+        public static string SymbolApiKey_Description {
+            get {
+                return ResourceManager.GetString("SymbolApiKey_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Determines if a package containing sources and symbols should be created. When specified with a nuspec, creates a regular NuGet package file and the corresponding symbols package..
         /// </summary>
         public static string Symbols_Description {
             get {
                 return ResourceManager.GetString("Symbols_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org..
+        /// </summary>
+        public static string SymbolSource_Description {
+            get {
+                return ResourceManager.GetString("SymbolSource_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -305,4 +305,10 @@
   <data name="Serviceable_Description" xml:space="preserve">
     <value>Sets the nuspec serviceable element to true.</value>
   </data>
+  <data name="SymbolSource_Description" xml:space="preserve">
+    <value>Specifies the symbol server URL. If not specified, nuget.smbsrc.net is used when pushing to nuget.org.</value>
+  </data>
+  <data name="SymbolApiKey_Description" xml:space="preserve">
+    <value>The API key for the symbol server.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/CommandRunnerUtility.cs
@@ -31,6 +31,16 @@ namespace NuGet.Commands
             return source;
         }
 
+        public static string ResolveSymbolSource(IPackageSourceProvider sourceProvider, string symbolSource)
+        {
+            if (!string.IsNullOrEmpty(symbolSource))
+            {
+                symbolSource = sourceProvider.ResolveAndValidateSource(symbolSource);
+            }
+
+            return symbolSource;
+        }
+
         public static string GetApiKey(ISettings settings, string source, string apiKey)
         {
             if (string.IsNullOrEmpty(apiKey))

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PushCommandTests.cs
@@ -36,6 +36,8 @@ namespace NuGet.Commands.Test
                     packageInfo.FullName,
                     packagePushDest.FullName,
                     null, // api key
+                    null, // symbols source
+                    null, // symbols api key
                     0, // timeout
                     false, // disable buffering
                     false, // no symbols

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Resources/PackageUpdateResourceTests.cs
@@ -138,10 +138,11 @@ namespace NuGet.Protocol.Tests
                 // Act
                 await resource.Push(
                     packagePath: packageInfo.FullName,
-                    symbolsSource: null,
+                    symbolSource: null,
                     timeoutInSecond: 5,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
+                    getSymbolApiKey: _ => null,
                     log: NullLogger.Instance);
 
                 // Assert
@@ -188,10 +189,11 @@ namespace NuGet.Protocol.Tests
                 // Act
                 await resource.Push(
                     packagePath: packageInfo.FullName,
-                    symbolsSource: null,
+                    symbolSource: null,
                     timeoutInSecond: 5,
                     disableBuffering: false,
                     getApiKey: _ => apiKey,
+                    getSymbolApiKey: _ => null,
                     log: NullLogger.Instance);
 
                 // Assert


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/2348

Previously, symbols would be automatically be pushed to nuget.smbsrc.net when you push a package to nuget.org (if the symbol package exists of course). There was no way to override the symbols source. And there was no way to push symbols when pushing to your own source.

Now there is
