### PR TITLE
Update build tools in VS15 - removes build warnings

### DIFF
--- a/src/NuGet.Clients/VisualStudio15.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio15.Packages/project.json
@@ -14,7 +14,7 @@
     "Microsoft.VisualStudio.Text.UI": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Threading": "15.0.20-pre",
-    "Microsoft.VSSDK.BuildTools": "15.0.25201-Dev15Preview2"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
Many build warning were caused by the Microsoft.VSSDK.BuildTools package superfluously consuming a framework DLL (Microsoft.Build.Framework). An update just pushed to the package removes this reference, and consuming the new package removes those warnings from our VS15 build. This is the VS15 analog to this: https://github.com/NuGet/NuGet.Client/commit/59003d98bdfcdd25019c249a95a07ffa9ad57d05
@emgarten @alpaix @joelverhagen 
