### PR TITLE
Add tests for nuget.exe HTTP and package caching

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestContext.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestContext.cs
@@ -1,0 +1,431 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class CachingTestContext
+    {
+        public CachingTestContext(TestDirectory testDirectory, MockServer mockServer, INuGetExe nuGetExe)
+        {
+            TestDirectory = testDirectory;
+            MockServer = mockServer;
+            NuGetExe = nuGetExe;
+
+            PackageFramework = FrameworkConstants.CommonFrameworks.Net45;
+            PackageIdentityA = new PackageIdentity("TestPackageA", new NuGetVersion("1.0.0"));
+            PackageIdentityB = new PackageIdentity("TestPackageB", new NuGetVersion("1.0.0"));
+
+            InitializeFiles();
+            InitializeServer();
+
+            MockServer.Start();
+        }
+
+        public TestDirectory TestDirectory { get; }
+        public MockServer MockServer { get; }
+
+        public NuGetFramework PackageFramework { get; }
+        public PackageIdentity PackageIdentityA { get; }
+        public PackageIdentity PackageIdentityB { get; }
+
+        public INuGetExe NuGetExe { get; private set; }
+        public string WorkingPath { get; private set; }
+        public string GlobalPackagesPath { get; private set; }
+        public string IsolatedHttpCachePath { get; private set; }
+        public string InputPackagesPath { get; private set; }
+        public string ProjectJsonPath { get; private set; }
+        public string PackagesConfigPath { get; private set; }
+        public string OutputPackagesPath { get; private set; }
+
+        public string PackageAVersionAPath { get; private set; }
+        public string PackageAVersionBPath { get; private set; }
+        public string PackageBPath { get; private set; }
+        public string CurrentPackageAPath { get; set; }
+        public bool IsPackageAAvailable { get; set; } = true;
+        public bool IsPackageBAvailable { get; set; } = true;
+
+        public string V2Source { get; private set; }
+        public string V3Source { get; private set; }
+
+        public string CurrentSource { get; set; }
+        public bool NoCache { get; set; }
+
+        private void InitializeServer()
+        {
+            var baseUrl = MockServer.Uri.TrimEnd(new[] { '/' });
+            var builder = new MockResponseBuilder(baseUrl);
+
+            CurrentSource = builder.GetV2Source();
+            V2Source = builder.GetV2Source();
+            V3Source = builder.GetV3Source();
+
+            AddPackageEndpoints(builder, PackageIdentityA, () => CurrentPackageAPath, () => IsPackageAAvailable);
+            AddPackageEndpoints(builder, PackageIdentityB, () => PackageBPath, () => IsPackageBAvailable);
+
+            // Add the V3 service index.
+            MockServer.Get.Add(
+                builder.GetV3IndexPath(),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        var mockResponse = builder.BuildV3IndexResponse(MockServer);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            // Add the V2 "service index".
+            var v2IndexPath = builder.GetV2IndexPath();
+            MockServer.Get.Add(
+                v2IndexPath,
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        if (!request.RawUrl.EndsWith(v2IndexPath))
+                        {
+                            response.StatusCode = 404;
+                            return;
+                        }
+
+                        var mockResponse = builder.BuildV2IndexResponse(MockServer);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+        }
+
+        private void AddPackageEndpoints(MockResponseBuilder builder, PackageIdentity identity, Func<string> getPackagePath, Func<bool> isAvailable)
+        {
+
+            // Add the /nuget/Packages(Id='',Version='') endpoint.
+            MockServer.Get.Add(
+                builder.GetODataPath(identity),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        if (!isAvailable())
+                        {
+                            response.StatusCode = 404;
+                            return;
+                        }
+                        
+                        var packagePath = getPackagePath();
+                        var mockResponse = builder.BuildODataResponse(packagePath);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            // Add the /nuget/FindPackagesById()?id='' endpoint.
+            MockServer.Get.Add(
+                builder.GetFindPackagesByIdPath(identity.Id),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        var packagePaths = new List<string>();
+
+                        if (isAvailable())
+                        {
+                            packagePaths.Add(getPackagePath());
+                        }
+                        
+                        var mockResponse = builder.BuildFindPackagesByIdResponse(packagePaths);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            // Add the registration index.
+            MockServer.Get.Add(
+                builder.GetRegistrationIndexPath(identity.Id),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        if (!isAvailable())
+                        {
+                            response.StatusCode = 404;
+                            return;
+                        }
+
+                        var mockResponse = builder.BuildRegistrationIndexResponse(MockServer, identity);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            // Add the flat index
+            MockServer.Get.Add(
+                builder.GetFlatIndexPath(identity.Id),
+                request =>
+                {
+                    return new Action<HttpListenerResponse>(response =>
+                    {
+                        if (!isAvailable())
+                        {
+                            response.StatusCode = 404;
+                            return;
+                        }
+
+                        var mockResponse = builder.BuildFlatIndex(identity.Version);
+
+                        response.ContentType = mockResponse.ContentType;
+                        MockServer.SetResponseContent(response, mockResponse.Content);
+                    });
+                });
+
+            // Add the .nupkg download.
+            Func<HttpListenerRequest, object> downloadAction = request =>
+            {
+                return new Action<HttpListenerResponse>(response =>
+                {
+                    if (!isAvailable())
+                    {
+                        response.StatusCode = 404;
+                        return;
+                    }
+
+                    var packagePath = getPackagePath();
+                    var mockResponse = builder.BuildDownloadResponse(packagePath);
+
+                    response.ContentType = mockResponse.ContentType;
+                    MockServer.SetResponseContent(response, mockResponse.Content);
+                });
+            };
+
+            MockServer.Get.Add(builder.GetFlatDownloadPath(identity), downloadAction);
+            MockServer.Get.Add(builder.GetDownloadPath(identity), downloadAction);
+        }
+
+        private void InitializeFiles()
+        {
+            WorkingPath = Path.Combine(TestDirectory, "working");
+            Directory.CreateDirectory(WorkingPath);
+
+            GlobalPackagesPath = Path.Combine(TestDirectory, "globalPackagesFolder");
+            Directory.CreateDirectory(GlobalPackagesPath);
+
+            IsolatedHttpCachePath = Path.Combine(TestDirectory, "httpCache");
+            Directory.CreateDirectory(IsolatedHttpCachePath);
+
+            InputPackagesPath = Path.Combine(TestDirectory, "packages");
+            Directory.CreateDirectory(InputPackagesPath);
+
+            PackageAVersionAPath = MakeTestPackage(InputPackagesPath, PackageIdentityA, $"{PackageIdentityA}.a.nupkg", "a.txt");
+            PackageAVersionBPath = MakeTestPackage(InputPackagesPath, PackageIdentityA, $"{PackageIdentityA}.b.nupkg", "b.txt");
+            PackageBPath = MakeTestPackage(InputPackagesPath, PackageIdentityB, $"{PackageIdentityB}.nupkg", "c.txt");
+
+            CurrentPackageAPath = PackageAVersionAPath;
+
+            PackagesConfigPath = Path.Combine(WorkingPath, "packages.config");
+            ProjectJsonPath = Path.Combine(WorkingPath, "project.json");
+
+            OutputPackagesPath = Path.Combine(WorkingPath, "packages");
+            Directory.CreateDirectory(OutputPackagesPath);
+        }
+
+        private string MakeTestPackage(string repositoryPath, PackageIdentity identity, string packageFileName, string contentFileName)
+        {
+            var directory = Path.Combine(repositoryPath, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(directory);
+            
+            File.WriteAllBytes(Path.Combine(directory, contentFileName), new byte[0]);
+
+            var assemblyFileName = "assembly.dll";
+            File.WriteAllBytes(Path.Combine(directory, assemblyFileName), new byte[0]);
+
+            var packageBuilder = new Packaging.PackageBuilder();
+
+            packageBuilder.Id = identity.Id;
+            packageBuilder.Version = identity.Version;
+            packageBuilder.AddFiles(directory, contentFileName, contentFileName);
+            packageBuilder.AddFiles(directory, assemblyFileName, $"lib/{PackageFramework.GetShortFolderName()}/assembly.dll");
+            packageBuilder.Authors.Add("NuGet");
+            packageBuilder.Description = "A test package";
+
+            var destination = Path.Combine(repositoryPath, packageFileName);
+            using (var destinationStream = new FileStream(destination, FileMode.Create, FileAccess.Write))
+            {
+                packageBuilder.Save(destinationStream);
+            }
+
+            Directory.Delete(directory, true);
+
+            return destination;
+        }
+
+        public void WritePackagesConfig(PackageIdentity packageIdentity)
+        {
+            var content = $@"<packages>
+  <package id=""{packageIdentity.Id}"" version=""{packageIdentity.Version}"" targetFramework=""{PackageFramework.GetShortFolderName()}"" />
+</packages>";
+
+            File.WriteAllText(PackagesConfigPath, content);
+        }
+
+        public void WriteProjectJson(PackageIdentity packageIdentity)
+        {
+            var content = $@"{{
+  ""dependencies"": {{
+    ""{packageIdentity.Id}"": ""{packageIdentity.Version}""
+  }},
+  ""frameworks"": {{
+    ""{PackageFramework.GetShortFolderName()}"": {{}}
+  }}
+}}";
+
+            File.WriteAllText(ProjectJsonPath, content);
+        }
+
+        public async Task AddToGlobalPackagesFolderAsync(PackageIdentity identity, string packagePath)
+        {
+            var settings = GetGlobalPackagesFolderSettings();
+
+            using (var fileStream = new FileStream(packagePath, FileMode.Open, FileAccess.Read))
+            {
+                using (await GlobalPackagesFolderUtility.AddPackageAsync(
+                    identity,
+                    fileStream,
+                    settings,
+                    Common.NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                }
+            }
+        }
+
+        public void AddPackageToHttpCache(PackageIdentity identity, string packagePath)
+        {
+            var result = InitializeHttpCacheResult(identity);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(result.CacheFile));
+
+            File.Delete(result.CacheFile);
+
+            File.Copy(packagePath, result.CacheFile);
+        }
+
+        public bool IsPackageInHttpCache(PackageIdentity identity)
+        {
+            var result = InitializeHttpCacheResult(identity);
+
+            return File.Exists(result.CacheFile);
+        }
+
+        private HttpCacheResult InitializeHttpCacheResult(PackageIdentity identity)
+        {
+            return HttpCacheUtility.InitializeHttpCacheResult(
+                NuGetExe.GetHttpCachePath(this),
+                new Uri(CurrentSource),
+                $"nupkg_{identity.Id}.{identity.Version}",
+                new HttpSourceCacheContext());
+        }
+
+        public string GetPackagePathInGlobalPackagesFolder(PackageIdentity identity)
+        {
+            var settings = GetGlobalPackagesFolderSettings();
+
+            using (var result = GlobalPackagesFolderUtility.GetPackage(identity, settings))
+            {
+                if (result == null)
+                {
+                    return null;
+                }
+
+                var resolver = new VersionFolderPathResolver(GlobalPackagesPath);
+                return resolver.GetInstallPath(identity.Id, identity.Version);
+            }
+        }
+
+        public string GetPackagePathInOutputDirectory(PackageIdentity identity)
+        {
+            var project = new FolderNuGetProject(OutputPackagesPath);
+
+            var path = project.GetInstalledPath(identity);
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return null;
+            }
+
+            return path;
+        }
+
+        public bool IsPackageInGlobalPackagesFolder(PackageIdentity identity)
+        {
+            return GetPackagePathInGlobalPackagesFolder(identity) != null;
+        }
+
+        public bool IsPackageInOutputDirectory(PackageIdentity identity)
+        {
+            return GetPackagePathInOutputDirectory(identity) != null;
+        }
+
+        public bool IsPackageAVersionA(string packagePath)
+        {
+            var path = Path.Combine(packagePath, "a.txt");
+            return File.Exists(path);
+        }
+
+        public bool IsPackageAVersionB(string packagePath)
+        {
+            var path = Path.Combine(packagePath, "b.txt");
+            return File.Exists(path);
+        }
+
+        public void ClearHttpCache()
+        {
+            Execute("locals http-cache -Clear");
+        }
+
+        public CommandRunnerResult Execute(string args)
+        {
+            return NuGetExe.Execute(this, args);
+        }
+
+        public string FinishArguments(string args)
+        {
+            args += $" -Source {CurrentSource}";
+
+            if (NoCache)
+            {
+                args += " -NoCache";
+            }
+
+            return args;
+        }
+
+        private Configuration.ISettings GetGlobalPackagesFolderSettings()
+        {
+            var settingsMock = new Mock<Configuration.ISettings>();
+            settingsMock
+                .Setup(x => x.GetValue("config", "globalPackagesFolder", true))
+                .Returns(GlobalPackagesPath);
+            var settings = settingsMock.Object;
+            return settings;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestRunner.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestRunner.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public static class CachingTestRunner
+    {
+        public static async Task<CachingValidations> ExecuteAsync(ICachingTest test, ICachingCommand command, INuGetExe nuGetExe, CachingType caching, ServerType server)
+        {
+            var testFolder = TestFileSystemUtility.CreateRandomTestFolder();
+            using (var mockServer = new MockServer())
+            {
+                var tc = new CachingTestContext(testFolder, mockServer, nuGetExe);
+
+                tc.NoCache = caching.HasFlag(CachingType.NoCache);
+                tc.CurrentSource = server == ServerType.V2 ? tc.V2Source : tc.V3Source;
+
+                tc.ClearHttpCache();
+
+                var args = await test.PrepareTestAsync(tc, command);
+
+                var result = tc.Execute(args);
+
+                return test.Validate(tc, command, result);
+            }
+        }
+
+        public static async Task<CachingValidations> ExecuteAsync(Type testType, Type commandType, INuGetExe nuGetExe, CachingType caching, ServerType server)
+        {
+            var test = (ICachingTest)Activator.CreateInstance(testType);
+            var command = (ICachingCommand)Activator.CreateInstance(commandType);
+
+            return await ExecuteAsync(
+                test,
+                command,
+                nuGetExe,
+                caching,
+                server);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTests.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    /// <summary>
+    /// The thought behind this test suite is to validate every permutation of test matrix comprised
+    /// of the following variables:
+    /// - Installation command (implementations of ICachingCommand)
+    /// - Caching aspect (implementation of ICachingTest)
+    /// - NoCache argument enabled or disabled
+    /// - Server type (V2 or V3)
+    /// </summary>
+    public class CachingTests
+    {
+        /// <summary>
+        /// This is a sanity check test that does not verify any caching.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
+        public async Task NuGetExe_Caching_InstallsToDestinationFolder(Type commandType, CachingType caching, ServerType server)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(InstallsToDestinationFolderTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.PackageInstalled, true);
+        }
+
+        /// <summary>
+        /// Inconsistencies tracked here:
+        /// https://github.com/NuGet/Home/issues/3244
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, true, false)] // Should either fail or install?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, true, true)] // Should fail?
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        public async Task NuGetExe_Caching_AllowsMissingPackageOnSource(Type commandType, CachingType caching, ServerType server, bool success, bool installed)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(AllowsMissingPackageOnSourceTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, success);
+            validations.Assert(CachingValidationType.PackageInstalled, installed);
+        }
+
+        /// <summary>
+        /// There is currently no way to disable populating the global packages folder.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
+        public async Task NuGetExe_Caching_PopulatesGlobalPackagesFolder(Type commandType, CachingType caching, ServerType server)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(PopulatesGlobalPackagesFolderTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.PackageInGlobalPackagesFolder, true);
+        }
+
+        /// <summary>
+        /// There is currently no way to disable getting the package from the global packages folder.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
+        public async Task NuGetExe_Caching_UsesGlobalPackagesFolderCopy(Type commandType, CachingType caching, ServerType server)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(UsesGlobalPackagesFolderCopyTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.PackageInstalled, true);
+            validations.Assert(CachingValidationType.PackageFromGlobalPackagesFolderUsed, true);
+            validations.Assert(CachingValidationType.PackageFromSourceNotUsed, true);
+        }
+
+        /// <summary>
+        /// Currently, only project.json restore uses the HTTP cache. Eventually, the
+        /// packages.config should use the HTTP cache as well.
+        /// https://github.com/NuGet/Home/issues/3132
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, false)]
+        public async Task NuGetExe_Caching_UsesHttpCacheCopy(Type commandType, CachingType caching, ServerType server, bool success)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(UsesHttpCacheCopyTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.PackageInstalled, true);
+            validations.Assert(CachingValidationType.PackageFromHttpCacheUsed, success);
+            validations.Assert(CachingValidationType.PackageFromSourceNotUsed, success);
+        }
+
+        /// <summary>
+        /// Currently, only project.json restore uses the HTTP cache. Eventually, the
+        /// packages.config should use the HTTP cache as well.
+        /// https://github.com/NuGet/Home/issues/3132
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, false)]
+        public async Task NuGetExe_Caching_WritesToHttpCacheTest(Type commandType, CachingType caching, ServerType server, bool success)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(WritesToHttpCacheTest),
+                commandType,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.PackageInHttpCache, success);
+        }
+
+        private static async Task<INuGetExe> GetNuGetExeAsync()
+        {
+            await Task.Yield();
+            
+            return NuGetExe.GetBuiltNuGetExe();
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingType.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingType.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    [Flags]
+    public enum CachingType
+    {
+        Default = 0,
+        NoCache = 1
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidation.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidation.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class CachingValidation
+    {
+        private static readonly Dictionary<CachingValidationType, Messages> validationMessages = new Dictionary<CachingValidationType, Messages>
+        {
+            {
+                CachingValidationType.CommandSucceeded,
+                new Messages
+                {
+                    True = "The command succeeded.",
+                    False = "The command failed."
+                }
+            },
+            {
+                CachingValidationType.PackageInstalled,
+                new Messages
+                {
+                    True = "The package was installed.",
+                    False = "The package was not installed."
+                }
+            },
+            {
+                CachingValidationType.PackageInGlobalPackagesFolder,
+                new Messages
+                {
+                    True = "The package was added to the global packages folder.",
+                    False = "The package was not added to the global packages folder."
+                }
+            },
+            {
+                CachingValidationType.PackageInHttpCache,
+                new Messages
+                {
+                    True = "The package was written to the HTTP cache.",
+                    False = "The package was not written to the HTTP cache."
+                }
+            },
+            {
+                CachingValidationType.PackageFromHttpCacheUsed,
+                new Messages
+                {
+                    True = "The package in the HTTP cache was used.",
+                    False = "The package in the HTTP cache was not used."
+                }
+            },
+            {
+                CachingValidationType.PackageFromSourceUsed,
+                new Messages
+                {
+                    True = "The package from the source was used.",
+                    False = "The package from the source was not used."
+                }
+            },
+            {
+                CachingValidationType.PackageFromSourceNotUsed,
+                new Messages
+                {
+                    True = "The package from the source was not used.",
+                    False = "The package from the source was used."
+                }
+            },
+            {
+                CachingValidationType.PackageFromGlobalPackagesFolderUsed,
+                new Messages
+                {
+                    True = "The package from the global packages folder was used.",
+                    False = "The package from the global packages folder was not used."
+                }
+            }
+        };
+
+        public CachingValidation(CachingValidationType type, bool isTrue)
+        {
+            IsTrue = isTrue;
+            Type = type;
+
+            Messages messages;
+            if (!validationMessages.TryGetValue(type, out messages))
+            {
+                throw new ArgumentException($"The caching validation type '{type}' does not have messages configured.", nameof(type));
+            }
+
+            Message = isTrue ? messages.True : messages.False;
+        }
+
+        public bool IsTrue { get; }
+        public CachingValidationType Type { get; }
+        public string Message { get; }
+
+        private class Messages
+        {
+            public string True { get; set; }
+            public string False { get; set; }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidationType.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidationType.cs
@@ -1,0 +1,14 @@
+﻿namespace NuGet.CommandLine.Test.Caching
+{
+    public enum CachingValidationType
+    {
+        CommandSucceeded,
+        PackageInstalled,
+        PackageInGlobalPackagesFolder,
+        PackageInHttpCache,
+        PackageFromHttpCacheUsed,
+        PackageFromSourceUsed,
+        PackageFromSourceNotUsed,
+        PackageFromGlobalPackagesFolderUsed
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidations.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidations.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class CachingValidations : IEnumerable<CachingValidation>
+    {
+        private readonly IDictionary<CachingValidationType, CachingValidation> _validations
+            = new Dictionary<CachingValidationType, CachingValidation>();
+
+        public CachingValidation this[CachingValidationType key]
+        {
+            get { return _validations[key]; }
+            set { _validations[key] = value; }
+        }
+
+        public void Add(CachingValidationType type, bool isTrue)
+        {
+            this[type] = new CachingValidation(type, isTrue);
+        }
+
+        public IEnumerator<CachingValidation> GetEnumerator()
+        {
+            return _validations.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public void Assert(CachingValidationType type, bool isTrue)
+        {
+            CachingValidation validation;
+
+            Xunit.Assert.True(_validations.TryGetValue(type, out validation), $"No validation of type '{type}' was found.");
+
+            if (isTrue)
+            {
+                Xunit.Assert.True(validation.IsTrue, $"The validation '{validation.Message}' ('{validation.Type}') was expected to be true and was not.");
+            }
+            else
+            {
+                Xunit.Assert.False(validation.IsTrue, $"The validation '{validation.Message}' ('{validation.Type}') was expected to be false and was not.");
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/ICachingCommand.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/ICachingCommand.cs
@@ -1,0 +1,42 @@
+﻿using NuGet.Packaging.Core;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    /// <summary>
+    /// The nuget.exe command to test. This interface focuses on nuget.exe commands that cache
+    /// packages or other data to the file system.
+    /// </summary>
+    public interface ICachingCommand
+    {
+        /// <summary>
+        /// Gets the display name for this command.
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// Prepare the string arguments for nuget.exe so the command can be executed.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        /// <param name="identity">The identity of the package to be installed.</param>
+        /// <returns>The string arguments for nuget.exe.</returns>
+        string PrepareArguments(CachingTestContext context, PackageIdentity identity);
+
+        /// <summary>
+        /// Determines whether the package was installed to the output directory.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        /// <param name="identity">The identity of the package to check.</param>
+        /// <returns>True if the package was installed to the output directory.</returns>
+        bool IsPackageInstalled(CachingTestContext context, PackageIdentity identity);
+
+        /// <summary>
+        /// Gets the path where the package was installed to. This should be an absolute path
+        /// to the directory where the package is extracted. Returns null of the package was
+        /// not installed.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        /// <param name="identity">The identity of the package.</param>
+        /// <returns>The path.</returns>
+        string GetInstalledPackagePath(CachingTestContext context, PackageIdentity identity);
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/InstallPackagesConfigCommand.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/InstallPackagesConfigCommand.cs
@@ -1,0 +1,28 @@
+﻿using NuGet.Packaging.Core;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class InstallPackagesConfigCommand : ICachingCommand
+    {
+        public string Description => "Executes a nuget.exe install on a packages.config";
+
+        public string GetInstalledPackagePath(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.GetPackagePathInOutputDirectory(identity);
+        }
+
+        public bool IsPackageInstalled(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.IsPackageInOutputDirectory(identity);
+        }
+
+        public string PrepareArguments(CachingTestContext context, PackageIdentity identity)
+        {
+            context.WritePackagesConfig(identity);
+
+            var args = $"install {context.PackagesConfigPath} -OutputDirectory {context.OutputPackagesPath}";
+
+            return context.FinishArguments(args);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/InstallSpecificVersionCommand.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/InstallSpecificVersionCommand.cs
@@ -1,0 +1,26 @@
+﻿using NuGet.Packaging.Core;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class InstallSpecificVersionCommand : ICachingCommand
+    {
+        public string Description => "Executes a nuget.exe install on a specific package ID and version";
+
+        public string GetInstalledPackagePath(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.GetPackagePathInOutputDirectory(identity);
+        }
+
+        public bool IsPackageInstalled(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.IsPackageInOutputDirectory(identity);
+        }
+
+        public string PrepareArguments(CachingTestContext context, PackageIdentity identity)
+        {
+            var args = $"install {identity.Id} -Version {identity.Version} -OutputDirectory {context.OutputPackagesPath}";
+
+            return context.FinishArguments(args);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/RestorePackagesConfigCommand.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/RestorePackagesConfigCommand.cs
@@ -1,0 +1,28 @@
+﻿using NuGet.Packaging.Core;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class RestorePackagesConfigCommand : ICachingCommand
+    {
+        public string Description => "Executes a nuget.exe restore on a packages.config";
+
+        public string GetInstalledPackagePath(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.GetPackagePathInOutputDirectory(identity);
+        }
+
+        public bool IsPackageInstalled(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.IsPackageInOutputDirectory(identity);
+        }
+
+        public string PrepareArguments(CachingTestContext context, PackageIdentity identity)
+        {
+            context.WritePackagesConfig(identity);
+
+            var args = $"restore {context.PackagesConfigPath} -PackagesDirectory {context.OutputPackagesPath}";
+
+            return context.FinishArguments(args);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/RestoreProjectJsonCommand.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Commands/RestoreProjectJsonCommand.cs
@@ -1,0 +1,28 @@
+﻿using NuGet.Packaging.Core;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class RestoreProjectJsonCommand : ICachingCommand
+    {
+        public string Description => "Executes a nuget.exe restore on a project.json";
+
+        public string GetInstalledPackagePath(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.GetPackagePathInGlobalPackagesFolder(identity);
+        }
+
+        public bool IsPackageInstalled(CachingTestContext context, PackageIdentity identity)
+        {
+            return context.IsPackageInGlobalPackagesFolder(identity);
+        }
+
+        public string PrepareArguments(CachingTestContext context, PackageIdentity identity)
+        {
+            context.WriteProjectJson(identity);
+
+            var args = $"restore {context.ProjectJsonPath}";
+
+            return context.FinishArguments(args);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/MockResponses/MockResponse.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/MockResponses/MockResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace NuGet.CommandLine.Test.Caching
+{
+    public class MockResponse
+    {
+        public string ContentType { get; set; }
+        public byte[] Content { get; set; }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/MockResponses/MockResponseBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/MockResponses/MockResponseBuilder.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Linq;
+using Newtonsoft.Json;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class MockResponseBuilder
+    {
+        private readonly string _baseUrl;
+
+        public MockResponseBuilder(string baseUrl)
+        {
+            _baseUrl = baseUrl;
+        }
+
+        public string GetDownloadPath(PackageIdentity identity)
+        {
+            var id = identity.Id.ToLowerInvariant();
+            var version = identity.Version.ToNormalizedString().ToLowerInvariant();
+
+            return $"/packages/{id}.{version}.nupkg";
+        }
+
+        public string GetFlatDownloadPath(PackageIdentity identity)
+        {
+            var id = identity.Id.ToLowerInvariant();
+            var version = identity.Version.ToNormalizedString().ToLowerInvariant();
+
+            return $"/flat/{id}/{version}/{id}.{version}.nupkg";
+        }
+
+        public string GetDownloadUrl(PackageIdentity identity)
+        {
+            return _baseUrl + GetDownloadPath(identity);
+        }
+
+        public string GetODataPath(PackageIdentity identity)
+        {
+            var id = identity.Id;
+            var version = identity.Version.ToNormalizedString();
+
+            return $"/nuget/Packages(Id='{id}',Version='{version}')";
+        }
+
+        public string GetFindPackagesByIdPath(string id)
+        {
+            return $"/nuget/FindPackagesById()?id='{id}'";
+        }
+
+        public string GetODataUrl(PackageIdentity identity)
+        {
+            return _baseUrl + GetODataPath(identity);
+        }
+
+        public string GetRegistrationIndexPath(string id)
+        {
+            return $"/reg/{id.ToLowerInvariant()}/index.json";
+        }
+
+        public string GetFlatIndexPath(string id)
+        {
+            return $"/flat/{id.ToLowerInvariant()}/index.json";
+        }
+
+        public string GetV3IndexPath()
+        {
+            return "/index.json";
+        }
+
+        public string GetV2IndexPath()
+        {
+            return "/nuget";
+        }
+
+        public string GetV3Source()
+        {
+            return _baseUrl + GetV3IndexPath();
+        }
+
+        public string GetV2Source()
+        {
+            return _baseUrl + GetV2IndexPath();
+        }
+
+        public MockResponse BuildODataResponse(string packagePath)
+        {
+            var entry = GetODataElement(packagePath);
+            var document = new XDocument(entry);
+
+            return new MockResponse
+            {
+                ContentType = "application/atom+xml;type=entry;charset=utf-8",
+                Content = Encoding.UTF8.GetBytes(document.ToString())
+            };
+        }
+        
+        public MockResponse BuildFindPackagesByIdResponse(IEnumerable<string> packagePaths)
+        {
+            return BuildODataFeedResponse("FindPackagesById", packagePaths);
+        }
+
+        private MockResponse BuildODataFeedResponse(string title, IEnumerable<string> packagePaths)
+        {
+            var nsAtom = "http://www.w3.org/2005/Atom";
+            var feedId = $"{_baseUrl}/nuget/{title}";
+            var document = new XDocument(
+                new XElement(XName.Get("feed", nsAtom),
+                    new XElement(XName.Get("id", nsAtom), feedId),
+                    new XElement(XName.Get("title", nsAtom), title)));
+
+            foreach(var packagePath in packagePaths)
+            {
+                document.Root.Add(GetODataElement(packagePath));
+            }
+
+            return new MockResponse
+            {
+                ContentType = "application/atom+xml;type=feed;charset=utf-8",
+                Content = Encoding.UTF8.GetBytes(document.ToString())
+            };
+        }
+
+        private XElement GetODataElement(string packagePath)
+        {
+            using (var packageArchiveReader = new PackageArchiveReader(packagePath))
+            {
+                var nuspec = packageArchiveReader.NuspecReader;
+                var identity = nuspec.GetIdentity();
+                var id = identity.Id;
+                var version = identity.Version.ToNormalizedString();
+                var hash = GetHash(packagePath);
+                var description = nuspec.GetDescription();
+                var listed = true;
+
+                var downloadUrl = GetDownloadUrl(identity);
+                var entryId = GetODataUrl(identity);
+
+                var nsAtom = "http://www.w3.org/2005/Atom";
+                XNamespace nsDataService = "http://schemas.microsoft.com/ado/2007/08/dataservices";
+                var nsMetadata = "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata";
+
+                var content = new XElement(XName.Get("content", nsAtom),
+                        new XAttribute("type", "application/zip"),
+                        new XAttribute("src", downloadUrl));
+
+                var properties = new XElement(XName.Get("properties", nsMetadata),
+                    new XElement(nsDataService + "Version", version),
+                    new XElement(nsDataService + "PackageHash", hash),
+                    new XElement(nsDataService + "PackageHashAlgorithm", "SHA512"),
+                    new XElement(nsDataService + "Description", description),
+                    new XElement(nsDataService + "Listed", listed));
+
+                var entry = new XElement(XName.Get("entry", nsAtom),
+                    new XAttribute(XNamespace.Xmlns + "d", nsDataService),
+                    new XAttribute(XNamespace.Xmlns + "m", nsMetadata),
+                    new XElement(XName.Get("id", nsAtom), entryId),
+                    new XElement(XName.Get("title", nsAtom), id),
+                    content,
+                    properties);
+
+                return entry;
+            }
+        }
+
+        public MockResponse BuildRegistrationIndexResponse(MockServer mockServer, PackageIdentity identity)
+        {
+            var id = identity.Id.ToLowerInvariant();
+            var version = identity.Version.ToNormalizedString().ToLowerInvariant();
+
+            var registrationIndex = Util.CreateSinglePackageRegistrationBlob(mockServer, id, version);
+
+            return new MockResponse
+            {
+                ContentType = "text/javascript",
+                Content = Encoding.UTF8.GetBytes(registrationIndex.ToString())
+            };
+        }
+
+        public MockResponse BuildFlatIndex(NuGetVersion version)
+        {
+            var flatIndex = JsonConvert.SerializeObject(new
+            {
+                versions = new[]
+                {
+                    version.ToNormalizedString()
+                }
+            });
+
+            return new MockResponse
+            {
+                ContentType = "text/javascript",
+                Content = Encoding.UTF8.GetBytes(flatIndex.ToString())
+            };
+        }
+
+        public MockResponse BuildV3IndexResponse(MockServer mockServer)
+        {
+            var indexJson = Util.CreateIndexJson();
+
+            Util.AddFlatContainerResource(indexJson, mockServer);
+            Util.AddRegistrationResource(indexJson, mockServer);
+
+            return new MockResponse
+            {
+                ContentType = "text/javascript",
+                Content = Encoding.UTF8.GetBytes(indexJson.ToString())
+            };
+        }
+
+        public MockResponse BuildV2IndexResponse(MockServer mockServer)
+        {
+            return new MockResponse
+            {
+                ContentType = null,
+                Content = new byte[0]
+            };
+        }
+
+        public MockResponse BuildDownloadResponse(string packagePath)
+        {
+            return new MockResponse
+            {
+                ContentType = "application/zip",
+                Content = File.ReadAllBytes(packagePath)
+            };
+        }
+
+        private static string GetHash(string packagePath)
+        {
+            using (var stream = new FileStream(packagePath, FileMode.Open, FileAccess.Read))
+            {
+                using (var sha512 = SHA512.Create())
+                {
+                    return Convert.ToBase64String(sha512.ComputeHash(stream));
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/INuGetExe.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/INuGetExe.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public interface INuGetExe
+    {
+        string GetHttpCachePath(CachingTestContext context);
+        CommandRunnerResult Execute(CachingTestContext context, string args);
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/NuGetExe.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/NuGetExe.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class NuGetExe : INuGetExe
+    {
+        private static ConcurrentDictionary<string, Task<NuGetExe>> _verifiedNuGetExe
+            = new ConcurrentDictionary<string, Task<NuGetExe>>();
+
+        private NuGetExe(string pathToExe)
+        {
+            PathToExe = pathToExe;
+        }
+
+        public string PathToExe { get; }
+
+        public bool Debug { get; set; }
+
+        public CommandRunnerResult Execute(CachingTestContext context, string args)
+        {
+            var timeout = 60 * 1000 * 1;
+            if (Debug)
+            {
+                args += " --debug -Verbosity detailed";
+                timeout *= 60;
+            }
+
+            return CommandRunner.Run(
+                PathToExe,
+                context.WorkingPath,
+                args,
+                timeOutInMilliseconds: timeout,
+                waitForExit: true,
+                environmentVariables: new Dictionary<string, string>
+                {
+                    { "NUGET_PACKAGES", context.GlobalPackagesPath },
+                    { "NUGET_HTTP_CACHE_PATH", context.IsolatedHttpCachePath }
+                });
+        }
+
+        public string GetHttpCachePath(CachingTestContext context)
+        {
+            var result = Execute(context, "locals http-cache -list");
+
+            var stdout = result.Item2.Trim();
+
+            // Example:
+            //   stdout = http-cache: C:\Users\jver\AppData\Local\NuGet\v3-cache
+            //   path   = C:\Users\jver\AppData\Local\NuGet\v3-cache
+            var path = stdout.Split(new[] { ':' }, 2)[1].Trim();
+
+            return path;
+        }
+
+        public static async Task<NuGetExe> Get320Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.2.0/nuget.exe",
+                "nuget.3.2.0.exe");
+        }
+
+        public static async Task<NuGetExe> Get330Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe",
+                "nuget.3.3.0.exe");
+        }
+
+        public static async Task<NuGetExe> Get340RcAsync()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.4.0-rc/nuget.exe",
+                "nuget.3.4.3-rc.exe");
+        }
+
+        public static async Task<NuGetExe> Get343Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.4.3/nuget.exe",
+                "nuget.3.4.3.exe");
+        }
+
+        public static async Task<NuGetExe> Get344Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe",
+                "nuget.3.4.4.exe");
+        }
+
+        public static async Task<NuGetExe> Get350Beta2Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.5.0-beta2/NuGet.exe",
+                "nuget.3.5.0-beta2.exe");
+        }
+
+        public static async Task<NuGetExe> Get350Rc1Async()
+        {
+            return await DownloadNuGetExeAsync(
+                "https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe",
+                "nuget.3.5.0-rc1.exe");
+        }
+
+        public static NuGetExe GetBuiltNuGetExe()
+        {
+            return new NuGetExe(Util.GetNuGetExePath());
+        }
+
+        private static async Task<NuGetExe> DownloadNuGetExeAsync(string requestUri, string fileName)
+        {
+            var temp = NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp);
+            var path = Path.Combine(temp, fileName);
+
+            return await _verifiedNuGetExe.GetOrAdd(
+                path,
+                thisPath => ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                    thisPath,
+                    async token =>
+                    {
+                        if (File.Exists(thisPath))
+                        {
+                            // Make sure we can run the executable.
+                            var helpResult = CommandRunner.Run(
+                                    thisPath,
+                                    ".",
+                                    "help",
+                                    waitForExit: true);
+
+                            if (helpResult.Item1 == 0)
+                            {
+                                return new NuGetExe(thisPath);
+                            }
+                        }
+
+                        // Download the executable.
+                        using (var httpClient = new System.Net.Http.HttpClient())
+                        using (var stream = await httpClient.GetStreamAsync(requestUri))
+                        using (var fileStream = new FileStream(thisPath, FileMode.Create))
+                        {
+                            await stream.CopyToAsync(fileStream);
+                        }
+
+                        return new NuGetExe(thisPath);
+                    },
+                    CancellationToken.None));
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/ServerType.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/ServerType.cs
@@ -1,0 +1,8 @@
+﻿namespace NuGet.CommandLine.Test.Caching
+{
+    public enum ServerType
+    {
+        V2,
+        V3
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/AllowsMissingPackageOnSourceTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/AllowsMissingPackageOnSourceTest.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class AllowsMissingPackageOnSourceTest : ICachingTest
+    {
+        public string Description => "Allows the requested package to be missing package on the source";
+
+        public async Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // The package is available in the global packages folder.
+            await context.AddToGlobalPackagesFolderAsync(context.PackageIdentityB, context.PackageBPath);
+
+            // The package is not available on the source.
+            context.IsPackageBAvailable = false;
+            
+            return command.PrepareArguments(context, context.PackageIdentityB);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInstalled,
+                command.IsPackageInstalled(context, context.PackageIdentityB));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/ICachingTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/ICachingTest.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    /// <summary>
+    /// This interface encapsulates the logic necessary for testing a certain aspect of nuget.exe.
+    /// Currently, the focus is only on the caching of packages and HTTP operations.
+    /// </summary>
+    public interface ICachingTest
+    {
+        /// <summary>
+        /// Gets the display name for this test.
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
+        /// Prepares the test context or file system for the nuget.exe command.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        /// <param name="command">The command to test.</param>
+        /// <returns>The string containing the arguments to pass to nuget.exe.</returns>
+        Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command);
+
+        /// <summary>
+        /// Validates the test context or file system after the command has been executed.
+        /// </summary>
+        /// <param name="context">The test context.</param>
+        /// <param name="command">The command that was executed.</param>
+        /// <param name="result">The command runner result, which is the output of the nuget.exe execution.</param>
+        /// <returns>The set of validations performed and their associated results.</returns>
+        CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result);
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/PopulatesDestinationFolderTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/PopulatesDestinationFolderTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class InstallsToDestinationFolderTest : ICachingTest
+    {
+        public string Description => "Installs the requested package to the destination folder";
+
+        public Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // The package is available on the source.
+            context.IsPackageBAvailable = true;
+
+            var args = command.PrepareArguments(context, context.PackageIdentityB);
+
+            return Task.FromResult(args);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInstalled,
+                command.IsPackageInstalled(context, context.PackageIdentityB));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/PopulatesGlobalPackagesFolderTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/PopulatesGlobalPackagesFolderTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class PopulatesGlobalPackagesFolderTest : ICachingTest
+    {
+        public string Description => "Adds the installed package to the global packages folder";
+
+        public Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // The package is available on the source.
+            context.IsPackageBAvailable = true;
+
+            var args = command.PrepareArguments(context, context.PackageIdentityB);
+
+            return Task.FromResult(args);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInGlobalPackagesFolder,
+                context.IsPackageInGlobalPackagesFolder(context.PackageIdentityB));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/ReadsFromHttpCacheTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/ReadsFromHttpCacheTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class UsesHttpCacheCopyTest : ICachingTest
+    {
+        public string Description => "Use the copy of the package in the HTTP cache instead of the source";
+
+        public Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // The second version of the package is available on the source.
+            context.IsPackageAAvailable = true;
+            context.CurrentPackageAPath = context.PackageAVersionBPath;
+
+            // Add the first version of the package to the HTTP.
+            context.AddPackageToHttpCache(context.PackageIdentityA, context.PackageAVersionAPath);
+
+            var args = command.PrepareArguments(context, context.PackageIdentityA);
+
+            return Task.FromResult(args);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInstalled,
+                command.IsPackageInstalled(context, context.PackageIdentityA));
+            
+            var path = command.GetInstalledPackagePath(context, context.PackageIdentityA);
+
+            validations.Add(
+                CachingValidationType.PackageFromHttpCacheUsed,
+                path != null && context.IsPackageAVersionA(path));
+
+            validations.Add(
+                CachingValidationType.PackageFromSourceNotUsed,
+                path == null || !context.IsPackageAVersionB(path));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/UsesGlobalPackagesFolderCopyTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/UsesGlobalPackagesFolderCopyTest.cs
@@ -1,0 +1,47 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class UsesGlobalPackagesFolderCopyTest : ICachingTest
+    {
+        public string Description => "Uses the copy of the package from the global packages folder instead of the source";
+
+        public async Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // Add the first version of the package to the global packages folder.
+            await context.AddToGlobalPackagesFolderAsync(context.PackageIdentityA, context.PackageAVersionAPath);
+
+            // A different version of the same package is available on the source.
+            context.CurrentPackageAPath = context.PackageAVersionBPath;
+            context.IsPackageAAvailable = true;
+            
+            return command.PrepareArguments(context, context.PackageIdentityA);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInstalled,
+                command.IsPackageInstalled(context, context.PackageIdentityA));
+
+            var path = command.GetInstalledPackagePath(context, context.PackageIdentityA);
+
+            validations.Add(
+                CachingValidationType.PackageFromGlobalPackagesFolderUsed,
+                path != null && context.IsPackageAVersionA(path));
+
+            validations.Add(
+                CachingValidationType.PackageFromSourceNotUsed,
+                path == null || !context.IsPackageAVersionB(path));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/WritesToHttpCacheTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/WritesToHttpCacheTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class WritesToHttpCacheTest : ICachingTest
+    {
+        public string Description => "Writes the installed package to the HTTP cache";
+
+        public Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // The package is available on the source.
+            context.IsPackageBAvailable = true;
+
+            var args = command.PrepareArguments(context, context.PackageIdentityB);
+
+            return Task.FromResult(args);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.PackageInHttpCache,
+                context.IsPackageInHttpCache(context.PackageIdentityB));
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MockServer.cs
@@ -417,7 +417,7 @@ namespace NuGet.CommandLine.Test
         {
             foreach (var m in _mappings)
             {
-                if (r.Url.AbsolutePath.StartsWith(m.Item1, StringComparison.Ordinal))
+                if (r.Url.PathAndQuery.StartsWith(m.Item1, StringComparison.Ordinal))
                 {
                     return m.Item2;
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -54,6 +54,30 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Caching\CachingType.cs" />
+    <Compile Include="Caching\CachingTestContext.cs" />
+    <Compile Include="Caching\CachingTestRunner.cs" />
+    <Compile Include="Caching\CachingValidation.cs" />
+    <Compile Include="Caching\CachingTests.cs" />
+    <Compile Include="Caching\CachingValidations.cs" />
+    <Compile Include="Caching\CachingValidationType.cs" />
+    <Compile Include="Caching\Commands\ICachingCommand.cs" />
+    <Compile Include="Caching\MockResponses\MockResponse.cs" />
+    <Compile Include="Caching\MockResponses\MockResponseBuilder.cs" />
+    <Compile Include="Caching\NuGetExe\INuGetExe.cs" />
+    <Compile Include="Caching\NuGetExe\NuGetExe.cs" />
+    <Compile Include="Caching\ServerType.cs" />
+    <Compile Include="Caching\Tests\ICachingTest.cs" />
+    <Compile Include="Caching\Commands\InstallPackagesConfigCommand.cs" />
+    <Compile Include="Caching\Commands\InstallSpecificVersionCommand.cs" />
+    <Compile Include="Caching\Commands\RestorePackagesConfigCommand.cs" />
+    <Compile Include="Caching\Commands\RestoreProjectJsonCommand.cs" />
+    <Compile Include="Caching\Tests\ReadsFromHttpCacheTest.cs" />
+    <Compile Include="Caching\Tests\WritesToHttpCacheTest.cs" />
+    <Compile Include="Caching\Tests\PopulatesGlobalPackagesFolderTest.cs" />
+    <Compile Include="Caching\Tests\PopulatesDestinationFolderTest.cs" />
+    <Compile Include="Caching\Tests\UsesGlobalPackagesFolderCopyTest.cs" />
+    <Compile Include="Caching\Tests\AllowsMissingPackageOnSourceTest.cs" />
     <Compile Include="ConsoleCredentialProviderTest.cs" />
     <Compile Include="ConsoleTest.cs" />
     <Compile Include="DefaultConfigurationFilePreserver.cs" />


### PR DESCRIPTION
This adds a suite of **96** tests that assert current functionality in `nuget.exe` caching. There are 96 tests because the a test matrix is constructed from the following variables:
1. NuGet.exe command
   1. install packages.config
   2. install ID -version VERSION
   3. restore packages.confg
   4. restore project.json
2. Caching flag
   1. Default functionality
   2. -NoCache
3. Server type
   1. V2
   2. V3
4. File system artifact (i.e something on the file system that effects the result)
   1. installation of packages to the destination folder (this is a sanity test)
   2. allows missing package on source but available in the global packages folder
   3. populates the global packages folder
   4. populates the HTTP cache
   5. uses the copy of the package from global packages folder vs. the source
   6. uses the copy of the package from the HTTP cache vs. the source

This results in `4 x 2 x 2 x 6 = 96` tests.

Note the the 2.x package cache is not tested. This is because NuGet 3.5+ does not use it at all.

So why are these tests so thorough? Three reasons:
1. The behavior of a few of these tests has changed in surprising (to me) ways from release to release.
2. Behavior is inconsistent between test permutations you would think to be similar. For example when interacting with a V2 server instead of V3, some caching behavior is different. "install packages.config" acts _slightly_ differently from "restore packages.config".
3. I was working on reviewing @MarkOsborneMS's -DirectDownload PR and could not easily identify any behavior changes (if any) the PR was introducing to the -NoCache flag.
4. I was investigating https://github.com/NuGet/Home/issues/3074.

This PR:
1. Takes a snapshot in time of what current "caching" functionality is in the NuGet client.
2. Provides an extensible test framework for future caching things. Namely, testing what -DirectDownload does.
3. Allows us, with some ease, to test previous versions of nuget.exe with the same test cases.
4. Calls out apparent anomalies in current functionality, also tracked by issues:
   - https://github.com/NuGet/Home/issues/3132
   - https://github.com/NuGet/Home/issues/3244

Caching is a feature. Let's thoroughly test it. Let's detect regressions or intentional behavior changes.

I am interested in feedback on this approach. Have I gone off the deep-end here? :smile: 

@emgarten @alpaix @rohit21agrawal @jainaashish @drewgil @zhili1208 @rrelyea @yishaigalatzer @MarkOsborneMS 
