### PR TITLE
Adding support for file:// URI sources

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -378,8 +378,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// </summary>
         /// <param name="source">The source string specified by -Source switch.</param>
         /// <returns>The source validation result.</returns>
-        private SourceValidationResult CheckSourceValidity(string source)
+        private SourceValidationResult CheckSourceValidity(string inputSource)
         {
+            // Convert file:// to a local path if needed, this noops for other types
+            var source = UriUtility.GetLocalPath(inputSource);
+
             // Convert a relative local URI into an absolute URI
             var packageSource = new PackageSource(source);
             Uri sourceUri;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourceUnzipped.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/FindLocalPackagesResourceUnzipped.cs
@@ -96,7 +96,7 @@ namespace NuGet.Protocol
 
         private static IReadOnlyList<LocalPackageInfo> GetPackagesCore(string root)
         {
-            var rootDirInfo = new DirectoryInfo(root);
+            var rootDirInfo = LocalFolderUtility.GetAndVerifyRootDirectory(root);
 
             if (!rootDirInfo.Exists)
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -27,7 +27,9 @@ namespace NuGet.Protocol
 
         public LocalV2FindPackageByIdResource(PackageSource packageSource)
         {
-            _source = packageSource.Source;
+            var rootDirInfo = LocalFolderUtility.GetAndVerifyRootDirectory(packageSource.Source);
+
+            _source = rootDirInfo.FullName;
         }
 
         public override Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -36,8 +36,10 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(source));
             }
 
-            _source = source.Source;
-            _resolver = new VersionFolderPathResolver(source.Source);
+            var rootDirInfo = LocalFolderUtility.GetAndVerifyRootDirectory(source.Source);
+
+            _source = rootDirInfo.FullName;
+            _resolver = new VersionFolderPathResolver(_source);
         }
 
         public override Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol
             }
             else if (packageSource.IsLocal)
             {
-                var path = packageSource.Source;
+                var path = UriUtility.GetLocalPath(packageSource.Source);
 
                 if (!Directory.Exists(path))
                 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
@@ -150,13 +150,13 @@ namespace NuGet.Protocol
             }
 
             // Verify the root path is a valid path.
-            GetAndVerifyRootDirectory(root);
+            var rootDirInfo = GetAndVerifyRootDirectory(root);
 
             // Search directories starting with the top directory for any package matching the identity
             // If multiple packages are found in the same directory that match (ex: 1.0, 1.0.0.0)
             // then favor the exact non-normalized match. If no exact match is found take the first
             // using the file system sort order. This is to match the legacy nuget 2.8.x behavior.
-            foreach (var directoryList in GetNupkgsFromFlatFolderChunked(root, log))
+            foreach (var directoryList in GetNupkgsFromFlatFolderChunked(rootDirInfo, log))
             {
                 LocalPackageInfo fallbackMatch = null;
 
@@ -211,12 +211,12 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(log));
             }
 
-            var rootDir = new DirectoryInfo(root);
+            var rootDirInfo = GetAndVerifyRootDirectory(root);
 
             // Find the matching nupkg for each sub directory.
-            if (rootDir.Exists)
+            if (rootDirInfo.Exists)
             {
-                foreach (var dir in rootDir.GetDirectories())
+                foreach (var dir in rootDirInfo.GetDirectories())
                 {
                     var package = GetPackagesConfigFolderPackage(dir);
 
@@ -255,13 +255,13 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(log));
             }
 
-            var rootDir = new DirectoryInfo(root);
+            var rootDirInfo = GetAndVerifyRootDirectory(root);
 
-            if (rootDir.Exists)
+            if (rootDirInfo.Exists)
             {
                 var searchPattern = GetPackagesConfigFolderSearchPattern(id);
 
-                foreach (var dir in rootDir.GetDirectories(searchPattern, SearchOption.TopDirectoryOnly))
+                foreach (var dir in rootDirInfo.GetDirectories(searchPattern, SearchOption.TopDirectoryOnly))
                 {
                     // Check the id and version of the path, if the id matches and the version
                     // is valid this will be non-null;
@@ -304,9 +304,11 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(log));
             }
 
+            var rootDirInfo = GetAndVerifyRootDirectory(root);
+
             // Try matching the exact version format
             var idVersion = $"{identity.Id}.{identity.Version.ToString()}";
-            var expectedPath = Path.Combine(root, idVersion, $"{idVersion}{PackagingCoreConstants.NupkgExtension}");
+            var expectedPath = Path.Combine(rootDirInfo.FullName, idVersion, $"{idVersion}{PackagingCoreConstants.NupkgExtension}");
             var expectedFile = new FileInfo(expectedPath);
 
             if (expectedFile.Exists)
@@ -321,13 +323,12 @@ namespace NuGet.Protocol
             }
 
             // Search all sub folders
-            var rootDir = new DirectoryInfo(root);
 
-            if (rootDir.Exists)
+            if (rootDirInfo.Exists)
             {
                 var searchPattern = GetPackagesConfigFolderSearchPattern(identity.Id);
 
-                foreach (var dir in rootDir.GetDirectories(searchPattern, SearchOption.TopDirectoryOnly))
+                foreach (var dir in rootDirInfo.GetDirectories(searchPattern, SearchOption.TopDirectoryOnly))
                 {
                     // Check the id and version of the path, if the id matches and the version
                     // is valid this will be non-null;
@@ -597,9 +598,9 @@ namespace NuGet.Protocol
             }
 
             // Verify the root path is a valid path.
-            GetAndVerifyRootDirectory(root);
+            var rootDirInfo = GetAndVerifyRootDirectory(root);
 
-            var pathResolver = new VersionFolderPathResolver(root);
+            var pathResolver = new VersionFolderPathResolver(rootDirInfo.FullName);
 
             // Verify the neccessary files exist
             var nupkgPath = pathResolver.GetPackageFilePath(identity.Id, identity.Version);
@@ -656,7 +657,7 @@ namespace NuGet.Protocol
             DirectoryInfo rootDirectoryInfo = GetAndVerifyRootDirectory(root);
 
             // Return all directory file list chunks in a flat list
-            foreach (var directoryList in GetNupkgsFromFlatFolderChunked(rootDirectoryInfo.FullName, log))
+            foreach (var directoryList in GetNupkgsFromFlatFolderChunked(rootDirectoryInfo, log))
             {
                 foreach (var file in directoryList)
                 {
@@ -677,8 +678,11 @@ namespace NuGet.Protocol
 
             try
             {
+                // Convert file:// to a local path if needed
+                var localPath = UriUtility.GetLocalPath(root);
+
                 // Verify that the directory is a valid path.
-                rootDirectoryInfo = new DirectoryInfo(root);
+                rootDirectoryInfo = new DirectoryInfo(localPath);
 
                 // The root must also be parsable as a URI (relative or absolute). This rejects
                 // sources that have the weird "C:Source" format. For more information about this 
@@ -726,7 +730,7 @@ namespace NuGet.Protocol
         /// Retrieve files in chunks, this helps maintain the legacy behavior of searching for
         /// certain non-normalized file names.
         /// </summary>
-        private static IEnumerable<FileInfo[]> GetNupkgsFromFlatFolderChunked(string root, ILogger log)
+        private static IEnumerable<FileInfo[]> GetNupkgsFromFlatFolderChunked(DirectoryInfo root, ILogger log)
         {
             if (root == null)
             {
@@ -739,7 +743,7 @@ namespace NuGet.Protocol
             }
 
             // Ignore missing directories for v2
-            if (!Directory.Exists(root))
+            if (!root.Exists)
             {
                 yield break;
             }
@@ -755,7 +759,7 @@ namespace NuGet.Protocol
             // Search all sub directories
             foreach (var subDirectory in GetDirectoriesSafe(root, log))
             {
-                var files = GetNupkgsFromDirectory(subDirectory.FullName, log);
+                var files = GetNupkgsFromDirectory(subDirectory, log);
 
                 if (files.Length > 0)
                 {
@@ -825,7 +829,7 @@ namespace NuGet.Protocol
             }
 
             // Match all nupkgs in the folder
-            foreach (var idPath in GetDirectoriesSafe(root, log))
+            foreach (var idPath in GetDirectoriesSafe(rootDirectoryInfo, log))
             {
                 foreach (var nupkg in GetPackagesV3(root, id: idPath.Name, log: log))
                 {
@@ -861,8 +865,8 @@ namespace NuGet.Protocol
             // Check for package files one level deep.
             DirectoryInfo rootDirectoryInfo = GetAndVerifyRootDirectory(root);
 
-            var idRoot = Path.Combine(rootDirectoryInfo.FullName, id);
-            if (!Directory.Exists(idRoot))
+            var idRoot = new DirectoryInfo(Path.Combine(rootDirectoryInfo.FullName, id));
+            if (!idRoot.Exists)
             {
                 // Directory is missing
                 yield break;
@@ -922,12 +926,11 @@ namespace NuGet.Protocol
         /// <summary>
         /// Retrieve directories and log exceptions that occur.
         /// </summary>
-        private static DirectoryInfo[] GetDirectoriesSafe(string root, ILogger log)
+        private static DirectoryInfo[] GetDirectoriesSafe(DirectoryInfo root, ILogger log)
         {
             try
             {
-                var rootDir = new DirectoryInfo(root);
-                return rootDir.GetDirectories();
+                return root.GetDirectories();
             }
             catch (Exception e)
             {
@@ -940,12 +943,11 @@ namespace NuGet.Protocol
         /// <summary>
         /// Retrieve files and log exceptions that occur.
         /// </summary>
-        private static FileInfo[] GetFilesSafe(string root, string filter, ILogger log)
+        private static FileInfo[] GetFilesSafe(DirectoryInfo root, string filter, ILogger log)
         {
             try
             {
-                var rootDir = new DirectoryInfo(root);
-                return rootDir.GetFiles(filter);
+                return root.GetFiles(filter);
             }
             catch (Exception e)
             {
@@ -1001,7 +1003,7 @@ namespace NuGet.Protocol
         /// <summary>
         /// Find all nupkgs in the top level of a directory.
         /// </summary>
-        private static FileInfo[] GetNupkgsFromDirectory(string root, ILogger log)
+        private static FileInfo[] GetNupkgsFromDirectory(DirectoryInfo root, ILogger log)
         {
             return GetFilesSafe(root, NupkgFilter, log);
         }

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -107,17 +107,6 @@ function Test-InstallPackageWithValidKnownSource {
 	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
 }
 
-function Test-InstallPackageWithFileProtocolSource {
-	# Arrange
-	$package = "Rules"
-	$project = New-ConsoleApplication
-	$source = "file://Rules"
-	$message = "Unsupported type of source '$source'. Please provide an http or local source."
-
-	# Act & Assert
-	Assert-Throws { Install-Package $package -ProjectName $project.Name -source $source } $message
-}
-
 function Test-InstallPackageWithFtpProtocolSource {
 	# Arrange
 	$package = "Rules"
@@ -162,6 +151,23 @@ function Test-SinglePackageInstallIntoSingleProject {
     Assert-Package $project Castle.Core
     Assert-SolutionPackage FakeItEasy
     Assert-SolutionPackage Castle.Core
+}
+
+# Test install-package -WhatIf to downgrade an installed package.
+function Test-PackageInstallWithFileUri {
+    # Arrange
+    $project = New-ConsoleApplication
+
+    $uri = $context.RepositoryRoot
+    $uri = $uri.replace("\", "/")
+    $uri = "file:///" + $uri
+    
+	# Act
+	Install-Package TestUpdatePackage -Version 2.0.0.0 -Source $uri
+
+	# Assert
+	# that the installed package is not touched.
+	Assert-Package $project TestUpdatePackage '2.0.0.0'
 }
 
 function Test-PackageInstallWhatIf {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -8,14 +8,136 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
+using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.Commands.Test
 {
     public class RestoreCommandTests
     {
+        [Fact]
+        public async Task RestoreCommand_FileUriV3Folder()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // Both TxMs reference packageA, but they are different types.
+            // Verify that the reference does not show up under libraries.
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""packageA"": ""4.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(UriUtility.CreateSourceUri(packageSource.FullName).AbsoluteUri));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    packageSource.FullName, 
+                    new PackageIdentity("packageA", NuGetVersion.Parse("4.0.0")));
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, lockFile.Libraries.Count);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_FileUriV2Folder()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            // Both TxMs reference packageA, but they are different types.
+            // Verify that the reference does not show up under libraries.
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""packageA"": ""4.0.0""
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(UriUtility.CreateSourceUri(packageSource.FullName).AbsoluteUri));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, "packageA", "4.0.0");
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, lockFile.Libraries.Count);
+            }
+        }
+
         [Fact]
         public async Task RestoreCommand_FindInV2FolderWithDifferentCasing()
         {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/UriUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/UriUtilityTests.cs
@@ -1,0 +1,26 @@
+﻿using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class UriUtilityTests
+    {
+        [Theory]
+        [InlineData("file:///test", "test")]
+        [InlineData("file://test", "test")]
+        [InlineData("https://api.nuget.org/v3/index.json", "https://api.nuget.org/v3/index.json")]
+        [InlineData("a/b/c", "a/b/c")]
+        [InlineData("/", "/")]
+        [InlineData("", "")]
+        [InlineData("ftp://test", "ftp://test")]
+        [InlineData("a", "a")]
+        [InlineData("..\\a", "..\\a")]
+        public void UriUtility_GetLocalPath(string input, string expected)
+        {
+            // Arrange & Act
+            var local = UriUtility.GetLocalPath(input);
+
+            // Assert
+            Assert.Equal(expected, local);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/FeedTypeUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/FeedTypeUtilityTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Test.Utility;
 using Xunit;
@@ -133,6 +134,22 @@ namespace NuGet.Protocol.Core.v3.Tests
         }
 
         [Fact]
+        public void FeedTypeUtility_NupkgAtRootIsV2_FileUri()
+        {
+            using (var root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                CreateFile(Path.Combine(root, "a.1.0.0.nupkg"));
+
+                // Act
+                var type = FeedTypeUtility.GetFeedType(new PackageSource(UriUtility.CreateSourceUri(root).AbsoluteUri));
+
+                // Assert
+                Assert.Equal(FeedType.FileSystemV2, type);
+            }
+        }
+
+        [Fact]
         public void FeedTypeUtility_NupkgInVersionFolderIsV3()
         {
             using (var root = TestFileSystemUtility.CreateRandomTestFolder())
@@ -144,6 +161,24 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 // Act
                 var type = FeedTypeUtility.GetFeedType(new PackageSource(root));
+
+                // Assert
+                Assert.Equal(FeedType.FileSystemV3, type);
+            }
+        }
+
+        [Fact]
+        public void FeedTypeUtility_NupkgInVersionFolderIsV3_FileUri()
+        {
+            using (var root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                CreateFile(Path.Combine(root, "a", "1.0.0", "a.1.0.0.nupkg.sha512"));
+                CreateFile(Path.Combine(root, "a", "1.0.0", "a.nuspec"));
+                CreateFile(Path.Combine(root, "a", "1.0.0", "a.1.0.0.nupkg"));
+
+                // Act
+                var type = FeedTypeUtility.GetFeedType(new PackageSource(UriUtility.CreateSourceUri(root).AbsoluteUri));
 
                 // Assert
                 Assert.Equal(FeedType.FileSystemV3, type);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalFolderUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalFolderUtilityTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
@@ -13,6 +14,22 @@ namespace NuGet.Protocol.Core.v3.Tests
 {
     public class LocalFolderUtilityTests
     {
+        [Fact]
+        public void LocalFolderUtility_GetAndVerifyRootDirectory_WithAbsoluteFileUri()
+        {
+            // Arrange
+            using (var root = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Act
+                var uri = UriUtility.CreateSourceUri(root, UriKind.Absolute);
+                var actual = LocalFolderUtility.GetAndVerifyRootDirectory(uri.AbsoluteUri);
+
+                // Assert
+                Assert.Equal(root.ToString(), actual.FullName);
+                Assert.True(actual.Exists, "The root directory should exist.");
+            }
+        }
+
         [Fact]
         public void LocalFolderUtility_GetAndVerifyRootDirectory_WithAbsolute()
         {
@@ -66,6 +83,7 @@ namespace NuGet.Protocol.Core.v3.Tests
         [InlineData("")]
         [InlineData(null)]
         [InlineData("X:Windows")]
+        [InlineData("http://nuget.org")]
         public void LocalFolderUtility_GetAndVerifyRootDirectory_RejectsInvalid(string source)
         {
             // Arrange & Act & Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/FindLocalPackagesResourceTests.cs
@@ -52,7 +52,11 @@ namespace NuGet.Protocol.Core.v3.Tests
                     new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
-                    new FindLocalPackagesResourceV3(rootV3)
+                    new FindLocalPackagesResourceV3(rootV3),
+                    new FindLocalPackagesResourcePackagesConfig(UriUtility.CreateSourceUri(rootPackagesConfig).AbsoluteUri),
+                    new FindLocalPackagesResourceUnzipped(UriUtility.CreateSourceUri(rootUnzip).AbsoluteUri),
+                    new FindLocalPackagesResourceV2(UriUtility.CreateSourceUri(rootV2).AbsoluteUri),
+                    new FindLocalPackagesResourceV3(UriUtility.CreateSourceUri(rootV3).AbsoluteUri)
                 };
 
                 foreach (var resource in resources)
@@ -87,7 +91,11 @@ namespace NuGet.Protocol.Core.v3.Tests
                     new FindLocalPackagesResourceV3(doesNotExist),
                     new FindLocalPackagesResourceUnzipped(emptyDir),
                     new FindLocalPackagesResourceV2(emptyDir),
-                    new FindLocalPackagesResourceV3(emptyDir)
+                    new FindLocalPackagesResourceV3(emptyDir),
+                    new FindLocalPackagesResourcePackagesConfig(UriUtility.CreateSourceUri(doesNotExist).AbsoluteUri),
+                    new FindLocalPackagesResourceUnzipped(UriUtility.CreateSourceUri(doesNotExist).AbsoluteUri),
+                    new FindLocalPackagesResourceV2(UriUtility.CreateSourceUri(doesNotExist).AbsoluteUri),
+                    new FindLocalPackagesResourceV3(UriUtility.CreateSourceUri(doesNotExist).AbsoluteUri),
                 };
 
                 foreach (var resource in resources)
@@ -130,7 +138,11 @@ namespace NuGet.Protocol.Core.v3.Tests
                     new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
-                    new FindLocalPackagesResourceV3(rootV3)
+                    new FindLocalPackagesResourceV3(rootV3),
+                    new FindLocalPackagesResourcePackagesConfig(UriUtility.CreateSourceUri(rootPackagesConfig).AbsoluteUri),
+                    new FindLocalPackagesResourceUnzipped(UriUtility.CreateSourceUri(rootUnzip).AbsoluteUri),
+                    new FindLocalPackagesResourceV2(UriUtility.CreateSourceUri(rootV2).AbsoluteUri),
+                    new FindLocalPackagesResourceV3(UriUtility.CreateSourceUri(rootV3).AbsoluteUri)
                 };
 
                 foreach (var resource in resources)
@@ -172,7 +184,11 @@ namespace NuGet.Protocol.Core.v3.Tests
                     new FindLocalPackagesResourcePackagesConfig(rootPackagesConfig),
                     new FindLocalPackagesResourceUnzipped(rootUnzip),
                     new FindLocalPackagesResourceV2(rootV2),
-                    new FindLocalPackagesResourceV3(rootV3)
+                    new FindLocalPackagesResourceV3(rootV3),
+                    new FindLocalPackagesResourcePackagesConfig(UriUtility.CreateSourceUri(rootPackagesConfig).AbsoluteUri),
+                    new FindLocalPackagesResourceUnzipped(UriUtility.CreateSourceUri(rootUnzip).AbsoluteUri),
+                    new FindLocalPackagesResourceV2(UriUtility.CreateSourceUri(rootV2).AbsoluteUri),
+                    new FindLocalPackagesResourceV3(UriUtility.CreateSourceUri(rootV3).AbsoluteUri)
                 };
 
                 foreach (var resource in resources)


### PR DESCRIPTION
This change adds support for file URIs in the protocol layer for both project.json and packages.config scenarios. Previously it was only supported for packages.config through NuGet.Core, but this fix will make the behavior consistent across project types.

I've also change several private methods to use DirectoryInfo instead of string for the root parameter to avoid any calls getting around the helper methods.

Based on @MarkOsborneMS's original fix here: https://github.com/MarkOsborneMS/NuGet.Client/commit/7ad7029187bcd6e9c50e82d1b867f04142aeb1c2

Fixes https://github.com/NuGet/Home/issues/3212

//cc @MarkOsborneMS @jainaashish @joelverhagen @rrelyea @rohit21agrawal @alpaix @drewgil 
