### PR TITLE
Re-enable pack's project.json dependency processing in nuget.exe

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PackCommand.cs
@@ -85,7 +85,6 @@ namespace NuGet.CommandLine
             packArgs.Logger = Console;
             packArgs.Arguments = Arguments;
             packArgs.OutputDirectory = OutputDirectory;
-            packArgs.BasePath = BasePath;
 
             // The directory that contains msbuild
             packArgs.MsBuildDirectory = new Lazy<string>(() => MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console));
@@ -97,6 +96,10 @@ namespace NuGet.CommandLine
             PackCommandRunner.SetupCurrentDirectory(packArgs);
 
             Console.WriteLine(LocalizedResourceManager.GetString("PackageCommandAttemptingToBuildPackage"), Path.GetFileName(packArgs.Path));
+
+            // If the BasePath is not specified, use the current directory
+            BasePath = String.IsNullOrEmpty(BasePath) ? packArgs.CurrentDirectory : BasePath;
+            packArgs.BasePath = BasePath;
 
             if (!String.IsNullOrEmpty(MinClientVersion))
             {


### PR DESCRIPTION
This is a partial reversion of the change in https://github.com/NuGet/NuGet.Client/commit/0b79c0d5acbf8e07c271430a25dce91904938e3f which broke nuget.exe pack's processing of project.json. This in turn meant that dependency information was being left out of the nuspec altogether.

BasePath being left blank means that we need to look in the current directory for project.json. The past behavior of utilizing the command's path in the case of a blank BasePath broke dotnet pack (which is why other commit removed it), but utilizing current directory in the absence of a path does not.

We need to look further at pack, but this will at least address the regression. I would hold off on throw-away test coverage work until we have a spec and plan for pack.
@joelverhagen @emgarten @alpaix
