### PR TITLE
Give more details when searching for a project.json recursively fails

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -576,9 +576,9 @@ namespace NuGet.CommandLine
             {
                 // Access to a subpath of the directory is denied.
                 var resourceMessage = LocalizedResourceManager.GetString("Error_UnableToLocateRestoreTarget_Because");
-                var message = string.Format(CultureInfo.CurrentCulture, resourceMessage, directory, e.Message);
+                var message = string.Format(CultureInfo.CurrentCulture, resourceMessage, directory);
 
-                throw new InvalidOperationException(message);
+                throw new InvalidOperationException(message, e);
             }
 
             // The directory did not contain a valid target, fail!

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -3346,7 +3346,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to find an msbuild solution, packages.config, or project.json file in the folder &apos;{0}&apos; because {1}.
+        ///   Looks up a localized string similar to Failed to find an msbuild solution, packages.config, or project.json file in the folder &apos;{0}&apos;..
         /// </summary>
         public static string Error_UnableToLocateRestoreTarget_Because {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6083,7 +6083,8 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>The folder '{0}' does not contain an msbuild solution, packages.config, or project.json file to restore.</value>
   </data>
   <data name="Error_UnableToLocateRestoreTarget_Because" xml:space="preserve">
-    <value>Failed to find an msbuild solution, packages.config, or project.json file in the folder '{0}' because {1}</value>
+    <value>Failed to find an msbuild solution, packages.config, or project.json file in the folder '{0}'.</value>
+    <comment>{0} is the folder that could not be accessed. The underlying failure is available in the inner exception message.</comment>
   </data>
   <data name="PushCommandTimeoutError" xml:space="preserve">
     <value>Pushing took too long. You can change the default timeout of 300 seconds by using the -Timeout &lt;seconds&gt; option with the push command.</value>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -95,11 +96,23 @@ namespace NuGet.Commands
 
         private static List<string> GetProjectJsonFilesInDirectory(string path)
         {
-            return Directory.GetFiles(path,
-                $"*{ProjectJsonPathUtilities.ProjectConfigFileName}",
-                SearchOption.AllDirectories)
-                    .Where(file => ProjectJsonPathUtilities.IsProjectConfig(file))
-                    .ToList();
+            try
+            {
+                return Directory.GetFiles(
+                    path,
+                    $"*{ProjectJsonPathUtilities.ProjectConfigFileName}",
+                    SearchOption.AllDirectories)
+                        .Where(file => ProjectJsonPathUtilities.IsProjectConfig(file))
+                        .ToList();
+            }
+            catch (UnauthorizedAccessException e)
+            {
+                // Access to a subpath of the directory is denied.
+                var resourceMessage = Strings.Error_UnableToLocateRestoreTarget_Because;
+                var message = string.Format(CultureInfo.CurrentCulture, resourceMessage, path);
+
+                throw new InvalidOperationException(message, e);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -186,6 +186,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Failed to find a project to restore in the folder &apos;{0}&apos;..
+        /// </summary>
+        public static string Error_UnableToLocateRestoreTarget_Because {
+            get {
+                return ResourceManager.GetString("Error_UnableToLocateRestoreTarget_Because", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package &apos;{0}&apos; specifies an invalid build action &apos;{1}&apos; for file &apos;{2}&apos;..
         /// </summary>
         public static string Error_UnknownBuildAction {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -409,4 +409,8 @@
   <data name="Error_InvalidTargetFramework" xml:space="preserve">
     <value>Failed to build package because of an unsupported targetFramework value on '{0}'.</value>
   </data>
+  <data name="Error_UnableToLocateRestoreTarget_Because" xml:space="preserve">
+    <value>Failed to find a project to restore in the folder '{0}'.</value>
+    <comment>{0} is the folder that could not be accessed. The underlying failure is available in the inner exception message.</comment>
+  </data>
 </root>


### PR DESCRIPTION
This is a follow up to https://github.com/NuGet/home/issues/3093. There are actually two cases where we search recursively for a project.json. The previous fix only addresses one of those places.

Also, I made the inner exception be the mechanism for displaying the underlying "access denied" error message. This more closely aligns with existing code (and provides a better stack trace).

/cc @emgarten @alpaix @rohit21agrawal @jainaashish @drewgil 
