### PR TITLE
Make PackageIdValidator.MaxPackageIdLength public

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Utility/PackageIdValidator.cs
@@ -10,7 +10,7 @@ namespace NuGet.Packaging
 {
     public static class PackageIdValidator
     {
-        internal const int MaxPackageIdLength = 100;
+        public const int MaxPackageIdLength = 100;
         private static readonly Regex _idRegex = new Regex(@"^\w+([_.-]\w+)*$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
 
         public static bool IsValidPackageId(string packageId)


### PR DESCRIPTION
The server needs this constant so that we can stay consistent with the client. 

We currently have a mismatch where the max server length is 128 but the max client length is 100. By making this constant public, we can prevent that from happening again in the future.

(https://github.com/NuGet/NuGetGallery/issues/3142)

@emgarten 
