### PR TITLE
Propogate cancelled token from PMC to down the hierarchy

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -1094,14 +1094,15 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         {
             BlockingCollection.Add(new FlushMessage());
 
-            WaitHandle.WaitAny(new WaitHandle[] { _flushSemaphore });
+            WaitHandle.WaitAny(new WaitHandle[] { _flushSemaphore, Token.WaitHandle });
         }
 
         public void ExecutePSScript(string scriptPath, bool throwOnFailure)
         {
             BlockingCollection.Add(new ScriptMessage(scriptPath));
 
-            WaitHandle.WaitAny(new WaitHandle[] { ScriptEndSemaphore });
+            // added Token waitHandler as well in case token is being cancelled.
+            WaitHandle.WaitAny(new WaitHandle[] { ScriptEndSemaphore, Token.WaitHandle });
 
             if (_scriptException != null)
             {


### PR DESCRIPTION
It does following things to handle aborting any process from PMC:
1. Propogate cancelled token from PMC to down the hierarchy till PackageManagement to handle current tasks.
2. Rollback current packages if needed to get to the previous state while aborting.
3. Don't wait forever for scriptEndSemaphore while executing install/ uninstall scripts during a cancelled process.

Fixes https://github.com/NuGet/Home/issues/3325
