### PR TITLE
Parse .NET Core project.json version strings as VersionRange

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectKNuGetProject.cs
@@ -139,9 +139,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 var moniker = item as INuGetPackageMoniker;
                 if (moniker != null)
                 {
-                    identity = new PackageIdentity(
-                        moniker.Id,
-                        NuGetVersion.Parse(moniker.Version));
+                    // As with build integrated projects (UWP project.json), treat the version as a
+                    // version range and use the minimum version of that range. Eventually, this
+                    // method should return VersionRange instances, not NuGetVersion so that the
+                    // UI can express the full project.json intent. This improvement is tracked
+                    // here: https://github.com/NuGet/Home/issues/3101
+                    var versionRange = VersionRange.Parse(moniker.Version);
+                    var version = versionRange.MinVersion;
+
+                    identity = new PackageIdentity(moniker.Id, version);
                 }
                 else
                 {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectKNuGetProjectTests.cs
@@ -21,6 +21,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     public class ProjectKNuGetProjectTests
     {
         [Fact]
+        public async Task ProjectKNuGetProject_WithVersionRange_GetInstalledPackagesAsync()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(testDirectory);
+
+                tc.PackageManager
+                    .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[] { new NuGetPackageMoniker { Id = "foo", Version = "1.0.0-*" } });
+
+                // Act
+                var actual = await tc.Target.GetInstalledPackagesAsync(CancellationToken.None);
+
+                // Assert
+                Assert.Equal(1, actual.Count());
+                var packageReference = actual.First();
+                Assert.Equal("foo", packageReference.PackageIdentity.Id);
+                Assert.Equal(NuGetVersion.Parse("1.0.0--"), packageReference.PackageIdentity.Version);
+            }
+        }
+
+        [Fact]
         public async Task ProjectKNuGetProject_WithPackageTypes_InstallPackageAsync()
         {
             // Arrange


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/3070 and https://github.com/NuGet/Home/issues/3095.

In a project.json you can specify a dependency with a version range, e.g. a floating version like `1.0.0-*`. The problem was that we were simply parsing this string as a `NuGetVersion` (which is a specific version) not a `VersionRange`. This problem is only occurring in .NET Core project.json projects, not UWP project.json.

Right now, our UI has a limitation where it only shows a specific version (not a version range). For this reason, we will now parse this string as a version range but only display the minimum of the version range. This is not an ideal solution since it's ugly and unhelpful but we are already doing this today with UWP project.json projects. The improvement to the UI to display version ranges is tracked here: https://github.com/NuGet/Home/issues/3101.

/cc @alpaix @yishaigalatzer @rohit21agrawal @mlorbetske
