### PR TITLE
When nuget.exe restore does not have -PackageSaveMode on second restore, restore fails

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -271,8 +271,15 @@ namespace NuGet.CommandLine
                     GetInstalledPackageReferences(packageReferenceFile, allowDuplicatePackageIds: true));
             }
 
+            // EffectivePackageSaveMode is None when -PackageSaveMode is not provided by the user. None is treated as
+            // Defaultv3 for V3 restore and should be treated as Defaultv2 for V2 restore. This is the case in the
+            // actual V2 restore flow and should match in this preliminary missing packages check.
+            var packageSaveMode = EffectivePackageSaveMode == Packaging.PackageSaveMode.None ?
+                Packaging.PackageSaveMode.Defaultv2 :
+                EffectivePackageSaveMode;
+
             var missingPackageReferences = installedPackageReferences.Where(reference =>
-                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, EffectivePackageSaveMode)).ToArray();
+                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity, packageSaveMode)).ToArray();
 
             if (missingPackageReferences.Length == 0)
             {

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -157,24 +157,25 @@ namespace NuGet.ProjectManagement
 
         public bool PackageExists(PackageIdentity packageIdentity, PackageSaveMode packageSaveMode)
         {
-            var verified = false;
-            var exists = true;
+            var packageExists = !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
+            var manifestExists = !string.IsNullOrEmpty(GetInstalledManifestFilePath(packageIdentity));
 
-            // Verify .nupkg present if specified
+            // A package must have either a nupkg or a nuspec to be valid
+            var result = packageExists || manifestExists;
+            
+            // Verify nupkg present if specified
             if ((packageSaveMode & PackageSaveMode.Nupkg) == PackageSaveMode.Nupkg)
             {
-                verified = true;
-                exists &= !string.IsNullOrEmpty(GetInstalledPackageFilePath(packageIdentity));
+                result &= packageExists;
             }
-
-            // Verify .nuspec present if specified
+            
+            // Verify nuspec present if specified
             if ((packageSaveMode & PackageSaveMode.Nuspec) == PackageSaveMode.Nuspec)
             {
-                verified = true;
-                exists &= !string.IsNullOrEmpty(GetInstalledManifestFilePath(packageIdentity));
+                result &= manifestExists;
             }
 
-            return verified && exists;
+            return result;
         }
 
         public bool ManifestExists(PackageIdentity packageIdentity)


### PR DESCRIPTION
This was a problem introduced when refactoring after https://github.com/NuGet/Home/issues/3082. I missed a gap in my testing.

The following series of commands should result in both a .nupkg and .nuspec for each restored package.

```
nuget.exe restore packages.config -PackageSaveMode nuspec
nuget.exe restore packages.config
```

The second command should default to `PackageSaveMode.Defaultv2` (which restores package files and .nupkg).

/cc @alpaix @MarkOsborneMS @rohit21agrawal 
