### PR TITLE
Lock NuGet core version script

### DIFF
--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -1,0 +1,40 @@
+
+function ReadPropertiesFile {
+    Param(
+        [Parameter(Mandatory=$True)]
+        [string]$Path
+    )
+    Write-Verbose "Reading properties file '$Path'"
+    $properties = @{}
+    Get-Content $Path |
+        ? { -not $_.StartsWith('#') } |
+        % { $_.Trim() } |
+        ? { $_ -ne '' } |
+        % { $tokens = $_ -split "\s*=\s*"; $properties.Add($tokens[0], $tokens[1]) }
+    $properties
+}
+
+function ReplaceTextInFiles {
+    Param(
+        [Parameter(ValueFromPipeline=$True, Mandatory=$True, Position=0)]
+        [string[]]$Files,
+        [Parameter(Mandatory=$True)]
+        [Alias('old')]
+        [string]$OldText,
+        [Parameter(Mandatory=$True)]
+        [Alias('new')]
+        [string]$NewText
+    )
+    Process {
+        $Files |
+            ?{ (Get-Content $_ | Out-String) -match $OldText } |
+            ?{ $pscmdlet.ShouldProcess($_, 'replace text') } |
+            %{
+                $updated = (Get-Content $_) | %{
+                    $_.Replace($OldText, $NewText)
+                }
+
+                Set-Content $_ $updated | Out-Null
+            }
+    }
+}

--- a/scripts/utils/LockNuGetCoreVersion.ps1
+++ b/scripts/utils/LockNuGetCoreVersion.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+Replaces floating version of NuGet core dependencies in NuGet clients projects to "{semver}-{label}-*".
+Mostly needed for release branches when dev builds in myget feed have more advanced version.
+
+.PARAMETER LockVersion
+Optional. New version of NuGet core packages.
+Defaults to current "{semver}-{labe}-*" from .teamcity.properties
+
+.PARAMETER OldVersion
+Optional. Old version string to look for when scanning project.json's.
+Will use default version "{semver}-*" from .teamcity.properties file if not specified.
+
+.PARAMETER NuGetRoot
+Optional. NuGet client repository root.
+
+.PARAMETER Force
+Optional switch to force replacing text when new and old versions are the same
+#>
+[CmdletBinding(SupportsShouldProcess=$True)]
+Param (
+    [Parameter(Mandatory=$false, Position=0)]
+    [Alias('version')]
+    [string]$LockVersion,
+    [Parameter(Mandatory=$false, Position=1)]
+    [string]$OldVersion,
+    [Parameter(Mandatory=$false, Position=2)]
+    [string]$NuGetRoot,
+    [switch]$Force)
+
+. "$PSScriptRoot\..\common.ps1"
+
+if (-not $NuGetRoot -and (Test-Path Env:\NuGetRoot)) {
+    $NuGetRoot = $env:NuGetRoot
+}
+
+if (-not $NuGetRoot) {
+    $NuGetRoot = Join-Path $PSScriptRoot '..\..\' -Resolve
+}
+
+if (Test-Path "$NuGetRoot\.teamcity.properties") {
+    $properties = ReadPropertiesFile "$NuGetRoot\.teamcity.properties"
+}
+
+if (-not $LockVersion -and $properties) {
+    $LockVersion = "$($properties['ReleaseProductVersion'])-$($properties['ReleaseLabel'])-*"
+}
+
+if (-not $LockVersion) {
+    throw "LOCK version string can't be found"
+}
+
+if (-not $OldVersion -and $properties) {
+    $OldVersion = "$($properties['ReleaseProductVersion'])-*"
+}
+
+if (-not $OldVersion) {
+    throw "OLD version string can't be found"
+}
+
+if ($OldVersion -eq $LockVersion -and -not $Force) {
+    Write-Output "NO-OP [$OldVersion == $LockVersion]"
+    exit 0
+}
+
+Write-Output "Locking NuGet core projects version [$OldVersion => $LockVersion]"
+
+gci "$NuGetRoot\src\NuGet.Clients" -include project.json -r | %{ $_.FullName } | ReplaceTextInFiles -old $OldVersion -new $LockVersion

--- a/scripts/utils/UpdateNuGetVersion.ps1
+++ b/scripts/utils/UpdateNuGetVersion.ps1
@@ -1,36 +1,58 @@
-[CmdletBinding()]
+<#
+.SYNOPSIS
+Replaces all occurances of build version string in project.json and other files
+
+.PARAMETER NewVersion
+New version string to set
+
+.PARAMETER OldVersion
+Optional. Old version string to replace.
+Will use version from .teamcity.properties file if not specified.
+
+.PARAMETER NuGetRoot
+Optional. NuGet client repository root.
+
+.PARAMETER Force
+Optional switch to force replacing text when new and old versions are the same
+#>
+[CmdletBinding(SupportsShouldProcess=$True)]
 Param (
     [Parameter(Mandatory=$true, Position=0)]
-    [string]$OldVersion,
-    [Parameter(Mandatory=$true, Position=1)]
+    [Alias('version')]
     [string]$NewVersion,
+    [Parameter(Mandatory=$false, Position=1)]
+    [string]$OldVersion,
     [Parameter(Mandatory=$false, Position=2)]
-    [string]$NuGetRoot = (Join-Path $PSScriptRoot '..\..\'))
+    [string]$NuGetRoot,
+    [switch]$Force)
 
-function ReplaceNuGetVersion
-{
-    Param(
-        [Parameter(ValueFromPipeline=$True, Mandatory=$True, Position=0)]
-        [string[]]$Files
-    )
-    Process {
-        $Files`
-            | ?{ (Get-Content $_ | Out-String) -match $OldVersion }`
-            | %{
-                Write-Output "Processing $_"
+. "$PSScriptRoot\..\common.ps1"
 
-                $updated = (Get-Content $_) | %{
-                    $_.Replace($OldVersion, $NewVersion)
-                }
+if (-not $NuGetRoot -and (Test-Path Env:\NuGetRoot)) {
+    $NuGetRoot = $env:NuGetRoot
+}
 
-                Set-Content $_ $updated | Out-Null
-            }
-    }
+if (-not $NuGetRoot) {
+    $NuGetRoot = Join-Path $PSScriptRoot '..\..\' -Resolve
+}
+
+if (-not $OldVersion -and (Test-Path "$NuGetRoot\.teamcity.properties")) {
+    $properties = ReadPropertiesFile "$NuGetRoot\.teamcity.properties"
+    $OldVersion = $properties['ReleaseProductVersion']
+}
+
+if (-not $OldVersion) {
+    throw "OLD version string can't be found"
+}
+
+if ($OldVersion -eq $NewVersion -and -not $Force) {
+    Write-Output "NO-OP [$OldVersion == $NewVersion]"
+    exit 0
 }
 
 Write-Output "Updating NuGet version [$OldVersion => $NewVersion]"
 
-ls -r project.json | %{ $_.FullName } | ReplaceNuGetVersion
+gci -r project.json | %{ $_.FullName } | ReplaceTextInFiles -old $OldVersion -new $NewVersion
 
 $miscFiles = @(
     "src\NuGet.Clients\VsExtension\source.extension.dev14.vsixmanifest",
@@ -41,4 +63,4 @@ $miscFiles = @(
     "appveyor.yml"
 )
 
-$miscFiles | %{ Join-Path $NuGetRoot $_ } | ReplaceNuGetVersion
+$miscFiles | %{ Join-Path $NuGetRoot $_ -Resolve } | ReplaceTextInFiles -old $OldVersion -new $NewVersion


### PR DESCRIPTION
Added script replacing NuGet core floating version in NuGet clients projects. Needed mostly in release branches to override more advanced builds coming from myget feed/dev builds.

//cc @joelverhagen @drewgil @rrelyea 
