### PR TITLE
Insert VSIX Id into Dev15 manifest

### DIFF
--- a/src/NuGet.Clients/VsExtension/source.extension.dev15.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.dev15.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.5.0" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="3.5.0" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 15</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Icon>Resources/nuget_96.png</Icon>


### PR DESCRIPTION
This is the identity we've used for previous releases from the "dev15"-suffixed branches. We will now ship both identities from the same branch. Fixes issue https://github.com/NuGet/Home/issues/3083.
@joelverhagen 
