### PR TITLE
Fix bug that reinstalls package with nuspec when PackageSaveMode is nuspec

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -271,18 +271,8 @@ namespace NuGet.CommandLine
                     GetInstalledPackageReferences(packageReferenceFile, allowDuplicatePackageIds: true));
             }
 
-            Func<Packaging.Core.PackageIdentity, bool> packageExistsFunc;
-            // If restoring nupkg only accept an existing package with a nupkg otherwise accept a nuspec or a nupkg
-            if ((EffectivePackageSaveMode & Packaging.PackageSaveMode.Nupkg) == Packaging.PackageSaveMode.Nupkg)
-            {
-                packageExistsFunc = nuGetPackageManager.PackageExistsInPackagesFolder;
-            }
-            else
-            {
-                packageExistsFunc = nuGetPackageManager.PackageOrManifestExistsInPackagesFolder;
-            }
             var missingPackageReferences = installedPackageReferences.Where(reference =>
-                !packageExistsFunc(reference.PackageIdentity)).ToArray();
+                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, EffectivePackageSaveMode)).ToArray();
 
             if (missingPackageReferences.Length == 0)
             {

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -271,8 +271,18 @@ namespace NuGet.CommandLine
                     GetInstalledPackageReferences(packageReferenceFile, allowDuplicatePackageIds: true));
             }
 
+            Func<Packaging.Core.PackageIdentity, bool> packageExistsFunc;
+            // If restoring nupkg only accept an existing package with a nupkg otherwise accept a nuspec or a nupkg
+            if ((EffectivePackageSaveMode & Packaging.PackageSaveMode.Nupkg) == Packaging.PackageSaveMode.Nupkg)
+            {
+                packageExistsFunc = nuGetPackageManager.PackageExistsInPackagesFolder;
+            }
+            else
+            {
+                packageExistsFunc = nuGetPackageManager.PackageOrManifestExistsInPackagesFolder;
+            }
             var missingPackageReferences = installedPackageReferences.Where(reference =>
-                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity)).ToArray();
+                !packageExistsFunc(reference.PackageIdentity)).ToArray();
 
             if (missingPackageReferences.Length == 0)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2225,7 +2225,7 @@ namespace NuGet.PackageManagement
             IEnumerable<SourceRepository> sourceRepositories, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
-            if (PackageExistsInPackagesFolder(packageIdentity))
+            if (PackageExistsInPackagesFolder(packageIdentity, nuGetProjectContext.PackageExtractionContext.PackageSaveMode))
             {
                 return false;
             }
@@ -2257,14 +2257,17 @@ namespace NuGet.PackageManagement
             return PackagesFolderNuGetProject.CopySatelliteFilesAsync(packageIdentity, nuGetProjectContext, token);
         }
 
+        /// <summary>
+        /// Checks whether package exists in packages folder and verifies that nupkg and nuspec are present as specified by packageSaveMode
+        /// </summary>
+        public bool PackageExistsInPackagesFolder(PackageIdentity packageIdentity, Packaging.PackageSaveMode packageSaveMode)
+        {
+            return PackagesFolderNuGetProject.PackageExists(packageIdentity, packageSaveMode);
+        }
+
         public bool PackageExistsInPackagesFolder(PackageIdentity packageIdentity)
         {
             return PackagesFolderNuGetProject.PackageExists(packageIdentity);
-        }
-
-        public bool PackageOrManifestExistsInPackagesFolder(PackageIdentity packageIdentity)
-        {
-            return PackagesFolderNuGetProject.PackageOrManifestExists(packageIdentity);
         }
 
         private Task ExecuteInstallAsync(

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2262,6 +2262,11 @@ namespace NuGet.PackageManagement
             return PackagesFolderNuGetProject.PackageExists(packageIdentity);
         }
 
+        public bool PackageOrManifestExistsInPackagesFolder(PackageIdentity packageIdentity)
+        {
+            return PackagesFolderNuGetProject.PackageOrManifestExists(packageIdentity);
+        }
+
         private Task ExecuteInstallAsync(
             NuGetProject nuGetProject,
             PackageIdentity packageIdentity,

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2260,7 +2260,7 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Checks whether package exists in packages folder and verifies that nupkg and nuspec are present as specified by packageSaveMode
         /// </summary>
-        public bool PackageExistsInPackagesFolder(PackageIdentity packageIdentity, Packaging.PackageSaveMode packageSaveMode)
+        public bool PackageExistsInPackagesFolder(PackageIdentity packageIdentity, PackageSaveMode packageSaveMode)
         {
             return PackagesFolderNuGetProject.PackageExists(packageIdentity, packageSaveMode);
         }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -155,6 +155,11 @@ namespace NuGet.ProjectManagement
             return !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
         }
 
+        public bool PackageOrManifestExists(PackageIdentity packageIdentity)
+        {
+            return !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity)) | !string.IsNullOrEmpty(GetInstalledManifestFilePath(packageIdentity));
+        }
+
         public Task<bool> CopySatelliteFilesAsync(PackageIdentity packageIdentity,
             INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
@@ -221,6 +226,27 @@ namespace NuGet.ProjectManagement
             }
 
             // Default to empty
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Get the path to the package nuspec.
+        /// </summary>
+        public string GetInstalledManifestFilePath(PackageIdentity packageIdentity)
+        {
+            // Check the expected location before searching all directories
+            var packageDirectory = PackagePathResolver.GetInstallPath(packageIdentity);
+            var manifestName = PackagePathResolver.GetManifestFileName(packageIdentity);
+
+            var installPath = Path.GetFullPath(Path.Combine(packageDirectory, manifestName));
+
+            // Keep the previous optimization of just going by the existance of the file if we find it.
+            if (File.Exists(installPath))
+            {
+                return installPath;
+            }
+
+            // Don't look in non-normalized paths for nuspec
             return string.Empty;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -155,19 +155,19 @@ namespace NuGet.ProjectManagement
             return !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
         }
 
-        public bool PackageExists(PackageIdentity packageIdentity, Packaging.PackageSaveMode packageSaveMode)
+        public bool PackageExists(PackageIdentity packageIdentity, PackageSaveMode packageSaveMode)
         {
             var packageExists = !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
             var manifestExists = !string.IsNullOrEmpty(GetInstalledManifestFilePath(packageIdentity));
             // A package must have either a nupkg or a nuspec to be valid
             var result = packageExists || manifestExists;
             // Verify nupkg present if specified
-            if ((packageSaveMode & Packaging.PackageSaveMode.Nupkg) == Packaging.PackageSaveMode.Nupkg)
+            if ((packageSaveMode & PackageSaveMode.Nupkg) == PackageSaveMode.Nupkg)
             {
                 result &= packageExists;
             }
             // Verify nuspec present if specified
-            if ((packageSaveMode & Packaging.PackageSaveMode.Nuspec) == Packaging.PackageSaveMode.Nuspec)
+            if ((packageSaveMode & PackageSaveMode.Nuspec) == PackageSaveMode.Nuspec)
             {
                 result &= manifestExists;
             }


### PR DESCRIPTION
Proposed fix for issue #3082: nuget restore with PackageSaveMode nuspec always reinstalls package

This fix only accepts an existing package with just a nuspec (and not a nupkg) when PackageSaveMode is also nuspec. 

Adding link to: https://github.com/NuGet/Home/issues/3082
