### PR TITLE
fix null ref exception for nuget pack projects which have a dependency on nupkg with a *.transform content file

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -1066,7 +1066,20 @@ namespace NuGet.CommandLine
         private IEnumerable<Packaging.IPackageFile> GetTransformFiles(PackageReaderBase package)
         {
             var groups = package.GetContentItems();
-            return groups.SelectMany(g => g.Items).Where(IsTransformFile).Select(f => new Packaging.PhysicalPackageFile() { TargetPath = f });
+            return groups.SelectMany(g => g.Items).Where(IsTransformFile).Select(f =>
+            {
+                var element = XElement.Load(package.GetStream(f));
+                var memStream = new MemoryStream();
+                element.Save(memStream);
+                memStream.Seek(0, SeekOrigin.Begin);
+
+                var file = new Packaging.PhysicalPackageFile(memStream)
+                {
+                    TargetPath = f
+                };
+                return file;
+            }
+        );
         }
 
         private static bool IsTransformFile(string file)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PhysicalPackageFile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PhysicalPackageFile.cs
@@ -17,10 +17,17 @@ namespace NuGet.Packaging
         {
         }
 
+        public PhysicalPackageFile(MemoryStream stream)
+        {
+            MemoryStream = stream;
+        }
+
         internal PhysicalPackageFile(Func<Stream> streamFactory)
         {
             _streamFactory = streamFactory;
         }
+
+        private MemoryStream MemoryStream { get; set; } 
 
         /// <summary>
         /// Path on disk
@@ -69,7 +76,18 @@ namespace NuGet.Packaging
 
         public Stream GetStream()
         {
-            return _streamFactory != null ? _streamFactory() : File.OpenRead(SourcePath);
+            if (_streamFactory != null)
+            {
+                return _streamFactory();
+            }
+            else if (SourcePath != null)
+            {
+                return File.OpenRead(SourcePath);
+            }
+            else
+            {
+                return MemoryStream;
+            }
         }
 
         public override string ToString()


### PR DESCRIPTION
fixes : https://github.com/NuGet/Home/issues/3160

Since the web.config.transform trying to be read is from the nupkg, we need to read it while the ZipArchive has not been disposed and store it in a MemoryStream to be retrieved later.

CC: @emgarten @alpaix @joelverhagen @drewgil @rrelyea @jainaashish 
