### PR TITLE
Adding Newtonsoft.Json 9.0.1 for netstandard support

### DIFF
--- a/src/NuGet.Clients/StandaloneUI/project.json
+++ b/src/NuGet.Clients/StandaloneUI/project.json
@@ -8,7 +8,6 @@
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",
     "Microsoft.VisualStudio.Shell.Interop.12.0": "12.0.30110",
-    "Newtonsoft.Json": "6.0.8",
     "Microsoft.Web.Xdt": "2.1.1",
     "NuGet.Protocol.VisualStudio": "3.5.0-*",
     "NuGet.ProjectManagement": "3.5.0-*",

--- a/src/NuGet.Core/NuGet.Client/project.json
+++ b/src/NuGet.Core/NuGet.Client/project.json
@@ -44,11 +44,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/project.json
@@ -47,9 +47,7 @@
     },
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.6"
       ],
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/src/NuGet.Core/NuGet.Commands/project.json
+++ b/src/NuGet.Core/NuGet.Commands/project.json
@@ -51,11 +51,6 @@
   },
   "frameworks": {
     "net45": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "frameworkAssemblies": {
         "System.Xml": "",
         "System.Xml.Linq": ""

--- a/src/NuGet.Core/NuGet.ContentModel/project.json
+++ b/src/NuGet.Core/NuGet.ContentModel/project.json
@@ -31,11 +31,6 @@
         "NETStandard.Library": "1.6.0",
         "System.ObjectModel": "4.0.12"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/project.json
@@ -45,11 +45,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },

--- a/src/NuGet.Core/NuGet.DependencyResolver/project.json
+++ b/src/NuGet.Core/NuGet.DependencyResolver/project.json
@@ -38,11 +38,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },

--- a/src/NuGet.Core/NuGet.LibraryModel/project.json
+++ b/src/NuGet.Core/NuGet.LibraryModel/project.json
@@ -38,11 +38,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core.Types/project.json
@@ -38,11 +38,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Packaging.Core/project.json
+++ b/src/NuGet.Core/NuGet.Packaging.Core/project.json
@@ -47,11 +47,6 @@
         "NETStandard.Library": "1.6.0",
         "System.Xml.XDocument": "4.0.11"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Packaging/project.json
+++ b/src/NuGet.Core/NuGet.Packaging/project.json
@@ -53,11 +53,6 @@
         "NETStandard.Library": "1.6.0",
         "System.IO.Compression": "4.1.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.ProjectModel/project.json
+++ b/src/NuGet.Core/NuGet.ProjectModel/project.json
@@ -7,7 +7,6 @@
     "projectUrl": "https://github.com/NuGet/NuGet.Client"
   },
   "dependencies": {
-    "Newtonsoft.Json": "6.0.4",
     "NuGet.DependencyResolver.Core": {
       "target": "project"
     }
@@ -31,16 +30,15 @@
         "define": [
           "IS_DESKTOP"
         ]
+      },
+      "dependencies": {
+        "Newtonsoft.Json": "6.0.4"
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "Newtonsoft.Json": "9.0.1",
         "System.Dynamic.Runtime": "4.0.11",
         "System.Threading.Thread": "4.0.0"
       },

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/project.json
@@ -52,11 +52,6 @@
         "NETStandard.Library": "1.6.0",
         "System.Net.Http": "4.1.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/project.json
@@ -34,8 +34,7 @@
     },
     "NuGet.Protocol.Core.Types": {
       "target": "project"
-    },
-    "Newtonsoft.Json": "6.0.4"
+    }
   },
   "frameworks": {
     "net45": {
@@ -49,16 +48,15 @@
         "define": [
           "IS_DESKTOP"
         ]
+      },
+      "dependencies": {
+        "Newtonsoft.Json": "6.0.4"
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "Newtonsoft.Json": "9.0.1",
         "System.Dynamic.Runtime": "4.0.11"
       },
       "buildOptions": {

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/project.json
@@ -32,11 +32,6 @@
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },

--- a/src/NuGet.Core/NuGet.Repositories/project.json
+++ b/src/NuGet.Core/NuGet.Repositories/project.json
@@ -35,11 +35,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Resolver/project.json
+++ b/src/NuGet.Core/NuGet.Resolver/project.json
@@ -42,11 +42,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.RuntimeModel/project.json
+++ b/src/NuGet.Core/NuGet.RuntimeModel/project.json
@@ -21,7 +21,6 @@
     }
   },
   "dependencies": {
-    "Newtonsoft.Json": "6.0.4",
     "NuGet.Versioning": {
       "target": "project"
     },
@@ -35,16 +34,15 @@
         "define": [
           "IS_DESKTOP"
         ]
+      },
+      "dependencies": {
+        "Newtonsoft.Json": "6.0.4"
       }
     },
     "netstandard1.3": {
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "Newtonsoft.Json": "9.0.1",
         "System.ObjectModel": "4.0.12",
         "System.Dynamic.Runtime": "4.0.11"
       },

--- a/src/NuGet.Core/NuGet.Test.Server/project.json
+++ b/src/NuGet.Core/NuGet.Test.Server/project.json
@@ -34,11 +34,6 @@
       "dependencies": {
         "NETStandard.Library": "1.6.0"
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -37,7 +37,6 @@
     "netstandard1.3": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {

--- a/src/NuGet.Core/SynchronizationTestApp/project.json
+++ b/src/NuGet.Core/SynchronizationTestApp/project.json
@@ -42,11 +42,6 @@
           "version": "1.0.0"
         }
       },
-      "imports": [
-        "dotnet5.6",
-        "dnxcore50",
-        "portable-net45+win8"
-      ],
       "buildOptions": {
         "define": [
           "IS_CORECLR"

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/project.json
@@ -12,8 +12,7 @@
     "NuGet.Test.Utility": {
       "target": "project"
     },
-    "xunit": "2.1.0",
-    "Newtonsoft.Json": "8.0.3"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/TestExtensions/TestablePluginCredentialProvider/project.json
+++ b/test/TestExtensions/TestablePluginCredentialProvider/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Newtonsoft.Json": "6.0.8"
+    "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
This change adds Newtonsoft.Json 9.0.1 under the netstandard dependency group. net45 will continue using 6.0.4 to match visual studio.

Removing unneeded imports.

Fixes https://github.com/NuGet/Home/issues/3233

//cc @joelverhagen @jainaashish @drewgil @rrelyea @rohit21agrawal @alpaix 
