### PR TITLE
Adding NUGET_XPROJ_WRITE_TARGETS

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -119,7 +119,13 @@ namespace NuGet.Commands
             }
 
             // Generate Targets/Props files
-            var msbuild = RestoreMSBuildFiles(_request.Project, graphs, localRepositories, contextForProject);
+            var msbuild = BuildAssetsUtils.RestoreMSBuildFiles(
+                _request.Project,
+                graphs,
+                localRepositories,
+                contextForProject,
+                _request,
+                _includeFlagGraphs);
 
             // If the request is for a v1 lock file then downgrade it and remove all v2 properties
             if (_request.LockFileVersion == 1)
@@ -408,7 +414,7 @@ namespace NuGet.Commands
                     toolSuccess = false;
                     _success = false;
                 }
-                
+
                 var checkResults = VerifyCompatibility(
                     toolPackageSpec,
                     new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>(),
@@ -644,107 +650,6 @@ namespace NuGet.Commands
             }
 
             return context;
-        }
-
-        private MSBuildRestoreResult RestoreMSBuildFiles(PackageSpec project,
-            IEnumerable<RestoreTargetGraph> targetGraphs,
-            IReadOnlyList<NuGetv3LocalRepository> repositories,
-            RemoteWalkContext context)
-        {
-            // Get the project graph
-            var projectFrameworks = project.TargetFrameworks.Select(f => f.FrameworkName).ToList();
-
-            // Non-Msbuild projects should skip targets and treat it as success
-            if (!context.IsMsBuildBased)
-            {
-                return new MSBuildRestoreResult(project.Name, project.BaseDirectory, success: true);
-            }
-
-            // Invalid msbuild projects should write out an msbuild error target
-            if (projectFrameworks.Count != 1
-                || !targetGraphs.Any())
-            {
-                return new MSBuildRestoreResult(project.Name, project.BaseDirectory, success: false);
-            }
-
-            // Gather props and targets to write out
-            var graph = targetGraphs
-                .Single(g => g.Framework.Equals(projectFrameworks[0]) && string.IsNullOrEmpty(g.RuntimeIdentifier));
-
-            var flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(_includeFlagGraphs, _request.Project, graph);
-
-            var targets = new List<string>();
-            var props = new List<string>();
-            foreach (var library in graph.Flattened
-                .Distinct()
-                .OrderBy(g => g.Data.Match.Library))
-            {
-                var includeLibrary = true;
-
-                LibraryIncludeFlags libraryFlags;
-                if (flattenedFlags.TryGetValue(library.Key.Name, out libraryFlags))
-                {
-                    includeLibrary = libraryFlags.HasFlag(LibraryIncludeFlags.Build);
-                }
-
-                // Skip libraries that do not include build files such as transitive packages
-                if (includeLibrary)
-                {
-                    var packageIdentity = new PackageIdentity(library.Key.Name, library.Key.Version);
-                    IList<string> packageFiles;
-                    context.PackageFileCache.TryGetValue(packageIdentity, out packageFiles);
-
-                    if (packageFiles != null)
-                    {
-                        var contentItemCollection = new ContentItemCollection();
-                        contentItemCollection.Load(packageFiles);
-
-                        // Find MSBuild thingies
-                        var groups = contentItemCollection.FindItemGroups(graph.Conventions.Patterns.MSBuildFiles);
-
-                        // Find the nearest msbuild group, this can include the root level Any group.
-                        var buildItems = NuGetFrameworkUtility.GetNearest(
-                            groups,
-                            graph.Framework,
-                            group =>
-                                group.Properties[ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker]
-                                    as NuGetFramework);
-
-                        if (buildItems != null)
-                        {
-                            // We need to additionally filter to items that are named "{packageId}.targets" and "{packageId}.props"
-                            // Filter by file name here and we'll filter by extension when we add things to the lists.
-                            var items = buildItems.Items
-                                .Where(item =>
-                                    Path.GetFileNameWithoutExtension(item.Path)
-                                    .Equals(library.Key.Name, StringComparison.OrdinalIgnoreCase))
-                                .ToList();
-
-                            var packageInfo = NuGetv3LocalRepositoryUtility.GetPackage(repositories, library.Key.Name, library.Key.Version);
-                            var pathResolver = packageInfo.Repository.PathResolver;
-
-                            targets.AddRange(items
-                                .Where(c => Path.GetExtension(c.Path).Equals(".targets", StringComparison.OrdinalIgnoreCase))
-                                .Select(c =>
-                                    Path.Combine(pathResolver.GetInstallPath(library.Key.Name, library.Key.Version),
-                                    c.Path.Replace('/', Path.DirectorySeparatorChar))));
-
-                            props.AddRange(items
-                                .Where(c => Path.GetExtension(c.Path).Equals(".props", StringComparison.OrdinalIgnoreCase))
-                                .Select(c =>
-                                    Path.Combine(pathResolver.GetInstallPath(library.Key.Name, library.Key.Version),
-                                    c.Path.Replace('/', Path.DirectorySeparatorChar))));
-                        }
-                    }
-                }
-            }
-
-            // Targets files contain a macro for the repository root. If only the user package folder was used
-            // allow a replacement. If fallback folders were used the macro cannot be applied.
-            // Do not use macros for fallback folders. Use only the first repository which is the user folder.
-            var repositoryRoot = repositories.First().RepositoryRoot;
-
-            return new MSBuildRestoreResult(project.Name, project.BaseDirectory, repositoryRoot, props, targets);
         }
 
         private void DowngradeLockFileToV1(LockFile lockFile)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Client;
+using NuGet.ContentModel;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+
+namespace NuGet.Commands
+{
+    public static class BuildAssetsUtils
+    {
+        internal static MSBuildRestoreResult RestoreMSBuildFiles(PackageSpec project,
+            IEnumerable<RestoreTargetGraph> targetGraphs,
+            IReadOnlyList<NuGetv3LocalRepository> repositories,
+            RemoteWalkContext context,
+            RestoreRequest request,
+            Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs)
+        {
+            // Non-Msbuild projects should skip targets and treat it as success
+            if (!context.IsMsBuildBased && !ForceWriteTargets())
+            {
+                return new MSBuildRestoreResult(project.Name, project.BaseDirectory, success: true);
+            }
+
+            // Invalid msbuild projects should write out an msbuild error target
+            if (!targetGraphs.Any())
+            {
+                return new MSBuildRestoreResult(project.Name, project.BaseDirectory, success: false);
+            }
+
+            // Framework -> (targets, props)
+            var buildAssetsByFramework = new Dictionary<NuGetFramework, TargetsAndProps>();
+
+            // Get assets for each framework
+            foreach (var projectFramework in project.TargetFrameworks.Select(f => f.FrameworkName))
+            {
+                var targetsAndProps =
+                    GetTargetsAndPropsForFramework(
+                        targetGraphs,
+                        repositories,
+                        context,
+                        request,
+                        includeFlagGraphs,
+                        projectFramework);
+
+                buildAssetsByFramework.Add(projectFramework, targetsAndProps);
+            }
+
+            // Conditionals for targets and props by framework is not currently supported.
+            if (NeedsMSBuildConditionals(buildAssetsByFramework))
+            {
+                return new MSBuildRestoreResult(project.Name, project.BaseDirectory, success: false);
+            }
+
+            // Since all targets and props are the same, any framework can be used.
+            // There must be at least one framework here since there are target graphs (checked above)
+            var combinedTargetsAndProps = buildAssetsByFramework.Values.First();
+
+            // Sort the results by string case to keep the results consistent across internal nuget changes
+            combinedTargetsAndProps.Props.Sort(StringComparer.Ordinal);
+            combinedTargetsAndProps.Targets.Sort(StringComparer.Ordinal);
+
+            // Targets files contain a macro for the repository root. If only the user package folder was used
+            // allow a replacement. If fallback folders were used the macro cannot be applied.
+            // Do not use macros for fallback folders. Use only the first repository which is the user folder.
+            var repositoryRoot = repositories.First().RepositoryRoot;
+
+            // Create a result which may be committed to disk later.
+            return new MSBuildRestoreResult(
+                project.Name,
+                project.BaseDirectory,
+                repositoryRoot,
+                combinedTargetsAndProps.Props,
+                combinedTargetsAndProps.Targets);
+        }
+
+        /// <summary>
+        /// Verifies that all targets and props assets are the same across frameworks. If there is a mismatch
+        /// this will return false.
+        /// A single framework will always return true.
+        /// </summary>
+        private static bool NeedsMSBuildConditionals(Dictionary<NuGetFramework, TargetsAndProps> buildAssetsByFramework)
+        {
+            if (buildAssetsByFramework.Count > 1)
+            {
+                var combinedAssets = buildAssetsByFramework.Select(entry =>
+                    entry.Value.Targets
+                        .Concat(entry.Value.Props)
+                        .OrderBy(s => s, StringComparer.Ordinal)
+                        .ToArray())
+                   .ToArray();
+
+                // Compare all groups to the first group
+                return combinedAssets.Skip(1).Any(group => !combinedAssets[0].SequenceEqual(group));
+            }
+
+            return false;
+        }
+
+        private static TargetsAndProps GetTargetsAndPropsForFramework(
+            IEnumerable<RestoreTargetGraph> targetGraphs,
+            IReadOnlyList<NuGetv3LocalRepository> repositories,
+            RemoteWalkContext context,
+            RestoreRequest request,
+            Dictionary<RestoreTargetGraph,
+            Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs,
+            NuGetFramework projectFramework)
+        {
+            var result = new TargetsAndProps();
+
+            // Skip runtime graphs, msbuild targets may not come from RID specific packages
+            var graph = targetGraphs
+                .Single(g => string.IsNullOrEmpty(g.RuntimeIdentifier) && g.Framework.Equals(projectFramework));
+
+            // Gather props and targets to write out
+            var buildGroupSets = GetMSBuildAssets(context, graph, request.Project, includeFlagGraphs);
+
+            // Second find the nearest group for each framework
+            foreach (var buildGroupSetsEntry in buildGroupSets)
+            {
+                var libraryIdentity = buildGroupSetsEntry.Key;
+                var buildGroupSet = buildGroupSetsEntry.Value;
+
+                // Find the nearest msbuild group, this can include the root level Any group.
+                var buildItems = NuGetFrameworkUtility.GetNearest(
+                        buildGroupSet,
+                        graph.Framework,
+                        group =>
+                            group.Properties[ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker]
+                                as NuGetFramework);
+
+                // Check if compatible build assets exist
+                if (buildItems != null)
+                {
+                    AddPropsAndTargets(repositories, libraryIdentity, buildItems, result);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Check if NUGET_XPROJ_WRITE_TARGETS is true.
+        /// </summary>
+        private static bool ForceWriteTargets()
+        {
+            var envVar = Environment.GetEnvironmentVariable("NUGET_XPROJ_WRITE_TARGETS");
+
+            bool forceWriteTargets = false;
+            if (!string.IsNullOrEmpty(envVar))
+            {
+                Boolean.TryParse(envVar, out forceWriteTargets);
+            }
+
+            return forceWriteTargets;
+        }
+
+        /// <summary>
+        /// Find all included msbuild assets for a graph.
+        /// </summary>
+        private static Dictionary<LibraryIdentity, ContentItemGroup[]> GetMSBuildAssets(
+            RemoteWalkContext context,
+            RestoreTargetGraph graph,
+            PackageSpec project,
+            Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs)
+        {
+            var buildGroupSets = new Dictionary<LibraryIdentity, ContentItemGroup[]>();
+
+            var flattenedFlags = IncludeFlagUtils.FlattenDependencyTypes(includeFlagGraphs, project, graph);
+
+            // First find all msbuild items in the packages
+            foreach (var library in graph.Flattened
+                .Distinct()
+                .OrderBy(g => g.Data.Match.Library))
+            {
+                var includeLibrary = true;
+
+                LibraryIncludeFlags libraryFlags;
+                if (flattenedFlags.TryGetValue(library.Key.Name, out libraryFlags))
+                {
+                    includeLibrary = libraryFlags.HasFlag(LibraryIncludeFlags.Build);
+                }
+
+                // Skip libraries that do not include build files such as transitive packages
+                if (includeLibrary)
+                {
+                    var packageIdentity = new PackageIdentity(library.Key.Name, library.Key.Version);
+                    IList<string> packageFiles;
+                    context.PackageFileCache.TryGetValue(packageIdentity, out packageFiles);
+
+                    if (packageFiles != null)
+                    {
+                        var contentItemCollection = new ContentItemCollection();
+                        contentItemCollection.Load(packageFiles);
+
+                        // Find MSBuild groups
+                        var buildGroupSet = contentItemCollection
+                            .FindItemGroups(graph.Conventions.Patterns.MSBuildFiles)
+                            .ToArray();
+
+                        buildGroupSets.Add(library.Key, buildGroupSet);
+                    }
+                }
+            }
+
+            return buildGroupSets;
+        }
+
+        /// <summary>
+        /// Add all valid targets and props to the passed in lists.
+        /// Modifies targetsAndProps
+        /// </summary>
+        private static void AddPropsAndTargets(
+            IReadOnlyList<NuGetv3LocalRepository> repositories,
+            LibraryIdentity libraryIdentity,
+            ContentItemGroup buildItems,
+            TargetsAndProps targetsAndProps)
+        {
+            // We need to additionally filter to items that are named "{packageId}.targets" and "{packageId}.props"
+            // Filter by file name here and we'll filter by extension when we add things to the lists.
+            var items = buildItems.Items
+                .Where(item =>
+                    Path.GetFileNameWithoutExtension(item.Path)
+                    .Equals(libraryIdentity.Name, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            var packageInfo = NuGetv3LocalRepositoryUtility.GetPackage(repositories, libraryIdentity.Name, libraryIdentity.Version);
+            var pathResolver = packageInfo.Repository.PathResolver;
+
+            targetsAndProps.Targets.AddRange(items
+                .Where(c => Path.GetExtension(c.Path).Equals(".targets", StringComparison.OrdinalIgnoreCase))
+                .Select(c =>
+                    Path.Combine(pathResolver.GetInstallPath(libraryIdentity.Name, libraryIdentity.Version),
+                    c.Path.Replace('/', Path.DirectorySeparatorChar))));
+
+            targetsAndProps.Props.AddRange(items
+                .Where(c => Path.GetExtension(c.Path).Equals(".props", StringComparison.OrdinalIgnoreCase))
+                .Select(c =>
+                    Path.Combine(pathResolver.GetInstallPath(libraryIdentity.Name, libraryIdentity.Version),
+                    c.Path.Replace('/', Path.DirectorySeparatorChar))));
+        }
+
+        private class TargetsAndProps
+        {
+            public List<string> Targets { get; } = new List<string>();
+
+            public List<string> Props { get; } = new List<string>();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -1987,7 +1987,7 @@ namespace NuGet.CommandLine.Test
                 var packageAPath = Path.Combine("fallback2", "packagea", "1.1.0-beta-01", "build", "uap", "packageA.targets");
 
                 // B is installed to the user folder
-                var packageBPath = "$(NuGetPackageRoot)" 
+                var packageBPath = "$(NuGetPackageRoot)"
                     + Path.DirectorySeparatorChar
                     + Path.Combine("packageb", "2.2.0-beta-02", "build", "uap", "packageB.targets");
 
@@ -2295,6 +2295,218 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
                 Assert.False(File.Exists(targetFilePath));
+            }
+        }
+
+        [Fact]
+        public void RestoreProjectJson_GenerateTargetsForXProjProjectsWithFlagSet()
+        {
+            // Arrange
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                string folderName = Path.GetFileName(workingPath);
+
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var nugetexe = Util.GetNuGetExePath();
+
+                Directory.CreateDirectory(repositoryPath);
+                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+                var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
+                var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
+
+                var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+                var targetA = Util.CreatePackageFile("build/uap/packageA.targets", targetContent);
+                var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
+
+                packageA.Files.Add(targetA);
+                packageA.Files.Add(libA);
+
+                var targetB = Util.CreatePackageFile("build/uap/packageB.targets", targetContent);
+                var libB = Util.CreatePackageFile("lib/uap/b.dll", "b");
+
+                packageB.Files.Add(targetB);
+                packageB.Files.Add(libB);
+
+                Util.CreateTestPackage(packageA, repositoryPath);
+                Util.CreateTestPackage(packageB, repositoryPath);
+
+                Util.CreateFile(workingPath, "project.json",
+                                                @"{
+                                                    'dependencies': {
+                                                    'packageA': '1.1.0-beta-*',
+                                                    'packageB': '2.2.0-beta-*'
+                                                    },
+                                                    'frameworks': {
+                                                                'uap10.0': { }
+                                                            }
+                                                  }");
+
+                Util.CreateFile(workingPath, "test.xproj", Util.GetCSProjXML("test"));
+
+                string[] args = new string[] {
+                    "restore",
+                    "-Source",
+                    repositoryPath,
+                    "-solutionDir",
+                    workingPath,
+                    "test.xproj"
+                };
+
+                var targetFilePath = Path.Combine(workingPath, "test.nuget.targets");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true,
+                    environmentVariables: new Dictionary<string, string>()
+                    {
+                        {  "NUGET_XPROJ_WRITE_TARGETS", "true" }
+                    });
+
+                // Assert
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(File.Exists(targetFilePath));
+            }
+        }
+
+        [Fact]
+        public void RestoreProjectJson_MultipleFrameworksForCSProjGeneratesTargets_SameTargets()
+        {
+            // Arrange
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                string folderName = Path.GetFileName(workingPath);
+
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var nugetexe = Util.GetNuGetExePath();
+
+                Directory.CreateDirectory(repositoryPath);
+                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+                var packageA = Util.CreateTestPackageBuilder("packageA", "1.0.0");
+
+                var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+                var targetARoot = Util.CreatePackageFile("build/packageA.targets", targetContent);
+
+                packageA.Files.Add(targetARoot);
+
+                Util.CreateTestPackage(packageA, repositoryPath);
+
+                Util.CreateFile(workingPath, "project.json",
+                                                @"{
+                                                    'dependencies': {
+                                                       'packageA': '1.0.0',
+                                                    },
+                                                    'frameworks': {
+                                                        'netstandard1.0': { },
+                                                        'netstandard1.5': { }
+                                                  }
+                                               }");
+
+                Util.CreateFile(workingPath, "test.csproj", Util.GetCSProjXML("test"));
+
+
+                string[] args = new string[] {
+                    "restore",
+                    "-Source",
+                    repositoryPath,
+                    "-solutionDir",
+                    workingPath,
+                    "test.csproj"
+                };
+
+                var targetFilePath = Path.Combine(workingPath, "test.nuget.targets");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                var messages = r.Item2 + " " + r.Item3;
+
+                // Assert
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(File.Exists(targetFilePath));
+                Assert.DoesNotContain("cannot be fully installed in projects targeting multiple frameworks", messages);
+
+                var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+                // Verify the target was added
+                Assert.True(targetsFile.IndexOf(@"build\packageA.targets") > -1);
+            }
+        }
+
+        // Verify that if different targets are selected for the same project between frameworks, that
+        // a warning is shown and no targets are added.
+        [Fact]
+        public void RestoreProjectJson_MultipleFrameworksForCSProjGeneratesTargets_DifferentTargets()
+        {
+            // Arrange
+            using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                string folderName = Path.GetFileName(workingPath);
+
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+                var nugetexe = Util.GetNuGetExePath();
+
+                Directory.CreateDirectory(repositoryPath);
+                Directory.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+                var packageA = Util.CreateTestPackageBuilder("packageA", "1.0.0");
+
+                var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+                var targetAns10 = Util.CreatePackageFile("build/netstandard1.0/packageA.targets", targetContent);
+                var targetAns13 = Util.CreatePackageFile("build/netstandard1.3/packageA.targets", targetContent);
+
+                packageA.Files.Add(targetAns10);
+                packageA.Files.Add(targetAns13);
+
+                Util.CreateTestPackage(packageA, repositoryPath);
+
+                Util.CreateFile(workingPath, "project.json",
+                                                @"{
+                                                    'dependencies': {
+                                                       'packageA': '1.0.0',
+                                                    },
+                                                    'frameworks': {
+                                                        'netstandard1.0': { },
+                                                        'netstandard1.5': { }
+                                                  }
+                                               }");
+
+                Util.CreateFile(workingPath, "test.csproj", Util.GetCSProjXML("test"));
+
+
+                string[] args = new string[] {
+                    "restore",
+                    "-Source",
+                    repositoryPath,
+                    "-solutionDir",
+                    workingPath,
+                    "test.csproj"
+                };
+
+                var targetFilePath = Path.Combine(workingPath, "test.nuget.targets");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true,
+                    timeOutInMilliseconds: -1);
+
+                // Assert
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+                Assert.True(File.Exists(targetFilePath));
+                Assert.Contains("cannot be fully installed in projects targeting multiple frameworks", File.ReadAllText(targetFilePath));
             }
         }
 


### PR DESCRIPTION
This change is preperation for the move from xproj to csproj. Setting the environment variable _NUGET_XPROJ_WRITE_TARGETS_ will write out targets and props files for the project during restore.

NuGet does not yet support writing targets and props with conditionals based on target framework, but it can avoid failing unless there is actually a conflict. For most projects and packages the same target file will be used for all frameworks.

Most of this change is refactoring the msbuild helpers into BuildAssetsUtils. The core logic for selecting targets and props is still the same.

Fixes https://github.com/NuGet/Home/issues/3102
Fixes https://github.com/NuGet/Home/issues/3196

//cc @joelverhagen @rohit21agrawal @jainaashish @alpaix @rrelyea @drewgil 
