### PR TITLE
Fixed nuget pm ui to not filter package's versions for build integrated projects

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -80,7 +80,10 @@ namespace NuGet.PackageManagement.UI
 
             _projectVersionRangeDict = new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var project in _nugetProjects)
+            // filter project.json based projects since allowedVersion is only applicable to packages.config
+            var packagesConfigProjects = _nugetProjects.Where(project => !(project is INuGetIntegratedProject));
+
+            foreach (var project in packagesConfigProjects)
             {
                 // cache allowed version range for each nuget project for current selected package
                 var packageReference = (await project.GetInstalledPackagesAsync(CancellationToken.None))


### PR DESCRIPTION
Fixed nuget pm ui to not filter package's versions for build integrated projects since allowedVersions is only applicable for packages.config

Fix https://github.com/NuGet/Home/issues/3046

@joelverhagen @emgarten @rrelyea 
