### PR TITLE
Add source logging for CoreXT

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2211,7 +2211,7 @@ namespace NuGet.PackageManagement
                         var packagePath = PackagesFolderNuGetProject.GetInstalledPackageFilePath(nuGetProjectAction.PackageIdentity);
                         if (File.Exists(packagePath))
                         {
-                            using (var downloadResourceResult = new DownloadResourceResult(File.OpenRead(packagePath)))
+                            using (var downloadResourceResult = new DownloadResourceResult(File.OpenRead(packagePath), nuGetProjectAction.SourceRepository?.PackageSource?.Source))
                             {
                                 await ExecuteInstallAsync(nuGetProject, nuGetProjectAction.PackageIdentity, downloadResourceResult, packageWithDirectoriesToBeDeleted, nuGetProjectContext, token);
                             }

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -241,7 +241,12 @@ namespace NuGet.PackageManagement
                 result.PackageStream.Seek(0, SeekOrigin.Begin);
                 var packageReader = new PackageArchiveReader(result.PackageStream);
                 result.PackageStream.Seek(0, SeekOrigin.Begin);
-                result = new DownloadResourceResult(result.PackageStream, packageReader);
+                result = new DownloadResourceResult(result.PackageStream, packageReader, sourceRepository.PackageSource.Source);
+            }
+            else
+            {
+                // bind the source
+                result = new DownloadResourceResult(result.PackageStream, result.PackageReader, sourceRepository.PackageSource.Source);
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -135,8 +135,13 @@ namespace NuGet.ProjectManagement
                     // Pend all the package files including the nupkg file
                     FileSystemUtility.PendAddFiles(addedPackageFilesList, Root, nuGetProjectContext);
 
-                    string format = string.IsNullOrEmpty(downloadResourceResult.PackageSource) ? Strings.AddedPackageToFolder : Strings.AddedPackageToFolderFromSource;
-                    nuGetProjectContext.Log(MessageLevel.Info, format, packageIdentity, Path.GetFullPath(Root), downloadResourceResult.PackageSource);
+                    nuGetProjectContext.Log(MessageLevel.Info, Strings.AddedPackageToFolder, packageIdentity, Path.GetFullPath(Root));
+
+                    // Extra logging with source for verbosity detailed
+                    if (!string.IsNullOrEmpty(downloadResourceResult.PackageSource))
+                    {
+                        nuGetProjectContext.Log(MessageLevel.Debug, Strings.AddedPackageToFolderFromSource, packageIdentity, Path.GetFullPath(Root), downloadResourceResult.PackageSource);
+                    }
 
                     return Task.FromResult(true);
                 },

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -135,7 +135,9 @@ namespace NuGet.ProjectManagement
                     // Pend all the package files including the nupkg file
                     FileSystemUtility.PendAddFiles(addedPackageFilesList, Root, nuGetProjectContext);
 
-                    nuGetProjectContext.Log(MessageLevel.Info, Strings.AddedPackageToFolder, packageIdentity, Path.GetFullPath(Root));
+                    string format = string.IsNullOrEmpty(downloadResourceResult.PackageSource) ? Strings.AddedPackageToFolder : Strings.AddedPackageToFolderFromSource;
+                    nuGetProjectContext.Log(MessageLevel.Info, format, packageIdentity, Path.GetFullPath(Root), downloadResourceResult.PackageSource);
+
                     return Task.FromResult(true);
                 },
                 token: token);

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -138,6 +138,7 @@ namespace NuGet.ProjectManagement
                     nuGetProjectContext.Log(MessageLevel.Info, Strings.AddedPackageToFolder, packageIdentity, Path.GetFullPath(Root));
 
                     // Extra logging with source for verbosity detailed
+                    // Used by external tool CoreXT to track package provenance
                     if (!string.IsNullOrEmpty(downloadResourceResult.PackageSource))
                     {
                         nuGetProjectContext.Log(MessageLevel.Debug, Strings.AddedPackageToFolderFromSource, packageIdentity, Path.GetFullPath(Root), downloadResourceResult.PackageSource);

--- a/src/NuGet.Core/NuGet.ProjectManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Strings.Designer.cs
@@ -69,6 +69,15 @@ namespace NuGet.ProjectManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Added package &apos;{0}&apos; to folder &apos;{1}&apos; from source &apos;{2}&apos;.
+        /// </summary>
+        public static string AddedPackageToFolderFromSource {
+            get {
+                return ResourceManager.GetString("AddedPackageToFolderFromSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Added package &apos;{0}&apos; to project &apos;{1}&apos;.
         /// </summary>
         public static string AddedPackageToMSBuildProject {

--- a/src/NuGet.Core/NuGet.ProjectManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Strings.resx
@@ -120,6 +120,9 @@
   <data name="AddedPackageToFolder" xml:space="preserve">
     <value>Added package '{0}' to folder '{1}'</value>
   </data>
+  <data name="AddedPackageToFolderFromSource" xml:space="preserve">
+    <value>Added package '{0}' to folder '{1}' from source '{2}'</value>
+  </data>
   <data name="AddedPackageToMSBuildProject" xml:space="preserve">
     <value>Added package '{0}' to project '{1}'</value>
   </data>

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/DownloadResourceResult.cs
@@ -14,6 +14,7 @@ namespace NuGet.Protocol.Core.Types
     {
         private readonly Stream _stream;
         private readonly PackageReaderBase _packageReader;
+        private readonly string _packageSource;
 
         public DownloadResourceResult(DownloadResourceResultStatus status)
         {
@@ -25,7 +26,7 @@ namespace NuGet.Protocol.Core.Types
             Status = status;
         }
 
-        public DownloadResourceResult(Stream stream)
+        public DownloadResourceResult(Stream stream, string source)
         {
             if (stream == null)
             {
@@ -34,12 +35,23 @@ namespace NuGet.Protocol.Core.Types
 
             Status = DownloadResourceResultStatus.Available;
             _stream = stream;
+            _packageSource = source;
+        }
+
+        public DownloadResourceResult(Stream stream)
+            : this(stream, source: null)
+        {
+        }
+
+        public DownloadResourceResult(Stream stream, PackageReaderBase packageReader, string source)
+            : this(stream, source)
+        {
+            _packageReader = packageReader;
         }
 
         public DownloadResourceResult(Stream stream, PackageReaderBase packageReader)
-            : this(stream)
+            : this(stream, packageReader, source: null)
         {
-            _packageReader = packageReader;
         }
 
         public DownloadResourceResultStatus Status { get; }
@@ -48,6 +60,11 @@ namespace NuGet.Protocol.Core.Types
         /// Gets the package <see cref="PackageStream"/>.
         /// </summary>
         public Stream PackageStream => _stream;
+
+        /// <summary>
+        /// Gets the source containing this package, if not from cache
+        /// </summary>
+        public string PackageSource => _packageSource;
 
         /// <summary>
         /// Gets the <see cref="PackageReaderBase"/> for the package.

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1913,15 +1913,16 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
+            var identity = new Packaging.Core.PackageIdentity("packageA", new Versioning.NuGetVersion("1.1.0"));
 
             using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 Directory.CreateDirectory(repositoryPath);
-                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage(identity.Id, identity.Version.ToNormalizedString(), repositoryPath);
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
-  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id="""+identity.Id+@""" version="""+identity.Version.ToNormalizedString()+@""" targetFramework=""net45"" />
 </packages>");
 
                 string[] args = new string[] { "restore", "-PackagesDirectory", "outputDir", "-Source", repositoryPath, "-Verbosity detailed" };
@@ -1935,8 +1936,10 @@ EndProject");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
-                var packageFileA = Path.Combine(workingPath, @"outputDir\packageA.1.1.0\packageA.1.1.0.nupkg");
-                Assert.True(File.Exists(packageFileA));
+                var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), false);
+                var packageFilePath = target.GetInstalledPackageFilePath(identity);
+                Assert.True(File.Exists(packageFilePath));
+
                 Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
             }
         }
@@ -1946,6 +1949,7 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
+            var identity = new Packaging.Core.PackageIdentity("Newtonsoft.Json", new Versioning.NuGetVersion("7.0.1"));
             var source = @"https://api.nuget.org/v3/index.json";
             using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
             {
@@ -1958,7 +1962,7 @@ EndProject");
 </configuration>");
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
-  <package id=""Newtonsoft.Json"" version=""7.0.1"" targetFramework=""net45"" />
+  <package id="""+identity.Id+@""" version="""+identity.Version.ToNormalizedString()+@""" targetFramework=""net45"" />
 </packages>");
 
                 string[] args = new string[] { "restore", "-PackagesDirectory", "outputDir", "-Source ", source, "-Verbosity detailed" };
@@ -1972,8 +1976,10 @@ EndProject");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
-                var packageFile = Path.Combine(workingPath, @"outputDir\newtonsoft.json.7.0.1\newtonsoft.json.7.0.1.nupkg");
-                Assert.True(File.Exists(packageFile));
+                var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), false);
+                var packageFilePath = target.GetInstalledPackageFilePath(identity);
+                Assert.True(File.Exists(packageFilePath));
+
                 Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
                 
                 // verify sorce logging reported the correct source
@@ -1988,6 +1994,7 @@ EndProject");
         {
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
+            var identity = new Packaging.Core.PackageIdentity("Newtonsoft.Json", new Versioning.NuGetVersion("7.0.1"));
 
             using (var workingPath = TestFileSystemUtility.CreateRandomTestFolder())
             {
@@ -2000,7 +2007,7 @@ EndProject");
 </configuration>");
                 Util.CreateFile(workingPath, "packages.config",
 @"<packages>
-  <package id=""Newtonsoft.Json"" version=""7.0.1"" targetFramework=""net45"" />
+  <package id="""+identity.Id+@""" version="""+identity.Version.ToNormalizedString()+@""" targetFramework=""net45"" />
 </packages>");
                 var globalPackagesFolder = Path.Combine(workingPath, @"globalPackages");
                 // Prime Cache
@@ -2023,8 +2030,9 @@ EndProject");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
-                var packageFile = Path.Combine(workingPath, @"outputDir\newtonsoft.json.7.0.1\newtonsoft.json.7.0.1.nupkg");
-                Assert.True(File.Exists(packageFile));
+                var target = new PackagePathResolver(Path.Combine(workingPath, @"outputDir"), false);
+                var packageFilePath = target.GetInstalledPackageFilePath(identity);
+                Assert.True(File.Exists(packageFilePath));
                 Assert.Contains(" from source ", r.Item2); // source logging present in verbose log
 
                 //verify source logging reported the globalPacakges folder


### PR DESCRIPTION
Microsoft's internal CoreXT tool has been running with a fork of nuget that adds additional logging indicating the source when a package is download from a remote source. e.g.:

> Added package 'Newtonsoft.Json.9.0.1' to folder 'E:\repos\mytest\packages' from source 'https://api.nuget.org/v3/index.json'

This PR merges that logging change back into the nuget mainline.
