### PR TITLE
Prompt in Package Manager Console when a "dotnet" update or install fails

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -248,6 +248,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             if (actions.Any())
             {
+                if (!ShouldContinueDueToDotnetDeprecation(project, actions, WhatIf.IsPresent))
+                {
+                    return;
+                }
+
                 if (WhatIf.IsPresent)
                 {
                     // For -WhatIf, only preview the actions

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellExecutionMessage.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Model/PowerShellExecutionMessage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement.PowerShellCmdlets
@@ -34,5 +35,14 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         }
 
         public string ScriptPath { get; set; }
+    }
+
+    /// <summary>
+    /// A message inserted into the Package Manager Console to signal that all messages in front of
+    /// this message in the <see cref="BlockingCollection{T}"/> should be flushed before
+    /// continuing.
+    /// </summary>
+    public class FlushMessage : Message
+    {
     }
 }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -2,9 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Text;
 using System.Threading;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
@@ -104,6 +108,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             {
                 var actions = await PackageManager.PreviewInstallPackageAsync(project, identity, resolutionContext, projectContext, PrimarySourceRepositories, null, CancellationToken.None);
 
+                if (!ShouldContinueDueToDotnetDeprecation(project, actions, isPreview))
+                {
+                    return;
+                }
+
                 if (isPreview)
                 {
                     PreviewNuGetPackageActions(actions);
@@ -144,6 +153,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             try
             {
                 var actions = await PackageManager.PreviewInstallPackageAsync(project, packageId, resolutionContext, projectContext, PrimarySourceRepositories, null, CancellationToken.None);
+
+                if (!ShouldContinueDueToDotnetDeprecation(project, actions, isPreview))
+                {
+                    return;
+                }
 
                 if (isPreview)
                 {
@@ -205,6 +219,71 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                     string.Join(", ", packageDirectoriesMarkedForDeletion));
                 WriteWarning(message);
             }
+        }
+
+        protected bool ShouldContinueDueToDotnetDeprecation(NuGetProject project, IEnumerable<NuGetProjectAction> actions, bool whatIf)
+        {
+            // Don't prompt if the user has chosen to ignore this warning.
+            // Also, -WhatIf should not prompt the user since there is not action performed anyway.
+            if (DotnetDeprecatedPrompt.GetDoNotShowPromptState() || whatIf)
+            {
+                return true;
+            }
+
+            // Determine if any of the project actions are affected by the deprecated framework.
+            var resolvedActions = actions
+                .Select(action => new ResolvedAction(project, action));
+
+            var projects = DotnetDeprecatedPrompt.GetAffectedProjects(resolvedActions);
+            if (!projects.Any())
+            {
+                return true;
+            }
+
+            var model = DotnetDeprecatedPrompt.GetDeprecatedFrameworkModel(projects);
+
+            // Flush the existing messages (e.g. logging from the action preview).
+            FlushBlockingCollection();
+
+            // Prompt the user to determine if the project actions should be executed.
+            var choices = new Collection<ChoiceDescription>
+            {
+                new ChoiceDescription(Resources.Cmdlet_No, Resources.Cmdlet_DeprecatedFrameworkNoHelp),
+                new ChoiceDescription(Resources.Cmdlet_Yes, Resources.Cmdlet_DeprecatedFrameworkYesHelp),
+                new ChoiceDescription(Resources.Cmdlet_YesDoNotPromptAgain, Resources.Cmdlet_DeprecatedFrameworkYesDoNotPromptAgainHelp)
+            };
+
+            var messageBuilder = new StringBuilder();
+            messageBuilder.Append(model.TextBeforeLink);
+            messageBuilder.Append(model.LinkText);
+            messageBuilder.Append(" (");
+            messageBuilder.Append(model.MigrationUrl);
+            messageBuilder.Append(")");
+            messageBuilder.Append(model.TextAfterLink);
+            messageBuilder.Append(" ");
+            messageBuilder.Append(Resources.Cmdlet_DeprecatedFrameworkContinue);
+
+            WriteLine();
+            var choice = Host.UI.PromptForChoice(
+                string.Empty,
+                messageBuilder.ToString(),
+                choices,
+                defaultChoice: 0);
+            WriteLine();
+
+            // Handle the response from the user.
+            if (choice == 2)
+            {
+                // Yes and do not prompt again.
+                DotnetDeprecatedPrompt.SaveDoNotShowPromptState(true);
+                return true;
+            }
+            else if (choice == 1) // Yes
+            {
+                return true;
+            }
+
+            return false; // No
         }
 
         /// <summary>

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
@@ -79,6 +79,42 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Would you like to continue with the project action(s) anyways?.
+        /// </summary>
+        internal static string Cmdlet_DeprecatedFrameworkContinue {
+            get {
+                return ResourceManager.GetString("Cmdlet_DeprecatedFrameworkContinue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not continue with the project action(s).
+        /// </summary>
+        internal static string Cmdlet_DeprecatedFrameworkNoHelp {
+            get {
+                return ResourceManager.GetString("Cmdlet_DeprecatedFrameworkNoHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Continue with the project action(s) and do not prompt for confirmation again.
+        /// </summary>
+        internal static string Cmdlet_DeprecatedFrameworkYesDoNotPromptAgainHelp {
+            get {
+                return ResourceManager.GetString("Cmdlet_DeprecatedFrameworkYesDoNotPromptAgainHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Continue with the project action(s).
+        /// </summary>
+        internal static string Cmdlet_DeprecatedFrameworkYesHelp {
+            get {
+                return ResourceManager.GetString("Cmdlet_DeprecatedFrameworkYesHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Stop to display more packages.
         /// </summary>
         internal static string Cmdlet_DisplayMorePackagesNoHelp {
@@ -471,6 +507,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         internal static string Cmdlet_YesAll {
             get {
                 return ResourceManager.GetString("Cmdlet_YesAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yes and &amp;Ignore future warnings.
+        /// </summary>
+        internal static string Cmdlet_YesDoNotPromptAgain {
+            get {
+                return ResourceManager.GetString("Cmdlet_YesDoNotPromptAgain", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
@@ -258,4 +258,19 @@
 {1} is a line separator.
 {2} is the exception message.</comment>
   </data>
+  <data name="Cmdlet_DeprecatedFrameworkNoHelp" xml:space="preserve">
+    <value>Do not continue with the project action(s)</value>
+  </data>
+  <data name="Cmdlet_DeprecatedFrameworkYesDoNotPromptAgainHelp" xml:space="preserve">
+    <value>Continue with the project action(s) and do not prompt for confirmation again</value>
+  </data>
+  <data name="Cmdlet_DeprecatedFrameworkYesHelp" xml:space="preserve">
+    <value>Continue with the project action(s)</value>
+  </data>
+  <data name="Cmdlet_YesDoNotPromptAgain" xml:space="preserve">
+    <value>Yes and &amp;Ignore future warnings</value>
+  </data>
+  <data name="Cmdlet_DeprecatedFrameworkContinue" xml:space="preserve">
+    <value>Would you like to continue with the project action(s) anyways?</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.UI/Models/DeprecatedFrameworkModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DeprecatedFrameworkModel.cs
@@ -13,11 +13,14 @@ namespace NuGet.PackageManagement.UI
     {
         public DeprecatedFrameworkModel(NuGetFramework deprecated, string migrationUrl, IEnumerable<NuGetProject> projects)
         {
-            Details = string.Format(
+            TextBeforeLink = string.Format(
                 CultureInfo.CurrentCulture,
                 Resources.Text_DeprecatedFramework_DocumentLink_Before,
                 deprecated.DotNetFrameworkName,
                 deprecated.GetShortFolderName());
+            LinkText = Resources.Text_DeprecatedFramework_DocumentLink;
+            TextAfterLink = Resources.Text_DeprecatedFramework_DocumentLink_After;
+            ProjectListText = Resources.Text_DeprecatedFramework_ProjectList;
 
             MigrationUrl = migrationUrl;
 
@@ -27,7 +30,10 @@ namespace NuGet.PackageManagement.UI
                 .ToList();
         }
 
-        public string Details { get; }
+        public string TextBeforeLink { get; }
+        public string LinkText { get; }
+        public string TextAfterLink { get; }
+        public string ProjectListText { get; }
         public string MigrationUrl { get; }
         public IReadOnlyList<string> Projects { get; }
     }

--- a/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Models\LoadingStatusViewModel.cs" />
     <Compile Include="Models\PackageSearchMetadataCache.cs" />
     <Compile Include="Models\PackageSearchStatus.cs" />
+    <Compile Include="Prompts\DotnetDeprecatedPrompt.cs" />
     <Compile Include="Resources\Domain.cs" />
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>

--- a/src/NuGet.Clients/PackageManagement.UI/Prompts/DotnetDeprecatedPrompt.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Prompts/DotnetDeprecatedPrompt.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.ProjectManagement;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class DotnetDeprecatedPrompt
+    {
+        private const string DotnetDeprecationUrl = "https://aka.ms/rugr4c";
+
+        public static DeprecatedFrameworkModel GetDeprecatedFrameworkModel(IEnumerable<NuGetProject> affectedProjects)
+        {
+            return new DeprecatedFrameworkModel(
+                FrameworkConstants.CommonFrameworks.DotNet,
+                DotnetDeprecationUrl,
+                affectedProjects);
+        }
+
+        public static IEnumerable<NuGetProject> GetAffectedProjects(IEnumerable<ResolvedAction> actions)
+        {
+            var projects = new HashSet<NuGetProject>();
+
+            foreach (var action in actions)
+            {
+                var buildIntegrationAction = action.Action as BuildIntegratedProjectAction;
+
+                if (buildIntegrationAction == null || buildIntegrationAction.RestoreResult.Success)
+                {
+                    continue;
+                }
+
+                // Get all failed compatibility check results.
+                var incompatible = buildIntegrationAction
+                    .RestoreResult
+                    .CompatibilityCheckResults
+                    .Where(result => !result.Success && result.Issues.Any());
+
+                // Only focus on compatibility check results when restoring for "dotnet".
+                var anyIncompatibleDotnet = incompatible.Any(result => string.Equals(
+                    result.Graph.Framework.Framework,
+                    FrameworkConstants.FrameworkIdentifiers.NetPlatform,
+                    StringComparison.OrdinalIgnoreCase));
+
+                if (anyIncompatibleDotnet)
+                {
+                    projects.Add(action.Project);
+                }
+            }
+
+            return projects;
+        }
+
+        public static void SaveDoNotShowPromptState(bool doNotshow)
+        {
+            RegistrySettingUtility.SetBooleanSetting(
+                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName,
+                doNotshow);
+        }
+
+        public static bool GetDoNotShowPromptState()
+        {
+            return RegistrySettingUtility.GetBooleanSetting(
+                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName);
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/NuGetUI.cs
@@ -22,7 +22,6 @@ namespace NuGet.PackageManagement.UI
     {
         private readonly INuGetUIContext _context;
         public const string LogEntrySource = "NuGet Package Manager";
-        private const string DotnetDeprecationUrl = "https://aka.ms/rugr4c";
 
         public NuGetUI(
             INuGetUIContext context,
@@ -54,10 +53,7 @@ namespace NuGet.PackageManagement.UI
         {
             var window = new DeprecatedFrameworkWindow(_context)
             {
-                DataContext = new DeprecatedFrameworkModel(
-                    FrameworkConstants.CommonFrameworks.DotNet,
-                    DotnetDeprecationUrl,
-                    projects)
+                DataContext = DotnetDeprecatedPrompt.GetDeprecatedFrameworkModel(projects)
             };
 
             var dialogResult = window.ShowModal();

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml
@@ -31,17 +31,17 @@
       Grid.Row="0"
       Margin="12,4,12,0"
       TextWrapping="Wrap">
-        <Run Text="{Binding Details, Mode=OneTime}" /><Hyperlink AutomationProperties.AutomationId="MigrationLink"
+        <Run Text="{Binding TextBeforeLink, Mode=OneTime}" /><Hyperlink AutomationProperties.AutomationId="MigrationLink"
                    NavigateUri="{Binding MigrationUrl, Mode=OneTime}"
                    Style="{StaticResource HyperlinkStyle}"
-                   RequestNavigate="OnMigrationUrlNavigate"><Run Text="{x:Static nuget:Resources.Text_DeprecatedFramework_DocumentLink}" />
-        </Hyperlink><Run Text="{x:Static nuget:Resources.Text_DeprecatedFramework_DocumentLink_After}" />
+                   RequestNavigate="OnMigrationUrlNavigate"><Run Text="{Binding LinkText, Mode=OneTime}" />
+        </Hyperlink><Run Text="{Binding TextAfterLink, Mode=OneTime}" />
     </TextBlock>
     <TextBlock
       Grid.Row="1"
       Margin="12,4,12,0"
       TextWrapping="Wrap"
-      Text="{x:Static nuget:Resources.Text_DeprecatedFramework_ProjectList}" />
+      Text="{Binding ProjectListText, Mode=OneTime}" />
 
     <Border
       Grid.Row="2"

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DeprecatedFrameworkWindow.xaml.cs
@@ -10,13 +10,13 @@ namespace NuGet.PackageManagement.UI
     {
         private bool _initialized;
         private INuGetUIContext _uiContext;
-
+        
         public DeprecatedFrameworkWindow(INuGetUIContext uiContext)
         {
             _initialized = false;
             _uiContext = uiContext;
             InitializeComponent();
-            _doNotShowCheckBox.IsChecked = IsDoNotShowDeprecatedFrameworkWindowEnabled();
+            _doNotShowCheckBox.IsChecked = DotnetDeprecatedPrompt.GetDoNotShowPromptState();
 
             if (StandaloneSwitch.IsRunningStandalone)
             {
@@ -69,16 +69,8 @@ namespace NuGet.PackageManagement.UI
         private void SaveDoNotShowPreviewWindowSetting(bool doNotshow)
         {
             _uiContext.ApplyShowDeprecatedFrameworkSetting(!doNotshow);
-            
-            RegistrySettingUtility.SetBooleanSetting(
-                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName,
-                doNotshow);
-        }
 
-        public static bool IsDoNotShowDeprecatedFrameworkWindowEnabled()
-        {
-            return RegistrySettingUtility.GetBooleanSetting(
-                Constants.DoNotShowDeprecatedFrameworkWindowRegistryName);
+            DotnetDeprecatedPrompt.SaveDoNotShowPromptState(doNotshow);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -11,15 +11,13 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using Resx = NuGet.PackageManagement.UI;
-using Microsoft.VisualStudio.Threading;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -370,7 +368,7 @@ namespace NuGet.PackageManagement.UI
                 settings.ShowPreviewWindow = false;
             }
 
-            if (DeprecatedFrameworkWindow.IsDoNotShowDeprecatedFrameworkWindowEnabled())
+            if (DotnetDeprecatedPrompt.GetDoNotShowPromptState())
             {
                 settings.ShowDeprecatedFrameworkWindow = false;
             }


### PR DESCRIPTION
Addresses https://github.com/NuGet/Home/issues/3247.

/cc @rrelyea @harikmenon @emgarten @alpaix @rohit21agrawal @drewgil @jainaashish 

Prompt text with `?` output:

```
The NuGet operation failed due to one or more packages being incompatible with your project. The '.NETPlatform,Version=v5.0' ('dotnet') project framework is deprecated. For more information about how to migrate your projects to a supported framework, please refer to the migration document (https://aka.ms/rugr4c).
[N] No  [Y] Yes  [I] Yes and Ignore future warnings  [?] Help (default is "N"):?
N - Do not continue with the project action(s).
Y - Continue with the project action(s).
I - Continue with the project action(s) and do not prompt for confirmation again.
```

Screenshot:

![image](https://cloud.githubusercontent.com/assets/94054/17267277/ebc42038-55b9-11e6-85f2-f29194d4b21d.png)
