### PR TITLE
End to End Test cases for - installing package from a local source that doesn't exist throws a bogus message

### DIFF
--- a/InstallPackageTest.ps1
+++ b/InstallPackageTest.ps1
@@ -1,7 +1,0 @@
-
-function Test-InstallPackageWithInvalidLocalSource {
-	# Arrange
-
-	# Act & Assert
-	Assert-Throws { Install-Package Rules -source c:\temp\data } "Unable to find package 'Rules' at source c:\temp\data. Source not found."
-}

--- a/InstallPackageTest.ps1
+++ b/InstallPackageTest.ps1
@@ -1,0 +1,7 @@
+
+function Test-InstallPackageWithInvalidLocalSource {
+	# Arrange
+
+	# Act & Assert
+	Assert-Throws { Install-Package Rules -source c:\temp\data } "Unable to find package 'Rules' at source c:\temp\data. Source not found."
+}

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -12,6 +12,17 @@ function Test-InstallPackageWithInvalidAbsoluteLocalSource {
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
 }
 
+function Test-InstallPackageWithValidAbsoluteLocalSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = pwd
+	$message = "Unable to find package '$package'"
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
 function Test-InstallPackageWithInvalidRelativeLocalSource {
 	# Arrange
 	$package = "Rules"
@@ -46,6 +57,17 @@ function Test-InstallPackageWithInvalidHttpSource {
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
 }
 
+function Test-InstallPackageWithIncompleteHttpSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "http://"
+	$message = "Unable to find package 'Rules' at source '$source'. Source not found."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
 function Test-InstallPackageWithInvalidKnownSource {
 	# Arrange
 	$package = "Rules"
@@ -63,6 +85,28 @@ function Test-InstallPackageWithValidKnownSource {
 	$project = New-ConsoleApplication
 	$source = "nuget.org"
 	$message = "Unable to find package '$package'"
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithFileProtocolSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "file://Rules"
+	$message = "Unsupported type of source  '$source'. Please provide an http or local source."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithFtpProtocolSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "ftp://Rules"
+	$message = "Unsupported type of source  '$source'. Please provide an http or local source."
 
 	# Act & Assert
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -61,16 +61,17 @@ function Test-InstallPackageWithInvalidHttpSourceVerbose {
 	$package = "Rules"
 	$project = New-ConsoleApplication
 	$source = "http://example.com"
-	$url = $source+"/FindPackagesById()?id='$package'"
-	$errorcode = "404 Not Found"
-	$message = "  GET $url   NotFound $url ? An error occurred while retrieving package metadata for '$package' from source '$source'."+
-               "  The V2 feed at '$url' returned an unexpected status code '$errorcode'. Unable to find package 'Rules' at source '$source'."
-	
+	$escapedSource = [regex]::Escape($source)
+	$escapedUrl = [regex]::Escape($source+"/FindPackagesById()?id='$package'")
+	$message = "\ \ GET\ $escapedUrl\ \ \ NotFound\ $escapedUrl\ [\w]+\ An\ error\ occurred\ while\ retrieving\ package\ metadata\ for\ '$package'\ from\ source\ '$escapedSource'\.\r\n\ \ The\ V2\ feed\ at\ '$escapedUrl'\ returned\ an\ unexpected\ status\ code\ '404\ Not\ Found'\.\ Unable\ to\ find\ package\ '$package'\ at\ source\ '$escapedSource'\."
+
 	# Act
 	$result = Install-Package $package -ProjectName $project.Name -source $source -Verbose *>&1
+	$resultString = [string]::Join(" ", $result)
+	$compare = $resultString -Match $message
 
 	# Assert
-	Assert-True { $message -match $result }
+	Assert-True $compare
 }
 
 function Test-InstallPackageWithIncompleteHttpSource {

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -50,8 +50,7 @@ function Test-InstallPackageWithInvalidHttpSource {
 	$package = "Rules"
 	$project = New-ConsoleApplication
 	$source = "http://example.com"
-	$message = "An error occurred while retrieving package metadata for '$package' from source '$source'.
-  The V2 feed at '$source/FindPackagesById()?id='$package'' returned an unexpected status code '404 Not Found'."
+	$message = "Unable to find package '$package' at source '$source'."
 
 	# Act & Assert
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -56,6 +56,23 @@ function Test-InstallPackageWithInvalidHttpSource {
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
 }
 
+function Test-InstallPackageWithInvalidHttpSourceVerbose {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "http://example.com"
+	$url = $source+"/FindPackagesById()?id='$package'"
+	$errorcode = "404 Not Found"
+	$message = "  GET $url   NotFound $url ? An error occurred while retrieving package metadata for '$package' from source '$source'."+
+               "  The V2 feed at '$url' returned an unexpected status code '$errorcode'. Unable to find package 'Rules' at source '$source'."
+	
+	# Act
+	$result = Install-Package $package -ProjectName $project.Name -source $source -Verbose *>&1
+
+	# Assert
+	Assert-True { $message -match $result }
+}
+
 function Test-InstallPackageWithIncompleteHttpSource {
 	# Arrange
 	$package = "Rules"

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -1,5 +1,73 @@
 # Verify Xunit 2.1.0 can be installed into a net45 project.
 # https://github.com/NuGet/Home/issues/1711
+
+function Test-InstallPackageWithInvalidAbsoluteLocalSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "c:\temp\data"
+	$message = "Unable to find package '$package' at source '$source'. Source not found."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithInvalidRelativeLocalSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "..\invalid_folder"
+	$message = "Unable to find package '$package' at source '$source'. Source not found."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithValidRelativeLocalSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "..\"
+	$message = "Unable to find package '$package'"
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithInvalidHttpSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "http://example.com"
+	$message = "An error occurred while retrieving package metadata for '$package' from source '$source'.
+  The V2 feed at '$source/FindPackagesById()?id='$package'' returned an unexpected status code '404 Not Found'."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithInvalidKnownSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "nuget.random"
+	$message = "Unable to find package 'Rules' at source '$source'. Source not found."
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
+function Test-InstallPackageWithValidKnownSource {
+	# Arrange
+	$package = "Rules"
+	$project = New-ConsoleApplication
+	$source = "nuget.org"
+	$message = "Unable to find package '$package'"
+
+	# Act & Assert
+	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
+}
+
 function Test-InstallXunit210WithEmptyBuildFolderSucceeds
 {
     param($context)


### PR DESCRIPTION
Adding test cases for -

bug : https://github.com/NuGet/Home/issues/1674

original code PR's : https://github.com/NuGet/NuGet.Client/pull/742 https://github.com/NuGet/NuGet.Client/pull/758

Added End to End test cases to check the correctness of the error messages for the source specified using source switch.

cc : @alpaix  @rohit21agrawal @jainaashish @rrelyea @emgarten @joelverhagen 
