### PR TITLE
Improve NuGetProject logging for "default project is not found" error

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
@@ -430,7 +430,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project &apos;{0}&apos; is not found..
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; is not found. Please check visual studio activity log for more detail..
         /// </summary>
         internal static string Cmdlet_ProjectNotFound {
             get {

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.Designer.cs
@@ -430,7 +430,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project &apos;{0}&apos; is not found. Please check visual studio activity log for more detail..
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; is not found. Please check ActivityLog.xml for more detail..
         /// </summary>
         internal static string Cmdlet_ProjectNotFound {
             get {

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
@@ -202,7 +202,7 @@
     <value>Package source '{0}' is not matching any of the enabled package sources.</value>
   </data>
   <data name="Cmdlet_ProjectNotFound" xml:space="preserve">
-    <value>Project '{0}' is not found. Please check visual studio activity log for more detail.</value>
+    <value>Project '{0}' is not found. Please check ActivityLog.xml for more detail.</value>
   </data>
   <data name="Cmdlet_PrompToDisplayMorePackages" xml:space="preserve">
     <value>There may be more packages to display. Do you want to continue?</value>

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Resources.resx
@@ -202,7 +202,7 @@
     <value>Package source '{0}' is not matching any of the enabled package sources.</value>
   </data>
   <data name="Cmdlet_ProjectNotFound" xml:space="preserve">
-    <value>Project '{0}' is not found.</value>
+    <value>Project '{0}' is not found. Please check visual studio activity log for more detail.</value>
   </data>
   <data name="Cmdlet_PrompToDisplayMorePackages" xml:space="preserve">
     <value>There may be more packages to display. Do you want to continue?</value>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -54,7 +54,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 if (string.IsNullOrEmpty(DefaultNuGetProjectName))
                 {
                     ActivityLog.LogWarning(
-                                ExceptionHelper.LogEntrySource, $"The default project name is null.");
+                                ExceptionHelper.LogEntrySource, "The default project name is null.");
                     return null;
                 }
 
@@ -153,7 +153,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     var projects = _nuGetAndEnvDTEProjectCache.GetNuGetProjects().Select(p => NuGetProject.GetUniqueNameOrName(p));
                     ActivityLog.LogWarning(
                                 ExceptionHelper.LogEntrySource,
-                                $"Cannot find project {nuGetProjectSafeName} in NuGetDTEProjectCache, NuGetDTEProjectCache contains {string.Join(",", projects)} .");
+                                $"[{nameof(GetNuGetProject)}] Cannot find project {nuGetProjectSafeName} in NuGetDTEProjectCache, NuGetDTEProjectCache contains {string.Join(",", projects)} .");
                 }
             }
             return nuGetProject;
@@ -551,7 +551,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         ActivityLog.LogWarning(
                                  ExceptionHelper.LogEntrySource,
-                                 $"There are no supported projects in the solution.");
+                                 $"[{nameof(EnsureNuGetAndEnvDTEProjectCache)}] There are no supported projects in the solution.");
                     }
 
                     foreach (var project in supportedProjects)
@@ -565,7 +565,7 @@ namespace NuGet.PackageManagement.VisualStudio
                             // Ignore failed projects.
                             ActivityLog.LogWarning(
                                 ExceptionHelper.LogEntrySource,
-                                $"The project {project.Name} failed to initialize as a NuGet project.");
+                                $"[{nameof(EnsureNuGetAndEnvDTEProjectCache)}] The project {project.Name} failed to initialize as a NuGet project.");
 
                             ExceptionHelper.WriteToActivityLog(ex);
                         }


### PR DESCRIPTION
This PR is for improving logging for "default project is not found" error

There are some cases which can cause "default project is not found" error.
1. Solution is not open.
2. Solution is not saved.
3. default project name is null.
4. no supported project.
5. can't find the default project name in cache.

This PR will log all those cases in Activity log.
https://github.com/NuGet/Home/issues/3299

@rrelyea @emgarten @alpaix @joelverhagen @rohit21agrawal 
