### PR TITLE
Added info message while applying allowed versions constraint during update packages

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -834,7 +834,7 @@ namespace NuGet.PackageManagement
                 prunedAvailablePackages = PrunePackageTree.PruneByUpdateConstraints(prunedAvailablePackages, projectInstalledPackageReferences, resolutionContext.VersionConstraints);
 
                 // Verify that the target is allowed by packages.config
-                GatherExceptionHelpers.ThrowIfVersionIsDisallowedByPackagesConfig(primaryTargetIds, projectInstalledPackageReferences, prunedAvailablePackages);
+                GatherExceptionHelpers.ThrowIfVersionIsDisallowedByPackagesConfig(primaryTargetIds, projectInstalledPackageReferences, prunedAvailablePackages, log);
 
                 // Remove versions that do not satisfy 'allowedVersions' attribute in packages.config, if any
                 prunedAvailablePackages = PrunePackageTree.PruneDisallowedVersions(prunedAvailablePackages, projectInstalledPackageReferences);
@@ -1265,8 +1265,10 @@ namespace NuGet.PackageManagement
                             new[] { packageIdentity });
                     }
 
+                    var log = new LoggerAdapter(nuGetProjectContext);
+
                     // Verify that the target is allowed by packages.config
-                    GatherExceptionHelpers.ThrowIfVersionIsDisallowedByPackagesConfig(packageIdentity.Id, projectInstalledPackageReferences, prunedAvailablePackages);
+                    GatherExceptionHelpers.ThrowIfVersionIsDisallowedByPackagesConfig(packageIdentity.Id, projectInstalledPackageReferences, prunedAvailablePackages, log);
 
                     // Remove versions that do not satisfy 'allowedVersions' attribute in packages.config, if any
                     prunedAvailablePackages = PrunePackageTree.PruneDisallowedVersions(prunedAvailablePackages, projectInstalledPackageReferences);
@@ -1287,7 +1289,7 @@ namespace NuGet.PackageManagement
                         preferredPackageReferences.Select(package => package.PackageIdentity),
                         prunedAvailablePackages,
                         SourceRepositoryProvider.GetRepositories().Select(s => s.PackageSource),
-                        new LoggerAdapter(nuGetProjectContext));
+                        log);
 
                     nuGetProjectContext.Log(ProjectManagement.MessageLevel.Info, Strings.AttemptingToResolveDependencies, packageIdentity, resolutionContext.DependencyBehavior);
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherExceptionHelpers.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherExceptionHelpers.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.PackageManagement
@@ -20,9 +21,10 @@ namespace NuGet.PackageManagement
         /// <param name="availablePackages">gathered packages</param>
         public static void ThrowIfVersionIsDisallowedByPackagesConfig(string target,
             IEnumerable<Packaging.PackageReference> packagesConfig,
-            IEnumerable<PackageDependencyInfo> availablePackages)
+            IEnumerable<PackageDependencyInfo> availablePackages,
+            ILogger logger)
         {
-            ThrowIfVersionIsDisallowedByPackagesConfig(new string[] { target }, packagesConfig, availablePackages);
+            ThrowIfVersionIsDisallowedByPackagesConfig(new string[] { target }, packagesConfig, availablePackages, logger);
         }
 
         /// <summary>
@@ -34,7 +36,8 @@ namespace NuGet.PackageManagement
         /// <param name="availablePackages">gathered packages</param>
         public static void ThrowIfVersionIsDisallowedByPackagesConfig(IEnumerable<string> targets,
             IEnumerable<Packaging.PackageReference> packagesConfig,
-            IEnumerable<PackageDependencyInfo> availablePackages)
+            IEnumerable<PackageDependencyInfo> availablePackages,
+            ILogger logger)
         {
             foreach (var target in targets)
             {
@@ -43,6 +46,12 @@ namespace NuGet.PackageManagement
 
                 if (configEntry != null)
                 {
+                    logger.LogMinimal(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.PackagesConfigAllowedVersions,
+                        configEntry.AllowedVersions.PrettyPrint(),
+                        "packages.config"));
+
                     var packagesForId = availablePackages.Where(package => StringComparer.OrdinalIgnoreCase.Equals(target, package.Id));
 
                     // check if package versions exist, but none satisfy the allowed range

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -366,6 +366,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Applying constraint &apos;{0}&apos; defined in &apos;{1}&apos;..
+        /// </summary>
+        public static string PackagesConfigAllowedVersions {
+            get {
+                return ResourceManager.GetString("PackagesConfigAllowedVersions", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///    Looks up a localized string similar to Packages could not be installed.
         /// </summary>
         public static string PackagesCouldNotBeInstalled {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -304,4 +304,9 @@
 {1} is the unsupported package type.
 {2} is the project name.</comment>
   </data>
+  <data name="PackagesConfigAllowedVersions" xml:space="preserve">
+    <value>Applying constraint '{0}' defined in '{1}'.</value>
+    <comment>{0} is the package constraint.
+{1} is the 'packages.config'</comment>
+  </data>
 </root>


### PR DESCRIPTION
Added info message while applying allowed versions constraint during update packages.

Fix https://github.com/NuGet/Home/issues/3013

@emgarten @joelverhagen @rrelyea  @alpaix 
