### PR TITLE
Ignore lock file project entries for init.ps1 and license checks

### DIFF
--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -374,7 +374,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                     if (buildIntegratedProject != null)
                     {
-                        var packages = BuildIntegratedProjectUtility.GetOrderedProjectDependencies(buildIntegratedProject);
+                        var packages = BuildIntegratedProjectUtility.GetOrderedProjectPackageDependencies(buildIntegratedProject);
                         sortedGlobalPackages.AddRange(packages);
                     }
                     else

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Commands;
 using NuGet.Common;
+using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -148,9 +149,11 @@ namespace NuGet.PackageManagement
             LockFile updatedLockFile)
         {
             var updatedPackages = updatedLockFile.Targets.SelectMany(target => target.Libraries)
+                .Where(library => library.Type == LibraryType.Package)
                 .Select(library => new PackageIdentity(library.Name, library.Version));
 
             var originalPackages = originalLockFile.Targets.SelectMany(target => target.Libraries)
+                .Where(library => library.Type == LibraryType.Package)
                 .Select(library => new PackageIdentity(library.Name, library.Version));
 
             var results = updatedPackages.Except(originalPackages, PackageIdentity.Comparer).ToList();
@@ -301,7 +304,9 @@ namespace NuGet.PackageManagement
                 }
 
                 // Verify all libraries are on disk
-                foreach (var library in lockFile.Libraries)
+                var packages = lockFile.Libraries.Where(library => library.Type == LibraryType.Package);
+
+                foreach (var library in packages)
                 {
                     var identity = new PackageIdentity(library.Name, library.Version);
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2109,7 +2109,7 @@ namespace NuGet.PackageManagement
 
                 // Run init.ps1 scripts
                 var sortedPackages =
-                    BuildIntegratedProjectUtility.GetOrderedProjectDependencies(buildIntegratedProject);
+                    BuildIntegratedProjectUtility.GetOrderedProjectPackageDependencies(buildIntegratedProject);
 
                 var addedPackages = new HashSet<PackageIdentity>(
                     BuildIntegratedRestoreUtility.GetAddedPackages(

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement.Projects;
@@ -30,34 +31,117 @@ namespace NuGet.ProjectManagement
             return pathResolver.GetInstallPath(identity.Id, identity.Version);
         }
 
-        public static IReadOnlyList<PackageIdentity> GetOrderedProjectDependencies(
+        /// <summary>
+        /// Orders all package dependencies in a project.
+        /// Project must be restored.
+        /// </summary>
+        public static IReadOnlyList<PackageIdentity> GetOrderedProjectPackageDependencies(
             BuildIntegratedNuGetProject buildIntegratedProject)
         {
-            var results = new List<PackageIdentity>();
+            var lockFile = GetLockFileOrNull(buildIntegratedProject);
 
+            if (lockFile != null)
+            {
+                return GetOrderedLockFilePackageDependencies(lockFile);
+            }
+
+            return new List<PackageIdentity>();
+        }
+
+        /// <summary>
+        /// Orders all dependencies in a project. This includes both packages and projects.
+        /// Project must be restored.
+        /// </summary>
+        public static IReadOnlyList<LibraryIdentity> GetOrderedProjectDependencies(
+            BuildIntegratedNuGetProject buildIntegratedProject)
+        {
+            var lockFile = GetLockFileOrNull(buildIntegratedProject);
+
+            if (lockFile != null)
+            {
+                return GetOrderedLockFileDependencies(lockFile);
+            }
+
+            return new List<LibraryIdentity>();
+        }
+
+        /// <summary>
+        /// Read lock file
+        /// </summary>
+        public static LockFile GetLockFileOrNull(BuildIntegratedNuGetProject buildIntegratedProject)
+        {
             var lockFilePath = ProjectJsonPathUtilities.GetLockFilePath(buildIntegratedProject.JsonConfigPath);
+            return GetLockFileOrNull(lockFilePath);
+        }
+
+        /// <summary>
+        /// Read lock file
+        /// </summary>
+        public static LockFile GetLockFileOrNull(string lockFilePath)
+        {
+            LockFile lockFile = null;
             var lockFileFormat = new LockFileFormat();
 
             // Read the lock file to find the full closure of dependencies
             if (File.Exists(lockFilePath))
             {
-                var lockFile = lockFileFormat.Read(lockFilePath);
+                lockFile = lockFileFormat.Read(lockFilePath);
+            }
 
-                var dependencies = new HashSet<PackageDependencyInfo>(PackageIdentity.Comparer);
+            return lockFile;
+        }
 
-                foreach (var target in lockFile.Targets)
+        /// <summary>
+        /// Lock file dependencies - packages only
+        /// </summary>
+        public static IReadOnlyList<PackageIdentity> GetOrderedLockFilePackageDependencies(LockFile lockFile)
+        {
+            return GetOrderedLockFileDependencies(lockFile)
+                .Where(library => library.Type == LibraryType.Package)
+                .Select(library => new PackageIdentity(library.Name, library.Version))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get ordered dependencies from the lock file
+        /// </summary>
+        /// <param name="lockFile"></param>
+        /// <returns></returns>
+        public static IReadOnlyList<LibraryIdentity> GetOrderedLockFileDependencies(LockFile lockFile)
+        {
+            var results = new List<LibraryIdentity>();
+
+            var dependencies = new HashSet<PackageDependencyInfo>(PackageIdentity.Comparer);
+            var typeMappings = new Dictionary<PackageDependencyInfo, LibraryIdentity>(PackageIdentity.Comparer);
+
+            foreach (var target in lockFile.Targets)
+            {
+                foreach (var targetLibrary in target.Libraries)
                 {
-                    foreach (var targetLibrary in target.Libraries)
+                    var identity = new PackageIdentity(targetLibrary.Name, targetLibrary.Version);
+                    var dependency = new PackageDependencyInfo(identity, targetLibrary.Dependencies);
+                    dependencies.Add(dependency);
+
+                    if (!typeMappings.ContainsKey(dependency))
                     {
-                        var identity = new PackageIdentity(targetLibrary.Name, targetLibrary.Version);
-                        var dependency = new PackageDependencyInfo(identity, targetLibrary.Dependencies);
-                        dependencies.Add(dependency);
+                        var libraryIdentity = new LibraryIdentity(
+                            targetLibrary.Name,
+                            targetLibrary.Version,
+                            LibraryType.Parse(targetLibrary.Type));
+
+                        typeMappings.Add(dependency, libraryIdentity);
                     }
                 }
+            }
 
-                // Sort dependencies
-                var sortedDependencies = SortPackagesByDependencyOrder(dependencies);
-                results.AddRange(sortedDependencies);
+            // Sort dependencies
+            var sortedDependencies = SortPackagesByDependencyOrder(dependencies);
+
+            foreach (var dependency in sortedDependencies)
+            {
+                // Convert back
+                // PackageDependencyInfo -> LibraryIdentity
+                results.Add(typeMappings[dependency]);
             }
 
             return results;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -27,6 +26,41 @@ namespace NuGet.Test
 {
     public class BuildIntegratedTests
     {
+        [Fact]
+        public void BuildIntegrated_VerifyGetAddedIsOnlyPackages()
+        {
+            // Arrange
+            var lockFile = new LockFile();
+            var lockFileEmpty = new LockFile();
+
+            var targetEmpty = new LockFileTarget();
+            lockFileEmpty.Targets.Add(targetEmpty);
+
+            var target = new LockFileTarget();
+            lockFile.Targets.Add(target);
+
+            target.Libraries.Add(new LockFileTargetLibrary()
+            {
+                Name = "a",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "package"
+            });
+
+            target.Libraries.Add(new LockFileTargetLibrary()
+            {
+                Name = "b",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "project"
+            });
+
+            // Act
+            var added = BuildIntegratedRestoreUtility.GetAddedPackages(lockFileEmpty, lockFile);
+
+            // Assert
+            Assert.Equal(1, added.Count);
+            Assert.Equal("a", added.Single().Id);
+        }
+
         // Verify that parent projects are restored when a child project is updated
         [Fact]
         public async Task TestPacManBuildIntegratedInstallPackageTransitive()
@@ -552,7 +586,7 @@ namespace NuGet.Test
         {
             // Arrange
             // This package is not compatible with netcore50 and will cause the rollback.
-            var oldVersioning = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.5")); 
+            var oldVersioning = new PackageIdentity("NuGet.Versioning", NuGetVersion.Parse("1.0.5"));
 
             // This package is compatible.
             var oldJson = new PackageIdentity("Newtonsoft.Json", NuGetVersion.Parse("6.0.8"));
@@ -1462,7 +1496,7 @@ namespace NuGet.Test
             }
 
             public TestExternalProjectReference(
-                BuildIntegratedNuGetProject project, 
+                BuildIntegratedNuGetProject project,
                 params BuildIntegratedNuGetProject[] children)
             {
                 Project = project;
@@ -1476,9 +1510,9 @@ namespace NuGet.Test
                     if (ProjectName != null)
                     {
                         return new ExternalProjectReference(
-                            ProjectName, 
+                            ProjectName,
                             null,
-                            null, 
+                            null,
                             Enumerable.Empty<string>());
                     }
                     else

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -6,11 +6,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
+using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -21,6 +21,96 @@ namespace ProjectManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
+        [Fact]
+        public void BuildIntegratedNuGetProject_SortDependenciesWithProjects()
+        {
+            // Arrange
+            var lockFile = new LockFile();
+            var target = new LockFileTarget();
+            lockFile.Targets.Add(target);
+
+            var targetA = new LockFileTargetLibrary()
+            {
+                Name = "a",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "package"
+            };
+            targetA.Dependencies.Add(new PackageDependency("b"));
+
+            var targetB = new LockFileTargetLibrary()
+            {
+                Name = "b",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "project"
+            };
+            targetA.Dependencies.Add(new PackageDependency("c"));
+
+            var targetC = new LockFileTargetLibrary()
+            {
+                Name = "c",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "package"
+            };
+
+            target.Libraries.Add(targetA);
+            target.Libraries.Add(targetC);
+            target.Libraries.Add(targetB);
+
+            // Act
+            var ordered = BuildIntegratedProjectUtility.GetOrderedLockFileDependencies(lockFile);
+
+            // Assert
+            Assert.Equal(3, ordered.Count);
+            Assert.Equal("a", ordered[0].Name);
+            Assert.Equal("b", ordered[1].Name);
+            Assert.Equal("c", ordered[2].Name);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_SortDependenciesWithProjects_GetPackagesOnly()
+        {
+            // Arrange
+            var lockFile = new LockFile();
+            var target = new LockFileTarget();
+            lockFile.Targets.Add(target);
+
+            var targetA = new LockFileTargetLibrary()
+            {
+                Name = "a",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "package"
+            };
+            targetA.Dependencies.Add(new PackageDependency("b"));
+
+            var targetB = new LockFileTargetLibrary()
+            {
+                Name = "b",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "project"
+            };
+            targetA.Dependencies.Add(new PackageDependency("c"));
+
+            var targetC = new LockFileTargetLibrary()
+            {
+                Name = "c",
+                Version = NuGetVersion.Parse("1.0.0"),
+                Type = "package"
+            };
+
+            target.Libraries.Add(targetA);
+            target.Libraries.Add(targetC);
+            target.Libraries.Add(targetB);
+
+            // Act
+            var ordered = BuildIntegratedProjectUtility.GetOrderedLockFilePackageDependencies(lockFile);
+
+            // Assert
+            Assert.Equal(2, ordered.Count);
+            Assert.Equal("a", ordered[0].Id);
+            // skip b
+            Assert.Equal("c", ordered[1].Id);
+        }
+
         [Fact]
         public void TestBuildIntegratedNuGetPackageSpecNameMatchesFilePath_ProjectNameJson()
         {


### PR DESCRIPTION
This change filters out project entries from the lock file for package operations such as init.ps1, UI package preview, and package license checks.

This was caused by the change from v1 to v2 lock files, previously it was not possible for projects to exist in the lock file for any UI related scenarios.

Fixes https://github.com/NuGet/Home/issues/3270

//cc @jainaashish @joelverhagen @rrelyea @rohit21agrawal @drewgil @alpaix 
