### PR TITLE
Skip RuntimeGraph generation for RIDless projects

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -83,10 +83,16 @@ namespace NuGet.Commands
             localRepositories.Add(userPackageFolder);
             localRepositories.AddRange(fallbackPackageFolders);
 
+            // Check if any non-empty RIDs exist before reading the runtime graph (runtime.json).
+            // Searching all packages for runtime.json and building the graph can be expensive.
+            var hasNonEmptyRIDs = frameworkRuntimePairs.Any(
+                tfmRidPair => !string.IsNullOrEmpty(tfmRidPair.RuntimeIdentifier));
+
             // Resolve runtime dependencies
-            var runtimeGraphs = new List<RestoreTargetGraph>();
-            if (runtimesByFramework.Count > 0)
+            if (hasNonEmptyRIDs)
             {
+                var runtimeGraphs = new List<RestoreTargetGraph>();
+
                 var runtimeTasks = new List<Task<RestoreTargetGraph[]>>();
                 foreach (var graph in graphs)
                 {


### PR DESCRIPTION
Restore was incorrectly checking for RIDs when deciding if a noop was possible. For portable projects that do not use RIDs the extra work to parse and build the runtime graph from runtime.json files is never used.

**Perf numbers**
Project: https://github.com/troydai/live.asp.net/
Before: 13 seconds
After: 5.5 seconds

Fixes https://github.com/NuGet/Home/issues/3150
