### PR TITLE
Avoid warnings when a package does not exist in a v3 folder

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
@@ -861,14 +861,14 @@ namespace NuGet.Protocol
             // Check for package files one level deep.
             DirectoryInfo rootDirectoryInfo = GetAndVerifyRootDirectory(root);
 
-            if (!rootDirectoryInfo.Exists)
+            var idRoot = Path.Combine(rootDirectoryInfo.FullName, id);
+            if (!Directory.Exists(idRoot))
             {
                 // Directory is missing
                 yield break;
             }
 
             var pathResolver = new VersionFolderPathResolver(root);
-            var idRoot = Path.Combine(root, id);
 
             foreach (var versionDir in GetDirectoriesSafe(idRoot, log))
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalFolderUtilityTests.cs
@@ -105,6 +105,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 Assert.Equal("a.1.0.0", packages[1].Identity.ToString());
                 Assert.Equal("b.1.0.0", packages[2].Identity.ToString());
                 Assert.Equal("c.1.0.0", packages[3].Identity.ToString());
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -135,6 +136,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 Assert.Equal(2, packages.Count);
                 Assert.Equal("a.1.0.0-beta", packages[0].Identity.ToString());
                 Assert.Equal("a.1.0.0", packages[1].Identity.ToString());
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -163,6 +165,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -190,6 +193,7 @@ namespace NuGet.Protocol.Core.v3.Tests
                 Assert.True(foundA.IsNupkg);
                 Assert.Equal(a, foundA.GetReader().GetIdentity());
                 Assert.Contains("a.1.0.0.nupkg", foundA.Path);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -370,6 +374,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Null(foundA);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -387,6 +392,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -404,6 +410,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -577,6 +584,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count());
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -621,6 +629,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count());
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -751,6 +760,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -767,6 +777,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -783,6 +794,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -799,6 +811,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -898,6 +911,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -914,6 +928,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -930,6 +945,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 
@@ -946,6 +962,7 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Assert
                 Assert.Equal(0, packages.Count);
+                Assert.Equal(0, testLogger.Messages.Count);
             }
         }
 


### PR DESCRIPTION
For v3 folders we can construct the path, this change checks that it exists before trying to list the directory.

LocalFolderUtility logs errors around missing directories as warnings. When checking all sources for a package id it is expected that the package will not exist in some cases. This change removes the extra unneeded warnings when probing folder paths.

Fixes https://github.com/NuGet/Home/issues/3194

//cc @rohit21agrawal @drewgil @joelverhagen @alpaix @jainaashish @rrelyea 
