### PR TITLE
Updated batch event apis to avoid using generics type in embedded introp type

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerProjectEvents.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerProjectEvents.cs
@@ -13,9 +13,9 @@ namespace NuGet.VisualStudio
     [Export(typeof(IVsPackageInstallerProjectEvents))]
     public class VsPackageInstallerProjectEvents : IVsPackageInstallerProjectEvents
     {
-        public event EventHandler<IVsPackageProjectMetadata> BatchStart;
+        public event VsPackageProjectEventHandler BatchStart;
 
-        public event EventHandler<IVsPackageProjectMetadata> BatchEnd;
+        public event VsPackageProjectEventHandler BatchEnd;
 
         [ImportingConstructor]
         public VsPackageInstallerProjectEvents(IPackageProjectEventsProvider eventProvider)
@@ -29,13 +29,13 @@ namespace NuGet.VisualStudio
         private void NotifyBatchStart(object sender, PackageProjectEventArgs e)
         {
             var handle = BatchStart;
-            handle?.Invoke(this, new VsPackageProjectMetadata(e.Id, e.Name));
+            handle?.Invoke(new VsPackageProjectMetadata(e.Id, e.Name));
         }
 
         private void NotifyBatchEnd(object sender, PackageProjectEventArgs e)
         {
             var handle = BatchEnd;
-            handle?.Invoke(this, new VsPackageProjectMetadata(e.Id, e.Name));
+            handle?.Invoke(new VsPackageProjectMetadata(e.Id, e.Name));
         }
 
     }

--- a/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageInstallerProjectEvents.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/IVsPackageInstallerProjectEvents.cs
@@ -17,12 +17,12 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Raised before any IVsPackageInstallerEvents events are raised for a project.
         /// </summary>
-        event EventHandler<IVsPackageProjectMetadata> BatchStart;
+        event VsPackageProjectEventHandler BatchStart;
 
         /// <summary>
         /// Raised after all IVsPackageInstallerEvents events are raised for a project.
         /// </summary>
-        event EventHandler<IVsPackageProjectMetadata> BatchEnd;
+        event VsPackageProjectEventHandler BatchEnd;
 
     }
 }

--- a/src/NuGet.Clients/VisualStudio/Extensibility/VsPackageEventHandler.cs
+++ b/src/NuGet.Clients/VisualStudio/Extensibility/VsPackageEventHandler.cs
@@ -8,4 +8,10 @@ namespace NuGet.VisualStudio
     /// </summary>
     /// <param name="metadata">Description of the package.</param>
     public delegate void VsPackageEventHandler(IVsPackageMetadata metadata);
+
+    /// <summary>
+    /// Defines an event handler delegate for nuget batch events with projects with packages.config file.
+    /// </summary>
+    /// <param name="metadata">Description of the package.</param>
+    public delegate void VsPackageProjectEventHandler(IVsPackageProjectMetadata metadata);
 }

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -97,12 +97,12 @@ namespace API.Test
             var batchStartIds = new List<string>();
             var batchEndIds = new List<string>();
 
-            packageProjectEventService.BatchStart += (o, args) =>
+            packageProjectEventService.BatchStart += (args) =>
             {
                 batchStartIds.Add(args.BatchId);
             };
 
-            packageProjectEventService.BatchEnd += (o, args) =>
+            packageProjectEventService.BatchEnd += (args) =>
             {
                 batchEndIds.Add(args.BatchId);
             };


### PR DESCRIPTION
ComImport doesn't allow to embedded generics type across assembly boundaries so updated new batch event apis interface IVsPackageInstallerProjectEvents to use delegate instead.

Previous PR - https://github.com/NuGet/NuGet.Client/issues/739

Original Issue - https://github.com/NuGet/Home/issues/3044
