### PR TITLE
Put VS14 and VS15 obj and bin directories in different locations

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -128,7 +128,7 @@ Invoke-BuildStep 'Building NuGet.Clients projects - VS14 dependencies' {
 ## ILMerge the VS14 exe only
 Invoke-BuildStep 'Merging NuGet.exe' {
         param($Configuration, $MSPFXPath)
-        Invoke-ILMerge $Configuration $MSPFXPath
+        Invoke-ILMerge $Configuration "14" $MSPFXPath
     } `
     -args $Configuration, $MSPFXPath `
     -skip:($SkipILMerge -or $Fast -or $SkipVS14) `

--- a/build/common.props
+++ b/build/common.props
@@ -13,13 +13,14 @@
 		<BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath>
 
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
 
-		<OutputPath>$(ArtifactRoot)\$(MSBuildProjectName)\$(Configuration)</OutputPath>
+		<OutputPath>$(ArtifactRoot)\$(MSBuildProjectName)\$(VisualStudioVersion)\$(Configuration)</OutputPath>
 		<OutputPath>$([System.IO.Path]::GetFullPath( $(OutputPath) ))\</OutputPath>
 
 		<AppxPackageDir>$(OutputPath)</AppxPackageDir>
 
-		<IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(MSBuildProjectName)\$(Configuration)</IntermediateOutputPath>
+		<IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(MSBuildProjectName)\$(VisualStudioVersion)\$(Configuration)</IntermediateOutputPath>
 		<IntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(IntermediateOutputPath) ))\</IntermediateOutputPath>
 
 		<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(EnlistmentRoot)\</SolutionDir>


### PR DESCRIPTION
Currently when you run a full build (both VS14 and VS15), the intermediate (`obj`) and output (`bin`) directories of NuGet.Client projects are the same for both the VS14 and VS15 builds. Since the VS15 build occurs first, this means that VS15 build artifacts have to be manually copied out of the output directory before the VS14 build since they are overwritten. 

This leads to worse diagnostics since one build is clobbering the other (you can never see what the VS14 `bin`/`obj` looked like). Also, this problem seems to be leading to intermittent VSIX build failures on the CI (.vsixignore and .vsixinclude are finding unexpected files). Finally, I think it's not a great idea to trust that the intermediates of one build are not effecting the intermediates of another build, since this class of problem can be very tricky to detect.

This change put a `VS14` and `VS15` parent directory around each project's `bin` and `obj` directory as well as parameterizing the `Invoke-ILMerge` step to pick either the VS14 or VS15 `nuget.exe`.

/cc @drewgil @alpaix @rrelyea 
