### PR TITLE
take options from packOptions instead of root of project.json

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -63,8 +63,6 @@ namespace NuGet.ProjectModel
             // Parse properties we know about
             var version = rawPackageSpec["version"];
             var authors = rawPackageSpec["authors"];
-            var owners = rawPackageSpec["owners"];
-            var tags = rawPackageSpec["tags"];
             var contentFiles = rawPackageSpec["contentFiles"];
 
             packageSpec.Name = name;
@@ -104,16 +102,11 @@ namespace NuGet.ProjectModel
             packageSpec.Title = rawPackageSpec.GetValue<string>("title");
             packageSpec.Description = rawPackageSpec.GetValue<string>("description");
             packageSpec.Authors = authors == null ? new string[] { } : authors.ValueAsArray<string>();
-            packageSpec.Owners = owners == null ? new string[] { } : owners.ValueAsArray<string>();
             packageSpec.ContentFiles = contentFiles == null ? new string[] { } : contentFiles.ValueAsArray<string>();
             packageSpec.Dependencies = new List<LibraryDependency>();
-            packageSpec.ProjectUrl = rawPackageSpec.GetValue<string>("projectUrl");
-            packageSpec.IconUrl = rawPackageSpec.GetValue<string>("iconUrl");
-            packageSpec.LicenseUrl = rawPackageSpec.GetValue<string>("licenseUrl");
             packageSpec.Copyright = rawPackageSpec.GetValue<string>("copyright");
             packageSpec.Language = rawPackageSpec.GetValue<string>("language");
-            packageSpec.Summary = rawPackageSpec.GetValue<string>("summary");
-            packageSpec.ReleaseNotes = rawPackageSpec.GetValue<string>("releaseNotes");
+            
 
             var buildOptions = rawPackageSpec["buildOptions"] as JObject;
             if (buildOptions != null)
@@ -123,22 +116,6 @@ namespace NuGet.ProjectModel
                     OutputName = buildOptions.GetValue<string>("outputName")
                 };
             }
-
-            var requireLicenseAcceptance = rawPackageSpec["requireLicenseAcceptance"];
-
-            if (requireLicenseAcceptance != null)
-            {
-                try
-                {
-                    packageSpec.RequireLicenseAcceptance = rawPackageSpec.GetValue<bool?>("requireLicenseAcceptance") ?? false;
-                }
-                catch (Exception ex)
-                {
-                    throw FileFormatException.Create(ex, requireLicenseAcceptance, packageSpecPath);
-                }
-            }
-
-            packageSpec.Tags = tags == null ? new string[] { } : tags.ValueAsArray<string>();
 
             var scripts = rawPackageSpec["scripts"] as JObject;
             if (scripts != null)
@@ -211,6 +188,30 @@ namespace NuGet.ProjectModel
                 {
                     PackageType = new PackageType[0]
                 };
+            }
+            var owners = rawPackOptions["owners"];
+            var tags = rawPackOptions["tags"];
+            packageSpec.Owners = owners == null ? new string[] { } : owners.ValueAsArray<string>();
+            packageSpec.Tags = tags == null ? new string[] { } : tags.ValueAsArray<string>();
+            packageSpec.ProjectUrl = rawPackOptions.GetValue<string>("projectUrl");
+            packageSpec.IconUrl = rawPackOptions.GetValue<string>("iconUrl");
+            packageSpec.Summary = rawPackOptions.GetValue<string>("summary");
+            packageSpec.ReleaseNotes = rawPackOptions.GetValue<string>("releaseNotes");
+            packageSpec.LicenseUrl = rawPackOptions.GetValue<string>("licenseUrl");
+            
+
+            var requireLicenseAcceptance = rawPackOptions["requireLicenseAcceptance"];
+
+            if (requireLicenseAcceptance != null)
+            {
+                try
+                {
+                    packageSpec.RequireLicenseAcceptance = rawPackOptions.GetValue<bool?>("requireLicenseAcceptance") ?? false;
+                }
+                catch (Exception ex)
+                {
+                    throw FileFormatException.Create(ex, requireLicenseAcceptance, packageSpec.FilePath);
+                }
             }
 
             var rawPackageType = rawPackOptions[PackageType];

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
@@ -41,19 +41,11 @@ namespace NuGet.ProjectModel
 
             SetValue(json, "description", packageSpec.Description);
             SetArrayValue(json, "authors", packageSpec.Authors);
-            SetArrayValue(json, "owners", packageSpec.Owners);
-            SetArrayValue(json, "tags", packageSpec.Tags);
-            SetValue(json, "projectUrl", packageSpec.ProjectUrl);
-            SetValue(json, "iconUrl", packageSpec.IconUrl);
-            SetValue(json, "licenseUrl", packageSpec.LicenseUrl);
             SetValue(json, "copyright", packageSpec.Copyright);
             SetValue(json, "language", packageSpec.Language);
-            SetValue(json, "summary", packageSpec.Summary);
-            SetValue(json, "releaseNotes", packageSpec.ReleaseNotes);
-            SetValue(json, "requireLicenseAcceptance", packageSpec.RequireLicenseAcceptance.ToString());
             SetArrayValue(json, "contentFiles", packageSpec.ContentFiles);
             SetDictionaryValue(json, "packInclude", packageSpec.PackInclude);
-            SetPackOptions(json, packageSpec.PackOptions);
+            SetPackOptions(json, packageSpec);
             SetDictionaryValues(json, "scripts", packageSpec.Scripts);
 
             if (packageSpec.Dependencies.Any())
@@ -98,14 +90,23 @@ namespace NuGet.ProjectModel
             JsonRuntimeFormat.WriteRuntimeGraph(json, packageSpec.RuntimeGraph);
         }
 
-        private static void SetPackOptions(JObject json, PackOptions packOptions)
+        private static void SetPackOptions(JObject json, PackageSpec packageSpec)
         {
+            var packOptions = packageSpec.PackOptions;
             if (packOptions == null)
             {
                 return;
             }
 
             var rawPackOptions = new JObject();
+            SetArrayValue(rawPackOptions, "owners", packageSpec.Owners);
+            SetArrayValue(rawPackOptions, "tags", packageSpec.Tags);
+            SetValue(rawPackOptions, "projectUrl", packageSpec.ProjectUrl);
+            SetValue(rawPackOptions, "iconUrl", packageSpec.IconUrl);
+            SetValue(rawPackOptions, "summary", packageSpec.Summary);
+            SetValue(rawPackOptions, "releaseNotes", packageSpec.ReleaseNotes);
+            SetValue(rawPackOptions, "licenseUrl", packageSpec.LicenseUrl);
+            SetValue(rawPackOptions, "requireLicenseAcceptance", packageSpec.RequireLicenseAcceptance.ToString());
             if (packOptions.PackageType != null)
             {
                 if (packOptions.PackageType.Count == 1)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -123,10 +123,12 @@ namespace NuGet.CommandLine.Test
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""packageB"": {
       ""version"": ""1.0.0"",
@@ -454,10 +456,12 @@ namespace NuGet.CommandLine.Test
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""frameworks"": {
     ""native"": {
     },
@@ -567,10 +571,12 @@ namespace NuGet.CommandLine.Test
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
-  ""copyright"": ""Copyright ©  2013""
+  ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
 }");
 
                 // Act
@@ -1124,10 +1130,12 @@ namespace Proj2
   ""version"": ""1.0.0.0"",
   ""title"": ""Proj2"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""p1"": {
       ""version"": ""1.5.11""
@@ -1141,10 +1149,12 @@ namespace Proj2
   ""version"": ""2.0.0.0"",
   ""title"": ""Proj6"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""p2"": {
       ""version"": ""1.5.11""
@@ -1343,10 +1353,12 @@ namespace Proj2
   ""version"": ""1.0.0.0"",
   ""title"": ""Proj2"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""p1"": {
       ""version"": ""1.5.11""
@@ -1360,10 +1372,12 @@ namespace Proj2
   ""version"": ""2.0.0.0"",
   ""title"": ""Proj6"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""p2"": {
       ""version"": ""1.5.11""
@@ -2998,8 +3012,6 @@ namespace " + projectName + @"
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
   ""frameworks"": {
@@ -3012,6 +3024,10 @@ namespace " + projectName + @"
   },
   ""packInclude"": {
     ""image"": ""contentFiles/any/any/image.jpg""
+  },
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
   }
 }
 ");
@@ -3155,10 +3171,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0-*"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""packageB"": {
       ""version"": ""1.0.0"",
@@ -3403,10 +3421,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0-rc-*"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""dependencies"": {
     ""packageB"": {
       ""version"": ""1.0.0"",
@@ -3468,10 +3488,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""frameworks"": {
     ""native"": {
     },
@@ -3592,12 +3614,14 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0"",
   ""title"": ""packageA"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""buildOptions"": {
     ""outputName"": """ + dllName + @""",
   },
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""copyright"": ""Copyright ©  2013"",
   ""frameworks"": {
     ""native"": {
@@ -3652,10 +3676,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0"",
   ""title"": ""proj1"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""frameworks"": {
     ""net46"": {
       ""frameworkAssemblies"": {
@@ -3713,10 +3739,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0"",
   ""title"": ""proj1"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""frameworks"": {
     ""net46"": {
       ""frameworkAssemblies"": {
@@ -3774,10 +3802,12 @@ stuff \n <<".Replace("\r\n", "\n");
   ""version"": ""1.0.0"",
   ""title"": ""proj1"",
   ""authors"": [ ""test"" ],
-  ""owners"": [ ""test"" ],
-  ""requireLicenseAcceptance"": ""false"",
   ""description"": ""Description"",
   ""copyright"": ""Copyright ©  2013"",
+  ""packOptions"": {
+    ""owners"": [ ""test"" ],
+    ""requireLicenseAcceptance"": ""false""
+    },
   ""frameworks"": {
     ""net46"": {
       ""frameworkAssemblies"": {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
@@ -20,24 +20,26 @@ namespace NuGet.ProjectModel.Test
     ""author1"",
     ""author2""
   ],
-  ""owners"": [
-    ""owner1"",
-    ""owner2""
-  ],
-  ""tags"": [
-    ""tag1"",
-    ""tag2""
-  ],
-  ""projectUrl"": ""http://my.url.com"",
-  ""iconUrl"": ""http://my.url.com"",
-  ""licenseUrl"": ""http://my.url.com"",
   ""copyright"": ""2016"",
   ""language"": ""en-US"",
-  ""summary"": ""Sum"",
-  ""releaseNotes"": ""release noted"",
-  ""requireLicenseAcceptance"": ""False"",
   ""packInclude"": {
     ""file"": ""file.txt""
+  },
+  ""packOptions"": {
+    ""owners"": [
+      ""owner1"",
+      ""owner2""
+    ],
+    ""tags"": [
+      ""tag1"",
+      ""tag2""
+    ],
+    ""projectUrl"": ""http://my.url.com"",
+    ""iconUrl"": ""http://my.url.com"",
+    ""summary"": ""Sum"",
+    ""releaseNotes"": ""release noted"",
+    ""licenseUrl"": ""http://my.url.com"",
+    ""requireLicenseAcceptance"": ""False""
   },
   ""scripts"": {
     ""script1"": [
@@ -65,8 +67,8 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-  ""requireLicenseAcceptance"": ""False"",
   ""packOptions"": {
+    ""requireLicenseAcceptance"": ""False"",
     ""packageType"": ""DotNetTool""
   }
 }";
@@ -80,8 +82,8 @@ namespace NuGet.ProjectModel.Test
         {
             // Arrange
             var json = @"{
-  ""requireLicenseAcceptance"": ""False"",
   ""packOptions"": {
+    ""requireLicenseAcceptance"": ""False"",
     ""packageType"": [
       ""DotNetTool"",
       ""Dependency""


### PR DESCRIPTION
fixes issue : https://github.com/NuGet/Home/issues/3161

take options like :
summary
tags
owners
releaseNotes
iconUrl
projectUrl
licenseUrl
requireLicenseAcceptance

from packOptions instead of the root of the project.json file.

//CC : @emgarten @joelverhagen @alpaix @drewgil @jainaashish @rrelyea 
