### PR TITLE
Fixed publishing of VS15 symbols for CI builds

### DIFF
--- a/.teamcity.properties
+++ b/.teamcity.properties
@@ -1,5 +1,14 @@
+# Collection of properties customizing TeamCity build configurations
 ReleaseLabel = rc1
 ReleaseProductVersion = 3.5.0
+# Enables publishing of NuGet packages to the MyGet/nugetbuild feed
+# Should be true for dev, and false for other branches
 ShouldPublishPackages = true
+# Enables publishing of a NuGet VS extension to the MyGet/nugetbuild feed
+# Should be true for dev, and false for other branches
 ShouldPublishVsix = true
+# Enables localization of a NuGet VS extension on wsr-tc
+# Should be false for dev, and true for other branches
 ShouldTriggerMsiBuild = false
+# NuGet.Core dependency version
+NuGet.Core.Version = 2.13.0-rtm-824

--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -15,6 +15,7 @@ function ReadPropertiesFile {
 }
 
 function ReplaceTextInFiles {
+    [CmdletBinding(SupportsShouldProcess=$True)]
     Param(
         [Parameter(ValueFromPipeline=$True, Mandatory=$True, Position=0)]
         [string[]]$Files,

--- a/scripts/utils/UpdateNuGetVersion.ps1
+++ b/scripts/utils/UpdateNuGetVersion.ps1
@@ -14,6 +14,9 @@ Optional. NuGet client repository root.
 
 .PARAMETER Force
 Optional switch to force replacing text when new and old versions are the same
+
+.EXAMPLE
+UpdateNuGetVersion.ps1 3.5.1 -Verbose
 #>
 [CmdletBinding(SupportsShouldProcess=$True)]
 Param (
@@ -55,6 +58,7 @@ Write-Output "Updating NuGet version [$OldVersion => $NewVersion]"
 gci -r project.json | %{ $_.FullName } | ReplaceTextInFiles -old $OldVersion -new $NewVersion
 
 $miscFiles = @(
+    "src\NuGet.Clients\NuGet.CommandLine\NuGet.CommandLine.nuspec"
     "src\NuGet.Clients\VsExtension\source.extension.dev14.vsixmanifest",
     "src\NuGet.Clients\VsExtension\source.extension.dev15.vsixmanifest",
     "src\NuGet.Clients\VsExtension\NuGetPackage.cs",

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>NuGet.CommandLine</id>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt</licenseUrl>
@@ -13,5 +13,6 @@
   </metadata>
   <files>
       <file src="NuGet.exe" target="tools" />
+      <file src="NuGet.pdb" target="tools" />
   </files>
 </package>

--- a/test/TestExtensions/GenerateTestPackages/project.json
+++ b/test/TestExtensions/GenerateTestPackages/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "NuGet.Core": "2.8.5"
+    "NuGet.Core": "2.13.0-rtm-824"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
Fixes NuGet/Home#3185
- Added a parameter pointing  to the right version of NuGet.Core for pdb publishing
- Added pdb to the command line package nuspec
- Minor script fixes

//cc @drewgil @rrelyea @joelverhagen @emgarten 
