### PR TITLE
Clone previous lock file libraries since we mutate and compare them to originals

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -121,7 +121,13 @@ namespace NuGet.Commands
                     var resolver = packageInfo.Repository.PathResolver;
                     
                     LockFileLibrary previousLibrary = null;
-                    previousLibraries?.TryGetValue(Tuple.Create(package.Id, package.Version), out previousLibrary);
+                    if (previousLibraries?.TryGetValue(Tuple.Create(package.Id, package.Version), out previousLibrary) == true)
+                    {
+                        // We mutate this previous library so we must take a clone of it. This is
+                        // important because later, when deciding whether the lock file has changed,
+                        // we compare the new lock file to the previous (in-memory) lock file.
+                        previousLibrary = previousLibrary.Clone();
+                    }
                     
                     var sha512 = File.ReadAllText(resolver.GetHashPath(package.Id, package.Version));
                     var path = PathUtility.GetPathWithForwardSlashes(

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileLibrary.cs
@@ -53,7 +53,7 @@ namespace NuGet.ProjectModel
                 && string.Equals(Sha512, other.Sha512, StringComparison.Ordinal)
                 && Version == other.Version)
             {
-                return Files.OrderedEquals(other.Files, s => s, StringComparer.OrdinalIgnoreCase, StringComparer.OrdinalIgnoreCase);
+                return Files.OrderedEquals(other.Files, s => s, StringComparer.Ordinal, StringComparer.Ordinal);
             }
 
             return false;
@@ -76,12 +76,31 @@ namespace NuGet.ProjectModel
             combiner.AddObject(Path);
             combiner.AddObject(MSBuildProject);
 
-            foreach (var file in Files.OrderBy(s => s, StringComparer.OrdinalIgnoreCase))
+            foreach (var file in Files.OrderBy(s => s, StringComparer.Ordinal))
             {
-                combiner.AddStringIgnoreCase(file);
+                combiner.AddObject(file);
             }
 
             return combiner.CombinedHash;
+        }
+
+        /// <summary>
+        /// Makes a deep clone of the lock file library.
+        /// </summary>
+        /// <returns>The cloned lock file library.</returns>
+        public LockFileLibrary Clone()
+        {
+            return new LockFileLibrary
+            {
+                Name = Name,
+                Type = Type,
+                Version = Version,
+                IsServiceable = IsServiceable,
+                Sha512 = Sha512,
+                Files = Files != null ? new List<string>(Files) : null,
+                Path = Path,
+                MSBuildProject = MSBuildProject
+            };
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -137,6 +137,7 @@ namespace NuGet.Commands.Test
 
                 var logger = new TestLogger();
                 var lockFilePath = Path.Combine(projectDir.FullName, "project.lock.json");
+                var lockFileFormat = new LockFileFormat();
 
                 var packageId = "PackageA";
                 var packageVersion = "1.0.0-Beta";
@@ -170,7 +171,8 @@ namespace NuGet.Commands.Test
                     logger)
                 {
                     LockFilePath = lockFilePath,
-                    IsLowercasePackagesDirectory = isLowercase
+                    IsLowercasePackagesDirectory = isLowercase,
+                    ExistingLockFile = lockFileFormat.Read(lockFilePath)
                 };
                 var commandB = new RestoreCommand(requestB);
                 var resultB = await commandB.ExecuteAsync();
@@ -203,7 +205,6 @@ namespace NuGet.Commands.Test
                 Assert.True(File.Exists(resolverB.GetPackageFilePath(packageId, libraryB.Version)));
 
                 // The lock file on disk should match the second restore's library.
-                var lockFileFormat = new LockFileFormat();
                 var diskLockFile = lockFileFormat.Read(lockFilePath);
                 var lockFileLibrary = diskLockFile
                     .Libraries

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileLibraryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileLibraryTests.cs
@@ -1,4 +1,10 @@
-﻿using NuGet.Versioning;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -6,7 +12,7 @@ namespace NuGet.ProjectModel.Test
     public class LockFileLibraryTests
     {
         [Fact]
-        public void LockFileLibraryTests_ComparesEqualPaths()
+        public void LockFileLibrary_ComparesEqualPaths()
         {
             // Arrange
             var libraryA = new LockFileLibrary
@@ -29,7 +35,30 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
-        public void LockFileLibraryTests_ComparesDifferentPaths()
+        public void LockFileLibrary_ComparesDifferentCasePaths()
+        {
+            // Arrange
+            var libraryA = new LockFileLibrary
+            {
+                Name = "SomeLibrary",
+                Version = new NuGetVersion("1.0.0"),
+                Path = "SomeLibrary/1.0.0"
+            };
+
+            // different case
+            var libraryB = new LockFileLibrary
+            {
+                Name = "SomeLibrary",
+                Version = new NuGetVersion("1.0.0"),
+                Path = "somelibrary/1.0.0"
+            };
+
+            // Act & Assert
+            Assert.False(libraryA.Equals(libraryB), "The two libraries should not be equal.");
+        }
+
+        [Fact]
+        public void LockFileLibrary_ComparesDifferentPaths()
         {
             // Arrange
             var libraryA = new LockFileLibrary
@@ -49,6 +78,135 @@ namespace NuGet.ProjectModel.Test
 
             // Act & Assert
             Assert.False(libraryA.Equals(libraryB), "The two libraries should not be equal.");
+        }
+
+        [Fact]
+        public void LockFileLibrary_ComparesDifferentCaseFiles()
+        {
+            // Arrange
+            var libraryA = new LockFileLibrary
+            {
+                Files = new List<string>
+                {
+                    "path/a.txt",
+                    "path/b.txt"
+                }
+            };
+
+            // different case
+            var libraryB = new LockFileLibrary
+            {
+                Files = new List<string>
+                {
+                    "path/a.txt",
+                    "PATH/b.txt"
+                }
+            };
+
+            // Act & Assert
+            Assert.False(libraryA.Equals(libraryB), "The two libraries should not be equal.");
+        }
+
+        [Fact]
+        public void LockFileLibrary_CloneIncludesAllProperties()
+        {
+            // Arrange
+            var original = new LockFileLibrary
+            {
+                Name = "SomeLibrary",
+                Version = new NuGetVersion("1.0.0"),
+                Path = "SomeLibrary/1.0.0",
+                IsServiceable = true,
+                MSBuildProject = "MSBuildProject",
+                Sha512 = "FAKE-HASH",
+                Type = LibraryType.Package,
+                Files = new List<string>
+                {
+                    "file/a.txt",
+                    "file/b.txt"
+                }
+            };
+            
+            // Use Newtonsoft.Json to enumerate all properties.
+            var originalSerialized = JsonConvert.SerializeObject(original, Formatting.Indented);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            var cloneSerialized = JsonConvert.SerializeObject(original, Formatting.Indented);
+            Assert.Equal(originalSerialized, cloneSerialized);
+        }
+
+        [Fact]
+        public void LockFileLibrary_CloneIsEqual()
+        {
+            // Arrange
+            var original = new LockFileLibrary
+            {
+                Name = "SomeLibrary",
+                Version = new NuGetVersion("1.0.0"),
+                Path = "SomeLibrary/1.0.0",
+                IsServiceable = true,
+                MSBuildProject = "MSBuildProject",
+                Sha512 = "FAKE-HASH",
+                Type = LibraryType.Package,
+                Files = new List<string>
+                {
+                    "file/a.txt",
+                    "file/b.txt"
+                }
+            };
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.Equal(original, clone);
+        }
+
+        [Fact]
+        public void LockFileLibrary_CloneReturnsDifferentInstance()
+        {
+            // Arrange
+            var original = new LockFileLibrary
+            {
+                Name = "SomeLibrary",
+                Version = new NuGetVersion("1.0.0"),
+                Path = "SomeLibrary/1.0.0",
+                IsServiceable = true,
+                MSBuildProject = "MSBuildProject",
+                Sha512 = "FAKE-HASH",
+                Type = LibraryType.Package,
+                Files = new List<string>
+                {
+                    "file/a.txt",
+                    "file/b.txt"
+                }
+            };
+
+            // Use Newtonsoft.Json to take a snapshot of all properties.
+            var originalSerializedBefore = JsonConvert.SerializeObject(original, Formatting.Indented);
+
+            // Act
+            var clone = original.Clone();
+
+            // Assert
+            Assert.NotSame(original, clone);
+
+            // Ensure that the clone is deep. Technically the properties that are read-only or value
+            // types do not need to be mutated, but this protects against future refactorings.
+            clone.Name += "Different";
+            clone.Version = new NuGetVersion("2.0.0");
+            clone.Path += "Different";
+            clone.IsServiceable = !clone.IsServiceable;
+            clone.MSBuildProject += "Different";
+            clone.Sha512 += "Different";
+            clone.Type += "Different";
+            clone.Files.Add("Different");
+
+            var originalSerializedAfter = JsonConvert.SerializeObject(original, Formatting.Indented);
+            Assert.Equal(originalSerializedBefore, originalSerializedAfter);
         }
     }
 }


### PR DESCRIPTION
In `LockFileBuilder` and `OriginalCaseGlobalPackagesFolder` we mutate the in-memory `LockFile` instance. This is the model of what is written to `project.lock.json`. However, when there is a previous lock file, we something pull the `LockFileLibrary` instance from the previous lock file and use it in the new lock file. This is a problem when we mutate the `LockFileLibrary`. We do this in two cases:
1. In `LockFileBuilder` when we fix up directory seperator characters.
2. In `OriginalCaseGlobalPackageFolder` when we fix up for `--legacy-packages-directory`.

If we share a `LockFileLibrary` instance between the old and new lock file, then mutate that instance, the lock file write no-op process will no-op when it shouldn't.

/cc @emgarten @alpaix @jainaashish 
