### PR TITLE
Fixed AppVeyor failing tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ test_script:
     } -ev +TestErrors
 
     Invoke-BuildStep 'Running NuGet.Clients tests - Dev14 dependencies' {
-      Test-ClientsProjects -Configuration Release -MSBuildVersion "14"
+      Test-ClientsProjects -Configuration Release -MSBuildVersion "14" -SkipProjects 'NuGet.CommandLine.Test'
     } -ev +TestErrors
 
     if ($TestErrors) {

--- a/build.ps1
+++ b/build.ps1
@@ -144,7 +144,8 @@ Invoke-BuildStep 'Running NuGet.Core tests' {
 
 Invoke-BuildStep 'Running NuGet.Clients tests - VS15 dependencies' {
         param($Configuration)
-        Test-ClientsProjects -Configuration $Configuration -MSBuildVersion "15"
+        # We don't run command line tests on VS15 as we don't build a nuget.exe for this version
+        Test-ClientsProjects -Configuration $Configuration -MSBuildVersion "15" -SkipProjects 'NuGet.CommandLine.Test'
     } `
     -args $Configuration `
     -skip:((-not $RunTests) -or $SkipVS15) `

--- a/src/NuGet.Core/Test.Utility/project.json
+++ b/src/NuGet.Core/Test.Utility/project.json
@@ -18,8 +18,10 @@
     }
   },
   "dependencies": {
-    "xunit": "2.1.0",
-    "Microsoft.VisualStudio.ProjectSystem.Interop": "1.0.0-*",
+    "Microsoft.VisualStudio.ProjectSystem.Interop":{
+      "type": "build",
+      "version": "1.0.0-*"
+    },
     "NuGet.PackageManagement": {
       "target": "project"
     },
@@ -28,7 +30,8 @@
     },
     "NuGet.Test.Utility": {
       "target": "project"
-    }
+    },
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "net45": {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInitCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInitCommandTests.cs
@@ -547,18 +547,11 @@ namespace NuGet.CommandLine.Test
             var invalidPath = "foo|<>|bar";
             using (var testInfo = new TestInfo(invalidPath, TestFileSystemUtility.CreateRandomTestFolder()))
             {
-                var args = new string[]
-                {
-                    "init",
-                    testInfo.SourceFeed,
-                    testInfo.DestinationFeed,
-                };
-
                 // Act
                 var result = CommandRunner.Run(
                     testInfo.NuGetExePath,
                     testInfo.WorkingPath,
-                    string.Join(" ", args),
+                    $"init \"{testInfo.SourceFeed}\" \"{testInfo.DestinationFeed}\"",
                     waitForExit: true);
 
                 // Assert
@@ -574,18 +567,11 @@ namespace NuGet.CommandLine.Test
             var invalidPath = "foo|<>|bar";
             using (var testInfo = new TestInfo(TestFileSystemUtility.CreateRandomTestFolder(), invalidPath))
             {
-                var args = new string[]
-                {
-                    "init",
-                    testInfo.SourceFeed,
-                    testInfo.DestinationFeed,
-                };
-
                 // Act
                 var result = CommandRunner.Run(
                     testInfo.NuGetExePath,
                     testInfo.WorkingPath,
-                    string.Join(" ", args),
+                    $"init \"{testInfo.SourceFeed}\" \"{testInfo.DestinationFeed}\"",
                     waitForExit: true);
 
                 // Assert

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -227,7 +227,7 @@ namespace NuGet.CommandLine.Test
                     "-OutputDirectory",
                     "outputDir",
                     "-Source",
-                    repositoryPath
+                    $"\"{repositoryPath}\""
                 };
 
                 // Act
@@ -238,7 +238,7 @@ namespace NuGet.CommandLine.Test
                     waitForExit: true);
 
                 // Assert
-                Assert.Equal(0, r.Item1);
+                Assert.True(0 == r.Item1, $"{r.Item2} {r.Item3}");
                 var packageFileA = Path.Combine(workingPath, @"outputDir\packageA.1.1.0\packageA.1.1.0.nupkg");
                 var packageFileB = Path.Combine(workingPath, @"outputDir\packageB.2.2.0\packageB.2.2.0.nupkg");
                 Assert.True(File.Exists(packageFileA));
@@ -300,7 +300,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(packageFileB));
             }
         }
-        
+
         public void InstallCommand_PackageSaveModeNuspec()
         {
             using (var source = TestFileSystemUtility.CreateRandomTestFolder())
@@ -330,7 +330,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, nupkgFiles.Length);
             }
         }
-        
+
         public void InstallCommand_PackageSaveModeNupkg()
         {
             using (var source = TestFileSystemUtility.CreateRandomTestFolder())
@@ -360,7 +360,7 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(0, nuspecFiles.Length);
             }
         }
-        
+
         public void InstallCommand_PackageSaveModeNuspecNupkg()
         {
             using (var source = TestFileSystemUtility.CreateRandomTestFolder())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -275,16 +275,15 @@ namespace NuGet.CommandLine.Test
                     server.Start();
 
                     // Act
-                    string[] args = new string[] { "push", packageFileName, "-Source", server.Uri + "push" };
                     var result = CommandRunner.Run(
                                     nugetexe,
                                     Directory.GetCurrentDirectory(),
-                                    string.Join(" ", args),
+                                    $"push {packageFileName} -Source {server.Uri}push",
                                     true);
                     server.Stop();
 
                     // Assert
-                    Assert.Equal(0, result.Item1);
+                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
                     var output = result.Item2;
                     Assert.Contains("Your package was pushed.", output);
                     AssertFileEqual(packageFileName, outputFileName);
@@ -600,7 +599,7 @@ namespace NuGet.CommandLine.Test
 
         // Regression test for the bug that "nuget.exe push" will retry forever instead of asking for
         // user's password when NuGet.Server uses Windows Authentication.
-        [Fact(Skip = "TODO: reconstruct faked response headers which won't crash HttpClient. " + 
+        [Fact(Skip = "TODO: reconstruct faked response headers which won't crash HttpClient. " +
             "Using real serevr, same sceanrio works fine")]
         public void PushCommand_PushToServerWontRetryForever()
         {
@@ -1367,24 +1366,16 @@ namespace NuGet.CommandLine.Test
                     serverV3.Start();
 
                     // Act
-                    string[] args = new string[]
-                    {
-                            "push",
-                            packageFileName,
-                            "-Source",
-                            serverV3.Uri + "index.json"
-                    };
-
                     var result = CommandRunner.Run(
                                     nugetexe,
                                     Directory.GetCurrentDirectory(),
-                                    string.Join(" ", args),
+                                    $"push {packageFileName} -Source {serverV3.Uri}index.json",
                                     true);
 
                     serverV3.Stop();
 
                     // Assert
-                    Assert.True(result.Item1 == 1, result.Item2 + " " + result.Item3);
+                    Assert.True(1 == result.Item1, $"{result.Item2} {result.Item3}");
 
                     var expectedOutput =
                         string.Format(
@@ -1491,20 +1482,10 @@ namespace NuGet.CommandLine.Test
                     server.Start();
 
                     // Act
-                    var args = new [] 
-                    {
-                        "push",
-                        packageFileName,
-                        testApiKey,
-                        "-Source",
-                        server.Uri + "nuget",
-                        "-NonInteractive"
-                    };
-
                     var result = CommandRunner.Run(
                         NuGetExePath,
                         Directory.GetCurrentDirectory(),
-                        string.Join(" ", args),
+                        $"push {packageFileName} {testApiKey} -Source {server.Uri}nuget -NonInteractive",
                         waitForExit: true);
 
                     server.Stop();


### PR DESCRIPTION
`Test.Utility` consumes `Microsoft.VisualStudio.ProjectSystem.Interop`
that propogates its interop dll to test projects and overrides the correct
vs14/vs15 signed interop dll. This caused strong-name verification failure
when loading test assemblies.

To fix that I changed the dependency type to `build` (non-transitive).

Also excluded `NuGet.CommandLine.Tests` from running on AppVeyor CI due to
their flakiness. The key issue was inability of AppVeyor to capture
console output.

According to Feodor:

> AppVeyor "console" is not the same as running an app in your local
> console. In some cases AppVeyor can't catch the output, especially if the
> app uses direct console API.

The workaround would be redirecting the output to file(s) and read it
later.
