### PR TITLE
Improve error message when invalid portable framework is installed

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -227,18 +228,18 @@ namespace NuGet.PackageManagement.UI
             {
                 // for exceptions that are known to be normal error cases, just
                 // display the message.
-                ProgressWindow.Log(ProjectManagement.MessageLevel.Info, ex.Message);
+                ProgressWindow.Log(MessageLevel.Info, ExceptionUtilities.DisplayMessage(ex, indent: true));
 
                 // write to activity log
-                var message = string.Format(CultureInfo.CurrentCulture, ex.ToString());
-                ActivityLog.LogError(LogEntrySource, message);
+                var activityLogMessage = string.Format(CultureInfo.CurrentCulture, ex.ToString());
+                ActivityLog.LogError(LogEntrySource, activityLogMessage);
             }
             else
             {
-                ProgressWindow.Log(ProjectManagement.MessageLevel.Error, ex.ToString());
+                ProgressWindow.Log(MessageLevel.Error, ex.ToString());
             }
 
-            ProgressWindow.ReportError(ex.Message);
+            ProgressWindow.ReportError(ExceptionUtilities.DisplayMessage(ex, indent: false));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
@@ -14,7 +14,7 @@ namespace NuGet.Common
     /// </summary>
     public static class ExceptionUtilities
     {
-        public static string DisplayMessage(Exception exception)
+        public static string DisplayMessage(Exception exception, bool indent)
         {
             if (exception == null)
             {
@@ -37,7 +37,12 @@ namespace NuGet.Common
             }
 
             // fall back to simply exploring all inner exceptions
-            return JoinMessages(GetMessages(exception));
+            return JoinMessages(GetMessages(exception), indent);
+        }
+
+        public static string DisplayMessage(Exception exception)
+        {
+            return DisplayMessage(exception, indent: true);
         }
 
         public static string DisplayMessage(AggregateException exception)
@@ -47,7 +52,7 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            return JoinMessages(GetMessages(exception));
+            return JoinMessages(GetMessages(exception), indent: true);
         }
 
         public static string DisplayMessage(TargetInvocationException exception)
@@ -57,7 +62,7 @@ namespace NuGet.Common
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            return JoinMessages(GetMessages(exception));
+            return JoinMessages(GetMessages(exception), indent: true);
         }
 
         private static IEnumerable<string> GetMessages(AggregateException exception)
@@ -126,17 +131,17 @@ namespace NuGet.Common
             }
         }
 
-        private static string JoinMessages(IEnumerable<string> messages)
+        private static string JoinMessages(IEnumerable<string> messages, bool indent)
         {
             var builder = new StringBuilder();
             foreach (var message in messages)
             {
                 // indent all but the first message
-                bool indent = builder.Length > 0;
+                bool indentNext = indent && builder.Length > 0;
 
                 foreach (var line in GetLines(message))
                 {
-                    if (indent)
+                    if (indentNext)
                     {
                         builder.Append("  ");
                     }

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkNameProvider.cs
@@ -453,7 +453,10 @@ namespace NuGet.Frameworks
                 {
                     // Frameworks within the portable profile are not allowed
                     // to have profiles themselves #1869
-                    throw new ArgumentException(Strings.InvalidPortableFrameworks);
+                    throw new ArgumentException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidPortableFrameworksDueToHyphen,
+                        shortPortableProfiles));
                 }
 
                 result.Add(framework);

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -162,7 +162,10 @@ namespace NuGet.Frameworks
 
                 if (String.IsNullOrEmpty(shortFramework))
                 {
-                    throw new FrameworkException(Strings.InvalidFrameworkIdentifier);
+                    throw new FrameworkException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidFrameworkIdentifier,
+                        shortFramework));
                 }
 
                 // add framework
@@ -195,7 +198,10 @@ namespace NuGet.Frameworks
                     }
                     else
                     {
-                        throw new FrameworkException(Strings.InvalidPortableFrameworks);
+                        throw new FrameworkException(string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.MissingPortableFrameworks,
+                            framework.DotNetFrameworkName));
                     }
                 }
                 else

--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFrameworkFactory.cs
@@ -133,7 +133,10 @@ namespace NuGet.Frameworks
                 {
                     // Frameworks within the portable profile are not allowed
                     // to have profiles themselves #1869
-                    throw new ArgumentException(Strings.InvalidPortableFrameworks);
+                    throw new ArgumentException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidPortableFrameworksDueToHyphen,
+                        profile));
                 }
 
                 result = new NuGetFramework(platform, version, profile);

--- a/src/NuGet.Core/NuGet.Frameworks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace NuGet.Frameworks {
     // with the /str option, or rebuild your VS project.
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
+    public class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -35,7 +35,7 @@ namespace NuGet.Frameworks {
         ///    Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.Frameworks.Strings", typeof(Strings).GetTypeInfo().Assembly);
@@ -50,7 +50,7 @@ namespace NuGet.Frameworks {
         ///    resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -62,16 +62,16 @@ namespace NuGet.Frameworks {
         /// <summary>
         ///    Looks up a localized string similar to Frameworks must have the same identifier, profile, and platform..
         /// </summary>
-        internal static string FrameworkMismatch {
+        public static string FrameworkMismatch {
             get {
                 return ResourceManager.GetString("FrameworkMismatch", resourceCulture);
             }
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Invalid framework identifier..
+        ///    Looks up a localized string similar to Invalid framework identifier &apos;{0}&apos;..
         /// </summary>
-        internal static string InvalidFrameworkIdentifier {
+        public static string InvalidFrameworkIdentifier {
             get {
                 return ResourceManager.GetString("InvalidFrameworkIdentifier", resourceCulture);
             }
@@ -80,18 +80,27 @@ namespace NuGet.Frameworks {
         /// <summary>
         ///    Looks up a localized string similar to Invalid framework version &apos;{0}&apos;..
         /// </summary>
-        internal static string InvalidFrameworkVersion {
+        public static string InvalidFrameworkVersion {
             get {
                 return ResourceManager.GetString("InvalidFrameworkVersion", resourceCulture);
             }
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Invalid portable frameworks..
+        ///    Looks up a localized string similar to Invalid portable frameworks &apos;{0}&apos;. A hyphen may not be in any of the portable framework names..
         /// </summary>
-        internal static string InvalidPortableFrameworks {
+        public static string InvalidPortableFrameworksDueToHyphen {
             get {
-                return ResourceManager.GetString("InvalidPortableFrameworks", resourceCulture);
+                return ResourceManager.GetString("InvalidPortableFrameworksDueToHyphen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Invalid portable frameworks for &apos;{0}&apos;. A portable framework must have at least one framework in the profile..
+        /// </summary>
+        public static string MissingPortableFrameworks {
+            get {
+                return ResourceManager.GetString("MissingPortableFrameworks", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Frameworks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Frameworks/Strings.resx
@@ -121,12 +121,19 @@
     <value>Frameworks must have the same identifier, profile, and platform.</value>
   </data>
   <data name="InvalidFrameworkIdentifier" xml:space="preserve">
-    <value>Invalid framework identifier.</value>
+    <value>Invalid framework identifier '{0}'.</value>
+    <comment>{0} is the invalid framework identifier.</comment>
   </data>
   <data name="InvalidFrameworkVersion" xml:space="preserve">
     <value>Invalid framework version '{0}'.</value>
+    <comment>{0} is the invalid framework version.</comment>
   </data>
-  <data name="InvalidPortableFrameworks" xml:space="preserve">
-    <value>Invalid portable frameworks.</value>
+  <data name="InvalidPortableFrameworksDueToHyphen" xml:space="preserve">
+    <value>Invalid portable frameworks '{0}'. A hyphen may not be in any of the portable framework names.</value>
+    <comment>{0} is the invalid portable framework string.</comment>
+  </data>
+  <data name="MissingPortableFrameworks" xml:space="preserve">
+    <value>Invalid portable frameworks for '{0}'. A portable framework must have at least one framework in the profile.</value>
+    <comment>{0} is the invalid portable framework string.</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -359,8 +359,6 @@ namespace NuGet.Packaging
             {
                 yield return new FrameworkSpecificGroup(framework, groups[framework].OrderBy(e => e, StringComparer.OrdinalIgnoreCase));
             }
-
-            yield break;
         }
 
         private NuGetFramework GetFrameworkFromPath(string path, bool allowSubFolders = false)
@@ -375,7 +373,22 @@ namespace NuGet.Packaging
             {
                 var folderName = parts[1];
 
-                var parsedFramework = NuGetFramework.ParseFolder(folderName, _frameworkProvider);
+                NuGetFramework parsedFramework;
+                try
+                {
+                    parsedFramework = NuGetFramework.ParseFolder(folderName, _frameworkProvider);
+                }
+                catch (ArgumentException e)
+                {
+                    // Include package name context in the exception.
+                    throw new PackagingException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.InvalidPackageFrameworkFolderName,
+                            path,
+                            GetIdentity()),
+                        e);
+                }
 
                 if (parsedFramework.IsSpecificFramework)
                 {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -177,6 +177,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The framework in the folder name of &apos;{0}&apos; in package &apos;{1}&apos; could not be parsed..
+        /// </summary>
+        public static string InvalidPackageFrameworkFolderName {
+            get {
+                return ResourceManager.GetString("InvalidPackageFrameworkFolderName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Installing {0} {1}..
         /// </summary>
         public static string Log_InstallingPackage {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -197,4 +197,9 @@
   <data name="FallbackFolderNotFound" xml:space="preserve">
     <value>Unable to find fallback package folder '{0}'.</value>
   </data>
+  <data name="InvalidPackageFrameworkFolderName" xml:space="preserve">
+    <value>The framework in the folder name of '{0}' in package '{1}' could not be parsed.</value>
+    <comment>{0} is the invalid path.
+{1} is the package ID and version.</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ExceptionUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ExceptionUtilitiesTests.cs
@@ -207,6 +207,29 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
+        public void ExceptionUtilities_SupportsDisablingIndentation()
+        {
+            /* Arrange
+             * Exceptions:
+             *  A -> B
+             */
+            var b = new Exception("B");
+            var a = new Exception("A", b);
+
+            // Act
+            var message = ExceptionUtilities.DisplayMessage(a, indent: false);
+
+            // Assert
+            var actual = GetLines(message);
+            var expected = new[]
+            {
+                "A",
+                "B"
+            };
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void ExceptionUtilities_IgnoresDuplicateAdjacent()
         {
             /* Arrange

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkNameProviderTests.cs
@@ -212,6 +212,20 @@ namespace NuGet.Test
             Assert.Equal(expected, identifier);
         }
 
+        [Fact]
+        public void FrameworkNameProvider_TryGetPortableFrameworks_RejectsInvalidPortableFrameworks()
+        {
+            // Arrange
+            var target = DefaultFrameworkNameProvider.Instance;
+            var input = "net45+win8+net-cf+net46";
+            IEnumerable<NuGetFramework> frameworks;
+
+            // Act & Assert
+            var actual = Assert.Throws<ArgumentException>(
+                () => target.TryGetPortableFrameworks(input, out frameworks));
+            Assert.Equal($"Invalid portable frameworks '{input}'. A hyphen may not be in any of the portable framework names.", actual.Message);
+        }
+
         [Theory]
         [InlineData("", "")]
         [InlineData("1", "1")]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkParseTests.cs
@@ -329,14 +329,17 @@ namespace NuGet.Test
         }
 
         [Theory]
-        [InlineData(".NETPortable,Version=v0.0,Profile=win+net-cf")]
-        [InlineData("portable-win+net-cf")]
-        [InlineData(".NETPortable,Version=v0.0,Profile=net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
-        [InlineData("portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
-        public void NuGetFramework_PortableWithInnerPortableProfileFails(string framework)
+        [InlineData(".NETPortable,Version=v0.0,Profile=win+net-cf", "win+net-cf")]
+        [InlineData("portable-win+net-cf", "win+net-cf")]
+        [InlineData(".NETPortable,Version=v0.0,Profile=net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS", "net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
+        [InlineData("portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS", "net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS")]
+        public void NuGetFramework_PortableWithInnerPortableProfileFails(string framework, string portableFrameworks)
         {
-            Assert.Throws<ArgumentException>(
+            var ex = Assert.Throws<ArgumentException>(
                 () => NuGetFramework.Parse(framework));
+            Assert.Equal(
+                $"Invalid portable frameworks '{portableFrameworks}'. A hyphen may not be in any of the portable framework names.",
+                ex.Message);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -170,5 +170,33 @@ namespace NuGet.Test
                 }
             }
         }
+
+        [Fact]
+        public void NuGetFramework_GetPortableShortFolderNameWithNoProfile()
+        {
+            // Arrange
+            var target = new NuGetFramework(".NETPortable", new Version(0, 0), string.Empty);
+
+            // Act & Arrange
+            var ex = Assert.Throws<FrameworkException>(() => target.GetShortFolderName());
+            Assert.Equal(
+                "Invalid portable frameworks for '.NETPortable,Version=v0.0'. " +
+                "A portable framework must have at least one framework in the profile.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void NuGetFramework_GetPortableShortFolderNameWithHyphenInProfile()
+        {
+            // Arrange
+            var target = new NuGetFramework(".NETPortable", new Version(0, 0), "net45+net-cf+win8");
+
+            // Act & Arrange
+            var ex = Assert.Throws<ArgumentException>(() => target.GetShortFolderName());
+            Assert.Equal(
+                "Invalid portable frameworks 'net45+net-cf+win8'. " +
+                "A hyphen may not be in any of the portable framework names.",
+                ex.Message);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageReaderTests.cs
@@ -522,8 +522,20 @@ namespace NuGet.Packaging.Test
 
                 using (PackageArchiveReader reader = new PackageArchiveReader(zip))
                 {
-                    Assert.Throws<ArgumentException>(
+                    var ex = Assert.Throws<PackagingException>(
                         () => reader.GetSupportedFrameworks());
+                    Assert.Equal(
+                        "The framework in the folder name of '" +
+                        "lib/portable-net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS/test.dll" +
+                        "' in package 'packageA.2.0.3' could not be parsed.",
+                        ex.Message);
+                    Assert.NotNull(ex.InnerException);
+                    Assert.IsType<ArgumentException>(ex.InnerException);
+                    Assert.Equal(
+                        "Invalid portable frameworks '" +
+                        "net+win+wpa+wp+sl+net-cf+netmf+MonoAndroid+MonoTouch+Xamarin.iOS" +
+                        "'. A hyphen may not be in any of the portable framework names.",
+                        ex.InnerException.Message);
                 }
             }
         }


### PR DESCRIPTION
Spoke to @harikmenon and @yishaigalatzer a while back about this one:
https://github.com/NuGet/Home/issues/2734

We made a change a while back to reject portable frameworks that have hyphens in them. For example, `portable-net45+win8` is totally fine but `portable-win8+net-cf+net45` is rejected. The original error message we gave has no information that allows the user to debug the problem. It just gave an error `Invalid portable frameworks.`. The new error looks like this:

![invalid-portable](https://cloud.githubusercontent.com/assets/94054/16427995/c68cf766-3d24-11e6-832b-b2ab7f7c7391.png)

I chose to continue to reject the portable frameworks since none of the official portable profiles (or Xamarin additions) have hyphens in them. This change simply improves the error experience so users can debug the problem and contact the package owners about their broken package.

/cc @emgarten @yishaigalatzer @rrelyea @harikmenon @maartenba 
