### PR TITLE
Map v2 list endpoint to package source Uri

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
@@ -7,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Credentials;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -23,7 +25,6 @@ namespace NuGet.CommandLine
         protected Command()
         {
             Arguments = new List<string>();
-            _credentialRequested = new HashSet<Uri>();
         }
 
         public IList<string> Arguments { get; private set; }
@@ -55,8 +56,7 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "Option_ForceEnglishOutput")]
         public bool ForceEnglishOutput { get; set; }
 
-        // Used to check if credential has been requested for a uri.
-        private readonly HashSet<Uri> _credentialRequested;
+        protected Configuration.ICredentialService CredentialService { get; private set; }
 
         public string CurrentDirectory
         {
@@ -158,11 +158,11 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider()
         {
-            var credentialService = new CredentialService(GetCredentialProviders(), Console.WriteError, NonInteractive);
+            CredentialService = new CredentialService(GetCredentialProviders(), Console.WriteError, NonInteractive);
 
-            HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(credentialService);
+            HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);
 
-            HttpHandlerResourceV3.CredentialService = credentialService;
+            HttpHandlerResourceV3.CredentialService = CredentialService;
 
             HttpHandlerResourceV3.CredentialsSuccessfullyUsed = (uri, credentials) =>
             {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -414,11 +414,17 @@ namespace NuGet.CommandLine.Test
             array.Add(resource);
         }
 
-        public static void AddLegacyUrlResource(JObject index, MockServer serverV2)
+        public static void AddLegacyGalleryResource(JObject index, MockServer serverV2, string relativeUri = null)
         {
+            var resourceUri = new Uri(serverV2.Uri);
+            if (relativeUri != null)
+            {
+                resourceUri = new Uri(resourceUri, relativeUri);
+            }
+
             var resource = new JObject
             {
-                { "@id", serverV2.Uri },
+                { "@id", resourceUri },
                 { "@type", "LegacyGallery/2.0.0" }
             };
 


### PR DESCRIPTION
... when acquiring credentials.

Fixes NuGet/Home#3179.

NuGetCore calls the credentials adapter with a "list" endpoint uri.
It may be different from a source uri, for instance when v3 source
advertises v2 search endpoint. If endpoints mapping is supplied, retrieve
the source uri and use it to acquire credentials.

//cc @rrelyea @emgarten @joelverhagen @pspill
