### PR TITLE
Don't ignore the -ApiKey parameter in nuget.exe delete

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DeleteCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DeleteCommand.cs
@@ -29,7 +29,11 @@ namespace NuGet.CommandLine
             string packageVersion = Arguments[1];
             string apiKeyValue = null;
 
-            if (Arguments.Count > 2)
+            if (!string.IsNullOrEmpty(ApiKey))
+            {
+                apiKeyValue = ApiKey;
+            }
+            else if (Arguments.Count > 2 && !string.IsNullOrEmpty(Arguments[2]))
             {
                 apiKeyValue = Arguments[2];
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -35,9 +35,13 @@ namespace NuGet.CommandLine
         public override async Task ExecuteCommandAsync()
         {
             string packagePath = Arguments[0];
-            string apiKeyValue = ApiKey;
+            string apiKeyValue = null;
 
-            if (string.IsNullOrEmpty(apiKeyValue) && Arguments.Count > 1)
+            if (!string.IsNullOrEmpty(ApiKey))
+            {
+                apiKeyValue = ApiKey;
+            }
+            else if (Arguments.Count > 1 && !string.IsNullOrEmpty(Arguments[1]))
             {
                 apiKeyValue = Arguments[1];
             }


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/3037

Simple bug. We just weren't referencing the `-ApiKey` argument. Added tests to avoid regressions.

/cc @alpaix @rohit21agrawal @jainaashish @rrelyea 
