### PR TITLE
Fix powershell log message for IntegratedProject

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2086,7 +2086,7 @@ namespace NuGet.PackageManagement
                 await restoreResult.CommitAsync(logger, token);
 
                 // Write out a message for each action
-                foreach (var action in nuGetProjectActions)
+                foreach (var action in actions)
                 {
                     var identityString = String.Format(CultureInfo.InvariantCulture, "{0} {1}",
                         action.PackageIdentity.Id,


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/3309

the bug is powershell show wrong message in update case for project.json.
the issue is project.json project merged all nuGetProjcetActions into one BuildIntegratedProjectAction.
then the log show first package identity for all actions.

Example: Update newtonsoft.json 6.0.1 to newtonsoft.json 9.0.1
there are two nuGetProjectActions: uninstall newtonsoft.json 6.0.1, install newtonsoft.json 9.0.1
they are merged into one BuildIntegratedProjectAction which is using the first package identity(newtonsoft.json 6.0.1 here). So the log will show one message for this action(installed newtonsoft.json 6.0.1), the right one should be "uninstalled newtonsoft.json 6.0.1, installed newtonsoft.json 9.0.1"

the fix is use nuGetProjectActions for logging.
@rrelyea @joelverhagen @emgarten 
