### PR TITLE
fix nuget pack discovery of project.json

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -252,7 +252,7 @@ namespace NuGet.CommandLine
             Packaging.Manifest manifest = null;
 
             // If there is a project.json file, load that and skip any nuspec that may exist
-            if (!PackCommandRunner.ProcessProjectJsonFile(builder, basePath, builder.Id, version, suffix, GetPropertyValue))
+            if (!PackCommandRunner.ProcessProjectJsonFile(builder, _project.DirectoryPath as string, builder.Id, version, suffix, GetPropertyValue))
             {
                 // If the package contains a nuspec file then use it for metadata
                 manifest = ProcessNuspec(builder, basePath);


### PR DESCRIPTION
Fixes issue : https://github.com/NuGet/Home/issues/3145

Summary of fix : NuGet was looking for project.json at the BasePath (which is a command line option for pack command). If user didn't specify BasePath, then it would assume that project.json did not exist. This fix passes the project directory as the path to look for project.json instead of BasePath.

CC: @emgarten @joelverhagen @alpaix @rrelyea 
