### PR TITLE
Allow netstandard to install contentFiles under the any tfm

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -17,23 +17,14 @@ namespace NuGet.Client
     /// </summary>
     public class ManagedCodeConventions
     {
-        private static readonly ContentPropertyDefinition TfmProperty = new ContentPropertyDefinition(PropertyNames.TargetFrameworkMoniker,
-            table: new Dictionary<string, object>()
-                {
-                    { "any", FrameworkConstants.CommonFrameworks.DotNet }
-                },
-            parser: TargetFrameworkName_Parser,
-            compatibilityTest: TargetFrameworkName_CompatibilityTest,
-            compareTest: TargetFrameworkName_NearestCompareTest);
-
         private static readonly ContentPropertyDefinition LocaleProperty = new ContentPropertyDefinition(PropertyNames.Locale,
             parser: Locale_Parser);
 
         private static readonly ContentPropertyDefinition AnyProperty = new ContentPropertyDefinition(
             PropertyNames.AnyValue,
-            parser: o => o); // Identity parser, all strings are valid for any
+            parser: (o, t) => o); // Identity parser, all strings are valid for any
         private static readonly ContentPropertyDefinition AssemblyProperty = new ContentPropertyDefinition(PropertyNames.ManagedAssembly,
-            parser: o => o.Equals(PackagingCoreConstants.EmptyFolder, StringComparison.Ordinal) ? o : null, // Accept "_._" as a pseudo-assembly
+            parser: (o, t) => o.Equals(PackagingCoreConstants.EmptyFolder, StringComparison.Ordinal) ? o : null, // Accept "_._" as a pseudo-assembly
             fileExtensions: new[] { ".dll", ".winmd", ".exe" });
         private static readonly ContentPropertyDefinition MSBuildProperty = new ContentPropertyDefinition(PropertyNames.MSBuild, fileExtensions: new[] { ".targets", ".props" });
         private static readonly ContentPropertyDefinition SatelliteAssemblyProperty = new ContentPropertyDefinition(PropertyNames.SatelliteAssembly, fileExtensions: new[] { ".resources.dll" });
@@ -41,6 +32,19 @@ namespace NuGet.Client
         private static readonly ContentPropertyDefinition CodeLanguageProperty = new ContentPropertyDefinition(
             PropertyNames.CodeLanguage,
             parser: CodeLanguage_Parser);
+
+        private static readonly Dictionary<string, object> DefaultTfmAny = new Dictionary<string, object>
+        {
+            { PropertyNames.TargetFrameworkMoniker, AnyFramework.Instance }
+        };
+
+        private static readonly PatternTable DotnetAnyTable = new PatternTable(new[]
+        {
+            new PatternTableEntry(
+                PropertyNames.TargetFrameworkMoniker,
+                "any",
+                FrameworkConstants.CommonFrameworks.DotNet)
+        });
 
         private RuntimeGraph _runtimeGraph;
 
@@ -53,7 +57,6 @@ namespace NuGet.Client
             _runtimeGraph = runtimeGraph;
 
             var props = new Dictionary<string, ContentPropertyDefinition>();
-            props[TfmProperty.Name] = TfmProperty;
             props[AnyProperty.Name] = AnyProperty;
             props[AssemblyProperty.Name] = AssemblyProperty;
             props[LocaleProperty.Name] = LocaleProperty;
@@ -63,8 +66,14 @@ namespace NuGet.Client
 
             props[PropertyNames.RuntimeIdentifier] = new ContentPropertyDefinition(
                 PropertyNames.RuntimeIdentifier,
-                parser: o => o, // Identity parser, all strings are valid runtime ids :)
+                parser: (o, t) => o, // Identity parser, all strings are valid runtime ids :)
                 compatibilityTest: RuntimeIdentifier_CompatibilityTest);
+
+            props[PropertyNames.TargetFrameworkMoniker] = new ContentPropertyDefinition(
+                PropertyNames.TargetFrameworkMoniker,
+                parser: TargetFrameworkName_Parser,
+                compatibilityTest: TargetFrameworkName_CompatibilityTest,
+                compareTest: TargetFrameworkName_NearestCompareTest);
 
             Properties = new ReadOnlyDictionary<string, ContentPropertyDefinition>(props);
 
@@ -92,14 +101,32 @@ namespace NuGet.Client
             }
         }
 
-        private static object CodeLanguage_Parser(string name)
+        private static object CodeLanguage_Parser(string name, PatternTable table)
         {
+            if (table != null)
+            {
+                object val;
+                if (table.TryLookup(PropertyNames.CodeLanguage, name, out val))
+                {
+                    return val;
+                }
+            }
+
             // Code language values must be alpha numeric.
             return name.All(c => char.IsLetterOrDigit(c)) ? name : null;
         }
 
-        private static object Locale_Parser(string name)
+        private static object Locale_Parser(string name, PatternTable table)
         {
+            if (table != null)
+            {
+                object val;
+                if (table.TryLookup(PropertyNames.Locale, name, out val))
+                {
+                    return val;
+                }
+            }
+
             if (name.Length == 2)
             {
                 return name;
@@ -112,16 +139,44 @@ namespace NuGet.Client
             return null;
         }
 
-        private static object TargetFrameworkName_Parser(string name)
+        private static object TargetFrameworkName_Parser(
+            string name,
+            PatternTable table)
         {
-            var result = NuGetFramework.Parse(name);
+            object obj = null;
+
+            // Check for replacements
+            if (table != null)
+            {
+                if (table.TryLookup(PropertyNames.TargetFrameworkMoniker, name, out obj))
+                {
+                    return obj;
+                }
+            }
+
+            return TargetFrameworkName_ParserCore(name);
+        }
+
+        private static NuGetFramework TargetFrameworkName_ParserCore(string name)
+        {
+            var result = NuGetFramework.ParseFolder(name);
 
             if (!result.IsUnsupported)
             {
                 return result;
             }
 
-            return new NuGetFramework(name, new Version(0, 0));
+            // Everything should be in the folder format, but fallback to 
+            // full parsing for legacy support.
+            result = NuGetFramework.ParseFrameworkName(name, DefaultFrameworkNameProvider.Instance);
+
+            if (!result.IsUnsupported)
+            {
+                return result;
+            }
+
+            // For unknown frameworks return the name as is.
+            return new NuGetFramework(name, FrameworkConstants.EmptyVersion);
         }
 
         private static bool TargetFrameworkName_CompatibilityTest(object criteria, object available)
@@ -290,107 +345,96 @@ namespace NuGet.Client
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                        "{any}/{tfm}/{any?}",
-                        "runtimes/{rid}/{any}/{tfm}/{any?}",
+                        new PatternDefinition("{any}/{tfm}/{any?}", table: DotnetAnyTable),
+                        new PatternDefinition("runtimes/{rid}/{any}/{tfm}/{any?}", table: DotnetAnyTable),
                     },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "{any}/{tfm}/{any?}",
-                        "runtimes/{rid}/{any}/{tfm}/{any?}",
+                        new PatternDefinition("{any}/{tfm}/{any?}", table: DotnetAnyTable),
+                        new PatternDefinition("runtimes/{rid}/{any}/{tfm}/{any?}", table: DotnetAnyTable),
                     });
 
                 RuntimeAssemblies = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                            "runtimes/{rid}/lib/{tfm}/{any?}",
-                            "lib/{tfm}/{any?}",
-                            new PatternDefinition("lib/{assembly?}", defaults: new Dictionary<string, object>
-                                {
-                                    { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
-                                })
-                        },
+                        new PatternDefinition("runtimes/{rid}/lib/{tfm}/{any?}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{tfm}/{any?}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{assembly?}", table: DotnetAnyTable,
+                            defaults: new Dictionary<string, object>
+                            {
+                                { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                            })
+                    },
                     pathPatterns: new PatternDefinition[]
                     {
-                            "runtimes/{rid}/lib/{tfm}/{assembly}",
-                            "lib/{tfm}/{assembly}",
-                            new PatternDefinition("lib/{assembly}", defaults: new Dictionary<string, object>
-                                {
-                                    { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
-                                })
-                        });
+                        new PatternDefinition("runtimes/{rid}/lib/{tfm}/{assembly}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{tfm}/{assembly}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{assembly}", table: DotnetAnyTable, defaults: new Dictionary<string, object>
+                            {
+                                { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+                            })
+                    });
 
                 CompileAssemblies = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                         {
-                            "ref/{tfm}/{any?}",
+                            new PatternDefinition("ref/{tfm}/{any?}", table: DotnetAnyTable),
                         },
                     pathPatterns: new PatternDefinition[]
                         {
-                            "ref/{tfm}/{assembly}",
+                            new PatternDefinition("ref/{tfm}/{assembly}", table: DotnetAnyTable),
                         });
 
                 NativeLibraries = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                         {
-                            "runtimes/{rid}/nativeassets/{tfm}/{any?}",
-                            new PatternDefinition("runtimes/{rid}/native/{any?}", defaults: new Dictionary<string, object>
-                            {
-                                { "tfm", AnyFramework.Instance }
-                            })
+                            new PatternDefinition("runtimes/{rid}/nativeassets/{tfm}/{any?}", table: DotnetAnyTable),
+                            new PatternDefinition("runtimes/{rid}/native/{any?}", table: null, defaults: DefaultTfmAny)
                         },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "runtimes/{rid}/nativeassets/{tfm}/{any}",
-                        new PatternDefinition("runtimes/{rid}/native/{any}", defaults: new Dictionary<string, object>
-                        {
-                            { "tfm", AnyFramework.Instance }
-                        })
+                        new PatternDefinition("runtimes/{rid}/nativeassets/{tfm}/{any}", table: DotnetAnyTable),
+                        new PatternDefinition("runtimes/{rid}/native/{any}", table: null, defaults: DefaultTfmAny)
                     });
 
                 ResourceAssemblies = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                        "runtimes/{rid}/lib/{tfm}/{locale?}/{any?}",
-                        "lib/{tfm}/{locale?}/{any?}"
+                        new PatternDefinition("runtimes/{rid}/lib/{tfm}/{locale?}/{any?}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{tfm}/{locale?}/{any?}", table: DotnetAnyTable),
                     },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "runtimes/{rid}/lib/{tfm}/{locale}/{satelliteAssembly}",
-                        "lib/{tfm}/{locale}/{satelliteAssembly}"
+                        new PatternDefinition("runtimes/{rid}/lib/{tfm}/{locale}/{satelliteAssembly}", table: DotnetAnyTable),
+                        new PatternDefinition("lib/{tfm}/{locale}/{satelliteAssembly}", table: DotnetAnyTable),
                     });
 
                 MSBuildFiles = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                        "build/{tfm}/{msbuild?}",
-                        new PatternDefinition("build/{msbuild?}", defaults: new Dictionary<string, object>
-                        {
-                            { "tfm", AnyFramework.Instance }
-                        })
+                        new PatternDefinition("build/{tfm}/{msbuild?}", table: DotnetAnyTable),
+                        new PatternDefinition("build/{msbuild?}", table: null, defaults: DefaultTfmAny)
                     },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "build/{tfm}/{msbuild}",
-                        new PatternDefinition("build/{msbuild}", defaults: new Dictionary<string, object>
-                        {
-                            { "tfm", AnyFramework.Instance }
-                        })
+                        new PatternDefinition("build/{tfm}/{msbuild}", table: DotnetAnyTable),
+                        new PatternDefinition("build/{msbuild}", table: null, defaults: DefaultTfmAny)
                     });
 
                 ContentFiles = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                     {
-                        "contentFiles/{codeLanguage}/{tfm}/{any?}"
+                        new PatternDefinition("contentFiles/{codeLanguage}/{tfm}/{any?}"),
                     },
                     pathPatterns: new PatternDefinition[]
                     {
-                        "contentFiles/{codeLanguage}/{tfm}/{any?}"
+                        new PatternDefinition("contentFiles/{codeLanguage}/{tfm}/{any?}"),
                     });
             }
         }

--- a/src/NuGet.Core/NuGet.ContentModel/ContentQueryDefinition.cs
+++ b/src/NuGet.Core/NuGet.ContentModel/ContentQueryDefinition.cs
@@ -49,14 +49,29 @@ namespace NuGet.ContentModel
         public string Pattern { get; }
         public IReadOnlyDictionary<string, object> Defaults { get; }
 
+        /// <summary>
+        /// Replacement token table.
+        /// </summary>
+        public PatternTable Table { get; }
+
         public PatternDefinition(string pattern)
-            : this(pattern, Enumerable.Empty<KeyValuePair<string, object>>())
+            : this(pattern, table: null, defaults: Enumerable.Empty<KeyValuePair<string, object>>())
         {
         }
 
-        public PatternDefinition(string pattern, IEnumerable<KeyValuePair<string, object>> defaults)
+        public PatternDefinition(string pattern, PatternTable table)
+            : this(pattern, table, Enumerable.Empty<KeyValuePair<string, object>>())
+        {
+        }
+
+        public PatternDefinition(
+            string pattern,
+            PatternTable table,
+            IEnumerable<KeyValuePair<string, object>> defaults)
         {
             Pattern = pattern;
+
+            Table = table;
             Defaults = new ReadOnlyDictionary<string, object>(defaults.ToDictionary(p => p.Key, p => p.Value));
         }
 

--- a/src/NuGet.Core/NuGet.ContentModel/PatternTable.cs
+++ b/src/NuGet.Core/NuGet.ContentModel/PatternTable.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.ContentModel
+{
+    /// <summary>
+    /// Replacement token table organized by property.
+    /// </summary>
+    public class PatternTable
+    {
+        private readonly Dictionary<string, Dictionary<string, object>> _table
+            = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+
+        public PatternTable()
+            : this(Enumerable.Empty<PatternTableEntry>())
+        {
+        }
+
+        public PatternTable(IEnumerable<PatternTableEntry> entries)
+        {
+            if (entries == null)
+            {
+                throw new ArgumentNullException(nameof(entries));
+            }
+
+            foreach (var entry in entries)
+            {
+                Dictionary<string, object> byProp;
+                if (!_table.TryGetValue(entry.PropertyName, out byProp))
+                {
+                    byProp = new Dictionary<string, object>(StringComparer.Ordinal);
+                    _table.Add(entry.PropertyName, byProp);
+                }
+
+                byProp.Add(entry.Name, entry.Value);
+            }
+        }
+
+        /// <summary>
+        /// Lookup a token and get the replacement if it exists.
+        /// </summary>
+        /// <param name="propertyName">Property moniker</param>
+        /// <param name="name">Token name</param>
+        /// <param name="value">Replacement value</param>
+        public bool TryLookup(string propertyName, string name, out object value)
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Dictionary<string, object> byProp;
+            if (_table.TryGetValue(propertyName, out byProp))
+            {
+                return byProp.TryGetValue(name, out value);
+            }
+
+            value = null;
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ContentModel/PatternTableEntry.cs
+++ b/src/NuGet.Core/NuGet.ContentModel/PatternTableEntry.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.ContentModel
+{
+    public class PatternTableEntry
+    {
+        /// <summary>
+        /// PropertyName moniker
+        /// </summary>
+        public string PropertyName { get; }
+
+        /// <summary>
+        /// Item name
+        /// </summary>
+        public string Name { get; } 
+
+        /// <summary>
+        /// Item replacement value
+        /// </summary>
+        public object Value { get; }
+
+        public PatternTableEntry(string propertyName, string name, object value)
+        {
+            if (propertyName == null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            PropertyName = propertyName;
+            Name = name;
+            Value = value;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ContentModel/SelectionCriteriaBuilder.cs
+++ b/src/NuGet.Core/NuGet.ContentModel/SelectionCriteriaBuilder.cs
@@ -56,7 +56,7 @@ namespace NuGet.ContentModel
                 else
                 {
                     object valueLookup;
-                    if (propertyDefinition.TryLookup(value, out valueLookup))
+                    if (propertyDefinition.TryLookup(value, table: null, value: out valueLookup))
                     {
                         Entry.Properties[key] = valueLookup;
                     }

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelContentFilesTests.cs
@@ -10,6 +10,56 @@ namespace NuGet.Client.Test
     public class ContentModelContentFilesTests
     {
         [Fact]
+        public void ContentFiles_NetStandardAny()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netstandard10.app") }));
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("netstandard1.0"));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "contentFiles/any/any/config1.xml"
+            });
+
+            // Act
+            var contentFileGroup = collection.FindBestItemGroup(criteria, conventions.Patterns.ContentFiles);
+            var file = contentFileGroup.Items.Single().Path;
+
+            // Assert
+            Assert.Equal("contentFiles/any/any/config1.xml", file);
+        }
+
+        [Fact]
+        public void ContentFiles_NetStandardFallbackToAny()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("netstandard13.app") }));
+
+            var criteria = conventions.Criteria.ForFramework(NuGetFramework.Parse("netstandard1.3"));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "contentFiles/any/any/config1.xml",
+                "contentFiles/any/dotnet/config1.xml",
+                "contentFiles/any/netstandard1.4/config1.xml"
+            });
+
+            // Act
+            var contentFileGroup = collection.FindBestItemGroup(criteria, conventions.Patterns.ContentFiles);
+            var file = contentFileGroup.Items.Single().Path;
+
+            // Assert
+            Assert.Equal("contentFiles/any/any/config1.xml", file);
+        }
+
+        [Fact]
         public void ContentFiles_BasicContentModelCheck()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
@@ -132,30 +132,6 @@ namespace NuGet.Client.Test
         }
 
         [Fact]
-        public void ContentModel_LibAnyMapsToDotnet()
-        {
-            // Arrange
-            var conventions = new ManagedCodeConventions(
-                new RuntimeGraph(
-                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
-
-            var collection = new ContentItemCollection();
-            collection.Load(new string[]
-            {
-                "lib/any/a.dll",
-            });
-
-            // Act
-            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
-                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
-                .ToList();
-
-            // Assert
-            Assert.Equal(1, groups.Count);
-            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
-        }
-
-        [Fact]
         public void ContentModel_LibRootIgnoreSubFolder()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelLibTests.cs
@@ -132,6 +132,30 @@ namespace NuGet.Client.Test
         }
 
         [Fact]
+        public void ContentModel_LibAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/any/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
         public void ContentModel_LibRootIgnoreSubFolder()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+using Xunit;
+
+namespace NuGet.Client.Test
+{
+    public class ContentModelTests
+    {
+        [Fact]
+        public void ContentModel_LibAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/any/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
+        public void ContentModel_RefAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "ref/any/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.CompileAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
+        public void ContentModel_RuntimesAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "runtimes/any/lib/any/a.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.RuntimeAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
+        public void ContentModel_ResourcesAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "lib/any/en-us/a.resources.dll",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.ResourceAssemblies)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
+        public void ContentModel_MSBuildAnyMapsToDotnet()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "build/any/a.targets",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.MSBuildFiles)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal(".NETPlatform,Version=v5.0", groups[0].Properties["tfm"].ToString());
+        }
+
+        [Fact]
+        public void ContentModel_ContentFilesAnyMapsToAny()
+        {
+            // Arrange
+            var conventions = new ManagedCodeConventions(
+                new RuntimeGraph(
+                    new List<CompatibilityProfile>() { new CompatibilityProfile("net46.app") }));
+
+            var collection = new ContentItemCollection();
+            collection.Load(new string[]
+            {
+                "contentFiles/any/any/a.txt",
+            });
+
+            // Act
+            var groups = collection.FindItemGroups(conventions.Patterns.ContentFiles)
+                .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
+                .ToList();
+
+            // Assert
+            Assert.Equal(1, groups.Count);
+            Assert.Equal("Any,Version=v0.0", groups[0].Properties["tfm"].ToString());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/PatternTableTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/PatternTableTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.Client.Test
+{
+    public class PatternTableTests
+    {
+        [Fact]
+        public void PatternTable_LookupWhenEmpty()
+        {
+            // Arrange
+            var table = new PatternTable();
+
+            // Act
+            object obj;
+            var b = table.TryLookup("tfm", "any", out obj);
+
+            // Assert
+            Assert.False(b);
+            Assert.Null(obj);
+        }
+
+        [Fact]
+        public void PatternTable_LookupWithValue()
+        {
+            // Arrange
+            var dotnet = NuGetFramework.Parse("dotnet");
+            var data = new List<PatternTableEntry>()
+            {
+                new PatternTableEntry("tfm", "any", dotnet)
+            };
+
+            var table = new PatternTable(data);
+
+            // Act
+            object obj;
+            var b = table.TryLookup("tfm", "any", out obj);
+
+            // Assert
+            Assert.True(b);
+            Assert.Equal(dotnet, obj);
+        }
+
+        [Fact]
+        public void PatternTable_LookupWithMiss()
+        {
+            // Arrange
+            var data = new List<PatternTableEntry>()
+            {
+                new PatternTableEntry("tfm", "dotnet", NuGetFramework.Parse("dotnet"))
+            };
+
+            var table = new PatternTable(data);
+
+            // Act
+            object obj;
+            var b = table.TryLookup("tfm", "any", out obj);
+
+            // Assert
+            Assert.False(b);
+            Assert.Null(obj);
+        }
+    }
+}


### PR DESCRIPTION
This change removes the `any` -> `dotnet` for contentFiles, unlike lib and other folders contentFiles does supports the `any` framework.

ContentModel previously defined token replacements such as `any` -> `dotnet` on a per pattern basis. All patterns that contained `{tfm}` would apply this replacement. This change moves the replacement table to the pattern which contains the folder name to allow fine grained control over it.

Fixes https://github.com/NuGet/Home/issues/3118

//cc @joelverhagen @alpaix @jainaashish @rohit21agrawal @rrelyea @drewgil 
