### PR TITLE
Use original case in V2 file names (e.g. packages.config restore or csproj update or install)

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -49,7 +49,7 @@ namespace NuGet.Packaging
 
         public string GetManifestFileName(PackageIdentity packageIdentity)
         {
-            return packageIdentity.Id.ToLowerInvariant() + PackagingCoreConstants.NuspecExtension;
+            return GetId(packageIdentity) + PackagingCoreConstants.NuspecExtension;
         }
 
         public string GetInstallPath(PackageIdentity packageIdentity)
@@ -69,11 +69,23 @@ namespace NuGet.Packaging
             return PackagePathHelper.GetInstalledPackageFilePath(packageIdentity, this);
         }
 
+        private string GetId(PackageIdentity identity)
+        {
+            // We use original case for the ID (no normalization).
+            return identity.Id;
+        }
+
+        private string GetVersion(PackageIdentity identity)
+        {
+            // We use original case for the version (no normalization).
+            return identity.Version.ToString();
+        }
+
         private StringBuilder GetPathBase(PackageIdentity packageIdentity)
         {
             var builder = new StringBuilder();
 
-            builder.Append(packageIdentity.Id.ToLowerInvariant());
+            builder.Append(GetId(packageIdentity));
 
             if (UseSideBySidePaths)
             {
@@ -81,7 +93,7 @@ namespace NuGet.Packaging
 
                 // Always use legacy package install path. Otherwise, restore may be broken for
                 // packages like 'Microsoft.Web.Infrastructure.1.0.0.0', installed using old clients.
-                builder.Append(packageIdentity.Version.ToString().ToLowerInvariant());
+                builder.Append(GetVersion(packageIdentity));
             }
 
             return builder;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -120,8 +120,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.True(content.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\B.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\A.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\B.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\A.dll</HintPath>"));
                 Assert.True(content.Contains(@"<Content Include=""test.txt"" />"));
             }
         }
@@ -200,8 +200,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -321,16 +321,16 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content1 = File.ReadAllText(projectFile1);
-                Assert.False(content1.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content1.Contains(@"<HintPath>..\packages\b.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content1.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
 
                 var content2 = File.ReadAllText(projectFile2);
-                Assert.True(content2.Contains(@"<HintPath>..\packages\b.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\b.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content2.Contains(@"<HintPath>..\packages\B.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\B.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -421,12 +421,12 @@ namespace NuGet.CommandLine.Test
                 Assert.Contains("No projects found with packages.config.", r.Item2);
 
                 var content1 = File.ReadAllText(projectFile1);
-                Assert.True(content1.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content1.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
 
                 var content2 = File.ReadAllText(projectFile2);
-                Assert.True(content2.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content2.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content2.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content2.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -504,7 +504,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.2.0.0-beta\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.2.0.0-beta\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -583,8 +583,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0-beta\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0-BETA\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -673,9 +673,9 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.3.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.3.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -764,9 +764,9 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.3.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.3.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -844,8 +844,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -924,8 +924,8 @@ namespace NuGet.CommandLine.Test
                 Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
 
                 var content = File.ReadAllText(projectFile);
-                Assert.False(content.Contains(@"<HintPath>..\packages\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content.Contains(@"<HintPath>..\packages\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -1127,8 +1127,8 @@ namespace NuGet.CommandLine.Test
 
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
-                Assert.False(content1.Contains(@"<HintPath>..\custom-pcks\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\custom-pcks\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\custom-pcks\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\custom-pcks\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 
@@ -1217,8 +1217,8 @@ namespace NuGet.CommandLine.Test
                 // Check the custom package folder is used in the assembly reference
                 var content1 = File.ReadAllText(projectFile);
                 var customPackageFolderName = new DirectoryInfo(packagesDirectory.Path).Name;
-                Assert.False(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\a.1.0.0\lib\net45\file.dll</HintPath>"));
-                Assert.True(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\a.2.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.False(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\A.1.0.0\lib\net45\file.dll</HintPath>"));
+                Assert.True(content1.Contains(@"<HintPath>..\..\" + customPackageFolderName + @"\A.2.0.0\lib\net45\file.dll</HintPath>"));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -32,8 +32,8 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(true, "packagea.1.0.0.0-beta")]
-        [InlineData(false, "packagea")]
+        [InlineData(true, "PackageA.1.0.0.0-BETA")]
+        [InlineData(false, "PackageA")]
         public void PackagePathResolver_GetPackageDirectoryName(bool useSideBySidePaths, string expected)
         {
             // Arrange
@@ -49,8 +49,8 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(true, "packagea.1.0.0.0-beta.nupkg")]
-        [InlineData(false, "packagea.nupkg")]
+        [InlineData(true, "PackageA.1.0.0.0-BETA.nupkg")]
+        [InlineData(false, "PackageA.nupkg")]
         public void PackagePathResolver_GetPackageFileName(bool useSideBySidePaths, string expected)
         {
             // Arrange
@@ -66,8 +66,8 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(true, "packagea.nuspec")]
-        [InlineData(false, "packagea.nuspec")]
+        [InlineData(true, "PackageA.nuspec")]
+        [InlineData(false, "PackageA.nuspec")]
         public void PackagePathResolver_GetManifestFileName(bool useSideBySidePaths, string expected)
         {
             // Arrange
@@ -83,8 +83,8 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
-        [InlineData(true, "packagea.1.0.0.0-beta")]
-        [InlineData(false, "packagea")]
+        [InlineData(true, "PackageA.1.0.0.0-BETA")]
+        [InlineData(false, "PackageA")]
         public void PackagePathResolver_GetInstallPath(bool useSideBySidePaths, string expected)
         {
             // Arrange


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/3209.

/cc @emgarten @drewgil @rrelyea 
