### PR TITLE
Fixed passing all supported frameworks with search query

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -211,9 +211,9 @@ namespace NuGet.Protocol
 
         public async Task<IReadOnlyList<V2FeedPackageInfo>> Search(string searchTerm, SearchFilter filters, int skip, int take, ILogger log, CancellationToken cancellationToken)
         {
-            var targetFramework = String.Join(@"/", filters.SupportedFrameworks);
-
-            var shortFormTargetFramework = NuGetFramework.Parse(targetFramework).GetShortFolderName();
+            // get target framework shortname of all the projects in a solution
+            var shortFormTargetFramework = string.Join("|", filters.SupportedFrameworks.Select(
+                targetFramework => NuGetFramework.Parse(targetFramework).GetShortFolderName()));
 
             // The search term comes in already encoded from VS
             var uri = string.Format(CultureInfo.InvariantCulture, SearchEndPointFormat,


### PR DESCRIPTION
Search packages with multiple projects now pass all supported frameworks in search querystring which helps it to list all available packages as per supported frameworks.

Fix https://github.com/NuGet/Home/issues/3068

@emgarten @alpaix @joelverhagen @rrelyea 
