### PR TITLE
Await package installs from IVsPackageInstaller.InstallPackagesFromVSExtensionRepository

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -182,7 +182,7 @@ namespace NuGet.VisualStudio
 
                     VSAPIProjectContext projectContext = new VSAPIProjectContext(skipAssemblyReferences, disableBindingRedirects);
 
-                    return InstallInternalAsync(
+                    await InstallInternalAsync(
                         project,
                         toInstall,
                         repoProvider,


### PR DESCRIPTION
This is a small fix to InstallPackagesFromVSExtensionRepository to await the install method. Returning the task to the JTF results in the caller continuing on and potentially making multiple installs in parallel.

Fixes https://github.com/NuGet/Home/issues/3182
