### PR TITLE
Add deprecated framework warning for dotnet

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Constants.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Constants.cs
@@ -6,5 +6,10 @@
         public const string SuppressUIDisclaimerRegistryName = "SuppressUILegalDisclaimer";
         public const string DoNotShowPreviewWindowRegistryName = "DoNotShowPreviewWindow";
         public const string IncludePrereleaseRegistryName = "IncludePrerelease";
+
+        /// <summary>
+        /// This is the registry key which tracks whether to show the deprecated framework window.
+        /// </summary>
+        public static readonly string DoNotShowDeprecatedFrameworkWindowRegistryName = "DoNotShowDeprecatedFrameworkWindow";
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/DeprecatedFrameworkModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DeprecatedFrameworkModel.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class DeprecatedFrameworkModel
+    {
+        public DeprecatedFrameworkModel(NuGetFramework deprecated, string migrationUrl, IEnumerable<NuGetProject> projects)
+        {
+            Details = string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.Text_DeprecatedFramework_DocumentLink_Before,
+                deprecated.DotNetFrameworkName,
+                deprecated.GetShortFolderName());
+
+            MigrationUrl = migrationUrl;
+
+            Projects = projects
+                .Select(project => NuGetProject.GetUniqueNameOrName(project))
+                .OrderBy(name => name)
+                .ToList();
+        }
+
+        public string Details { get; }
+        public string MigrationUrl { get; }
+        public IReadOnlyList<string> Projects { get; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Options.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Options.cs
@@ -14,6 +14,7 @@ namespace NuGet.PackageManagement.UI
         public Options()
         {
             ShowPreviewWindow = true;
+            ShowDeprecatedFrameworkWindow = true;
             CreateFileConflictActions();
             CreateDependencyBehaviors();
             ShowClassicOptions = true;
@@ -114,6 +115,24 @@ namespace NuGet.PackageManagement.UI
                 {
                     _showPreviewWindow = value;
                     OnPropertyChanged(nameof(ShowPreviewWindow));
+                }
+            }
+        }
+
+        private bool _showDeprecatedFrameworkWindow;
+
+        public bool ShowDeprecatedFrameworkWindow
+        {
+            get
+            {
+                return _showDeprecatedFrameworkWindow;
+            }
+            set
+            {
+                if (_showDeprecatedFrameworkWindow != value)
+                {
+                    _showDeprecatedFrameworkWindow = value;
+                    OnPropertyChanged(nameof(ShowDeprecatedFrameworkWindow));
                 }
             }
         }

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagement.UI.csproj
@@ -79,12 +79,16 @@
     <Compile Include="Converters\EnumDescriptionValueConverter.cs" />
     <Compile Include="Converters\NotNullOrTrueToBooleanConverter.cs" />
     <Compile Include="DisplayVersion.cs" />
+    <Compile Include="Models\DeprecatedFrameworkModel.cs" />
     <Compile Include="Models\LoadingStatusViewModel.cs" />
     <Compile Include="Models\PackageSearchMetadataCache.cs" />
     <Compile Include="Models\PackageSearchStatus.cs" />
     <Compile Include="Resources\Domain.cs" />
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Xamls\DeprecatedFrameworkWindow.xaml.cs">
+      <DependentUpon>DeprecatedFrameworkWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Xamls\RestartRequestBar.xaml.cs">
       <DependentUpon>RestartRequestBar.xaml</DependentUpon>
@@ -273,6 +277,10 @@
     <Page Include="Themes\generic.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Xamls\DeprecatedFrameworkWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Xamls\RestartRequestBar.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
@@ -945,6 +945,42 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to migration document.
+        /// </summary>
+        public static string Text_DeprecatedFramework_DocumentLink {
+            get {
+                return ResourceManager.GetString("Text_DeprecatedFramework_DocumentLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ..
+        /// </summary>
+        public static string Text_DeprecatedFramework_DocumentLink_After {
+            get {
+                return ResourceManager.GetString("Text_DeprecatedFramework_DocumentLink_After", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The NuGet operation failed due to one or more packages being incompatible with your project. The &apos;{0}&apos; (&apos;{1}&apos;) project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the .
+        /// </summary>
+        public static string Text_DeprecatedFramework_DocumentLink_Before {
+            get {
+                return ResourceManager.GetString("Text_DeprecatedFramework_DocumentLink_Before", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following project(s) target the deprecated framework:.
+        /// </summary>
+        public static string Text_DeprecatedFramework_ProjectList {
+            get {
+                return ResourceManager.GetString("Text_DeprecatedFramework_ProjectList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} downloads.
         /// </summary>
         public static string Text_Downloads {
@@ -1339,7 +1375,16 @@ namespace NuGet.PackageManagement.UI {
                 return ResourceManager.GetString("Warning_ProjectJson", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deprecated Framework.
+        /// </summary>
+        public static string WindowTitle_DeprecatedFramework {
+            get {
+                return ResourceManager.GetString("WindowTitle_DeprecatedFramework", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.resx
@@ -567,4 +567,24 @@ Packages installed into Website projects will not be restored during build. Cons
     <value>These options are not applicable to projects managing their dependencies through project.json.</value>
     <comment>To be displayed for the VS UI opened through a solution. bug #2665</comment>
   </data>
+  <data name="Text_DeprecatedFramework_DocumentLink_Before" xml:space="preserve">
+    <value>The NuGet operation failed due to one or more packages being incompatible with your project. The '{0}' ('{1}') project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the </value>
+    <comment>This text goes immediately before the document link.
+{0} is the full name of the deprecated framework (e.g. ".NETFramework,Version=v4.5").
+{1} is the short folder representation of the framework (e.g. "net45").</comment>
+  </data>
+  <data name="WindowTitle_DeprecatedFramework" xml:space="preserve">
+    <value>Deprecated Framework</value>
+  </data>
+  <data name="Text_DeprecatedFramework_ProjectList" xml:space="preserve">
+    <value>The following project(s) target the deprecated framework:</value>
+  </data>
+  <data name="Text_DeprecatedFramework_DocumentLink" xml:space="preserve">
+    <value>migration document</value>
+    <comment>The text has the document hyperlink applied to it.</comment>
+  </data>
+  <data name="Text_DeprecatedFramework_DocumentLink_After" xml:space="preserve">
+    <value>.</value>
+    <comment>This test goes immediately after the document link.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
@@ -17,6 +17,8 @@ namespace NuGet.PackageManagement.UI
     /// <remarks>This is not expected to be thread safe.</remarks>
     public interface INuGetUI
     {
+        bool WarnAboutDotnetDeprecation(IEnumerable<NuGetProject> projects);
+
         bool PromptForLicenseAcceptance(IEnumerable<PackageLicenseInfo> packages);
 
         void LaunchExternalLink(Uri url);
@@ -52,6 +54,11 @@ namespace NuGet.PackageManagement.UI
         /// True if the option to preview actions first is checked
         /// </summary>
         bool DisplayPreviewWindow { get; }
+
+        /// <summary>
+        /// True if the option to ignore the deprecated framework window is unchecked
+        /// </summary>
+        bool DisplayDeprecatedFrameworkWindow { get; }
 
         /// <summary>
         /// Package currently selected in the UI

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUIContext.cs
@@ -32,12 +32,20 @@ namespace NuGet.PackageManagement.UI
         void PersistSettings();
 
         /// <summary>
-        /// Apply the setting of wether to show preview window to all existing
+        /// Apply the setting of whether to show preview window to all existing
         /// package manager windows after user changes it by checking/unchecking the
         /// checkbox on the preview window.
         /// </summary>
         /// <param name="show">The value of the setting.</param>
         void ApplyShowPreviewSetting(bool show);
+
+        /// <summary>
+        /// Apply the setting of whether to show the deprecated framework window to all existing
+        /// package manager windows after a user changes it by checking/unchecking the checkbox on
+        /// the deprecated framework window.
+        /// </summary>
+        /// <param name="show">The value of the setting.</param>
+        void ApplyShowDeprecatedFrameworkSetting(bool show);
 
         IEnumerable<IVsPackageManagerProvider> PackageManagerProviders { get; }
     }

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -22,6 +22,7 @@ namespace NuGet.PackageManagement.UI
     {
         private readonly INuGetUIContext _context;
         public const string LogEntrySource = "NuGet Package Manager";
+        private const string DotnetDeprecationUrl = "https://aka.ms/rugr4c";
 
         public NuGetUI(
             INuGetUIContext context,
@@ -37,6 +38,30 @@ namespace NuGet.PackageManagement.UI
             ForceRemove = false;
             Projects = Enumerable.Empty<NuGetProject>();
             DisplayPreviewWindow = true;
+            DisplayDeprecatedFrameworkWindow = true;
+        }
+
+        public bool WarnAboutDotnetDeprecation(IEnumerable<NuGetProject> projects)
+        {
+            var result = false;
+
+            UIDispatcher.Invoke(() => { result = WarnAboutDotnetDeprecationImpl(projects); });
+
+            return result;
+        }
+
+        private bool WarnAboutDotnetDeprecationImpl(IEnumerable<NuGetProject> projects)
+        {
+            var window = new DeprecatedFrameworkWindow(_context)
+            {
+                DataContext = new DeprecatedFrameworkModel(
+                    FrameworkConstants.CommonFrameworks.DotNet,
+                    DotnetDeprecationUrl,
+                    projects)
+            };
+
+            var dialogResult = window.ShowModal();
+            return dialogResult ?? false;
         }
 
         public bool PromptForLicenseAcceptance(IEnumerable<PackageLicenseInfo> packages)
@@ -134,6 +159,12 @@ namespace NuGet.PackageManagement.UI
         }
 
         public bool DisplayPreviewWindow
+        {
+            set;
+            get;
+        }
+
+        public bool DisplayDeprecatedFrameworkWindow
         {
             set;
             get;

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUIContext.cs
@@ -66,6 +66,8 @@ namespace NuGet.PackageManagement.UI
 
         public abstract void ApplyShowPreviewSetting(bool show);
 
+        public abstract void ApplyShowDeprecatedFrameworkSetting(bool show);
+
         public IEnumerable<IVsPackageManagerProvider> PackageManagerProviders { get; }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/UserSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserSettings.cs
@@ -18,6 +18,7 @@ namespace NuGet.PackageManagement.UI
         {
             IncludePrerelease = RegistrySettingUtility.GetBooleanSetting(Constants.IncludePrereleaseRegistryName);
             ShowPreviewWindow = true;
+            ShowDeprecatedFrameworkWindow = true;
             SelectedFilter = ItemFilter.Installed;
             DependencyBehavior = DependencyBehavior.Lowest;
             FileConflictAction = FileConflictAction.PromptUser;
@@ -27,6 +28,8 @@ namespace NuGet.PackageManagement.UI
         public string SourceRepository { get; set; }
 
         public bool ShowPreviewWindow { get; set; }
+
+        public bool ShowDeprecatedFrameworkWindow { get; set; }
 
         public bool RemoveDependencies { get; set; }
 

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
@@ -1,0 +1,107 @@
+﻿<nuget:VsDialogWindow
+  x:Class="NuGet.PackageManagement.UI.DeprecatedFrameworkWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+  x:Name="_self"
+  ShowInTaskbar="False"
+  WindowStyle="SingleBorderWindow"
+  Background="{DynamicResource {x:Static nuget:Brushes.BackgroundBrushKey}}"
+  Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+  WindowStartupLocation="CenterOwner"
+  Title="{x:Static nuget:Resources.WindowTitle_DeprecatedFramework}"
+  Height="500"
+  Width="500">
+  <Window.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <nuget:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Window.Resources>
+
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="auto" />
+      <RowDefinition Height="auto" />
+      <RowDefinition />
+      <RowDefinition Height="auto" />
+    </Grid.RowDefinitions>
+    <TextBlock
+      Grid.Row="0"
+      Margin="12,4,12,0"
+      TextWrapping="Wrap">
+        <Run Text="{Binding Details, Mode=OneTime}" /><Hyperlink AutomationProperties.AutomationId="MigrationLink"
+                   NavigateUri="{Binding MigrationUrl, Mode=OneTime}"
+                   Style="{StaticResource HyperlinkStyle}"
+                   RequestNavigate="OnMigrationUrlNavigate"><Run Text="{x:Static nuget:Resources.Text_DeprecatedFramework_DocumentLink}" />
+        </Hyperlink><Run Text="{x:Static nuget:Resources.Text_DeprecatedFramework_DocumentLink_After}" />
+    </TextBlock>
+    <TextBlock
+      Grid.Row="1"
+      Margin="12,4,12,0"
+      TextWrapping="Wrap"
+      Text="{x:Static nuget:Resources.Text_DeprecatedFramework_ProjectList}" />
+
+    <Border
+      Grid.Row="2"
+      Margin="12,12"
+      BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
+      BorderThickness="1">
+      <ScrollViewer
+        HorizontalScrollBarVisibility="Auto"
+        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
+        IsTabStop="True">
+        <ItemsControl
+          ItemsSource="{Binding Path=Projects}"
+          IsTabStop="False">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate>
+                <StackPanel Margin="6, 6">
+                    <TextBlock Text="{Binding}" />
+                </StackPanel>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </Border>
+
+    <Grid
+      Grid.Row="3">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="auto" />
+        <ColumnDefinition />
+        <ColumnDefinition
+          Width="auto" />
+        <ColumnDefinition
+          Width="auto" />
+      </Grid.ColumnDefinitions>
+      <CheckBox
+        x:Name="_doNotShowCheckBox"
+        Grid.Column="0"
+        Margin="12"
+        MinWidth="180"
+        VerticalAlignment="Center"
+        Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+        Content="{x:Static nuget:Resources.DoNotShowThisAgain}"
+        Checked="DoNotShowCheckBox_Checked"
+        Unchecked="DoNotShowCheckBox_Unchecked" />
+      <Button
+        Grid.Column="2"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="0,12"
+        AutomationProperties.AutomationId="OK"
+        Content="{x:Static nuget:Resources.Button_OK}"
+        Click="OkButtonClicked" />
+      <Button
+        Grid.Column="3"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="6,12,12,12"
+        AutomationProperties.AutomationId="Cancel"
+        Content="{x:Static nuget:Resources.Button_Cancel}"
+        Click="CancelButtonClicked" />
+    </Grid>
+  </Grid>
+</nuget:VsDialogWindow>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Windows;
+using System.Windows.Documents;
+
+namespace NuGet.PackageManagement.UI
+{
+    public partial class DeprecatedFrameworkWindow : VsDialogWindow
+    {
+        private bool _initialized;
+        private INuGetUIContext _uiContext;
+
+        public DeprecatedFrameworkWindow(INuGetUIContext uiContext)
+        {
+            _initialized = false;
+            _uiContext = uiContext;
+            InitializeComponent();
+            _doNotShowCheckBox.IsChecked = IsDoNotShowDeprecatedFrameworkWindowEnabled();
+
+            if (StandaloneSwitch.IsRunningStandalone)
+            {
+                Background = SystemColors.WindowBrush;
+            }
+            _initialized = true;
+        }
+
+        private void OnMigrationUrlNavigate(object sender, RoutedEventArgs e)
+        {
+            var hyperlink = (Hyperlink)sender;
+            if (hyperlink != null
+                && hyperlink.NavigateUri != null)
+            {
+                UIUtility.LaunchExternalLink(hyperlink.NavigateUri);
+                e.Handled = true;
+            }
+        }
+
+        private void CancelButtonClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void OkButtonClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void DoNotShowCheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            SaveDoNotShowPreviewWindowSetting(doNotshow: true);
+        }
+
+        private void DoNotShowCheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            SaveDoNotShowPreviewWindowSetting(doNotshow: false);
+        }
+
+        private void SaveDoNotShowPreviewWindowSetting(bool doNotshow)
+        {
+            _uiContext.ApplyShowDeprecatedFrameworkSetting(!doNotshow);
+            
+            RegistrySettingUtility.SetBooleanSetting(
+                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName,
+                doNotshow);
+        }
+
+        public static bool IsDoNotShowDeprecatedFrameworkWindowEnabled()
+        {
+            return RegistrySettingUtility.GetBooleanSetting(
+                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName);
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml.cs
@@ -136,6 +136,7 @@ namespace NuGet.PackageManagement.UI
                     nugetUi.ForceRemove = model.Options.ForceRemove;
                     nugetUi.Projects = model.GetSelectedProjects(action);
                     nugetUi.DisplayPreviewWindow = model.Options.ShowPreviewWindow;
+                    nugetUi.DisplayDeprecatedFrameworkWindow = model.Options.ShowDeprecatedFrameworkWindow;
                     nugetUi.ProgressWindow.ActionType = actionType;
                 });
         }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -258,6 +258,11 @@ namespace NuGet.PackageManagement.UI
             _detailModel.Options.ShowPreviewWindow = show;
         }
 
+        public void ApplyShowDeprecatedFrameworkSetting(bool show)
+        {
+            _detailModel.Options.ShowDeprecatedFrameworkWindow = show;
+        }
+
         private void ApplySettings(
             UserSettings settings,
             Configuration.ISettings nugetSettings)
@@ -271,6 +276,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             _detailModel.Options.ShowPreviewWindow = settings.ShowPreviewWindow;
+            _detailModel.Options.ShowDeprecatedFrameworkWindow = settings.ShowDeprecatedFrameworkWindow;
             _detailModel.Options.RemoveDependencies = settings.RemoveDependencies;
             _detailModel.Options.ForceRemove = settings.ForceRemove;
             _topPanel.CheckboxPrerelease.IsChecked = settings.IncludePrerelease;
@@ -342,6 +348,7 @@ namespace NuGet.PackageManagement.UI
             {
                 SourceRepository = SelectedSource?.SourceName,
                 ShowPreviewWindow = _detailModel.Options.ShowPreviewWindow,
+                ShowDeprecatedFrameworkWindow = _detailModel.Options.ShowDeprecatedFrameworkWindow,
                 RemoveDependencies = _detailModel.Options.RemoveDependencies,
                 ForceRemove = _detailModel.Options.ForceRemove,
                 DependencyBehavior = _detailModel.Options.SelectedDependencyBehavior.Behavior,
@@ -357,9 +364,15 @@ namespace NuGet.PackageManagement.UI
         private UserSettings LoadSettings()
         {
             var settings = Model.Context.GetSettings(GetSettingsKey());
+
             if (PreviewWindow.IsDoNotShowPreviewWindowEnabled())
             {
                 settings.ShowPreviewWindow = false;
+            }
+
+            if (DeprecatedFrameworkWindow.IsDoNotShowDeprecatedFrameworkWindowEnabled())
+            {
+                settings.ShowDeprecatedFrameworkWindow = false;
             }
 
             return settings;
@@ -941,6 +954,7 @@ namespace NuGet.PackageManagement.UI
             nugetUi.RemoveDependencies = options.RemoveDependencies;
             nugetUi.ForceRemove = options.ForceRemove;
             nugetUi.DisplayPreviewWindow = options.ShowPreviewWindow;
+            nugetUi.DisplayDeprecatedFrameworkWindow = options.ShowDeprecatedFrameworkWindow;
 
             nugetUi.Projects = Model.Context.Projects;
             nugetUi.ProgressWindow.ActionType = actionType;

--- a/src/NuGet.Clients/StandaloneUI/StandaloneUIContext.cs
+++ b/src/NuGet.Clients/StandaloneUI/StandaloneUIContext.cs
@@ -102,5 +102,10 @@ namespace StandaloneUI
         {
             // no-op
         }
+
+        public override void ApplyShowDeprecatedFrameworkSetting(bool show)
+        {
+            // no-op
+        }
     }
 }

--- a/src/NuGet.Clients/VsExtension/VisualStudioUIContext.cs
+++ b/src/NuGet.Clients/VsExtension/VisualStudioUIContext.cs
@@ -61,5 +61,19 @@ namespace NuGetVSExtension
                 }
             }
         }
+
+        public override void ApplyShowDeprecatedFrameworkSetting(bool show)
+        {
+            var serviceProvider = ServiceLocator.GetInstance<IServiceProvider>();
+            IVsUIShell uiShell = (IVsUIShell)serviceProvider.GetService(typeof(SVsUIShell));
+            foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
+            {
+                var packageManagerControl = VsUtility.GetPackageManagerControl(windowFrame);
+                if (packageManagerControl != null)
+                {
+                    packageManagerControl.ApplyShowDeprecatedFrameworkSetting(show);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
If there is a restore failure prior to install or update on a `dotnet` project, throw a dialog warning that `dotnet` is a deprecated framework. The conditions to show the dialog are:
- The project is UWP or PCL project.json (`BuildIntegratedNuGetProject`)
- The restore fails with package incompatibilities.
- At least one of the project's being upgrade targets a `dotnet` framework (including `dotnet50` - `dotnet56`).
- The user has not checked `Do not show this again`.

![image](https://cloud.githubusercontent.com/assets/94054/16930389/d7208670-4cf0-11e6-988c-f6663fe4ede7.png)

The link still needs to be updated to point to the correct documentation. This can be done through the aka.ms site without a code change.

Addresses https://github.com/NuGet/Home/issues/3137.

/cc @rohit21agrawal @emgarten @harikmenon @rrelyea @ericstj 
