### PR TITLE
Added nuget batch events for multiple install/ uninstall actions for a project

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerProjectEvents.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerProjectEvents.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using NuGet.PackageManagement;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// Contains batch events to be raised when performing multiple packages install/ uninstall in a project with packages.config
+    /// </summary>
+    [Export(typeof(IVsPackageInstallerProjectEvents))]
+    public class VsPackageInstallerProjectEvents : IVsPackageInstallerProjectEvents
+    {
+        public event EventHandler<IVsPackageProjectMetadata> BatchStart;
+
+        public event EventHandler<IVsPackageProjectMetadata> BatchEnd;
+
+        [ImportingConstructor]
+        public VsPackageInstallerProjectEvents(IPackageProjectEventsProvider eventProvider)
+        {
+            var eventSource = eventProvider.GetPackageProjectEvents();
+
+            eventSource.BatchStart += NotifyBatchStart;
+            eventSource.BatchEnd += NotifyBatchEnd;
+        }
+
+        private void NotifyBatchStart(object sender, PackageProjectEventArgs e)
+        {
+            var handle = BatchStart;
+            handle?.Invoke(this, new VsPackageProjectMetadata(e.Id, e.Name));
+        }
+
+        private void NotifyBatchEnd(object sender, PackageProjectEventArgs e)
+        {
+            var handle = BatchEnd;
+            handle?.Invoke(this, new VsPackageProjectMetadata(e.Id, e.Name));
+        }
+
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageProjectMetadata.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageProjectMetadata.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.ProjectManagement;
+
+namespace NuGet.VisualStudio
+{
+    internal class VsPackageProjectMetadata : IVsPackageProjectMetadata
+    {
+        public VsPackageProjectMetadata() : this(string.Empty, string.Empty)
+        { }
+
+        public VsPackageProjectMetadata(string id, string name)
+        {
+            BatchId = id ?? string.Empty;
+            ProjectName = name ?? string.Empty;
+        }
+
+        public string BatchId { get; }
+
+        public string ProjectName { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/NuGet.VisualStudio.Implementation.csproj
@@ -57,6 +57,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonResources.cs" />
+    <Compile Include="Extensibility\VsPackageInstallerProjectEvents.cs" />
+    <Compile Include="Extensibility\VsPackageProjectMetadata.cs" />
     <Compile Include="Extensibility\VsSemanticVersionComparer.cs" />
     <Compile Include="Extensibility\VsFrameworkParser.cs" />
     <Compile Include="Extensibility\VsFrameworkCompatibility.cs" />

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageInstallerProjectEvents.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageInstallerProjectEvents.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// Contains batch events which are raised when packages are installed or uninstalled from projects with packages.config
+    /// and the current solution.
+    /// </summary>
+    [ComImport]
+    [Guid("3b76690b-eb3e-4cfa-b5af-6574c567c842")]
+    public interface IVsPackageInstallerProjectEvents
+    {
+        /// <summary>
+        /// Raised before any IVsPackageInstallerEvents events are raised for a project.
+        /// </summary>
+        event EventHandler<IVsPackageProjectMetadata> BatchStart;
+
+        /// <summary>
+        /// Raised after all IVsPackageInstallerEvents events are raised for a project.
+        /// </summary>
+        event EventHandler<IVsPackageProjectMetadata> BatchEnd;
+
+    }
+}

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageProjectMetadata.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageProjectMetadata.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace NuGet.VisualStudio
+{
+    /// <summary>
+    /// Contains information about project with packages.config where we're executing nuget actions.
+    /// </summary>
+    [ComImport]
+    [Guid("7ce0caae-1b99-4cd1-80bf-348972975bcf")]
+    public interface IVsPackageProjectMetadata
+    {
+        /// <summary>
+        /// Unique batch id for batch start/end events of the project.
+        /// </summary>
+        string BatchId { get; }
+
+        /// <summary>
+        /// Name of the project.
+        /// </summary>
+        string ProjectName { get; }
+    }
+}

--- a/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
+++ b/src/NuGet.Clients/VisualStudio/VisualStudio.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Extensibility\IVsGlobalPackagesInitScriptExecutor.cs" />
     <Compile Include="Extensibility\IVsFrameworkCompatibility.cs" />
     <Compile Include="Extensibility\IVsPackageInstaller2.cs" />
+    <Compile Include="Extensibility\IVsPackageInstallerProjectEvents.cs" />
     <Compile Include="Extensibility\IVsPackageSourceProvider.cs" />
     <Compile Include="Extensibility\IVsPackageInstaller.cs" />
     <Compile Include="Extensibility\IVsPackageInstallerEvents.cs" />
@@ -81,6 +82,7 @@
     <Compile Include="Extensibility\IVsPackageMetadata.cs" />
     <Compile Include="Extensibility\IVsPackageRestorer.cs" />
     <Compile Include="Extensibility\IVsPackageUninstaller.cs" />
+    <Compile Include="Extensibility\IVsPackageProjectMetadata.cs" />
     <Compile Include="Extensibility\IVsSemanticVersionComparer.cs" />
     <Compile Include="Extensibility\VsPackageEventHandler.cs" />
     <Compile Include="IVsPackageManagerProvider.cs" />

--- a/src/NuGet.Core/NuGet.PackageManagement/Events/IPackageProjectEventsProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Events/IPackageProjectEventsProvider.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Internal version of the public IVsPackageInstallerProjectEvents
+    /// </summary>
+    public interface IPackageProjectEventsProvider
+    {
+        PackageProjectEvents GetPackageProjectEvents();
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEventArgs.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEventArgs.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Event arguments for nuget batch events.
+    /// </summary>
+    public class PackageProjectEventArgs : EventArgs
+    {
+        public PackageProjectEventArgs(string id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public string Id { get; }
+        public string Name { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEvents.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEvents.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Package project events relayed to the public IVsPackageInstallerProjectEvents.
+    /// </summary>
+    public class PackageProjectEvents
+    {
+        /// <summary>
+        /// Raised when batch processing of install/ uninstall packages starts at a project level
+        /// </summary>
+        public event EventHandler<PackageProjectEventArgs> BatchStart;
+
+        /// <summary>
+        /// Raised when batch processing of install/ uninstall packages ends at a project level
+        /// </summary>
+        public event EventHandler<PackageProjectEventArgs> BatchEnd;
+
+        internal void NotifyBatchStart(PackageProjectEventArgs e)
+        {
+            var handler = BatchStart;
+            handler?.Invoke(this, e);
+        }
+
+        internal void NotifyBatchEnd(PackageProjectEventArgs e)
+        {
+            var handler = BatchEnd;
+            handler?.Invoke(this, e);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEventsProvider.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Events/PackageProjectEventsProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Provider for the PackageEvents singleton
+    /// </summary>
+    [Export(typeof(IPackageProjectEventsProvider))]
+    public class PackageProjectEventsProvider : IPackageProjectEventsProvider
+    {
+        private static PackageProjectEvents _instance;
+
+        public PackageProjectEvents GetPackageProjectEvents()
+        {
+            return Instance;
+        }
+
+        internal static PackageProjectEvents Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new PackageProjectEvents();
+                }
+
+                return _instance;
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectManagement/Events/PackageEvents.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Events/PackageEvents.cs
@@ -46,50 +46,39 @@ namespace NuGet.ProjectManagement
 
         internal void NotifyInstalling(PackageEventArgs e)
         {
-            if (PackageInstalling != null)
-            {
-                PackageInstalling(this, e);
-            }
+            var handler = PackageInstalling;
+            handler?.Invoke(this, e);
         }
 
         internal void NotifyInstalled(PackageEventArgs e)
         {
-            if (PackageInstalled != null)
-            {
-                PackageInstalled(this, e);
-            }
+            var handler = PackageInstalled;
+            handler?.Invoke(this, e);
         }
 
         internal void NotifyUninstalling(PackageEventArgs e)
         {
-            if (PackageUninstalling != null)
-            {
-                PackageUninstalling(this, e);
-            }
+            var handler = PackageUninstalling;
+            handler?.Invoke(this, e);
         }
 
         internal void NotifyUninstalled(PackageEventArgs e)
         {
-            if (PackageUninstalled != null)
-            {
-                PackageUninstalled(this, e);
-            }
+            var handler = PackageUninstalled;
+            handler?.Invoke(this, e);
         }
 
         internal void NotifyReferenceAdded(PackageEventArgs e)
         {
-            if (PackageReferenceAdded != null)
-            {
-                PackageReferenceAdded(this, e);
-            }
+            var handler = PackageInstalled;
+            handler?.Invoke(this, e);
+            PackageReferenceAdded?.Invoke(this, e);
         }
 
         internal void NotifyReferenceRemoved(PackageEventArgs e)
         {
-            if (PackageReferenceRemoved != null)
-            {
-                PackageReferenceRemoved(this, e);
-            }
+            var handler = PackageReferenceRemoved;
+            handler?.Invoke(this, e);
         }
     }
 }

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -689,3 +689,17 @@ function ExecuteInitPS1OnAspNetCore
     Assert-True ($global:PackageInitPS1Var -eq 1)
 }
 
+function Test-BatchEventsApi 
+{
+    param($context)
+
+    # Arrange
+    $p = New-ClassLibrary
+
+    # Act
+    $result = [API.Test.InternalAPITestHook]::BatchEventsApi("owin","1.0.0") 
+
+    # Assert
+    Assert-True $result
+}
+

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4768,6 +4768,715 @@ namespace NuGet.Test
             Assert.Equal(bVersionRange.ToString(), packageDependency.VersionRange.ToString());
         }
 
+        [Fact]
+        public async Task TestPacMan_InstallPackage_BatchEvent_Raised()
+        {
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+                    var projectName = string.Empty;
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                        projectName = args.Name;
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(projectA, target,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                    // Assert
+                    // Check that the packages.config file exists after the installation
+                    Assert.True(File.Exists(projectA.PackagesConfigNuGetProject.FullPath));
+
+                    // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                    var packagesInPackagesConfig =
+                        (await projectA.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(1, packagesInPackagesConfig.Count);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                    Assert.Equal("testA", projectName);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_UpdatePackage_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(projectA, target,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                    // Assert
+                    // Check that the packages.config file exists after the installation
+                    Assert.True(File.Exists(projectA.PackagesConfigNuGetProject.FullPath));
+
+                    // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                    var packagesInPackagesConfig =
+                        (await projectA.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(1, packagesInPackagesConfig.Count);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+
+                    // Update
+                    var updatePackage = new PackageIdentity("packageA", NuGetVersion.Parse("2.0.0"));
+                    AddToPackagesFolder(updatePackage, packageSource);
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(projectA, updatePackage,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                    // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                    packagesInPackagesConfig =
+                        (await projectA.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(1, packagesInPackagesConfig.Count);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 2);
+                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(batchStartIds[1], batchEndIds[1]);
+                    Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_UninstallPackage_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(projectA, target,
+                        new ResolutionContext(), new TestNuGetProjectContext(), sourceRepositoryProvider.GetRepositories().First(),
+                        null, token);
+
+                    // Main Act
+                    var uninstallationContext = new UninstallationContext();
+                    await nuGetPackageManager.UninstallPackageAsync(projectA, target.Id,
+                        uninstallationContext, new TestNuGetProjectContext(), token);
+
+                    // Assert
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 2);
+                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                    Assert.Equal(batchStartIds[1], batchEndIds[1]);
+                    Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_ExecuteMultipleNugetActions_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var actions = new List<NuGetProjectAction>();
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // Add package
+                    var packageA1 = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    var packageA2 = new PackageIdentity("packageA", NuGetVersion.Parse("2.0.0"));
+                    var packageB1 = new PackageIdentity("packageB", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(packageA1, packageSource);
+                    AddToPackagesFolder(packageA2, packageSource);
+                    AddToPackagesFolder(packageB1, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+                    var projectName = string.Empty;
+
+                    await nuGetPackageManager.InstallPackageAsync(projectA, packageA1,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                        projectName = args.Name;
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // nuget actions
+                    actions.Add(NuGetProjectAction.CreateInstallProjectAction(packageA2,
+                        sourceRepositoryProvider.GetRepositories().First()));
+                    actions.Add(NuGetProjectAction.CreateUninstallProjectAction(packageB1));
+
+                    // Main Act
+                    await
+                        nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, actions,
+                            new TestNuGetProjectContext(), token);
+
+                    //Assert
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                    Assert.Equal("testA", projectName);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_InstallPackagesInMultipleProjects_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+                    var projectB = testSolutionManager.AddNewMSBuildProject("testB");
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+                    var projectNames = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                        projectNames.Add(args.Name);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // Act
+                    await nuGetPackageManager.InstallPackageAsync(projectA, target,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+                    await nuGetPackageManager.InstallPackageAsync(projectB, target,
+                        new ResolutionContext(), new TestNuGetProjectContext(),
+                        sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                    // Assert Project1
+                    // Check that the packages.config file exists after the installation
+                    Assert.True(File.Exists(projectA.PackagesConfigNuGetProject.FullPath));
+                    Assert.True(File.Exists(projectB.PackagesConfigNuGetProject.FullPath));
+
+                    // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                    var packagesInPackagesConfig =
+                        (await projectA.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(1, packagesInPackagesConfig.Count);
+                    var packagesInPackagesConfigB =
+                        (await projectB.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(1, packagesInPackagesConfigB.Count);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 2);
+                    Assert.True(batchEndIds.Count == 2);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                    Assert.Equal(batchStartIds[1], batchEndIds[1]);
+                    Assert.NotEqual(batchStartIds[0], batchStartIds[1]);
+                    Assert.True(projectNames.Count == 2);
+                    Assert.Equal("testA", projectNames[0]);
+                    Assert.Equal("testB", projectNames[1]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_ExecuteNugetActions_NoOP_BatchEvent()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    // Main Act
+                    await
+                        nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, new List<NuGetProjectAction>(),
+                            new TestNuGetProjectContext(), token);
+
+                    // Check that the packages.config file exists after the installation
+                    Assert.False(File.Exists(projectA.PackagesConfigNuGetProject.FullPath));
+                    // Check that there are no packages returned by PackagesConfigProject
+                    var packagesInPackagesConfig =
+                        (await projectA.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                    Assert.Equal(0, packagesInPackagesConfig.Count);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_InstallPackage_Fail_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA",
+                        NuGetFramework.Parse("netcoreapp10"));
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    Exception exception = null;
+                    try
+                    {
+                        // Act
+                        await nuGetPackageManager.InstallPackageAsync(projectA, target,
+                            new ResolutionContext(), new TestNuGetProjectContext(),
+                            sourceRepositoryProvider.GetRepositories().First(), null, token);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
+
+                    // Assert
+                    Assert.NotNull(exception);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_DownloadPackageTask_Fail_BatchEvent_NotRaised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    // Add package
+                    var target = new PackageIdentity("packageA", NuGetVersion.Parse("1.0.0"));
+                    AddToPackagesFolder(target, packageSource);
+
+                    var projectActions = new List<NuGetProjectAction>();
+                    projectActions.Add(
+                        NuGetProjectAction.CreateInstallProjectAction(target, null));
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    Exception exception = null;
+                    try
+                    {
+                        // Act
+                        await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, projectActions,
+                            new TestNuGetProjectContext(), token);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
+
+                    // Assert
+                    Assert.NotNull(exception);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 0);
+                    Assert.True(batchEndIds.Count == 0);
+
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_DownloadPackageResult_Fail_BatchEvent_Raised()
+        {
+            // Arrange
+            using (var packageSource = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<Configuration.PackageSource>()
+                    {
+                        new Configuration.PackageSource(packageSource.Path)
+                    });
+
+                using (var testSolutionManager = new TestSolutionManager(true))
+                {
+                    var testSettings = new Configuration.NullSettings();
+                    var token = CancellationToken.None;
+                    var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                    var nuGetPackageManager = new NuGetPackageManager(
+                        sourceRepositoryProvider,
+                        testSettings,
+                        testSolutionManager,
+                        deleteOnRestartManager);
+                    var projectA = testSolutionManager.AddNewMSBuildProject("testA");
+
+                    var projectActions = new List<NuGetProjectAction>();
+                    projectActions.Add(
+                        NuGetProjectAction.CreateInstallProjectAction(
+                            new PackageIdentity("inValidPackageA", new NuGetVersion("1.0.0")),
+                            sourceRepositoryProvider.GetRepositories().First()));
+
+                    // batch handlers
+                    var batchStartIds = new List<string>();
+                    var batchEndIds = new List<string>();
+
+                    // add batch events handler
+                    nuGetPackageManager.BatchStart += (o, args) =>
+                    {
+                        batchStartIds.Add(args.Id);
+                    };
+
+                    nuGetPackageManager.BatchEnd += (o, args) =>
+                    {
+                        batchEndIds.Add(args.Id);
+                    };
+
+                    Exception exception = null;
+                    try
+                    {
+                        // Act
+                        await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, projectActions,
+                            new TestNuGetProjectContext(), token);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
+
+                    // Assert
+                    Assert.NotNull(exception);
+
+                    // Check batch events data
+                    Assert.True(batchStartIds.Count == 1);
+                    Assert.True(batchEndIds.Count == 1);
+                    Assert.Equal(batchStartIds[0], batchEndIds[0]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task TestPacMan_InstallPackage_BuildIntegratedProject_BatchEvent_NotRaised()
+        {
+            // Arrange
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV3OnlySourceRepositoryProvider();
+            using (var testSolutionManager = new TestSolutionManager(true))
+            {
+                var testSettings = new Configuration.NullSettings();
+                var token = CancellationToken.None;
+                var deleteOnRestartManager = new TestDeleteOnRestartManager();
+                var nuGetPackageManager = new NuGetPackageManager(
+                    sourceRepositoryProvider,
+                    testSettings,
+                    testSolutionManager,
+                    deleteOnRestartManager);
+
+                var installationCompatibility = new Mock<IInstallationCompatibility>();
+                nuGetPackageManager.InstallationCompatibility = installationCompatibility.Object;
+
+                var buildIntegratedProject = testSolutionManager.AddBuildIntegratedProject();
+                var packageIdentity = PackageWithDependents[0];
+
+                // batch handlers
+                var batchStartIds = new List<string>();
+                var batchEndIds = new List<string>();
+
+                // add batch events handler
+                nuGetPackageManager.BatchStart += (o, args) =>
+                {
+                    batchStartIds.Add(args.Id);
+                };
+
+                nuGetPackageManager.BatchEnd += (o, args) =>
+                {
+                    batchEndIds.Add(args.Id);
+                };
+
+                // Act
+                await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, packageIdentity,
+                    new ResolutionContext(), new TestNuGetProjectContext(),
+                    sourceRepositoryProvider.GetRepositories().First(), null, token);
+
+                // Assert
+                // Check batch events data
+                Assert.True(batchStartIds.Count == 0);
+                Assert.True(batchEndIds.Count == 0);
+            }
+        }
+
+        private static void AddToPackagesFolder(PackageIdentity package, string root)
+        {
+            var dir = Path.Combine(root, $"{package.Id}.{package.Version.ToString()}");
+            Directory.CreateDirectory(dir);
+
+            var context = new SimpleTestPackageContext()
+            {
+                Id = package.Id,
+                Version = package.Version.ToString()
+            };
+
+            context.AddFile("lib/net45/a.dll");
+            SimpleTestPackageUtility.CreateOPCPackage(context, dir);
+        }
+
         private SourceRepositoryProvider CreateSource(List<SourcePackageDependencyInfo> packages)
         {
             var resourceProviders = new List<Lazy<INuGetResourceProvider>>();

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
@@ -86,6 +87,34 @@ namespace API.Test
             }
 
             return false;
+        }
+
+        public static bool BatchEventsApi(string id, string version)
+        {
+            var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
+            var packageProjectEventService = ServiceLocator.GetInstance<IVsPackageInstallerProjectEvents>();
+            var installerServices = ServiceLocator.GetInstance<IVsPackageInstaller>();
+            var batchStartIds = new List<string>();
+            var batchEndIds = new List<string>();
+
+            packageProjectEventService.BatchStart += (o, args) =>
+            {
+                batchStartIds.Add(args.BatchId);
+            };
+
+            packageProjectEventService.BatchEnd += (o, args) =>
+            {
+                batchEndIds.Add(args.BatchId);
+            };
+
+            foreach (EnvDTE.Project project in dte.Solution.Projects)
+            {
+                installerServices.InstallPackage(null, project, id, version, false);
+            }
+
+            return batchStartIds.Count == 1 &&
+                   batchEndIds.Count == 1 &&
+                   batchStartIds[0].Equals(batchEndIds[0], StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Recently we saw nuget performance takes a major hit when resharper installed and enabled. And that's because when we do multiple installation/ uninstallation of packages across projects, with each operation nuget raise multiple events about package installation, reference added, etc.. and resharper do their own build intellisense stuff with each of these events. Since most of these stuff happens on main thread so it almost doubled nuget operations time as well as a unresponsive visual studio ui while the whole operation is in progress.

So this PR is to target this issue and provide nuget batch events which will intimate resharper of any other third party that a bulk operation of multiple installation n uninstallation is in progress so they would hold on to their stuff until they receive batch end event.

We've already prototyped this solution and checked with updated resharper build, so with these batch events, it almost reduced the unnecessary performance overhead of resharper. Same operation which earlier took ~124 secs with resharper, now takes ~74 secs.

Fix https://github.com/NuGet/Home/issues/3044

Spec - https://github.com/NuGet/Home/wiki/Batch-Events 
