### PR TITLE
Consider a build integrated action an uninstall only if all project actions are uninstalls

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1977,8 +1977,17 @@ namespace NuGet.PackageManagement
                     nuGetProjectActions,
                     restoreResult);
 
+                // If this build integrated project action represents only uninstalls, mark the entire operation
+                // as an uninstall. Otherwise, mark it as an install. This is important because install operations
+                // are a bit more sensitive to errors (thus resulting in rollbacks).
+                var actionType = NuGetProjectActionType.Install;
+                if (nuGetProjectActions.All(x => x.NuGetProjectActionType == NuGetProjectActionType.Uninstall))
+                {
+                    actionType = NuGetProjectActionType.Uninstall;
+                }
+
                 return new BuildIntegratedProjectAction(nuGetProjectActions.First().PackageIdentity,
-                       nuGetProjectActions.First().NuGetProjectActionType,
+                       actionType,
                        originalLockFile,
                        rawPackageSpec,
                        restoreResult,


### PR DESCRIPTION
If a build integrated project action represents only uninstalls, mark the entire operation as an uninstall. Otherwise, mark it as an install. This is important because install operations are a bit more sensitive to errors (thus resulting in rollbacks).

Fix https://github.com/NuGet/Home/issues/3139.

/cc @emgarten @jainaashish @alpaix @rohit21agrawal 
