### PR TITLE
Change project typew for test in order to support dev15 --old project…

### DIFF
--- a/test/EndToEnd/tests/PackTest.ps1
+++ b/test/EndToEnd/tests/PackTest.ps1
@@ -36,7 +36,7 @@ function Test-PackFromProjectWithDevelopmentDependencySet {
 
     # Arrange 
 
-    $p = New-MvcApplication
+    $p = New-WebApplication
 
     # install packages from the Basic MVC app manually
 


### PR DESCRIPTION
… not available in dev15
E2E test runs will now pass in Dev15.
Addresses https://github.com/NuGet/Home/issues/3057
I'm utilizing a different project type which checks the same boxes as the now-unavailable MVC5 project - it has a csproj, web.config, package.config. Will test the same code path in the same way as the old test scenario.
