### PR TITLE
PM UI now uses all enabled sources to resolve dependencies just like PMC

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -169,13 +169,15 @@ namespace NuGet.PackageManagement.UI
                         versionConstraints: VersionConstraints.None,
                         gatherCache: gatherCache);
 
+                    var secondarySources = _sourceProvider.GetRepositories().Where(e => e.PackageSource.IsEnabled);
+
                     var actions = await _packageManager.PreviewUpdatePackagesAsync(
                         packagesToUpdateInProject,
                         project,
                         resolutionContext,
                         uiService.ProgressWindow,
                         uiService.ActiveSources,
-                        uiService.ActiveSources,
+                        secondarySources,
                         token);
                     resolvedActions.AddRange(actions.Select(action => new ResolvedAction(project, action))
                         .ToList());

--- a/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
+++ b/src/NuGet.Core/NuGet.Resolver/ResolverUtility.cs
@@ -129,7 +129,9 @@ namespace NuGet.Resolver
             if (!availablePackages.Any(package => StringComparer.OrdinalIgnoreCase.Equals(problemPackageId, package.Id)) ||
                 !dependantPackages.Any())
             {
-                var packageSourceList = string.Join(", ", packageSources.Select(source => string.Format(CultureInfo.InvariantCulture, "'{0}'", source.Name)));
+                var packageSourceList = string.Join(", ",
+                    packageSources.Where(source => source.IsEnabled)
+                        .Select(source => string.Format(CultureInfo.InvariantCulture, "'{0}'", source.Name)));
 
                 if (packageSources.Any())
                 {


### PR DESCRIPTION
PM UI now uses all enabled sources to resolve dependencies just like PMC does... also improved error message in case failed to resolve dependencies by listing correct no of sources used unlike earlier where we were listing all the sources configured which was kind of confusing to the customers.

Fixes https://github.com/NuGet/Home/issues/3311

@emgarten @rrelyea @joelverhagen @alpaix 
