### PR TITLE
fix update ui issue for net core projects

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -27,9 +27,12 @@ namespace NuGet.PackageManagement.UI
             PackageItemListViewModel searchResultPackage,
             ItemFilter filter)
         {
+
             await base.SetCurrentPackage(searchResultPackage, filter);
 
-            UpdateInstalledVersion();
+            InstalledVersion = searchResultPackage.InstalledVersion;
+            SelectedVersion.IsCurrentInstalled = InstalledVersion == SelectedVersion.Version;
+            OnPropertyChanged(nameof(SelectedVersion));
         }
 
         public override bool IsSolution


### PR DESCRIPTION
Fixes issue : https://github.com/NuGet/Home/issues/3041

fix update ui issue for net core projects where detailcontrol installed version does not show right version (in the installedversion textbox) after updating a package

this is because for netcore projects we do not get notified when a package update is complete, so by the time the json file is updated with the new version, we have already updated the UI with the older version.

the fix basically involves picking up the right version from the packageitemlistviewmodel instead of relying on the json file .

CC: @alpaix @emgarten @joelverhagen @rrelyea 
