### PR TITLE
workaround for mono bug in package extraction where local timezone is a positive offset from UTC

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/ZipArchiveExtensions.cs
@@ -65,24 +65,24 @@ namespace NuGet.Packaging
         {
             var attr = File.GetAttributes(fileFullPath);
 
-            if (!attr.HasFlag(FileAttributes.Directory) &&
+            try
+            {
+                if (!attr.HasFlag(FileAttributes.Directory) &&
                 entry.LastWriteTime.DateTime != DateTime.MinValue && // Ignore invalid times
                 entry.LastWriteTime.UtcDateTime <= DateTime.UtcNow) // Ignore future times
-            {
-                try
                 {
                     File.SetLastWriteTimeUtc(fileFullPath, entry.LastWriteTime.UtcDateTime);
                 }
-                catch (ArgumentOutOfRangeException ex)
-                {
-                    string message = string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.FailedFileTime,
-                        fileFullPath, // {0}
-                        ex.Message); // {1}
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                string message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.FailedFileTime,
+                    fileFullPath, // {0}
+                    ex.Message); // {1}
 
-                    logger.LogVerbose(message);
-                }
+                logger.LogVerbose(message);
             }
         }
     }


### PR DESCRIPTION
Fixes another workaround for : https://github.com/NuGet/Home/issues/2992

Basically ZipArchive on Mono uses DateTime.MinValue for zips which have a last write time missing in the zip file. If this value is casted to a DateTimeOffset, it blows up with a ArgumentOutOfRangeException.

(Interesting link here : https://leeoades.wordpress.com/2012/10/31/datetime-minvalue-be-careful/ )

CC : @mrward @emgarten @alpaix @joelverhagen @rrelyea 
