### PR TITLE
add git aliases to repository

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,117 @@
+#### To include this .gitconfig file, run git config --local include.path ../.gitconfig from your repository root. #####
+# alias {{{
+[alias]
+    # basic {{{
+    st = status -s
+    cl = clone
+    ci = commit
+    co = checkout
+    br = branch
+    r = reset
+    cp = cherry-pick
+    gr = grep -Ii
+    # }}}
+    # tweak defaults {{{
+    diff = diff --word-diff
+    branch = branch -ra
+    grep = grep -Ii
+    bra = branch -ra
+    ai = add --interactive
+    # grep on filename
+    f = "!git ls-files | grep -i"
+    # }}}
+    # commit {{{
+    cm = commit -m
+    cma = commit -a -m
+    ca = commit --amend
+    amend = commit --amend
+    caa = commit -a --amend -C HEAD
+    # }}}
+    # log commands {{{
+    ls = log --pretty=format:"%C(green)%h\\ %C(yellow)[%ad]%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate --date=relative
+    ll = log --pretty=format:"%C(yellow)%h%Cred%d\\ %Creset%s%Cblue\\ [%cn]" --decorate --numstat
+    lc  = "!f() { git ll "$1"^.."$1"; }; f"
+    lnc = log --pretty=format:"%h\\ %s\\ [%cn]"
+    fl = log -u
+    filelog = log -u
+    # }}}
+    # diff {{{
+    d = diff --word-diff
+    dc = diff --cached
+    # diff last commit
+    dlc = diff --cached HEAD^
+    dr  = "!f() { git diff -w "$1"^.."$1"; }; f"
+    diffr  = "!f() { git diff "$1"^.."$1"; }; f"
+    # }}}
+    # reset commands {{{
+    r1 = reset HEAD^
+    r2 = reset HEAD^^
+    rh = reset --hard
+    rh1 = reset HEAD^ --hard
+    rh2 = reset HEAD^^ --hard
+    # }}}
+    # git svn {{{
+    svnr = svn rebase
+    svnd = svn dcommit
+    svnl = svn log --oneline --show-commit
+    # }}}
+    # stash {{{
+    sl = stash list
+    sa = stash apply
+    ss = stash save
+    # }}}
+    # assume aliases {{{
+    assume = update-index --assume-unchanged
+    unassume = update-index --no-assume-unchanged
+    # show assumed files
+    assumed = "!git ls-files -v | grep ^h | cut -c 3-"
+    # unassume all the assumed files
+    unassumeall = "!git assumed | xargs git update-index --no-assume-unchanged"
+    assumeall = "!git status -s | awk {'print $2'} | xargs git assume"
+    # }}}
+    # subtree {{{
+    #   add
+    sba = "!f() { git subtree add --prefix $2 $1 master --squash; }; f"
+    #   update/pull
+    sbu = "!f() { git subtree pull --prefix $2 $1 master --squash; }; f"
+    # }}}
+    # various useful {{{
+    # last tag created
+    lasttag = describe --tags --abbrev=0
+    lt = describe --tags --abbrev=0
+
+    # pull rebase & push
+    pushtodev = "!f(){ git pull origin dev && git push; };f"
+    # conflict/merges
+    ours = "!f() { git co --ours $@ && git add $@; }; f"
+    theirs = "!f() { git co --theirs $@ && git add $@; }; f"
+
+    #list remotes
+    rem="!git config -l | grep remote.*url | tail -n +2"
+
+    #apply patch from other local repo
+    lap = "!f() { git --git-dir=$1 format-patch -k -1 --stdout $2 | git am -3 -k; }; f"
+
+    #open markdown files edited in last commit
+    last = "!gvim $(git show HEAD --format="" --name-only | grep -e .*md$ | xargs)"
+    #open just created markdown in working directory
+    newmd = "!gvim $(git status -s | awk {'print $2'})"
+
+    # initial empty commit
+    empty = "!git commit -am\"[empty] Initial commit\" --allow-empty"
+
+    # list all aliases
+    la = "!git config -l | grep alias | cut -c 7-"
+    # }}}
+    # convoluted aliases {{{
+    # grep from root folder
+    gra = "!f() { A=$(pwd) && TOPLEVEL=$(git rev-parse --show-toplevel) && cd $TOPLEVEL && git grep --full-name -In $1 | xargs -I{} echo $TOPLEVEL/{} && cd $A; }; f"
+    #rename branch tree to done-
+    done = "!f() { git branch | grep "$1" | cut -c 3- | grep -v done | xargs -I{} git branch -m {} done-{}; }; f"
+    #add bitbucket remote
+    ra = "!f() { git remote add $1 https://bitbucket.org/$2.git; }; f"
+    # }}}
+    # worktree list {{{
+    wl = worktree list
+    # }}}
+# }}}


### PR DESCRIPTION
This is an optional pull request to add some cool git aliases to our repository. In order to make use of these aliases, users will have to run "git config --local include.path ../.gitconfig " from the repository root.

Some of the very useful ones (which I use the most ) are : 
pushtodev : this basically pulls & rebases from origin dev before pushing.
r1 : reset --hard to one commit before

etc etc.

@joelverhagen @emgarten @alpaix @rrelyea @drewgil @mishra14 @jainaashish 
