### PR TITLE
Split Silverlight tests into separate test file (to allow easy exclusion or isolated runs)

### DIFF
--- a/test/EndToEnd/tests/Silverlight.ps1
+++ b/test/EndToEnd/tests/Silverlight.ps1
@@ -1,0 +1,38 @@
+function Test-BindingRedirectDoesNotAddToSilverlightProject {
+    param(
+        $context
+    )
+    # Arrange
+    $c = New-SilverlightApplication
+
+    # Act
+    $c | Install-Package TestSL -Version 1.0 -Source $context.RepositoryPath
+
+    # Assert
+    $c | %{ Assert-Reference $_ TestSL 1.0.0.0; 
+            Assert-Reference $_ HostSL 1.0.1.0; }
+
+    Assert-NoBindingRedirect $c app.config HostSL '0.0.0.0-1.0.1.0' '1.0.1.0'
+}
+
+function Test-InstallPackageRespectReferencesAccordingToDifferentFrameworks
+{
+    param ($context)
+
+    # Arrange
+    $p1 = New-SilverlightClassLibrary
+    $p2 = New-ConsoleApplication
+
+    # Act
+    ($p1, $p2) | Install-Package RefPackage -Source $context.RepositoryPath
+
+    # Assert
+    Assert-Package $p1 'RefPackage'
+    Assert-Reference $p1 'fear'
+    Assert-Null (Get-AssemblyReference $p1 'mafia')
+
+    Assert-Package $p2 'RefPackage'
+    Assert-Reference $p2 'one'
+    Assert-Reference $p2 'three'
+    Assert-Null (Get-AssemblyReference $p2 'two')
+}

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -653,24 +653,6 @@ function Test-SimpleBindingRedirectsMultipleConfigs {
     Assert-BindingRedirect $a web.config B '0.0.0.0-2.0.0.0' '2.0.0.0'
 }
 
-
-function Test-BindingRedirectDoesNotAddToSilverlightProject {
-    param(
-        $context
-    )
-    # Arrange
-    $c = New-SilverlightApplication
-
-    # Act
-    $c | Install-Package TestSL -Version 1.0 -Source $context.RepositoryPath
-
-    # Assert
-    $c | %{ Assert-Reference $_ TestSL 1.0.0.0; 
-            Assert-Reference $_ HostSL 1.0.1.0; }
-
-    Assert-NoBindingRedirect $c app.config HostSL '0.0.0.0-1.0.1.0' '1.0.1.0'
-}
-
 function Test-SimpleBindingRedirectsClassLibraryUpdatePackage {
     # Arrange
     $a = New-ClassLibrary
@@ -2251,28 +2233,6 @@ function Test-InstallPackageRespectAssemblyReferenceFilterOnSecondProject
     Assert-Package $q 'B' '1.0.0'
     Assert-Reference $q 'GrayscaleEffect'
     Assert-Null (Get-AssemblyReference $q 'Ookii.Dialogs.Wpf')
-}
-
-function Test-InstallPackageRespectReferencesAccordingToDifferentFrameworks
-{
-    param ($context)
-
-    # Arrange
-    $p1 = New-SilverlightClassLibrary
-    $p2 = New-ConsoleApplication
-
-    # Act
-    ($p1, $p2) | Install-Package RefPackage -Source $context.RepositoryPath
-
-    # Assert
-    Assert-Package $p1 'RefPackage'
-    Assert-Reference $p1 'fear'
-    Assert-Null (Get-AssemblyReference $p1 'mafia')
-
-    Assert-Package $p2 'RefPackage'
-    Assert-Reference $p2 'one'
-    Assert-Reference $p2 'three'
-    Assert-Null (Get-AssemblyReference $p2 'two')
 }
 
 function Test-InstallPackageThrowsIfMinClientVersionIsNotSatisfied

--- a/test/EndToEnd/tests/update.ps1
+++ b/test/EndToEnd/tests/update.ps1
@@ -1489,7 +1489,7 @@ function Test-UpdatePackageThrowsIfMinClientVersionIsNotSatisfied
     param ($context)
 
     # Arrange
-    $p = New-SilverlightClassLibrary
+    $p = New-ClassLibrary
 
     $p | Install-Package kitty -version 1.0.0 -Source $context.RepositoryPath
 


### PR DESCRIPTION
/cc @alpaix @drewgil 

It seems the test hang has to do with msbuild crashing sometimes when creating a Silverlight project. Investigation is on-going.
