### PR TITLE
Don't use a new namespace for the .nuspec when package types are specified

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestSchemaUtility.cs
@@ -48,11 +48,6 @@ namespace NuGet.Packaging
         /// Allows XDT transformation
         /// </summary>
         internal const string SchemaVersionV6 = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
-
-        /// <summary>
-        /// Added packageTypes element under metadata.
-        /// </summary>
-        internal const string SchemaVersionV7 = "http://schemas.microsoft.com/packaging/2016/04/nuspec.xsd";
         
         private static readonly string[] VersionToSchemaMappings = new[] {
             SchemaVersionV1,
@@ -60,8 +55,7 @@ namespace NuGet.Packaging
             SchemaVersionV3,
             SchemaVersionV4,
             SchemaVersionV5,
-            SchemaVersionV6,
-            SchemaVersionV7
+            SchemaVersionV6
         };
 
 #if !IS_CORECLR

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestVersionUtility.cs
@@ -16,7 +16,6 @@ namespace NuGet.Packaging
         public const int TargetFrameworkSupportForDependencyContentsAndToolsVersion = 4;
         public const int TargetFrameworkSupportForReferencesVersion = 5;
         public const int XdtTransformationVersion = 6;
-        public const int PackageTypeVersion = 7;
 
         public static int GetManifestVersion(ManifestMetadata metadata)
         {
@@ -26,11 +25,6 @@ namespace NuGet.Packaging
         private static int GetMaxVersionFromMetadata(ManifestMetadata metadata)
         {
             // Important: always add newer version checks at the top
-            
-            if (metadata.PackageTypes != null && metadata.PackageTypes.Any())
-            {
-                return PackageTypeVersion;
-            }
 
             bool referencesHasTargetFramework =
               metadata.PackageAssemblyReferences != null &&

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
@@ -10,7 +10,7 @@ namespace NuGet.Packaging.Test
     public class ManifestVersionUtilityTest
     {
         [Fact]
-        public void GetManifestVersionReturns7IfPackageTypesAreSet()
+        public void GetManifestVersionReturns1IfPackageTypesAreSet()
         {
             // Arrange
             var metadata = new ManifestMetadata
@@ -29,7 +29,7 @@ namespace NuGet.Packaging.Test
             var version = ManifestVersionUtility.GetManifestVersion(metadata);
 
             // Assert
-            Assert.Equal(7, version);
+            Assert.Equal(1, version);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageBuilderTest.cs
@@ -576,7 +576,7 @@ namespace NuGet.Packaging.Test
 
                 // Assert
                 Assert.Equal(@"<?xml version=""1.0"" encoding=""utf-8""?>
-<package xmlns=""http://schemas.microsoft.com/packaging/2016/04/nuspec.xsd"">
+<package xmlns=""http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"">
   <metadata>
     <id>A</id>
     <version>1.0.0</version>


### PR DESCRIPTION
After conversing with @rrelyea, @rohit21agrawal, and @emgarten.

Fixes https://github.com/NuGet/Home/issues/3140.
