### PR TITLE
Remove Microsoft.Build[.Framework] version conflicts from Dev14 build

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -133,8 +133,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
@@ -63,7 +63,7 @@
     </When>
   </Choose>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine">
       <HintPath>$(ProgramFiles)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.VCProjectEngine.dll</HintPath>

--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio.Facade.csproj
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio.Facade.csproj
@@ -45,7 +45,7 @@
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </ItemGroup>
   <Choose>
     <When Condition="$(VisualStudioVersion)=='14.0'">

--- a/src/NuGet.Clients/VisualStudio14.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio14.Packages/project.json
@@ -14,7 +14,7 @@
     "Microsoft.VisualStudio.Text.UI": "14.2.25123",
     "Microsoft.VisualStudio.Text.UI.Wpf": "14.2.25123",
     "Microsoft.VisualStudio.Threading": "14.1.131",
-    "Microsoft.VSSDK.BuildTools": "14.2.25201"
+    "Microsoft.VSSDK.BuildTools": "14.3.25420"
   },
   "frameworks": {
     "net46": {}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -44,8 +44,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="Microsoft.Build.Framework, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -44,7 +44,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build, Version=$(VisualStudioVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
This reduces our Dev14 warning count considerably. The cause was a superfluous dependency in the Microsoft.VSSDK.BuildTools package. The owner has now removed it from the v14 package and I've consumed the new version here.
When they make the Dev15 package fix available, I'll also add it.
Making the explicit Microsoft.Build and Microsoft.Build.Framework dependencies pegged to VS version is also necessary to remove the conflict.
These conflicts are just build noise, as runtime version redirects exist for both assemblies in VS's config.
@joelverhagen @emgarten @alpaix 
