### PR TITLE
Removing auto fallback to v1 lock files

### DIFF
--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -477,9 +477,9 @@ namespace NuGetVSExtension
                 packageFolderPaths.AddRange(nugetPaths.FallbackPackageFolders);
 
                 // Verify all packages exist and have the expected hashes
-                var restoreRequired = await BuildIntegratedRestoreUtility.IsRestoreRequired(
+                var restoreRequired = BuildIntegratedRestoreUtility.IsRestoreRequired(
                     projects,
-                    packageFolderPaths, 
+                    packageFolderPaths,
                     referenceContext);
 
                 if (restoreRequired)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
@@ -100,13 +100,6 @@ namespace NuGet.Commands
             var externalReferences = msbuildProvider.GetReferences(project.MSBuildProjectPath).ToList();
             request.ExternalProjects = externalReferences;
 
-            // Determine if this needs to fall back to an older lock file format
-            // Skip this if the arguments override the lock file version
-            if (restoreContext.LockFileVersion == null)
-            {
-                request.LockFileVersion = LockFileUtilities.GetLockFileVersion(externalReferences);
-            }
-
             // The lock file is loaded later since this is an expensive operation
 
             var summaryRequest = new RestoreSummaryRequest(

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -105,7 +105,6 @@ namespace NuGet.PackageManagement
             using (var request = new RestoreRequest(packageSpec, providers, logger, disposeProviders: false))
             {
                 request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
-                request.LockFileVersion = await GetLockFileVersion(project, context);
 
                 // Add the existing lock file if it exists
                 var lockFilePath = ProjectJsonPathUtilities.GetLockFilePath(project.JsonConfigPath);
@@ -271,7 +270,7 @@ namespace NuGet.PackageManagement
         /// If a full restore is required this will return false.
         /// </summary>
         /// <remarks>Floating versions and project.json files with supports require a full restore.</remarks>
-        public static async Task<bool> IsRestoreRequired(
+        public static bool IsRestoreRequired(
             IReadOnlyList<BuildIntegratedNuGetProject> projects,
             IReadOnlyList<string> packageFolderPaths,
             ExternalProjectReferenceContext referenceContext)
@@ -293,11 +292,9 @@ namespace NuGet.PackageManagement
                 var lockFileFormat = new LockFileFormat();
                 var lockFile = lockFileFormat.Read(lockFilePath, referenceContext.Logger);
 
-                var lockFileVersion = await GetLockFileVersion(project, referenceContext);
-
                 var packageSpec = referenceContext.GetOrCreateSpec(project.ProjectName, project.JsonConfigPath);
 
-                if (!lockFile.IsValidForPackageSpec(packageSpec, lockFileVersion))
+                if (!lockFile.IsValidForPackageSpec(packageSpec, LockFileFormat.Version))
                 {
                     // The project.json file has been changed and the lock file needs to be updated.
                     return true;
@@ -403,27 +400,6 @@ namespace NuGet.PackageManagement
 
             // sort parents by name to make this more deterministic during restores
             return parents.OrderBy(parent => parent.ProjectName, StringComparer.Ordinal).ToList();
-        }
-
-        /// <summary>
-        /// If the project is non-xproj and has no xproj references it may fallback to v1.
-        /// </summary>
-        public static async Task<int> GetLockFileVersion(
-            NuGetProject project,
-            ExternalProjectReferenceContext referenceContext)
-        {
-            var lockFileVersion = LockFileFormat.Version;
-
-            var buildProject = project as BuildIntegratedNuGetProject;
-
-            if (buildProject != null)
-            {
-                var references = await buildProject.GetProjectReferenceClosureAsync(referenceContext);
-
-                lockFileVersion = LockFileUtilities.GetLockFileVersion(references);
-            }
-
-            return lockFileVersion;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileUtilities.cs
@@ -23,26 +23,5 @@ namespace NuGet.ProjectModel
 
             return lockFile;
         }
-
-        // MSBuild for VS2015U1 fails when projects are in the lock file since it treats them as packages.
-        // To work around that NuGet will downgrade the lock file if there are only csproj references.
-        // Projects with zero project references can go to v2, and projects with xproj references must be
-        // at least v2 to work.
-        // references should include the parent project
-        public static int GetLockFileVersion(IReadOnlyList<ExternalProjectReference> references)
-        {
-            var version = LockFileFormat.Version;
-
-            // if xproj is used the higher version must be used
-            if (references.Any(reference => reference.ExternalProjectReferences.Count > 0)
-                && !references.Any(reference =>
-                        reference.MSBuildProjectPath?.EndsWith(XProjUtility.XProjExtension) == true))
-            {
-                // Fallback to v1 for non-xprojs with p2ps
-                version = 1;
-            }
-
-            return version;
-        }
     }
 }


### PR DESCRIPTION
This change removes automatic fallback of v2 to v1 lock files based on the types of projects used. The previous check relied on xproj to bump the version to v2, however with xproj going away this can no longer be used. The fallback was originally added as a temporary workaround for users with the latest version of NuGet who were still on Visual Studio 2015 Update 1. With the release of Updates 2 and 3 this is no longer needed.

Fixes https://github.com/NuGet/Home/issues/3011

//cc @rrelyea @joelverhagen @rohit21agrawal @drewgil @jainaashish @alpaix 
