### PR TITLE
Remove MSBuild batching in order to fix perf regression (regresses C#…

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -31,7 +31,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public class BuildIntegratedProjectSystem : BuildIntegratedNuGetProject
     {
         private IScriptExecutor _scriptExecutor;
-        private IVsProjectBuildSystem _buildSystem;
 
         public BuildIntegratedProjectSystem(
             string jsonConfigPath,
@@ -61,29 +60,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 return _scriptExecutor;
             }
-        }
-
-        public IVsProjectBuildSystem ProjectBuildSystem
-        {
-            get
-            {
-                if (_buildSystem == null)
-                {
-                    _buildSystem = EnvDTEProjectUtility.GetVsProjectBuildSystem(EnvDTEProject);
-                }
-
-                return _buildSystem;
-            }
-        }
-
-        public override void BeginProcessing()
-        {
-            ProjectBuildSystem?.StartBatchEdit();
-        }
-
-        public override void EndProcessing()
-        {
-            ProjectBuildSystem?.EndBatchEdit();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2085,10 +2085,8 @@ namespace NuGet.PackageManagement
                 }
 
                 // Write out the lock file
-                buildIntegratedProject.BeginProcessing();
                 var logger = new ProjectContextLogger(nuGetProjectContext);
                 await restoreResult.CommitAsync(logger, token);
-                buildIntegratedProject.EndProcessing();
 
                 // Write out a message for each action
                 foreach (var action in nuGetProjectActions)

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -234,16 +234,6 @@ namespace NuGet.ProjectManagement.Projects
             return Task.FromResult(false);
         }
 
-        public virtual void BeginProcessing()
-        {
-            // Intentional no-op
-        }
-
-        public virtual void EndProcessing()
-        {
-            // Intentional no-op
-        }
-
         private async Task<JObject> GetJsonAsync()
         {
             try


### PR DESCRIPTION
… project creation by ~500ms).

This is a reversion of the salient bits of https://github.com/NuGet/NuGet.Client/commit/3b6f15a17a681dd4c5acc36fe5db2b13d9b058e0

@emgarten @jainaashish @joelverhagen @alpaix 
