### PR TITLE
Depend on specific version of NuGet.Core (2.12.0-rtm-815), not a floating version

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/project.json
+++ b/src/NuGet.Clients/NuGet.Credentials/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "NuGet.PackageManagement": "3.5.0-*",
-    "NuGet.Core": "2.12.0-*"
+    "NuGet.Core": "2.12.0-rtm-815"
   },
   "frameworks": {
     "net45": {}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v2/project.json
@@ -36,7 +36,7 @@
     "NuGet.Protocol.Core.Types": {
       "target": "project"
     },
-    "NuGet.Core": "2.12.0-rtm-*"
+    "NuGet.Core": "2.12.0-rtm-815"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
Currently the floating version matches `2.12.0-rtm-815` so there is not net change. However, moving forward we want to be explicit about the NuGet.Core version we are depending on. This change was already made for the `3.5.0-beta2` release.

/cc @rohit21agrawal @jainaashish @alpaix @rrelyea 
