### PR TITLE
update the epoch time on the basis of which build number is calculated

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -254,7 +254,7 @@ Function Enable-DelaySigning {
 }
 
 Function Get-BuildNumber() {
-    $SemanticVersionDate = '2015-11-30'
+    $SemanticVersionDate = '2016-07-13'
     [int](((Get-Date) - (Get-Date $SemanticVersionDate)).TotalMinutes / 5)
 }
 

--- a/build/common.xproj.props
+++ b/build/common.xproj.props
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
-    <SemanticVersionDate>2015-11-30</SemanticVersionDate>
+    <SemanticVersionDate>2016-07-13</SemanticVersionDate>
     <Ticks1>$([System.DateTime]::Parse($(SemanticVersionDate)).Ticks)</Ticks1>
     <Ticks2>$([System.DateTime]::Now.Ticks)</Ticks2>
     <SpanTicks>$([MSBuild]::Subtract($(Ticks2), $(Ticks1)))</SpanTicks>


### PR DESCRIPTION
build numbers started exceeding 65535 (maximum value of ushort), leading to build failures.

Will need to run nuget locals -clear all after syncing this change.

CC: @emgarten @joelverhagen @alpaix @rrelyea 
