### PR TITLE
Understand packages.config vs project.json usage in NuGet

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/NuGetAndEnvDTEProjectCache.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/NuGetAndEnvDTEProjectCache.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.Telemetry;
 using NuGet.ProjectManagement;
 using EnvDTEProject = EnvDTE.Project;
 
@@ -137,6 +139,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 return EnvDTEProjectName;
             }
 
+            // Emit project specific telemetry as we are adding the project to the cache.
+            // This ensures we do not emit the events over and over while the solution is
+            // open.
+            NuGetProjectTelemetryService.Instance.EmitNuGetProject(
+                project,
+                nuGetProject,
+                CancellationToken.None);
+
+            // Add the project to the cache.
             AddShortName(EnvDTEProjectName);
 
             _projectNamesCache[EnvDTEProjectName.CustomUniqueName] = EnvDTEProjectName;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VsHierarchyItem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VsHierarchyItem.cs
@@ -30,6 +30,16 @@ namespace NuGet.PackageManagement.VisualStudio
         {
         }
 
+        internal bool TryGetProjectId(out Guid projectId)
+        {
+            var result = _hierarchy.GetGuidProperty(
+                VSConstants.VSITEMID_ROOT,
+                (int)__VSHPROPID.VSHPROPID_ProjectIDGuid,
+                out projectId);
+
+            return result == VSConstants.S_OK;
+        }
+
         internal uint VsItemID
         {
             get { return _vsitemid; }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/PackageManagement.VisualStudio.csproj
@@ -104,6 +104,7 @@
     <Compile Include="IDE\NuGetAndEnvDTEProjectCache.cs" />
     <Compile Include="IDE\EnvDTEProjectName.cs" />
     <Compile Include="IDE\IScriptExecutor.cs" />
+    <Compile Include="Telemetry\ProjectTelemetryEvent.cs" />
     <Compile Include="IDE\PackageInitPS1State.cs" />
     <Compile Include="IDE\VsCommonOperations.cs" />
     <Compile Include="IDE\VsHierarchyItem.cs" />
@@ -149,6 +150,11 @@
     <Compile Include="Setting\WritableSettingsStoreWrapper.cs" />
     <Compile Include="SourceControl\DTESourceControlUtility.cs" />
     <Compile Include="SourceControl\VsSourceControlTracker.cs" />
+    <Compile Include="Telemetry\NuGetProjectType.cs" />
+    <Compile Include="Telemetry\ProjectDependencyStatistics.cs" />
+    <Compile Include="Telemetry\ProjectInformation.cs" />
+    <Compile Include="Telemetry\NuGetProjectTelemetryService.cs" />
+    <Compile Include="Telemetry\NuGetTelemetryService.cs" />
     <Compile Include="Utility\EnvDTESolutionUtility.cs" />
     <Compile Include="Utility\FrameworkAssemblyResolver.cs" />
     <Compile Include="Utility\MessageHelper.cs" />

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using EnvDTE;
+using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectManagement;
+using NuGet.ProjectManagement.Projects;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public class NuGetProjectTelemetryService
+    {
+        public static NuGetProjectTelemetryService Instance = new NuGetProjectTelemetryService(
+            NuGetTelemetryService.Instance);
+
+        private readonly NuGetTelemetryService _nuGetTelemetryService;
+        private readonly string _nuGetVersion;
+
+        public NuGetProjectTelemetryService(NuGetTelemetryService telemetryService)
+        {
+            _nuGetVersion = ClientVersionUtility.GetNuGetAssemblyVersion();
+            _nuGetTelemetryService = telemetryService;
+        }
+
+        public void EmitNuGetProject(Project vsProject, NuGetProject nuGetProject, CancellationToken token)
+        {
+            // Get the project ID.
+            var vsHierarchyItem = VsHierarchyUtility.GetHierarchyItemForProject(vsProject);
+            Guid projectId;
+            if (!vsHierarchyItem.TryGetProjectId(out projectId))
+            {
+                projectId = Guid.Empty;
+            }
+
+            // Emit the events.
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                // Emit the project information.
+                try
+                {
+                    var projectType = NuGetProjectType.Unknown;
+                    if (nuGetProject is MSBuildNuGetProject)
+                    {
+                        projectType = NuGetProjectType.PackagesConfig;
+                    }
+                    else if (nuGetProject is BuildIntegratedNuGetProject)
+                    {
+                        projectType = NuGetProjectType.UwpProjectJson;
+                    }
+                    else if (nuGetProject is ProjectKNuGetProjectBase)
+                    {
+                        projectType = NuGetProjectType.NetCoreProjectJson;
+                    }
+
+                    var projectInformation = new ProjectInformation(
+                        _nuGetVersion,
+                        projectId,
+                        projectType);
+
+                    _nuGetTelemetryService.EmitProjectInformation(projectInformation);
+                }
+                catch
+                {
+                    // Ignore failures.
+                }
+
+                // Emit the project dependency statistics.
+                try
+                {
+                    var installedPackages = await nuGetProject.GetInstalledPackagesAsync(token);
+                    var installedPackagesCount = installedPackages.Count();
+
+                    var projectDependencyStatistics = new ProjectDependencyStatistics(
+                        _nuGetVersion,
+                        projectId,
+                        installedPackagesCount);
+
+                    _nuGetTelemetryService.EmitProjectDependencyStatistics(projectDependencyStatistics);
+                }
+                catch
+                {
+                    // Ignore failures.
+                }
+            });
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectType.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectType.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    /// <summary>
+    /// The different types of NuGet projects.
+    /// </summary>
+    public enum NuGetProjectType
+    {
+        /// <summary>
+        /// Used if the project does not support NuGet.
+        /// </summary>
+        Unsupported = 0,
+
+        /// <summary>
+        /// Used if the <see cref="NuGetProject"/> is not a recognized type.
+        /// </summary>
+        Unknown = 1,
+
+        /// <summary>
+        /// Corresponds to <see cref="MSBuildNuGetProject"/>.
+        /// </summary>
+        PackagesConfig = 2,
+
+        /// <summary>
+        /// Corresponds to <see cref="BuildIntegratedNuGetProject"/>.
+        /// </summary>
+        UwpProjectJson = 3,
+
+        /// <summary>
+        /// Corresponds to <see cref="ProjectKNuGetProjectBase"/>.
+        /// </summary>
+        NetCoreProjectJson = 4,
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetTelemetryService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetTelemetryService.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Common;
+using NuGet.VisualStudio.Facade.Telemetry;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public class NuGetTelemetryService
+    {
+        public static NuGetTelemetryService Instance = new NuGetTelemetryService(new TelemetrySession());
+
+        private const string EventNamePrefix = "VS/NuGet/";
+        private const string PropertyNamePrefix = "VS.NuGet.";
+
+        private const string NuGetVersionPropertyName = PropertyNamePrefix + "NuGetVersion";
+        private const string ProjectIdPropertyName = PropertyNamePrefix + "ProjectId";
+
+        private const string ProjectInformationEventName = EventNamePrefix + "ProjectInformation";
+        private const string NuGetProjectTypePropertyName = PropertyNamePrefix + "NuGetProjectType";
+        
+        private const string ProjectDependencyStatisticsEventName = EventNamePrefix + "DependencyStatistics";
+        private const string InstalledPackageCountPropertyName = PropertyNamePrefix + "InstalledPackageCount";
+
+        private readonly ITelemetrySession _telemetrySession;
+        private readonly string _nuGetVersion;
+
+        public NuGetTelemetryService(ITelemetrySession telemetrySession)
+        {
+            _nuGetVersion = ClientVersionUtility.GetNuGetAssemblyVersion();
+            _telemetrySession = telemetrySession;
+        }
+
+        public void EmitProjectInformation(ProjectInformation projectInformation)
+        {
+            EmitEvent(
+                ProjectInformationEventName,
+                projectInformation,
+                new Dictionary<string, object>
+                {
+                    { NuGetProjectTypePropertyName, (int) projectInformation.NuGetProjectType }
+                });
+        }
+
+        public void EmitProjectDependencyStatistics(ProjectDependencyStatistics projectDependencyStatistics)
+        {
+            EmitEvent(
+                ProjectDependencyStatisticsEventName,
+                projectDependencyStatistics,
+                new Dictionary<string, object>
+                {
+                    { InstalledPackageCountPropertyName, projectDependencyStatistics.InstalledPackageCount }
+                });
+        }
+
+        private void EmitEvent(string eventName, ProjectTelemetryEvent projectTelemetryEvent, Dictionary<string, object> properties)
+        {
+            var telemetryEvent = new TelemetryEvent(eventName);
+
+            foreach (var pair in properties)
+            {
+                telemetryEvent.Properties[pair.Key] = pair.Value;
+            }
+
+            telemetryEvent.Properties[NuGetVersionPropertyName] = projectTelemetryEvent.NuGetVersion;
+            telemetryEvent.Properties[ProjectIdPropertyName] = projectTelemetryEvent.ProjectId.ToString();
+
+            _telemetrySession.PostEvent(telemetryEvent);
+        }
+    }
+
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectDependencyStatistics.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectDependencyStatistics.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public class ProjectDependencyStatistics : ProjectTelemetryEvent
+    {
+        public ProjectDependencyStatistics(
+            string nuGetVersion,
+            Guid projectId,
+            int installedPackageCount)
+            : base(nuGetVersion, projectId)
+        {
+            InstalledPackageCount = installedPackageCount;
+        }
+
+        /// <summary>
+        /// The number of NuGet packages install to this project.
+        /// </summary>
+        public int InstalledPackageCount { get; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectInformation.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectInformation.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public class ProjectInformation : ProjectTelemetryEvent
+    {
+        public ProjectInformation(
+            string nuGetVersion,
+            Guid projectId,
+            NuGetProjectType nuGetProjectType)
+            : base(nuGetVersion, projectId)
+        {
+            NuGetProjectType = nuGetProjectType;
+        }
+
+        /// <summary>
+        /// The type of NuGet project this project is.
+        /// </summary>
+        public NuGetProjectType NuGetProjectType { get; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/ProjectTelemetryEvent.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.PackageManagement.Telemetry
+{
+    public class ProjectTelemetryEvent
+    {
+        public ProjectTelemetryEvent(string nuGetVersion, Guid projectId)
+        {
+            NuGetVersion = nuGetVersion;
+            ProjectId = projectId;
+        }
+
+        /// <summary>
+        /// The version of NuGet that emitted this event.
+        /// </summary>
+        public string NuGetVersion { get; }
+
+        /// <summary>
+        /// The project ID related to this event.
+        /// </summary>
+        public Guid ProjectId { get; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -193,7 +193,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 callerObject: null);
         }
 
-        private static VsHierarchyItem GetHierarchyItemForProject(Project project)
+        public static VsHierarchyItem GetHierarchyItemForProject(Project project)
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 

--- a/src/NuGet.Clients/VisualStudio.Facade/Telemetry/ITelemetrySession.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Telemetry/ITelemetrySession.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Facade.Telemetry
+{
+    public interface ITelemetrySession
+    {
+        void PostEvent(TelemetryEvent telemetryEvent);
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetryEvent.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetryEvent.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NuGet.VisualStudio.Facade.Telemetry
+{
+    public class TelemetryEvent
+    {
+        public TelemetryEvent(string eventName)
+        {
+            Name = eventName;
+            Properties = new Dictionary<string, object>();
+        }
+
+        public string Name { get; }
+        public IDictionary<string, object> Properties { get; }
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetrySession.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetrySession.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if VS14
+using Microsoft.VisualStudio.Telemetry;
+using VsTelemetryEvent = Microsoft.VisualStudio.Telemetry.TelemetryEvent;
+#endif
+
+namespace NuGet.VisualStudio.Facade.Telemetry
+{
+#if VS14
+    public class TelemetrySession : ITelemetrySession
+    {
+        public void PostEvent(TelemetryEvent telemetryEvent)
+        {
+            var vsTelemetryEvent = new VsTelemetryEvent(telemetryEvent.Name);
+
+            foreach (var pair in telemetryEvent.Properties)
+            {
+                vsTelemetryEvent.Properties[pair.Key] = pair.Value;
+            }
+
+            TelemetryService.DefaultSession.PostEvent(vsTelemetryEvent);
+        }
+    }
+#elif VS15
+    public class TelemetrySession : ITelemetrySession
+    {
+        public void PostEvent(TelemetryEvent telemetryEvent)
+        {
+            // Do nothing.
+        }
+    }
+#endif
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio.Facade.csproj
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio.Facade.csproj
@@ -68,8 +68,11 @@
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Telemetry\ITelemetrySession.cs" />
     <Compile Include="ProjectHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Telemetry\TelemetryEvent.cs" />
+    <Compile Include="Telemetry\TelemetrySession.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/NuGet.Clients/VisualStudio14.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio14.Packages/project.json
@@ -14,7 +14,8 @@
     "Microsoft.VisualStudio.Text.UI": "14.2.25123",
     "Microsoft.VisualStudio.Text.UI.Wpf": "14.2.25123",
     "Microsoft.VisualStudio.Threading": "14.1.131",
-    "Microsoft.VSSDK.BuildTools": "14.3.25420"
+    "Microsoft.VSSDK.BuildTools": "14.3.25420",
+    "Microsoft.VisualStudio.Telemetry": "14.1.680-update09A45013"
   },
   "frameworks": {
     "net46": {}

--- a/src/NuGet.Clients/VsExtension/.vsixignore.dev14
+++ b/src/NuGet.Clients/VsExtension/.vsixignore.dev14
@@ -1,6 +1,10 @@
 # assemblies not to be included in VSIX
 ICSharpCode.SharpZipLib.dll
+Microsoft.ApplicationInsights.dll
+Microsoft.ApplicationInsights.PersistenceChannel.dll
+Microsoft.ApplicationInsights.UniversalTelemetryChannel.dll
 Microsoft.CSharp.dll
+Microsoft.Diagnostics.Tracing.EventSource.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll
 Microsoft.ServiceBus.dll
@@ -38,9 +42,15 @@ Microsoft.TeamFoundation.WorkItemTracking.Client.QueryLanguage.dll
 Microsoft.TeamFoundation.WorkItemTracking.Common.dll
 Microsoft.TeamFoundation.WorkItemTracking.Proxy.dll
 Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
+Microsoft.Threading.Tasks.dll
+Microsoft.Threading.Tasks.Extensions.Desktop.dll
+Microsoft.Threading.Tasks.Extensions.dll
+Microsoft.VisualStudio.RemoteControl.dll
 Microsoft.VisualStudio.Services.Client.dll
 Microsoft.VisualStudio.Services.Common.dll
 Microsoft.VisualStudio.Services.WebApi.dll
+Microsoft.VisualStudio.Telemetry.dll
+Microsoft.VisualStudio.Utilities.Internal.dll
 Microsoft.WindowsAzure.Configuration.dll
 Newtonsoft.Json.dll
 System.ComponentModel.Composition.dll
@@ -48,6 +58,7 @@ System.dll
 System.IdentityModel.dll
 System.IdentityModel.Tokens.Jwt.dll
 System.IO.Compression.dll
+System.Net.dll
 System.Net.Http.dll
 System.Net.Http.Formatting.dll
 System.Net.Http.WebRequest.dll

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="ProjectKNuGetProjectTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Telemetry\NuGetTelemetryServiceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -55,9 +56,21 @@
       <Project>{306cddfa-ff0b-4299-930c-9ec6c9308160}</Project>
       <Name>PackageManagement.VisualStudio</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\VisualStudio.Facade\VisualStudio.Facade.csproj">
+      <Project>{EEA49A74-6EFC-410E-9745-BAD367AC151D}</Project>
+      <Name>VisualStudio.Facade</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="$(VisualStudioVersion)=='14.0'">

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/NuGetTelemetryServiceTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Moq;
+using NuGet.PackageManagement.Telemetry;
+using NuGet.VisualStudio.Facade.Telemetry;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test.Telemetry
+{
+    public class NuGetTelemetryServiceTests
+    {
+        [Theory]
+        [InlineData(NuGetProjectType.Unsupported, 0)]
+        [InlineData(NuGetProjectType.Unknown, 1)]
+        [InlineData(NuGetProjectType.PackagesConfig, 2)]
+        [InlineData(NuGetProjectType.UwpProjectJson, 3)]
+        [InlineData(NuGetProjectType.NetCoreProjectJson, 4)]
+        public void NuGetTelemetryService_EmitProjectInformation(NuGetProjectType projectType, int expectedProjectType)
+        {
+            // Arrange
+            var telemetrySession = new Mock<ITelemetrySession>();
+            TelemetryEvent lastTelemetryEvent = null;
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+
+            var projectInformation = new ProjectInformation(
+                "3.5.0-beta2",
+                new Guid("15e9591f-9391-4ddf-a246-ca9e0351277d"),
+                projectType);
+            var target = new NuGetTelemetryService(telemetrySession.Object);
+
+            // Act
+            target.EmitProjectInformation(projectInformation);
+
+            // Assert
+            telemetrySession.Verify(x => x.PostEvent(It.IsAny<TelemetryEvent>()), Times.Once);
+            Assert.NotNull(lastTelemetryEvent);
+            Assert.Equal("VS/NuGet/ProjectInformation", lastTelemetryEvent.Name);
+            Assert.Equal(3, lastTelemetryEvent.Properties.Count);
+
+            object nuGetVersion;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.NuGetVersion", out nuGetVersion));
+            Assert.IsType<string>(nuGetVersion);
+            Assert.Equal(projectInformation.NuGetVersion, nuGetVersion);
+
+            object projectId;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.ProjectId", out projectId));
+            Assert.IsType<string>(projectId);
+            Assert.Equal(projectInformation.ProjectId.ToString(), projectId);
+
+            object actualProjectType;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.NuGetProjectType", out actualProjectType));
+            Assert.IsType<int>(actualProjectType);
+            Assert.Equal(expectedProjectType, actualProjectType);
+        }
+
+        [Fact]
+        public void NuGetTelemetryService_EmitProjectDependencyStatistics()
+        {
+            // Arrange
+            var telemetrySession = new Mock<ITelemetrySession>();
+            TelemetryEvent lastTelemetryEvent = null;
+            telemetrySession
+                .Setup(x => x.PostEvent(It.IsAny<TelemetryEvent>()))
+                .Callback<TelemetryEvent>(x => lastTelemetryEvent = x);
+
+            var projectInformation = new ProjectDependencyStatistics(
+                "3.5.0-beta2",
+                new Guid("15e9591f-9391-4ddf-a246-ca9e0351277d"),
+                3);
+            var target = new NuGetTelemetryService(telemetrySession.Object);
+
+            // Act
+            target.EmitProjectDependencyStatistics(projectInformation);
+
+            // Assert
+            telemetrySession.Verify(x => x.PostEvent(It.IsAny<TelemetryEvent>()), Times.Once);
+            Assert.NotNull(lastTelemetryEvent);
+            Assert.Equal("VS/NuGet/DependencyStatistics", lastTelemetryEvent.Name);
+            Assert.Equal(3, lastTelemetryEvent.Properties.Count);
+
+            object nuGetVersion;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.NuGetVersion", out nuGetVersion));
+            Assert.IsType<string>(nuGetVersion);
+            Assert.Equal(projectInformation.NuGetVersion, nuGetVersion);
+
+            object projectId;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.ProjectId", out projectId));
+            Assert.IsType<string>(projectId);
+            Assert.Equal(projectInformation.ProjectId.ToString(), projectId);
+
+            object installedPackageCount;
+            Assert.True(lastTelemetryEvent.Properties.TryGetValue("VS.NuGet.InstalledPackageCount", out installedPackageCount));
+            Assert.IsType<int>(installedPackageCount);
+            Assert.Equal(projectInformation.InstalledPackageCount, installedPackageCount);
+        }
+    }
+}


### PR DESCRIPTION
Emits two events. Worked with @harikmenon to come up with this list.
1. `VS/NuGet/ProjectInformation` which has three properties.
   1. `NuGetVersion`: the NuGet client version.
   2. `ProjectId`: the project ID GUID.
   3. `NuGetProjectType`: an enum indicating the type of project.
2. `VS/NuGet/DependencyStatistics`
   1. `NuGetVersion`: the NuGet client version.
   2. `ProjectId`: the project ID GUID.
   3. `InstalledPackageCount`: the number of NuGet packages installed to the project.

These events are emitted when the project is added to the `NuGetProject` cache. This is basically when a solution is opened and when a new project is added to an already open solution.

Dev15 emits nothing.

/cc @emgarten @rohit21agrawal @alpaix @jainaashish @rrelyea @harikmenon 
