### PR TITLE
Properly handle cancellation in the HttpSourceAuthenticationHandler

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/ConsoleCredentialProvider.cs
@@ -41,7 +41,7 @@ namespace NuGet.CommandLine
             if (nonInteractive)
             {
                 return Task.FromResult(
-                    new CredentialResponse(null, CredentialStatus.ProviderNotApplicable));
+                    new CredentialResponse(CredentialStatus.ProviderNotApplicable));
             }
             
             switch (type)
@@ -76,7 +76,7 @@ namespace NuGet.CommandLine
                     SecurePassword = password
                 };
 
-                var cred = new CredentialResponse(credentials, CredentialStatus.Success);
+                var cred = new CredentialResponse(credentials);
 
                 var task = Task.FromResult(cred);
 

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialProviderAdapter.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialProviderAdapter.cs
@@ -55,7 +55,7 @@ namespace NuGet.Credentials
                 isRetry);
 
             var response = cred != null
-                ? new CredentialResponse(cred, CredentialStatus.Success)
+                ? new CredentialResponse(cred)
                 : new CredentialResponse(CredentialStatus.ProviderNotApplicable);
 
             return Task.FromResult(response);

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialResponse.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialResponse.cs
@@ -1,34 +1,35 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Net;
 
 namespace NuGet.Credentials
 {
     public class CredentialResponse
     {
-        private CredentialResponse()
-        {
-        }
-
         /// <summary>
-        /// Creates a Credential response object without giving credentials.
-        /// Note should only be done if the status is ProviderNotApplicable.
+        /// Creates a credential response object without giving credentials. This constructor is used only if the
+        /// credential provider was not able to get credentials. The <paramref name="status"/> indicates why the
+        /// provider was not able to get credentials.
         /// </summary>
-        /// <param name="status"></param>
+        /// <param name="status">The status of why the credential provider was not able to get credentials.</param>
         public CredentialResponse(CredentialStatus status) : this(null, status)
         {
         }
 
         /// <summary>
-        /// Crates a credential response object
+        /// Creates a credential response object with a given set of credentials. This constuctor is used only if the
+        /// credential provider was able to get credentials.
         /// </summary>
-        /// <param name="credentials"></param>
-        /// <param name="status"></param>
-        public CredentialResponse(ICredentials credentials, CredentialStatus status)
+        /// <param name="credentials">The credentials fetched by the credential provider.</param>
+
+        public CredentialResponse(ICredentials credentials) : this(credentials, CredentialStatus.Success)
         {
-            if ((credentials != null && status == CredentialStatus.ProviderNotApplicable) ||
+        }
+
+        private CredentialResponse(ICredentials credentials, CredentialStatus status)
+        {
+            if ((credentials != null && status != CredentialStatus.Success) ||
                 (credentials == null && status == CredentialStatus.Success))
             {
                 throw new ProviderException(Resources.ProviderException_InvalidCredentialResponse);

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
@@ -122,25 +122,21 @@ namespace NuGet.Credentials
                             cancellationToken);
 
                         // Check that the provider gave us a valid response.
-                        if (response == null || (response.Status != CredentialStatus.ProviderNotApplicable && 
-                                                 response.Status != CredentialStatus.Success))
+                        if (response == null || (response.Status != CredentialStatus.Success &&
+                                                 response.Status != CredentialStatus.ProviderNotApplicable &&
+                                                 response.Status != CredentialStatus.UserCanceled))
                         {
                             throw new ProviderException(Resources.ProviderException_MalformedResponse);
                         }
 
-                        AddToCredentialCache(uri, type, provider, response);
+                        if (response.Status != CredentialStatus.UserCanceled)
+                        {
+                            AddToCredentialCache(uri, type, provider, response);
+                        }
                     }
 
                     if (response.Status == CredentialStatus.Success)
                     {
-                        if (response.Credentials == null)
-                        {
-                            // It is invalid to have a success without getting credentials.  that should
-                            // instead be a failure. (or Provider not applicable if the endpoint is not
-                            // one the provider works with).
-                            throw new ProviderException(Resources.ProviderException_MalformedResponse);
-                        }
-
                         _retryCache[retryKey] = true;
                         creds = response.Credentials;
                         break;

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialStatus.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialStatus.cs
@@ -10,6 +10,7 @@ namespace NuGet.Credentials
     public enum CredentialStatus
     {
         Success,
-        ProviderNotApplicable
+        ProviderNotApplicable,
+        UserCanceled
     }
 }

--- a/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
@@ -96,7 +96,7 @@ namespace NuGet.Credentials
                 {
                     var result = new NetworkCredential(response.Username, response.Password);
 
-                    taskResponse = new CredentialResponse(result, CredentialStatus.Success);
+                    taskResponse = new CredentialResponse(result);
                 }
                 else
                 {

--- a/src/NuGet.Clients/VsExtension/VisualStudioAccountProvider.cs
+++ b/src/NuGet.Clients/VsExtension/VisualStudioAccountProvider.cs
@@ -224,7 +224,7 @@ namespace NuGetVSExtension
                 throw new InvalidOperationException(Resources.AccountProvider_NoValidCrededentialsFound);
             }
 
-            var response = new CredentialResponse(credentials, CredentialStatus.Success);
+            var response = new CredentialResponse(credentials);
 
             return response;
         }

--- a/src/NuGet.Clients/VsExtension/VsCredentialProviderAdapter.cs
+++ b/src/NuGet.Clients/VsExtension/VsCredentialProviderAdapter.cs
@@ -61,7 +61,7 @@ namespace NuGetVSExtension
 
             return credentials == null
                 ? new CredentialResponse(CredentialStatus.ProviderNotApplicable)
-                : new CredentialResponse(credentials, CredentialStatus.Success);
+                : new CredentialResponse(credentials);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/AmbientAuthenticationState.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/AmbientAuthenticationState.cs
@@ -10,16 +10,22 @@ namespace NuGet.Protocol
     {
         internal const int MaxAuthRetries = 3;
 
-        public bool IsBlocked { get; set; } = false;
-        public int AuthenticationRetriesCount { get; set; }
+        public bool IsBlocked { get; private set; } = false;
+        public int AuthenticationRetriesCount { get; private set; } = 0;
+
+        public void Block()
+        {
+            IsBlocked = true;
+        }
 
         public void Increment()
         {
             AuthenticationRetriesCount++;
 
-            if (AuthenticationRetriesCount > MaxAuthRetries)
+            if (AuthenticationRetriesCount >= MaxAuthRetries)
             {
-                IsBlocked = true;
+                // Block future attempts.
+                Block();
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceAuthenticationHandler.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
@@ -135,14 +136,14 @@ namespace NuGet.Protocol
 
                 var authState = GetAuthenticationState();
 
-                authState.Increment();
-
                 if (authState.IsBlocked)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     return null;
                 }
 
-                // Prompt the user
+                // Construct a reasonable message for the prompt to use.
                 CredentialRequestType type;
                 string message;
                 if (statusCode == HttpStatusCode.Unauthorized)
@@ -161,21 +162,16 @@ namespace NuGet.Protocol
                         Strings.Http_CredentialsForForbidden,
                         _packageSource.Source);
                 }
-
+                
                 var promptCredentials = await PromptForCredentialsAsync(
                     type,
                     message,
+                    authState,
                     log,
                     cancellationToken);
 
                 if (promptCredentials == null)
                 {
-                    // null means cancelled by user or error occured
-                    // block subsequent attempts to annoy user with prompts
-                    authState.IsBlocked = true;
-
-                    cancellationToken.ThrowIfCancellationRequested();
-
                     return null;
                 }
 
@@ -206,6 +202,7 @@ namespace NuGet.Protocol
         private async Task<ICredentials> PromptForCredentialsAsync(
             CredentialRequestType type,
             string message,
+            AmbientAuthenticationState authState,
             ILogger log,
             CancellationToken token)
         {
@@ -223,21 +220,32 @@ namespace NuGet.Protocol
 
                 promptCredentials = await _credentialService
                     .GetCredentialsAsync(_packageSource.SourceUri, proxy, type, message, token);
-            }
-            catch (TaskCanceledException)
-            {
-                throw; // pass-thru
+                
+                if (promptCredentials == null)
+                {
+                    // If this is the case, this means none of the credential providers were able to
+                    // handle the credential request or no credentials were available for the
+                    // endpoint.
+                    authState.Block();
+                }
+                else
+                {
+                    authState.Increment();
+                }
             }
             catch (OperationCanceledException)
             {
-                // A valid response for VS dialog when user hits cancel button
-                promptCredentials = null;
+                // This indicates a non-human cancellation.
+                throw;
             }
             catch (Exception e)
             {
-                // Fatal credential service failure
-                log.LogError(ExceptionUtilities.DisplayMessage(e));
-                promptCredentials = null;
+                // If this is the case, this means there was a fatal exception when interacting
+                // with the credential service (or its underlying credential providers). Either way,
+                // block asking for credentials for the live of this operation.
+                log.LogError(ExceptionUtilities.DisplayMessage(e));                
+                promptCredentials = null;                
+                authState.Block();
             }
             finally
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCredentials.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCredentials.cs
@@ -14,30 +14,47 @@ namespace NuGet.Protocol
     /// </summary>
     public class HttpSourceCredentials : CredentialCache, ICredentials
     {
+        public HttpSourceCredentials()
+        {
+            Credentials = null;
+        }
+
         /// <summary>
         /// Credentials can be changed by other threads, for this reason volatile
         /// is added below so that the value is not cached anywhere.
         /// </summary>
-        private volatile ICredentials _credentials;
+        private volatile VersionedCredentials _credentials;
 
         /// <summary>
-        /// Latest credentials to be used.
+        /// The latest credentials to be used.
         /// </summary>
         public ICredentials Credentials
         {
             get
             {
-                return _credentials;
+                return _credentials.Credentials;
             }
 
             set
             {
-                Version = Guid.NewGuid();
-                _credentials = value;
+                // We must update the credentials and it's associated version GUID atomically. This
+                // can be achieved with a reference assignment. It is important that credentials and
+                // version always match. In other words, if the credentials are updated, it should
+                // at no instant be possible to get old version GUID and the new credentials.
+                _credentials = new VersionedCredentials(value);
             }
         }
 
-        public Guid Version { get; private set; } = Guid.NewGuid();
+        /// <summary>
+        /// The latest version ID of the <see cref="Credentials"/>.
+        /// </summary>
+        public Guid Version
+        {
+            get
+            {
+                return _credentials.Version;
+            }
+        }
 
         /// <summary>
         /// Used by the HttpClientHandler to retrieve the current credentials.
@@ -52,7 +69,7 @@ namespace NuGet.Protocol
             if (currentCredentials == null)
             {
                 // This is used to match the value of HttpClientHandler.UseDefaultCredentials = true
-                result = CredentialCache.DefaultNetworkCredentials;
+                result = DefaultNetworkCredentials;
             }
             else
             {
@@ -61,6 +78,18 @@ namespace NuGet.Protocol
             }
 
             return result;
+        }
+
+        private class VersionedCredentials
+        {
+            public VersionedCredentials(ICredentials credentials)
+            {
+                Version = Guid.NewGuid();
+                Credentials = credentials;
+            }
+
+            public ICredentials Credentials { get; }
+            public Guid Version { get; }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyAuthenticationHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/ProxyAuthenticationHandler.cs
@@ -198,14 +198,9 @@ namespace NuGet.Protocol
                     message: message,
                     cancellationToken: cancellationToken);
             }
-            catch (TaskCanceledException)
-            {
-                throw; // pass-thru
-            }
             catch (OperationCanceledException)
             {
-                // A valid response for VS dialog when user hits cancel button
-                promptCredentials = null;
+                throw; // pass-thru
             }
             catch (Exception e)
             {

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
@@ -88,7 +88,7 @@ namespace NuGet.Credentials.Test
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential())));
             var uri1 = new Uri("http://uri1");
             var uri2 = new Uri("http://uri2");
 
@@ -143,7 +143,7 @@ namespace NuGet.Credentials.Test
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+                .Returns(Task.FromResult(new CredentialResponse (new NetworkCredential())));
             var uri1 = new Uri("http://uri1");
             var webProxy = new WebProxy();
 
@@ -205,7 +205,7 @@ namespace NuGet.Credentials.Test
                     _lockTestConcurrencyCount++;
                     Assert.Equal(1, _lockTestConcurrencyCount);
                     _lockTestConcurrencyCount--;
-                    return Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success));
+                    return Task.FromResult(new CredentialResponse (new NetworkCredential()));
                 });
             var tasks = new Task[10];
 
@@ -242,7 +242,7 @@ namespace NuGet.Credentials.Test
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult(new CredentialResponse (new NetworkCredential(), CredentialStatus.Success)));
+                .Returns(() => Task.FromResult(new CredentialResponse (new NetworkCredential())));
             var uri1 = new Uri("http://host/some/path");
             var uri2 = new Uri("http://host/some2/path2");
 
@@ -406,7 +406,7 @@ namespace NuGet.Credentials.Test
                     It.IsAny<bool>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()))
-                .Returns(() => Task.FromResult(new CredentialResponse(new NetworkCredential(), CredentialStatus.Success)));
+                .Returns(() => Task.FromResult(new CredentialResponse(new NetworkCredential())));
             var uri1 = new Uri("http://uri1");
 
             // Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceAuthenticationHandlerTests.cs
@@ -160,7 +160,53 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task SendAsync_WhenCancelledDuringAcquiringCredentials_Throws()
+        public async Task SendAsync_WhenTaskCanceledExceptionThrownDuringAcquiringCredentials_Throws()
+        {
+            // Arrange
+            var packageSource = new PackageSource("http://package.source.net");
+            var clientHandler = new HttpClientHandler();
+            
+            var credentialService = Mock.Of<ICredentialService>();
+            Mock.Get(credentialService)
+                .Setup(
+                    x => x.GetCredentialsAsync(
+                        packageSource.SourceUri,
+                        It.IsAny<IWebProxy>(),
+                        CredentialRequestType.Unauthorized,
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new TaskCanceledException());
+
+            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
+
+            int retryCount = 0;
+            var innerHandler = new LambdaMessageHandler(
+                _ =>
+                {
+                    retryCount++;
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                });
+            handler.InnerHandler = innerHandler;
+
+            // Act & Assert
+            await Assert.ThrowsAsync<TaskCanceledException>(
+                () => SendAsync(handler));
+
+            Assert.Equal(1, retryCount);
+
+            Mock.Get(credentialService)
+                .Verify(
+                    x => x.GetCredentialsAsync(
+                        packageSource.SourceUri,
+                        It.IsAny<IWebProxy>(),
+                        CredentialRequestType.Unauthorized,
+                        It.IsAny<string>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WhenOperationCanceledExceptionThrownDuringAcquiringCredentials_Throws()
         {
             // Arrange
             var packageSource = new PackageSource("http://package.source.net");
@@ -177,19 +223,23 @@ namespace NuGet.Protocol.Tests
                         CredentialRequestType.Unauthorized,
                         It.IsAny<string>(),
                         It.IsAny<CancellationToken>()))
-                .ThrowsAsync(new TaskCanceledException())
+                .ThrowsAsync(new OperationCanceledException())
                 .Callback(() => cts.Cancel());
 
             var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
 
             int retryCount = 0;
             var innerHandler = new LambdaMessageHandler(
-                _ => { retryCount++; return new HttpResponseMessage(HttpStatusCode.Unauthorized); });
+                _ =>
+                {
+                    retryCount++;
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                });
             handler.InnerHandler = innerHandler;
 
             // Act & Assert
-            await Assert.ThrowsAsync<TaskCanceledException>(
-                () => SendAsync(handler, cancellationToken: cts.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => SendAsync(handler));
 
             Assert.Equal(1, retryCount);
 
@@ -207,6 +257,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WithWrongCredentials_StopsRetryingAfter3Times()
         {
+            // Arrange
             var packageSource = new PackageSource("http://package.source.net");
             var clientHandler = new HttpClientHandler();
 
@@ -225,15 +276,21 @@ namespace NuGet.Protocol.Tests
 
             int retryCount = 0;
             var innerHandler = new LambdaMessageHandler(
-                _ => { retryCount++; return new HttpResponseMessage(HttpStatusCode.Unauthorized); });
+                _ =>
+                {
+                    retryCount++;
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                });
             handler.InnerHandler = innerHandler;
 
+            // Act
             var response = await SendAsync(handler);
 
+            // Assert
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            Assert.Equal(HttpSourceAuthenticationHandler.MaxAuthRetries+1, retryCount);
+            Assert.Equal(HttpSourceAuthenticationHandler.MaxAuthRetries + 1, retryCount);
 
             Mock.Get(credentialService)
                 .Verify(
@@ -249,19 +306,31 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WithMissingCredentials_Returns401()
         {
+            // Arrange
             var packageSource = new PackageSource("http://package.source.net");
             var clientHandler = new HttpClientHandler();
 
             var credentialService = Mock.Of<ICredentialService>();
-            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService)
-            {
-                InnerHandler = GetLambdaMessageHandler(HttpStatusCode.Unauthorized)
-            };
 
+            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
+
+            int retryCount = 0;
+            var innerHandler = new LambdaMessageHandler(
+                _ =>
+                {
+                    retryCount++;
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                });
+            handler.InnerHandler = innerHandler;
+
+            // Act
             var response = await SendAsync(handler);
 
+            // Assert
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+            Assert.Equal(1, retryCount);
 
             Mock.Get(credentialService)
                 .Verify(
@@ -277,6 +346,7 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task SendAsync_WhenCredentialServiceThrows_Returns401()
         {
+            // Arrange
             var packageSource = new PackageSource("http://package.source.net");
             var clientHandler = new HttpClientHandler();
 
@@ -291,15 +361,25 @@ namespace NuGet.Protocol.Tests
                        It.IsAny<CancellationToken>()))
                .Throws(new InvalidOperationException("Credential service failed acquring user credentials"));
 
-            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService)
-            {
-                InnerHandler = GetLambdaMessageHandler(HttpStatusCode.Unauthorized)
-            };
+            var handler = new HttpSourceAuthenticationHandler(packageSource, clientHandler, credentialService);
 
+            int retryCount = 0;
+            var innerHandler = new LambdaMessageHandler(
+                _ =>
+                {
+                    retryCount++;
+                    return new HttpResponseMessage(HttpStatusCode.Unauthorized);
+                });
+            handler.InnerHandler = innerHandler;
+
+            // Act
             var response = await SendAsync(handler);
 
+            // Assert
             Assert.NotNull(response);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+            Assert.Equal(1, retryCount);
 
             Mock.Get(credentialService)
                 .Verify(


### PR DESCRIPTION
This fixes https://github.com/NuGet/Home/issues/2885 and https://github.com/NuGet/Home/issues/3148.

Changes:
- Do not increment auth attempt when system cancellation occurs. This is the root cause.
- Added `CredentialStatus.UserCanceled` to differentiate between user cancellation and application cancellation (which is signaled by an `OperationCanceledException`). Note that the `VisualStudioAccountProvider` throws `OperationCanceledException` in both cases, but this is existing functionality. I am following up with the UI owner to see if there is a way to tease these signals apart.
- Do not cache `CredentialStatus.UserCanceled` responses.
- Cleaned up the `CredentialResponse` constructor to remove ambiguity.
- Update `HttpSourceCredentials` so that the `Credentials` and `Version` property are updated atomically.

/cc @alpaix @pspill @emgarten @rrelyea 
