### PR TITLE
Enabled password encryption on .NET Core/Windows

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,8 +55,17 @@ do
 	if grep -q "netcoreapp1.0" "$testProject"; then
 		pushd $testDir
 
-		echo "$DOTNET test $testDir --configuration release --framework netcoreapp1.0"
-		$DOTNET test $testDir --configuration release --framework netcoreapp1.0
+		case "$(uname -s)" in
+			Linux)
+				echo "$DOTNET test $testDir --configuration release --framework netcoreapp1.0 -notrait Platform=Windows -notrait Platform=Darwin"
+				$DOTNET test $testDir --configuration release --framework netcoreapp1.0 -notrait Platform=Windows -notrait Platform=Darwin
+				;;
+			Darwin)
+				echo "$DOTNET test $testDir --configuration release --framework netcoreapp1.0 -notrait Platform=Windows -notrait Platform=Linux"
+				$DOTNET test $testDir --configuration release --framework netcoreapp1.0 -notrait Platform=Windows -notrait Platform=Linux
+				;;
+			*) ;;
+		esac
 
 		if [ $? -ne 0 ]; then
 			echo "$testDir FAILED on CoreCLR"

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -438,6 +438,7 @@ Function Test-XProject {
                     $opts += '-v'
                 }
                 $opts += 'test', '--configuration', $Configuration, '--framework', 'netcoreapp1.0'
+                $opts += '-notrait', 'Platform=Linux', '-notrait', 'Platform=Darwin'
                 if ($VerbosePreference) {
                     $opts += '-verbose'
                 }
@@ -469,6 +470,7 @@ Function Test-XProject {
                     $htmlOutput = Join-Path $_ "bin\$Configuration\net46\win7-x64\xunit.results.html"
                     $desktopTestAssembly = Join-Path $_ "bin\$Configuration\net46\win7-x64\$directoryName.dll"
                     $opts = $desktopTestAssembly, '-html', $htmlOutput
+                    $opts += '-notrait', 'Platform=Linux', '-notrait', 'Platform=Darwin'
                     if ($VerbosePreference) {
                         $opts += '-verbose'
                     }
@@ -620,7 +622,7 @@ Function Invoke-ILMerge {
     if (-Not (Test-Path $outputFolder)) {
         New-Item -ItemType Directory -Path $outputFolder | Out-Null
     }
-    
+
     $includeList = Read-FileList (Join-Path $buildArtifactsFolder '.mergeinclude')
     $notInList = $buildArtifacts | ?{ -not ($includeList -contains $_) }
     if ($notInList) {

--- a/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Proxy/ProxyCache.cs
@@ -82,23 +82,24 @@ namespace NuGet.Configuration
 
         public WebProxy GetUserConfiguredProxy()
         {
-            // Try reading from the settings. The values are stored as 3 config values http_proxy, http_proxy_user, http_proxy_password
+            // Try reading from the settings. The values are stored as 3 config values http_proxy, http_proxy.user, http_proxy.password
             var host = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationConstants.HostKey);
             if (!string.IsNullOrEmpty(host))
             {
                 // The host is the minimal value we need to assume a user configured proxy.
                 var webProxy = new WebProxy(host);
 
-#if !IS_CORECLR
-                var userName = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationConstants.UserKey);
-                var password = SettingsUtility.GetDecryptedValue(_settings, SettingsUtility.ConfigSection, ConfigurationConstants.PasswordKey);
-
-                if (!string.IsNullOrEmpty(userName)
-                    && !string.IsNullOrEmpty(password))
+                if (RuntimeEnvironmentHelper.IsWindows)
                 {
-                    webProxy.Credentials = new NetworkCredential(userName, password);
+                    var userName = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationConstants.UserKey);
+                    var password = SettingsUtility.GetDecryptedValue(_settings, SettingsUtility.ConfigSection, ConfigurationConstants.PasswordKey);
+
+                    if (!string.IsNullOrEmpty(userName)
+                        && !string.IsNullOrEmpty(password))
+                    {
+                        webProxy.Credentials = new NetworkCredential(userName, password);
+                    }
                 }
-#endif
 
                 var noProxy = _settings.GetValue(SettingsUtility.ConfigSection, ConfigurationConstants.NoProxy);
                 if (!string.IsNullOrEmpty(noProxy))

--- a/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.Designer.cs
@@ -69,6 +69,15 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Encryption is not supported on non-Windows platforms..
+        /// </summary>
+        public static string Error_EncryptionUnsupported {
+            get {
+                return ResourceManager.GetString("Error_EncryptionUnsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to There are no writable config files..
         /// </summary>
         public static string Error_NoWritableConfig {
@@ -177,7 +186,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Password decryption is not supported on .NET Core for this platform. The following feed uses an encrypted password: &apos;{0}&apos;. You can use a clear text password as a workaround.
+        ///    Looks up a localized string similar to Password decryption is not supported on .NET Core for this platform. The following feed uses an encrypted password: &apos;{0}&apos;. You can use a clear text password as a workaround..
         /// </summary>
         public static string UnsupportedDecryptPassword {
             get {
@@ -186,7 +195,7 @@ namespace NuGet.Configuration {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Password encryption is not supported on .NET Core for this platform. The following feed try to use an encrypted password: &apos;{0}&apos;. You can use a clear text password as a workaround.
+        ///    Looks up a localized string similar to Password encryption is not supported on .NET Core for this platform. The following feed try to use an encrypted password: &apos;{0}&apos;. You can use a clear text password as a workaround..
         /// </summary>
         public static string UnsupportedEncryptPassword {
             get {

--- a/src/NuGet.Core/NuGet.Configuration/Resources.resx
+++ b/src/NuGet.Core/NuGet.Configuration/Resources.resx
@@ -120,6 +120,9 @@
   <data name="Argument_Cannot_Be_Null_Or_Empty" xml:space="preserve">
     <value>Value cannot be null or empty string.</value>
   </data>
+  <data name="Error_EncryptionUnsupported" xml:space="preserve">
+    <value>Encryption is not supported on non-Windows platforms.</value>
+  </data>
   <data name="Error_NoWritableConfig" xml:space="preserve">
     <value>There are no writable config files.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Configuration/Utility/EncryptionUtility.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Utility/EncryptionUtility.cs
@@ -14,25 +14,27 @@ namespace NuGet.Configuration
 
         public static string EncryptString(string value)
         {
-#if IS_CORECLR
-            throw new NotSupportedException();
-#else
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                throw new NotSupportedException(Resources.Error_EncryptionUnsupported);
+            }
+
             var decryptedByteArray = Encoding.UTF8.GetBytes(value);
             var encryptedByteArray = ProtectedData.Protect(decryptedByteArray, _entropyBytes, DataProtectionScope.CurrentUser);
             var encryptedString = Convert.ToBase64String(encryptedByteArray);
             return encryptedString;
-#endif
         }
 
         public static string DecryptString(string encryptedString)
         {
-#if IS_CORECLR
-            throw new NotSupportedException();
-#else
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                throw new NotSupportedException(Resources.Error_EncryptionUnsupported);
+            }
+
             var encryptedByteArray = Convert.FromBase64String(encryptedString);
             var decryptedByteArray = ProtectedData.Unprotect(encryptedByteArray, _entropyBytes, DataProtectionScope.CurrentUser);
             return Encoding.UTF8.GetString(decryptedByteArray);
-#endif
         }
 
         public static string GenerateUniqueToken(string caseInsensitiveKey)

--- a/src/NuGet.Core/NuGet.Configuration/project.json
+++ b/src/NuGet.Core/NuGet.Configuration/project.json
@@ -47,6 +47,7 @@
     "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
+        "System.Security.Cryptography.ProtectedData": "4.0.0",
         "System.Xml.XDocument": "4.0.11"
       },
       "buildOptions": {

--- a/src/NuGet.Core/NuGet.Test.Utility/Traits/Platform.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/Traits/Platform.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Test.Utility
+{
+    /// <summary>
+    /// Platform names used to filter test cases for specific OS-es
+    /// </summary>
+    public static class Platform
+    {
+        public const string Windows = "Windows";
+        public const string Linux = "Linux";
+        public const string Darwin = "Darwin";
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/Traits/PlatformAttribute.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/Traits/PlatformAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit.Sdk;
+
+namespace NuGet.Test.Utility
+{
+    /// <summary>
+    /// Test trait attribute applied to a test method to specify a platform filter.
+    /// </summary>
+    [TraitDiscoverer("NuGet.Test.Utility.PlatformDiscoverer", "NuGet.Test.Utility")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class PlatformAttribute : Attribute, ITraitAttribute
+    {
+        public PlatformAttribute(string platform) { }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/Traits/PlatformDiscoverer.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/Traits/PlatformDiscoverer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace NuGet.Test.Utility
+{
+    /// <summary>
+    /// This class discovers all of the tests and test classes that have
+    /// applied the Platform trait attribute
+    /// </summary>
+    public class PlatformDiscoverer : ITraitDiscoverer
+    {
+        /// <summary>
+        /// Gets the trait values from the Platform attribute.
+        /// </summary>
+        /// <param name="traitAttribute">The trait attribute containing the trait values.</param>
+        /// <returns>The trait values.</returns>
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            var ctorArgs = traitAttribute.GetConstructorArguments().ToList();
+            yield return new KeyValuePair<string, string>("Platform", ctorArgs[0].ToString());
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/project.json
+++ b/src/NuGet.Core/NuGet.Test.Utility/project.json
@@ -18,15 +18,16 @@
     }
   },
   "dependencies": {
-    "xunit": "2.1.0",
     "NuGet.Packaging": {
       "target": "project"
-    }
+    },
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.IO.Compression": ""
+        "System.IO.Compression": "",
+        "System.Runtime": ""
       },
       "buildOptions": {
         "define": [
@@ -41,8 +42,8 @@
       ],
       "dependencies": {
         "NETStandard.Library": "1.6.0",
-        "System.IO.Compression.ZipFile": "4.0.1",
-        "System.Diagnostics.Process": "4.1.0"
+        "System.Diagnostics.Process": "4.1.0",
+        "System.IO.Compression.ZipFile": "4.0.1"
       },
       "buildOptions": {
         "define": [

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using NuGet.Test.Utility;
 using Xunit;
 
-namespace NuGet.Configuration
+namespace NuGet.Configuration.Test
 {
     public class PackageSourceCredentialTests
     {
@@ -34,30 +35,42 @@ namespace NuGet.Configuration
             Assert.Equal("password", credentials.Password);
         }
 
-#if !IS_CORECLR
-        [Fact]
-        public void FromUserInput_WithStorePasswordEncrypted_EncryptsPassword()
+        [Fact, Platform(Platform.Windows)]
+        public void FromUserInput_WithStorePasswordEncrypted_OnWindows_EncryptsPassword()
         {
             var credentials = PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: false);
 
             Assert.NotEqual("password", credentials.PasswordText);
             Assert.Equal("password", credentials.Password);
         }
-#else
-        [Fact]
-        public void FromUserInput_WithStorePasswordEncrypted_Throws()
+
+        [Fact, Platform(Platform.Linux)]
+        public void FromUserInput_WithStorePasswordEncrypted_OnLinux_Throws()
         {
             Assert.Throws<NuGetConfigurationException>(() => PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: false));
         }
 
-        [Fact]
-        public void Password_WithEncryptedPassword_Throws()
+        [Fact, Platform(Platform.Linux)]
+        public void Password_WithEncryptedPassword_OnLinux_Throws()
         {
             var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
 
             Assert.Throws<NuGetConfigurationException>(() => credentials.Password);
         }
-#endif
+
+        [Fact, Platform(Platform.Darwin)]
+        public void FromUserInput_WithStorePasswordEncrypted_OnMacOS_Throws()
+        {
+            Assert.Throws<NuGetConfigurationException>(() => PackageSourceCredential.FromUserInput("source", "user", "password", storePasswordInClearText: false));
+        }
+
+        [Fact, Platform(Platform.Darwin)]
+        public void Password_WithEncryptedPassword_OnMacOS_Throws()
+        {
+            var credentials = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+
+            Assert.Throws<NuGetConfigurationException>(() => credentials.Password);
+        }
 
         [Fact]
         public void IsValid_WithNonEmptyValues_ReturnsTrue()

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/project.json
@@ -1,15 +1,16 @@
 ﻿{
   "dependencies": {
+    "NuGet.Common": {
+      "target": "project"
+    },
     "NuGet.Configuration": {
       "target": "project"
     },
-    "xunit": "2.1.0",
     "NuGet.Test.Utility": {
       "target": "project"
     },
-    "NuGet.Common": {
-      "target": "project"
-    }
+    "xunit": "2.1.0",
+    "xunit.extensibility.execution": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {
@@ -19,14 +20,15 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "moq.netcore": "4.4.0-beta8",
         "dotnet-test-xunit": "1.0.0-rc2-173384-19",
-        "System.Threading.Tasks.Parallel": "4.0.1",
-        "System.Diagnostics.TraceSource": "4.0.0",
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.0"
-        }
+        },
+        "moq.netcore": "4.4.0-beta8",
+        "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Security.Cryptography.ProtectedData": "4.0.0",
+        "System.Threading.Tasks.Parallel": "4.0.1"
       },
       "buildOptions": {
         "define": [
@@ -39,10 +41,10 @@
         "Microsoft.CSharp": "",
         "System": "",
         "System.Core": "",
-        "System.Runtime": "",
-        "System.Threading.Tasks": "",
         "System.Net": "",
-        "System.Net.Http": ""
+        "System.Net.Http": "",
+        "System.Runtime": "",
+        "System.Threading.Tasks": ""
       },
       "dependencies": {
         "Moq": "4.2.1510.2205"


### PR DESCRIPTION
Fixes NuGet/Home#1851

Enabled password encryption of source and proxy credentials on all Windows
frameworks by replacing `#if !IS_CORECLR` with `RuntimeEnvironmentHelper.IsWindows`

Updated tests.

Also fixes Nuget/Home#2065

Introduced `Platform` xUnit trait to be able running OS specific tests.

On Windows:

```
xunit <test-project> -notrait Platform=Linux -notrait Platform=Darwin
```

On Linux

```
xunit <test-project> -notrait Platform=Windows
```

//cc @emgarten @joelverhagen @rrelyea @rohit21agrawal @drewgil @jainaashish 
