### PR TITLE
Avoid duplicate nuspec files during v3 extraction

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/IPackageCoreReader.cs
@@ -54,6 +54,11 @@ namespace NuGet.Packaging.Core
         /// </summary>
         Stream GetNuspec();
 
+        /// <summary>
+        /// Nuspec path
+        /// </summary>
+        string GetNuspecFile();
+
         IEnumerable<string> CopyFiles(
             string destination,
             IEnumerable<string> packageFiles,

--- a/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageArchiveReader.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using NuGet.Common;
@@ -120,11 +119,6 @@ namespace NuGet.Packaging
             }
 
             return stream;
-        }
-
-        public override Stream GetNuspec()
-        {
-            return GetStream(this.GetNuspecFile());
         }
 
         protected override void Dispose(bool disposing)

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtraction/PackageHelper.cs
@@ -42,7 +42,7 @@ namespace NuGet.Packaging
             return IsRoot(path) && IsNuspec(path);
         }
 
-        private static bool IsRoot(string path)
+        public static bool IsRoot(string path)
         {
             // True if the path contains no directory slashes.
             return path.IndexOfAny(Slashes) == -1;

--- a/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageExtractor.cs
@@ -286,7 +286,7 @@ namespace NuGet.Packaging
                                     var nuspecFileName = Path.GetFileName(targetNuspec);
                                     var hashFileName = Path.GetFileName(hashPath);
                                     var packageFiles = packageReader.GetFiles()
-                                        .Where(file => ShouldInclude(file, nupkgFileName, nuspecFileName, hashFileName));
+                                        .Where(file => ShouldInclude(file, hashFileName));
                                     var packageFileExtractor = new PackageFileExtractor(
                                         packageFiles,
                                         versionFolderPathContext.XmlDocFileSaveMode);
@@ -348,8 +348,6 @@ namespace NuGet.Packaging
 
         private static bool ShouldInclude(
             string fullName,
-            string nupkgFileName,
-            string nuspecFileName,
             string hashFileName)
         {
             // Not all the files from a zip file are needed
@@ -373,9 +371,15 @@ namespace NuGet.Packaging
                 return false;
             }
 
-            if (string.Equals(fullName, nupkgFileName, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(fullName, hashFileName, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(fullName, nuspecFileName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(fullName, hashFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Skip nupkgs and nuspec files found in the root, the valid ones are already extracted
+            if (PackageHelper.IsRoot(fullName) 
+                && (PackageHelper.IsNuspec(fullName) 
+                    || fullName.EndsWith(PackagingCoreConstants.NupkgExtension, StringComparison.OrdinalIgnoreCase)))
             {
                 return false;
             }

--- a/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageFolderReader.cs
@@ -60,10 +60,7 @@ namespace NuGet.Packaging
             _root = folder;
         }
 
-        /// <summary>
-        /// Opens the nuspec file in read only mode.
-        /// </summary>
-        public override Stream GetNuspec()
+        public override string GetNuspecFile()
         {
             // This needs to be explicitly case insensitive in order to work on XPlat, since GetFiles is normally case sensitive on non-Windows
             var nuspecFiles = _root.GetFiles("*.*", SearchOption.TopDirectoryOnly).Where(f => f.Name.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase)).ToArray();
@@ -77,7 +74,7 @@ namespace NuGet.Packaging
                 throw new PackagingException(Strings.MultipleNuspecFiles);
             }
 
-            return nuspecFiles[0].OpenRead();
+            return nuspecFiles[0].FullName;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -89,7 +89,11 @@ namespace NuGet.Packaging
         {
             // This is the default implementation. It is overridden and optimized in
             // PackageArchiveReader and PackageFolderReader.
+            return GetStream(GetNuspecFile());
+        }
 
+        public virtual string GetNuspecFile()
+        {
             // Find all nuspecs in the root folder.
             var nuspecPaths = GetFiles()
                 .Where(entryPath => PackageHelper.IsManifest(entryPath))
@@ -104,7 +108,7 @@ namespace NuGet.Packaging
                 throw new PackagingException(Strings.MultipleNuspecFiles);
             }
 
-            return GetStream(nuspecPaths.Single());
+            return nuspecPaths.Single();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderExtensions.cs
@@ -31,26 +31,5 @@ namespace NuGet.Packaging
 
             return satelliteFiles;
         }
-
-        public static string GetNuspecFile(this IPackageCoreReader packageReader)
-        {
-            // Find all nuspec files in the root folder of the zip.
-            var nuspecEntries = packageReader.GetFiles()
-                .Select(f => f.TrimStart('/').Replace('/', Path.DirectorySeparatorChar))
-                .Where(f => f.EndsWith(PackagingCoreConstants.NuspecExtension, StringComparison.OrdinalIgnoreCase))
-                .Where(f => string.Equals(f, Path.GetFileName(f), StringComparison.OrdinalIgnoreCase))
-                .ToArray();
-
-            if (nuspecEntries.Length == 0)
-            {
-                throw new PackagingException(Strings.MissingNuspec);
-            }
-            else if (nuspecEntries.Length > 1)
-            {
-                throw new PackagingException(Strings.MultipleNuspecFiles);
-            }
-
-            return nuspecEntries[0];
-        }
     }
 }


### PR DESCRIPTION
The V3 folder format requires nuspec files to be named with the package id. This change fixes an issue where the nuspec is copied but the original nuspec is also extracted. This causes problems later when using the package folder reader to read the nuspec.

This fix also adds GetNuspecFile to the package reader instead of an extension method. The previous check did not filter out non-root nuspec files and could have found extra duplicates that should have been ignored. It also improves performance for the package folder reader which has an optimized path for finding the nuspec on disk.

Fixes https://github.com/NuGet/Home/issues/3231

//cc @joelverhagen @alpaix @rrelyea @rohit21agrawal @jainaashish @drewgil 
