### PR TITLE
Make HTTP caching more testable by splitting implementation out of HttpSource

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/LocalsCommand.cs
@@ -61,7 +61,7 @@ namespace NuGet.CommandLine.Commands
             switch (localResourceName)
             {
                 case LocalResourceName.HttpCache:
-                    PrintLocalResourcePath(_httpCacheResourceName, SettingsUtility.GetHttpCacheFolder(Settings));
+                    PrintLocalResourcePath(_httpCacheResourceName, SettingsUtility.GetHttpCacheFolder());
                     break;
                 case LocalResourceName.PackagesCache:
                     PrintLocalResourcePath(_packagesCacheResourceName, MachineCache.Default?.Source);
@@ -73,7 +73,7 @@ namespace NuGet.CommandLine.Commands
                     PrintLocalResourcePath(_tempResourceName, NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp));
                     break;
                 case LocalResourceName.All:
-                    PrintLocalResourcePath(_httpCacheResourceName, SettingsUtility.GetHttpCacheFolder(Settings));
+                    PrintLocalResourcePath(_httpCacheResourceName, SettingsUtility.GetHttpCacheFolder());
                     PrintLocalResourcePath(_packagesCacheResourceName, MachineCache.Default?.Source);
                     PrintLocalResourcePath(_globalPackagesResourceName, SettingsUtility.GetGlobalPackagesFolder(Settings));
                     PrintLocalResourcePath(_tempResourceName, NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp));
@@ -185,7 +185,7 @@ namespace NuGet.CommandLine.Commands
         private bool ClearNuGetHttpCache()
         {
             var success = true;
-            var httpCacheFolderPath = SettingsUtility.GetHttpCacheFolder(Settings);
+            var httpCacheFolderPath = SettingsUtility.GetHttpCacheFolder();
 
             if (!string.IsNullOrEmpty(httpCacheFolderPath))
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/NuGetPathContext.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NuGetPathContext.cs
@@ -37,7 +37,7 @@ namespace NuGet.Configuration
             {
                 FallbackPackageFolders = SettingsUtility.GetFallbackPackageFolders(settings),
                 UserPackageFolder = SettingsUtility.GetGlobalPackagesFolder(settings),
-                HttpCacheFolder = SettingsUtility.GetHttpCacheFolder(settings)
+                HttpCacheFolder = SettingsUtility.GetHttpCacheFolder()
             };
         }
 

--- a/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/SettingsUtility.cs
@@ -16,6 +16,7 @@ namespace NuGet.Configuration
         private const string GlobalPackagesFolderKey = "globalPackagesFolder";
         private const string GlobalPackagesFolderEnvironmentKey = "NUGET_PACKAGES";
         private const string FallbackPackagesFolderEnvironmentKey = "NUGET_FALLBACK_PACKAGES";
+        private const string HttpCacheEnvironmentKey = "NUGET_HTTP_CACHE_PATH";
         private const string RepositoryPathKey = "repositoryPath";
         public static readonly string DefaultGlobalPackagesFolderPath = "packages" + Path.DirectorySeparatorChar;
 
@@ -212,11 +213,23 @@ namespace NuGet.Configuration
                 .ToList();
         }
 
-        public static string GetHttpCacheFolder(ISettings settings)
+        /// <summary>
+        /// Get the HTTP cache folder from either an environment variable or a default.
+        /// </summary>
+        public static string GetHttpCacheFolder()
         {
-            if (settings == null)
+            var path = Environment.GetEnvironmentVariable(HttpCacheEnvironmentKey);
+            if (!string.IsNullOrEmpty(path))
             {
-                throw new ArgumentNullException(nameof(settings));
+                // Verify the path is absolute
+                VerifyPathIsRooted(HttpCacheEnvironmentKey, path);
+            }
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                path = Path.GetFullPath(path);
+                return path;
             }
             
             return NuGetEnvironment.GetFolderPath(NuGetFolderPath.HttpCacheDirectory);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace NuGet.Protocol
+{
+    public class HttpCacheResult
+    {
+        public HttpCacheResult(TimeSpan maxAge, string newCacheFile, string cacheFile)
+        {
+            MaxAge = maxAge;
+            NewCacheFile = newCacheFile;
+            CacheFile = cacheFile;
+        }
+
+        public TimeSpan MaxAge { get; }
+        public string NewCacheFile { get; }
+        public string CacheFile { get; }
+        public Stream Stream { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheUtility.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    public static class HttpCacheUtility
+    {
+        private const int BufferSize = 8192;
+
+        public static HttpCacheResult InitializeHttpCacheResult(
+            string httpCacheDirectory,
+            Uri baseUri,
+            string cacheKey,
+            HttpSourceCacheContext context)
+        {
+            // When the MaxAge is TimeSpan.Zero, this means the caller is passing in a folder different than
+            // the global HTTP cache used by default. Additionally, creating and cleaning up the directory is
+            // all the responsibility of the caller.
+            var maxAge = context.MaxAge;
+            string newFile;
+            string cacheFile;
+            if (!maxAge.Equals(TimeSpan.Zero))
+            {
+                var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(baseUri.OriginalString));
+                var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
+
+                var cacheFolder = Path.Combine(httpCacheDirectory, baseFolderName);
+
+                cacheFile = Path.Combine(cacheFolder, baseFileName);
+
+                newFile = cacheFile + "-new";
+            }
+            else
+            {
+                cacheFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
+
+                newFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
+            }
+
+            return new HttpCacheResult(maxAge, newFile, cacheFile);
+        }
+
+        private static string ComputeHash(string value)
+        {
+            var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;
+            byte[] hash;
+            using (var sha = SHA1.Create())
+            {
+                hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
+            }
+
+            const string hex = "0123456789abcdef";
+            return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
+        }
+
+        private static string RemoveInvalidFileNameChars(string value)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            return new string(
+                value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()
+                )
+                .Replace("__", "_")
+                .Replace("__", "_");
+        }
+
+        public static Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
+        {
+            if (!maxAge.Equals(TimeSpan.Zero))
+            {
+                string cacheFolder = Path.GetDirectoryName(cacheFile);
+                if (!Directory.Exists(cacheFolder))
+                {
+                    Directory.CreateDirectory(cacheFolder);
+                }
+            }
+
+            if (File.Exists(cacheFile))
+            {
+                var fileInfo = new FileInfo(cacheFile);
+                var age = DateTime.UtcNow.Subtract(fileInfo.LastWriteTimeUtc);
+                if (age < maxAge)
+                {
+                    var stream = new FileStream(
+                        cacheFile,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read | FileShare.Delete,
+                        BufferSize,
+                        useAsync: true);
+
+                    return stream;
+                }
+            }
+
+            return null;
+        }
+
+        public static async Task CreateCacheFileAsync(
+            HttpCacheResult result,
+            string uri,
+            HttpResponseMessage response,
+            HttpSourceCacheContext context,
+            Action<Stream> ensureValidContents,
+            CancellationToken cancellationToken)
+        {
+            // The update of a cached file is divided into two steps:
+            // 1) Delete the old file.
+            // 2) Create a new file with the same name.
+            using (var fileStream = new FileStream(
+                result.NewCacheFile,
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                BufferSize,
+                useAsync: true))
+            {
+                using (var networkStream = await response.Content.ReadAsStreamAsync())
+                {
+                    await networkStream.CopyToAsync(fileStream, BufferSize, cancellationToken);
+                }
+
+                // Validate the content before putting it into the cache.
+                fileStream.Seek(0, SeekOrigin.Begin);
+                ensureValidContents?.Invoke(fileStream);
+            }
+
+            if (File.Exists(result.CacheFile))
+            {
+                // Process B can perform deletion on an opened file if the file is opened by process A
+                // with FileShare.Delete flag. However, the file won't be actually deleted until A close it.
+                // This special feature can cause race condition, so we never delete an opened file.
+                if (!IsFileAlreadyOpen(result.CacheFile))
+                {
+                    File.Delete(result.CacheFile);
+                }
+            }
+
+            // If the destination file doesn't exist, we can safely perform moving operation.
+            // Otherwise, moving operation will fail.
+            if (!File.Exists(result.CacheFile))
+            {
+                File.Move(
+                    result.NewCacheFile,
+                    result.CacheFile);
+            }
+
+            // Even the file deletion operation above succeeds but the file is not actually deleted,
+            // we can still safely read it because it means that some other process just updated it
+            // and we don't need to update it with the same content again.
+            result.Stream = new FileStream(
+                result.CacheFile,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read | FileShare.Delete,
+                BufferSize,
+                useAsync: true);
+        }
+
+        private static bool IsFileAlreadyOpen(string filePath)
+        {
+            FileStream stream = null;
+
+            try
+            {
+                stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+            }
+            catch
+            {
+                return true;
+            }
+            finally
+            {
+                if (stream != null)
+                {
+                    stream.Dispose();
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -21,7 +18,6 @@ namespace NuGet.Protocol
 {
     public class HttpSource : IDisposable
     {
-        private const int BufferSize = 8192;
         private readonly Func<Task<HttpHandlerResource>> _messageHandlerFactory;
         private readonly Uri _baseUri;
         private HttpClient _httpClient;
@@ -70,7 +66,11 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token)
         {
-            var result = InitializeHttpCacheResult(request.CacheKey, request.CacheContext);
+            var result = HttpCacheUtility.InitializeHttpCacheResult(
+                HttpCacheDirectory,
+                _baseUri,
+                request.CacheKey,
+                request.CacheContext);
 
             return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                 result.CacheFile,
@@ -140,7 +140,7 @@ namespace NuGet.Protocol
 
                         throttledResponse.Response.EnsureSuccessStatusCode();
 
-                        await CreateCacheFileAsync(
+                        await HttpCacheUtility.CreateCacheFileAsync(
                             result,
                             request.Uri,
                             throttledResponse.Response,
@@ -300,103 +300,13 @@ namespace NuGet.Protocol
             return httpClient;
         }
 
-        private HttpCacheResult InitializeHttpCacheResult(string cacheKey, HttpSourceCacheContext context)
-        {
-            // When the MaxAge is TimeSpan.Zero, this means the caller is passing in a folder different than
-            // the global HTTP cache used by default. Additionally, creating and cleaning up the directory is
-            // all the responsibility of the caller.
-            var maxAge = context.MaxAge;
-            string newFile;
-            string cacheFile;
-            if (!maxAge.Equals(TimeSpan.Zero))
-            {
-                var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(_baseUri.OriginalString));
-                var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
-
-                var cacheFolder = Path.Combine(HttpCacheDirectory, baseFolderName);
-
-                cacheFile = Path.Combine(cacheFolder, baseFileName);
-
-                newFile = cacheFile + "-new";
-            }
-            else
-            {
-                cacheFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
-
-                newFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
-            }
-
-            return new HttpCacheResult(maxAge, newFile, cacheFile);
-        }
-
-        private async Task CreateCacheFileAsync(
-            HttpCacheResult result,
-            string uri,
-            HttpResponseMessage response,
-            HttpSourceCacheContext context,
-            Action<Stream> ensureValidContents,
-            CancellationToken cancellationToken)
-        {
-            // The update of a cached file is divided into two steps:
-            // 1) Delete the old file.
-            // 2) Create a new file with the same name.
-            using (var fileStream = new FileStream(
-                result.NewCacheFile,
-                FileMode.Create,
-                FileAccess.ReadWrite,
-                FileShare.None,
-                BufferSize,
-                useAsync: true))
-            {
-                using (var networkStream = await response.Content.ReadAsStreamAsync())
-                {
-                    await networkStream.CopyToAsync(fileStream, 8192, cancellationToken);
-                }
-
-                // Validate the content before putting it into the cache.
-                fileStream.Seek(0, SeekOrigin.Begin);
-                ensureValidContents?.Invoke(fileStream);
-            }
-
-            if (File.Exists(result.CacheFile))
-            {
-                // Process B can perform deletion on an opened file if the file is opened by process A
-                // with FileShare.Delete flag. However, the file won't be actually deleted until A close it.
-                // This special feature can cause race condition, so we never delete an opened file.
-                if (!IsFileAlreadyOpen(result.CacheFile))
-                {
-                    File.Delete(result.CacheFile);
-                }
-            }
-
-            // If the destination file doesn't exist, we can safely perform moving operation.
-            // Otherwise, moving operation will fail.
-            if (!File.Exists(result.CacheFile))
-            {
-                File.Move(
-                    result.NewCacheFile,
-                    result.CacheFile);
-            }
-
-            // Even the file deletion operation above succeeds but the file is not actually deleted,
-            // we can still safely read it because it means that some other process just updated it
-            // and we don't need to update it with the same content again.
-            result.Stream = new FileStream(
-                result.CacheFile,
-                FileMode.Open,
-                FileAccess.Read,
-                FileShare.Read | FileShare.Delete,
-                BufferSize,
-                useAsync: true);
-        }
-
         public string HttpCacheDirectory
         {
             get
             {
                 if (_httpCacheDirectory == null)
                 {
-                    _httpCacheDirectory = NuGetEnvironment.GetFolderPath(NuGetFolderPath.HttpCacheDirectory);
+                    _httpCacheDirectory = SettingsUtility.GetHttpCacheFolder();
                 }
 
                 return _httpCacheDirectory;
@@ -407,80 +317,7 @@ namespace NuGet.Protocol
 
         protected virtual Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
-            if (!maxAge.Equals(TimeSpan.Zero))
-            {
-                string cacheFolder = Path.GetDirectoryName(cacheFile);
-                if (!Directory.Exists(cacheFolder))
-                {
-                    Directory.CreateDirectory(cacheFolder);
-                }
-            }
-
-            if (File.Exists(cacheFile))
-            {
-                var fileInfo = new FileInfo(cacheFile);
-                var age = DateTime.UtcNow.Subtract(fileInfo.LastWriteTimeUtc);
-                if (age < maxAge)
-                {
-                    var stream = new FileStream(
-                        cacheFile,
-                        FileMode.Open,
-                        FileAccess.Read,
-                        FileShare.Read | FileShare.Delete,
-                        BufferSize,
-                        useAsync: true);
-
-                    return stream;
-                }
-            }
-
-            return null;
-        }
-
-        private static string ComputeHash(string value)
-        {
-            var trailing = value.Length > 32 ? value.Substring(value.Length - 32) : value;
-            byte[] hash;
-            using (var sha = SHA1.Create())
-            {
-                hash = sha.ComputeHash(Encoding.UTF8.GetBytes(value));
-            }
-
-            const string hex = "0123456789abcdef";
-            return hash.Aggregate("$" + trailing, (result, ch) => "" + hex[ch / 0x10] + hex[ch % 0x10] + result);
-        }
-
-        private static string RemoveInvalidFileNameChars(string value)
-        {
-            var invalid = Path.GetInvalidFileNameChars();
-            return new string(
-                value.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray()
-                )
-                .Replace("__", "_")
-                .Replace("__", "_");
-        }
-
-        private static bool IsFileAlreadyOpen(string filePath)
-        {
-            FileStream stream = null;
-
-            try
-            {
-                stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
-            }
-            catch
-            {
-                return true;
-            }
-            finally
-            {
-                if (stream != null)
-                {
-                    stream.Dispose();
-                }
-            }
-
-            return false;
+            return HttpCacheUtility.TryReadCacheFile(uri, maxAge, cacheFile);
         }
 
         public static HttpSource Create(SourceRepository source)
@@ -548,21 +385,6 @@ namespace NuGet.Protocol
                     Interlocked.Exchange(ref _throttle, null)?.Release();
                 }
             }
-        }
-
-        private class HttpCacheResult
-        {
-            public HttpCacheResult(TimeSpan maxAge, string newCacheFile, string cacheFile)
-            {
-                MaxAge = maxAge;
-                NewCacheFile = newCacheFile;
-                CacheFile = cacheFile;
-            }
-
-            public TimeSpan MaxAge { get; }
-            public string NewCacheFile { get; }
-            public string CacheFile { get; }
-            public Stream Stream { get; set; }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGetPathContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/NuGetPathContextTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Configuration.Test
                 ConfigurationFileTestUtility.CreateConfigurationFile(nugetConfigPath, mockBaseDirectory, config);
                 Settings settings = new Settings(mockBaseDirectory);
 
-                var http = SettingsUtility.GetHttpCacheFolder(settings);
+                var http = SettingsUtility.GetHttpCacheFolder();
 
                 // Act
                 var pathContext = NuGetPathContext.Create(settings);
@@ -52,7 +52,7 @@ namespace NuGet.Configuration.Test
             using (var mockBaseDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var globalFolder = SettingsUtility.GetGlobalPackagesFolder(NullSettings.Instance);
-                var http = SettingsUtility.GetHttpCacheFolder(NullSettings.Instance);
+                var http = SettingsUtility.GetHttpCacheFolder();
 
                 // Act
                 var pathContext = NuGetPathContext.Create(NullSettings.Instance);


### PR DESCRIPTION
- Add `NUGET_HTTP_CACHE` environment variable for setting the HTTP cache location
- Make HTTP caching more testable by splitting implementation out of `HttpSource`

This is moving code without changing functionality.

/cc @emgarten @alpaix @MarkOsborneMS 
