### PR TITLE
Improve GetRuntimeGraph performance

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -341,6 +341,10 @@ namespace NuGet.Commands
 
             _logger.LogVerbose(Strings.Log_ScanningForRuntimeJson);
             runtimeGraph = RuntimeGraph.Empty;
+
+            // maintain visited nodes to avoid duplicate runtime graph for the same node
+            var visitedNodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             graph.Graphs.ForEach(node =>
             {
                 var match = node?.Item?.Data?.Match;
@@ -351,6 +355,12 @@ namespace NuGet.Commands
 
                 // Ignore runtime.json from rejected nodes
                 if (node.Disposition == Disposition.Rejected)
+                {
+                    return;
+                }
+
+                // ignore the same node again
+                if (!visitedNodes.Add(match.Library.Name))
                 {
                     return;
                 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/3152

Simple improvement to maintain visited nodes while loading runtime graphs for packages to avoid duplicates which improved GetRuntimeGraph performance by ~90% in this case. For the same scenario (mentioned in Issue) it now takes ~400ms compare to ~3800ms, which is ~70% less time compare to resolver walk time.

@rrelyea @emgarten @joelverhagen @alpaix @yishaigalatzer 
