### PR TITLE
Fixed allowedVersions update filter at solution level UI

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -634,14 +634,28 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
         protected async Task<IEnumerable<IPackageSearchMetadata>> GetPackagesFromRemoteSourceAsync(string packageId, bool includePrerelease)
         {
-            var metadataProvider = new MultiSourcePackageMetadataProvider(PrimarySourceRepositories, optionalLocalRepository: null, optionalGlobalLocalRepositories: null, projects: new NuGetProject[] { Project }, isSolution: false, logger: Common.NullLogger.Instance);
-            return await metadataProvider.GetPackageMetadataListAsync(packageId, includePrerelease, false, Token);
+            var metadataProvider = new MultiSourcePackageMetadataProvider(
+                PrimarySourceRepositories,
+                optionalLocalRepository: null,
+                optionalGlobalLocalRepositories: null,
+                logger: Common.NullLogger.Instance);
+
+            return await metadataProvider.GetPackageMetadataListAsync(
+                packageId,
+                includePrerelease,
+                includeUnlisted: false,
+                cancellationToken: Token);
         }
 
         protected async Task<IPackageSearchMetadata> GetLatestPackageFromRemoteSourceAsync(PackageIdentity identity, bool includePrerelease)
         {
-            var metadataProvider = new MultiSourcePackageMetadataProvider(PrimarySourceRepositories, optionalLocalRepository: null, optionalGlobalLocalRepositories: null, projects: new NuGetProject[] { Project }, isSolution: false, logger: Common.NullLogger.Instance);
-            return await metadataProvider.GetLatestPackageMetadataAsync(identity, includePrerelease, Token);
+            var metadataProvider = new MultiSourcePackageMetadataProvider(
+                PrimarySourceRepositories,
+                optionalLocalRepository: null,
+                optionalGlobalLocalRepositories: null,
+                logger: Common.NullLogger.Instance);
+
+            return await metadataProvider.GetLatestPackageMetadataAsync(identity, Project, includePrerelease, Token);
         }
 
         protected async Task<IEnumerable<string>> GetPackageIdsFromRemoteSourceAsync(string idPrefix, bool includePrerelease)

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/IPackageMetadataProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/IPackageMetadataProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement.UI
@@ -28,11 +29,12 @@ namespace NuGet.PackageManagement.UI
         /// Retrieves a package metadata of a highest available version along with list of all available versions
         /// </summary>
         /// <param name="identity">Desired package identity</param>
+        /// <param name="project">Project reference to determine the latest version</param>
         /// <param name="includePrerelease">Filters pre-release versions</param>
         /// <param name="cancellationToken">A cancellation token</param>
         /// <returns>Package metadata</returns>
-        Task<IPackageSearchMetadata> GetLatestPackageMetadataAsync(PackageIdentity identity,
-            bool includePrerelease, CancellationToken cancellationToken);
+        Task<IPackageSearchMetadata> GetLatestPackageMetadataAsync(PackageIdentity identity, 
+            NuGetProject project, bool includePrerelease, CancellationToken cancellationToken);
 
         /// <summary>
         /// Retrieves a list of metadata objects of all available versions for given package id.

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/UpdatePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/UpdatePackageFeed.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
@@ -21,31 +22,43 @@ namespace NuGet.PackageManagement.UI
         private readonly IPackageMetadataProvider _metadataProvider;
         private readonly PackageSearchMetadataCache _cachedUpdates;
         private readonly Common.ILogger _logger;
+        private readonly NuGetProject[] _projects;
 
         public UpdatePackageFeed(
             IEnumerable<PackageIdentity> installedPackages,
             IPackageMetadataProvider metadataProvider,
-            PackageSearchMetadataCache cachedUpdates,
+            NuGetProject[] projects,
+            PackageSearchMetadataCache optionalCachedUpdates,
             Common.ILogger logger)
         {
             if (installedPackages == null)
             {
                 throw new ArgumentNullException(nameof(installedPackages));
             }
+
             _installedPackages = installedPackages;
 
             if (metadataProvider == null)
             {
                 throw new ArgumentNullException(nameof(metadataProvider));
             }
+
             _metadataProvider = metadataProvider;
 
-            _cachedUpdates = cachedUpdates;
+            if (projects == null)
+            {
+                throw new ArgumentNullException(nameof(projects));
+            }
+
+            _projects = projects;
+
+            _cachedUpdates = optionalCachedUpdates;
 
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
+
             _logger = logger;
         }
 
@@ -74,7 +87,7 @@ namespace NuGet.PackageManagement.UI
                 : LoadingStatus.NoMoreItems;
             result.SourceSearchStatus = new Dictionary<string, LoadingStatus>
             {
-                { "Update", loadingStatus }
+                ["Update"] = loadingStatus
             };
 
             return result;
@@ -85,28 +98,83 @@ namespace NuGet.PackageManagement.UI
             return _cachedUpdates.Packages.Where(p => p.Identity.Id.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) != -1);
         }
 
-        private async Task<IEnumerable<IPackageSearchMetadata>> GetPackagesWithUpdatesAsync(string searchText, SearchFilter searchFilter, CancellationToken cancellationToken)
+        public async Task<IEnumerable<IPackageSearchMetadata>> GetPackagesWithUpdatesAsync(string searchText, SearchFilter searchFilter, CancellationToken cancellationToken)
         {
             var packages = _installedPackages
                 .GetEarliest()
                 .Where(p => p.Id.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) != -1)
                 .OrderBy(p => p.Id);
 
-            var latestItems = await TaskCombinators.ThrottledAsync(
-                packages, 
-                (p, t) => _metadataProvider.GetLatestPackageMetadataAsync(p, searchFilter.IncludePrerelease, t), 
+            // Prefetch metadata for all installed packages
+            var prefetch = await TaskCombinators.ThrottledAsync(
+                packages,
+                (p, t) => _metadataProvider.GetPackageMetadataListAsync(p.Id, searchFilter.IncludePrerelease, includeUnlisted: false, cancellationToken: t),
                 cancellationToken);
 
-            var packagesWithUpdates = packages
-                .Join(latestItems.Where(i => i != null),
-                    p => p.Id,
-                    m => m.Identity.Id,
-                    (p, m) => new { cv = p.Version, m = m },
-                    StringComparer.OrdinalIgnoreCase)
-                .Where(j => VersionComparer.VersionRelease.Compare(j.cv, j.m.Identity.Version) < 0)
-                .Select(j => j.m);
+            // Flatten the result list
+            var prefetchedPackages = prefetch
+                .Where(p => p != null)
+                .SelectMany(p => p)
+                .ToArray();
 
-            return packagesWithUpdates;
+            // Traverse all projects and determine packages with updates
+            var packagesWithUpdates = new List<IPackageSearchMetadata>();
+            foreach(var project in _projects)
+            {
+                var installed = await project.GetInstalledPackagesAsync(cancellationToken);
+                foreach (var installedPackage in installed)
+                {
+                    var installedVersion = installedPackage.PackageIdentity.Version;
+                    var allowedVersions = installedPackage.AllowedVersions ?? VersionRange.All;
+
+                    // filter packages based on current package identity
+                    var allPackages = prefetchedPackages
+                        .Where(p => StringComparer.OrdinalIgnoreCase.Equals(
+                            p.Identity.Id,
+                            installedPackage.PackageIdentity.Id))
+                        .ToArray();
+
+                    // and allowed versions
+                    var allowedPackages = allPackages
+                        .Where(p => allowedVersions.Satisfies(p.Identity.Version));
+
+                    // peek the highest available
+                    var highest = allowedPackages
+                        .OrderByDescending(e => e.Identity.Version, VersionComparer.VersionRelease)
+                        .FirstOrDefault();
+
+                    if (highest != null &&
+                        VersionComparer.VersionRelease.Compare(installedVersion, highest.Identity.Version) < 0)
+                    {
+                        packagesWithUpdates.Add(highest.WithVersions(ToVersionInfo(allPackages)));
+                    }
+                }
+            }
+
+            // select the earliest package update candidates
+            var uniquePackageIds = packagesWithUpdates
+                .Select(p => p.Identity)
+                .GetEarliest();
+
+            // get unique list of package metadata as similar updates may come from different projects
+            var uniquePackages = uniquePackageIds
+                .GroupJoin(
+                    packagesWithUpdates,
+                    id => id,
+                    p => p.Identity,
+                    (id, pl) => pl.First());
+
+            return uniquePackages.ToArray();
+        }
+
+        private static IEnumerable<VersionInfo> ToVersionInfo(IEnumerable<IPackageSearchMetadata> packages)
+        {
+            return packages?
+                .OrderByDescending(m => m.Identity.Version, VersionComparer.VersionRelease)
+                .Select(m => new VersionInfo(m.Identity.Version, m.DownloadCount)
+                {
+                    PackageSearchMetadata = m
+                });
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -659,7 +659,12 @@ namespace NuGet.PackageManagement.UI
 
             if (filter == ItemFilter.UpdatesAvailable)
             {
-                return new UpdatePackageFeed(installedPackages, metadataProvider, context.CachedPackages, logger);
+                return new UpdatePackageFeed(
+                    installedPackages,
+                    metadataProvider,
+                    context.Projects,
+                    context.CachedPackages,
+                    logger);
             }
 
             throw new InvalidOperationException("Unsupported feed type");
@@ -673,8 +678,6 @@ namespace NuGet.PackageManagement.UI
                 context.SourceRepositories,
                 context.PackageManager?.PackagesFolderSourceRepository,
                 context.PackageManager?.GlobalPackageFolderRepositories,
-                context.Projects,
-                context.IsSolution,
                 logger);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
@@ -1,33 +1,71 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.PackageManagement.UI.Test
 {
     public class MultiSourcePackageMetadataProviderTests
     {
+        private readonly MultiSourcePackageMetadataProvider _target;
+        private readonly PackageMetadataResource _metadataResource;
+
+        public MultiSourcePackageMetadataProviderTests()
+        {
+            // dependencies and data
+            _metadataResource = Mock.Of<PackageMetadataResource>();
+
+            var provider = Mock.Of<INuGetResourceProvider>();
+            Mock.Get(provider)
+                .Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(Tuple.Create(true, (INuGetResource)_metadataResource)));
+            Mock.Get(provider)
+                .Setup(x => x.ResourceType)
+                .Returns(typeof(PackageMetadataResource));
+
+            var logger = new TestLogger();
+            var packageSource = new Configuration.PackageSource("http://fake-source");
+            var source = new SourceRepository(packageSource, new[] { provider });
+
+            // target
+            _target = new MultiSourcePackageMetadataProvider(
+                new[] { source },
+                optionalLocalRepository: null,
+                optionalGlobalLocalRepositories: null,
+                logger: logger);
+        }
+
         [Fact]
         public async Task GetLatestPackageMetadataAsync_Always_SendsASingleRequestPerSource()
         {
             // Arrange
-            var tc = new TestContext();
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            var testProject = SetupProject(testPackageIdentity, allowedVersions: null);
 
             // Act
-            await tc.Target.GetLatestPackageMetadataAsync(
-                tc.PackageIdentity,
-                includePrerelease: true,
-                cancellationToken: CancellationToken.None);
+            await _target.GetLatestPackageMetadataAsync(
+                    testPackageIdentity,
+                    testProject,
+                    includePrerelease: true,
+                    cancellationToken: CancellationToken.None);
 
             // Assert
-            tc.PackageMetadata.Verify(
-                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+            Mock.Get(_metadataResource).Verify(
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -35,17 +73,17 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackageMetadataAsync_Always_SendsASingleRequestPerSource()
         {
             // Arrange
-            var tc = new TestContext();
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
 
             // Act
-            await tc.Target.GetPackageMetadataAsync(
-                tc.PackageIdentity,
+            await _target.GetPackageMetadataAsync(
+                testPackageIdentity,
                 includePrerelease: true,
                 cancellationToken: CancellationToken.None);
 
             // Assert
-            tc.PackageMetadata.Verify(
-                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+            Mock.Get(_metadataResource).Verify(
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -53,60 +91,128 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackageMetadataListAsync_Always_SendsASingleRequestPerSource()
         {
             // Arrange
-            var tc = new TestContext();
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
 
             // Act
-            await tc.Target.GetPackageMetadataListAsync(
-                tc.PackageIdentity.Id,
+            await _target.GetPackageMetadataListAsync(
+                testPackageIdentity.Id,
                 includePrerelease: true,
                 includeUnlisted: false,
                 cancellationToken: CancellationToken.None);
 
             // Assert
-            tc.PackageMetadata.Verify(
-                x => x.GetMetadataAsync(tc.PackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+            Mock.Get(_metadataResource).Verify(
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
-        private class TestContext
+        [Fact]
+        public async Task GetLatestPackageMetadataAsync_WithAllVersions_RetrievesLatestVersion()
         {
-            public TestContext()
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            var testProject = SetupProject(testPackageIdentity, allowedVersions: null);
+            SetupRemotePackageMetadata(testPackageIdentity.Id, "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            // Act
+            var latest = await _target.GetLatestPackageMetadataAsync(
+                testPackageIdentity,
+                testProject,
+                includePrerelease: true,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(latest);
+            Assert.Equal("2.0.1", latest.Identity.Version.ToString());
+
+            var actualVersions = await latest.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetLatestPackageMetadataAsync_WithAllowedVersions_RetrievesLatestVersion()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            var testProject = SetupProject(testPackageIdentity, "[1,2)");
+            SetupRemotePackageMetadata(testPackageIdentity.Id, "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            // Act
+            var latest = await _target.GetLatestPackageMetadataAsync(
+                testPackageIdentity,
+                testProject,
+                includePrerelease: true,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(latest);
+            Assert.Equal("1.0.1", latest.Identity.Version.ToString());
+
+            var actualVersions = await latest.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackageMetadataListAsync_WithMultipleSources_UnifiesVersions()
+        {
+            // Arrange
+            var testPackageId = "FakePackage";
+            SetupRemotePackageMetadata(testPackageId, "1.0.0", "2.0.0", "2.0.1", "1.0.1", "2.0.0", "1.0.0", "1.0.1");
+
+            // Act
+            var packages = await _target.GetPackageMetadataListAsync(
+                testPackageId,
+                includePrerelease: true,
+                includeUnlisted: false,
+                cancellationToken: CancellationToken.None);
+
+            // Assert
+            Assert.NotEmpty(packages);
+
+            var actualVersions = packages.Select(p => p.Identity.Version.ToString()).ToArray();
+            Assert.Equal(
+                new[] { "1.0.0", "2.0.0", "2.0.1", "1.0.1" },
+                actualVersions);
+        }
+
+        private NuGetProject SetupProject(PackageIdentity packageIdentity, string allowedVersions)
+        {
+            var installedPackages = new[]
             {
-                // dependencies and data
-                PackageMetadata = new Mock<PackageMetadataResource>();
+                new PackageReference(
+                    packageIdentity,
+                    NuGetFramework.Parse("net45"),
+                    userInstalled: true,
+                    developmentDependency: false,
+                    requireReinstallation: false,
+                    allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null)
+            };
 
-                var provider = new Mock<INuGetResourceProvider>();
-                provider
-                    .Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
-                    .Returns(() => Task.FromResult(Tuple.Create(true, (INuGetResource)PackageMetadata.Object)));
-                provider
-                    .Setup(x => x.ResourceType)
-                    .Returns(typeof(PackageMetadataResource));
+            var project = Mock.Of<NuGetProject>();
+            Mock.Get(project)
+                .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<IEnumerable<PackageReference>>(installedPackages));
+            return project;
+        }
 
-                var logger = new TestLogger();
-                var packageSource = new Configuration.PackageSource("http://fake-source");
-                var source = new SourceRepository(packageSource, new[] { provider.Object });
-                PackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+        private void SetupRemotePackageMetadata(string id, params string[] versions)
+        {
+            var metadata = versions
+                .Select(v => PackageSearchMetadataBuilder
+                    .FromIdentity(new PackageIdentity(id, new NuGetVersion(v)))
+                    .Build());
 
-                // project
-                using (var testSolutionManager = new TestSolutionManager(true))
-                {
-                    var project = testSolutionManager.AddNewMSBuildProject();
-
-                    // target
-                    Target = new MultiSourcePackageMetadataProvider(
-                    new[] { source },
-                    null,
-                    null,
-                    new[] { project },
-                    false,
-                    logger);
-                }
-            }
-
-            public MultiSourcePackageMetadataProvider Target { get; }
-            public PackageIdentity PackageIdentity { get; }
-            public Mock<PackageMetadataResource> PackageMetadata { get; }
-        } 
+            Mock.Get(_metadataResource)
+                .Setup(x => x.GetMetadataAsync(id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(metadata));
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/UpdatePackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/UpdatePackageFeedTests.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    public class UpdatePackageFeedTests
+    {
+        private readonly MultiSourcePackageMetadataProvider _metadataProvider;
+        private readonly PackageMetadataResource _metadataResource;
+
+        public UpdatePackageFeedTests()
+        {
+            // dependencies and data
+            _metadataResource = Mock.Of<PackageMetadataResource>();
+
+            var provider = Mock.Of<INuGetResourceProvider>();
+            Mock.Get(provider)
+                .Setup(x => x.TryCreate(It.IsAny<SourceRepository>(), It.IsAny<CancellationToken>()))
+                .Returns(() => Task.FromResult(Tuple.Create(true, (INuGetResource)_metadataResource)));
+            Mock.Get(provider)
+                .Setup(x => x.ResourceType)
+                .Returns(typeof(PackageMetadataResource));
+
+            var logger = new TestLogger();
+            var packageSource = new Configuration.PackageSource("http://fake-source");
+            var source = new SourceRepository(packageSource, new[] { provider });
+
+            // target
+            _metadataProvider = new MultiSourcePackageMetadataProvider(
+                new[] { source },
+                optionalLocalRepository: null,
+                optionalGlobalLocalRepositories: null,
+                logger: logger);
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithAllVersions_RetrievesSingleUpdate()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            var projectA = SetupProject("FakePackage", "1.0.0");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            Assert.Single(packages);
+            var updateCandidate = packages.Single();
+            Assert.Equal("2.0.1", updateCandidate.Identity.Version.ToString());
+
+            var actualVersions = await updateCandidate.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithAllowedVersions_RetrievesSingleUpdate()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            var projectA = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            Assert.Single(packages);
+            var updateCandidate = packages.Single();
+            Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
+
+            var actualVersions = await updateCandidate.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate1()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+
+            // Both projects need to be updated to different versions
+            // projectA: 1.0.0 => 2.0.1
+            // projectB: 1.0.0 => 1.0.1
+            var projectA = SetupProject("FakePackage", "1.0.0");
+            var projectB = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            // Should retrieve a single update item with the lowest version and full list of available versions
+            Assert.Single(packages);
+            var updateCandidate = packages.Single();
+            Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
+
+            var actualVersions = await updateCandidate.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate2()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+
+            // Only one project needs to be updated
+            // projectA: 2.0.0 => 2.0.1
+            // projectB: 1.0.1 => None
+            var projectA = SetupProject("FakePackage", "2.0.0");
+            var projectB = SetupProject("FakePackage", "1.0.1", "[1,2)");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            // Should retrieve a single update item with the lowest version and full list of available versions
+            Assert.Single(packages);
+            var updateCandidate = packages.Single();
+            Assert.Equal("2.0.1", updateCandidate.Identity.Version.ToString());
+
+            var actualVersions = await updateCandidate.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate3()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+
+            // Only one project needs to be updated
+            // projectA: 2.0.1 => None
+            // projectB: 1.0.0 => 1.0.1
+            var projectA = SetupProject("FakePackage", "2.0.1");
+            var projectB = SetupProject("FakePackage", "1.0.0", "[1,2)");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            // Should retrieve a single update item with the lowest version and full list of available versions
+            Assert.Single(packages);
+            var updateCandidate = packages.Single();
+            Assert.Equal("1.0.1", updateCandidate.Identity.Version.ToString());
+
+            var actualVersions = await updateCandidate.GetVersionsAsync();
+            Assert.NotEmpty(actualVersions);
+            Assert.Equal(
+                new[] { "2.0.1", "2.0.0", "1.0.1", "1.0.0", "0.0.1" },
+                actualVersions.Select(v => v.Version.ToString()).ToArray());
+        }
+
+        [Fact]
+        public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesNoUpdates()
+        {
+            // Arrange
+            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+
+            var projectA = SetupProject("FakePackage", "2.0.1");
+            var projectB = SetupProject("FakePackage", "1.0.1", "[1,2)");
+            SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
+
+            var _target = new UpdatePackageFeed(new[] { testPackageIdentity }, _metadataProvider, new[] { projectA, projectB }, null, new TestLogger());
+
+            // Act
+            var packages = await _target.GetPackagesWithUpdatesAsync(
+                "fake", new SearchFilter(), CancellationToken.None);
+
+            // Assert
+            Assert.Empty(packages);
+        }
+
+        private NuGetProject SetupProject(string packageId, string packageVersion, string allowedVersions = null)
+        {
+            var packageIdentity = new PackageIdentity(packageId, NuGetVersion.Parse(packageVersion));
+
+            var installedPackages = new[]
+            {
+                new PackageReference(
+                    packageIdentity,
+                    NuGetFramework.Parse("net45"),
+                    userInstalled: true,
+                    developmentDependency: false,
+                    requireReinstallation: false,
+                    allowedVersions: allowedVersions != null ? VersionRange.Parse(allowedVersions) : null)
+            };
+
+            var project = Mock.Of<NuGetProject>();
+            Mock.Get(project)
+                .Setup(x => x.GetInstalledPackagesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<IEnumerable<PackageReference>>(installedPackages));
+            return project;
+        }
+
+        private void SetupRemotePackageMetadata(string id, params string[] versions)
+        {
+            var metadata = versions
+                .Select(v => PackageSearchMetadataBuilder
+                    .FromIdentity(new PackageIdentity(id, new NuGetVersion(v)))
+                    .Build());
+
+            Mock.Get(_metadataResource)
+                .Setup(x => x.GetMetadataAsync(id, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(metadata));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Converters\IconUrlToImageCacheConverterTests.cs" />
     <Compile Include="ConverterTests.cs" />
     <Compile Include="Feeds\MultiSourcePackageMetadataProviderTests.cs" />
+    <Compile Include="Feeds\UpdatePackageFeedTests.cs" />
     <Compile Include="PackageItemLoaderTests.cs" />
     <Compile Include="PackageManagerProviderTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Fixes NuGet/Home#333.

Re-wrote `UpdatePackageFeed.GetPackagesWithUpdatesAsync` so that it
retrieves updates per project with respect to individual allowedVersions
filter; then it unifies the list of package update candidates. This method
serves solution level updates search.

Changed the signature of
`MultiSourcePackageMetadataProvider.GetLatestPackageMetadataAsync` by
adding `project` argument to retrieve update for. The only consumer of this
method is a PMC commandlet calling it within a single project context (never
for solution or multiple-project context).

Added tests

//cc @jainaashish @joelverhagen @emgarten @rrelyea 
