### PR TITLE
fix issue where a .csproj targeting netstandard1.3 had a wrong output folder in nupkg

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -738,7 +738,22 @@ namespace NuGet.CommandLine
         private void AddOutputFiles(Packaging.PackageBuilder builder)
         {
             // Get the target framework of the project
-            FrameworkName targetFramework = TargetFramework;
+            NuGetFramework nugetFramework;
+            if (_usingJsonFile && builder.TargetFrameworks.Any())
+            {
+                if (builder.TargetFrameworks.Count > 1)
+                {
+                    var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("Error_MultipleTargetFrameworks"));
+                    throw new CommandLineException(message);
+                }
+                nugetFramework = builder.TargetFrameworks.First();
+            }
+            else
+            {
+                nugetFramework = TargetFramework != null ? NuGetFramework.Parse(TargetFramework.FullName) : null;
+            }
 
             // Get the target file path
             string targetPath = TargetPath;
@@ -792,13 +807,12 @@ namespace NuGet.CommandLine
                     {
                         targetFolder = Path.Combine(ReferenceFolder, Path.GetDirectoryName(file.Replace(TargetPath, string.Empty)));
                     }
-                    else if (targetFramework == null)
+                    else if (nugetFramework == null)
                     {
                         targetFolder = ReferenceFolder;
                     }
                     else
                     {
-                        NuGetFramework nugetFramework = NuGetFramework.Parse(targetFramework.FullName);
                         string shortFolderName = nugetFramework.GetShortFolderName();
                         targetFolder = Path.Combine(ReferenceFolder, shortFolderName);
                     }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2932,6 +2932,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to project.json cannot contain multiple Target Frameworks..
+        /// </summary>
+        public static string Error_MultipleTargetFrameworks {
+            get {
+                return ResourceManager.GetString("Error_MultipleTargetFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error parsing packages.config file at {0}: {1}.
         /// </summary>
         public static string Error_PackagesConfigParseError {
@@ -3333,6 +3342,15 @@ namespace NuGet.CommandLine {
         public static string Error_UnableToLocateRestoreTarget {
             get {
                 return ResourceManager.GetString("Error_UnableToLocateRestoreTarget", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to find an msbuild solution, packages.config, or project.json file in the folder &apos;{0}&apos; because {1}.
+        /// </summary>
+        public static string Error_UnableToLocateRestoreTarget_Because {
+            get {
+                return ResourceManager.GetString("Error_UnableToLocateRestoreTarget_Because", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -495,11 +495,11 @@
 To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck '{0}'.</value>
   </data>
   <data name="ProjectRestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
-   <value>Nothing to do. This project does not specify any packages for NuGet to restore.</value>
- </data>
+    <value>Nothing to do. This project does not specify any packages for NuGet to restore.</value>
+  </data>
   <data name="SolutionRestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
-   <value>Nothing to do. None of the projects in this solution specify any packages for NuGet to restore.</value>
- </data>
+    <value>Nothing to do. None of the projects in this solution specify any packages for NuGet to restore.</value>
+  </data>
   <data name="Error_CannotGetGetAllProjectFileNamesMethod" xml:space="preserve">
     <value>Cannot get the GetAllProjectFileNamesMethod from type  Mono.XBuild.CommandLine.SolutionParser.</value>
   </data>
@@ -6097,5 +6097,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   </data>
   <data name="OutputNuGetVersion" xml:space="preserve">
     <value>{0} Version: {1}</value>
+  </data>
+  <data name="Error_MultipleTargetFrameworks" xml:space="preserve">
+    <value>project.json cannot contain multiple Target Frameworks.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -474,6 +474,7 @@ namespace NuGet.Commands
                         throw new Exception(String.Format(CultureInfo.CurrentCulture, Strings.Error_InvalidTargetFramework, framework.FrameworkName));
                     }
 
+                    builder.TargetFrameworks.Add(framework.FrameworkName);
                     AddDependencyGroups(framework.Dependencies.Concat(spec.Dependencies), framework.FrameworkName, builder);
                 }
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -68,6 +68,7 @@ namespace NuGet.Packaging
             Authors = new HashSet<string>();
             Owners = new HashSet<string>();
             Tags = new HashSet<string>();
+            TargetFrameworks = new List<NuGetFramework>();
             // Just like parameter replacements, these are also case insensitive, for consistency.
             Properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
@@ -212,6 +213,12 @@ namespace NuGet.Packaging
         {
             get;
             private set;
+        }
+
+        public IList<NuGetFramework> TargetFrameworks
+        {
+            get;
+            set;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/3108

NuGet pack for csproj + project.json was getting the TargetFramework for the project from the VS Project system instead of project.json. This PR adds code so project.json will provide the target framework if it exists.

CC: @alpaix @joelverhagen @emgarten @rrelyea 
