### PR TITLE
Add -DirectDownload option to nuget.exe to disable writing to caches

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -38,6 +38,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandNoCache")]
         public bool NoCache { get; set; }
 
+        [Option(typeof(NuGetCommand), "CommandDirectDownload")]
+        public bool DirectDownload { get; set; }
+
         [Option(typeof(NuGetCommand), "CommandDisableParallelProcessing")]
         public bool DisableParallelProcessing { get; set; }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -234,6 +234,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Download directly without populating any caches with metadata or binaries..
+        /// </summary>
+        internal static string CommandDirectDownload {
+            get {
+                return ResourceManager.GetString("CommandDirectDownload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disable parallel processing of packages for this command..
         /// </summary>
         internal static string CommandDisableParallelProcessing {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5327,4 +5327,7 @@ nuget locals global-packages -list</value>
     <value>nuget restore MySoluion.sln</value>
     <comment>command line example, do not localize</comment>
   </data>
+  <data name="CommandDirectDownload" xml:space="preserve">
+    <value>Download directly without populating any caches with metadata or binaries.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -254,15 +254,21 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 {
                     await TaskScheduler.Default;
 
-                    var result = await PackageRestoreManager.RestoreMissingPackagesAsync(solutionDirectory,
-                        packages,
-                        this,
-                        Token);
-
-                    if (result.Restored)
+                    using (var cacheContext = new SourceCacheContext())
                     {
-                        await PackageRestoreManager.RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
-                        return;
+                        var downloadContext = new PackageDownloadContext(cacheContext);
+
+                        var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
+                            solutionDirectory,
+                            packages,
+                            this,
+                            downloadContext,
+                            Token);
+                        if (result.Restored)
+                        {
+                            await PackageRestoreManager.RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
+                            return;
+                        }
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.DependencyResolver;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -88,8 +87,13 @@ namespace NuGet.Commands
 
             var localProviders = new List<IRemoteDependencyProvider>()
             {
-                // Do not throw or warn for gloabal cache
-                new SourceRepositoryDependencyProvider(globalPackagesSource, log, cacheContext, ignoreFailedSources: true, ignoreWarning: true)
+                // Do not throw or warn for global cache
+                new SourceRepositoryDependencyProvider(
+                    globalPackagesSource,
+                    log,
+                    cacheContext,
+                    ignoreFailedSources: true,
+                    ignoreWarning: true)
             };
 
             // Add fallback sources as local providers also
@@ -100,7 +104,12 @@ namespace NuGet.Commands
                 var fallbackRepository = new NuGetv3LocalRepository(path);
                 var fallbackSource = Repository.Factory.GetCoreV3(path, FeedType.FileSystemV3);
 
-                var provider = new SourceRepositoryDependencyProvider(fallbackSource, log, cacheContext, ignoreFailedSources: false, ignoreWarning: false);
+                var provider = new SourceRepositoryDependencyProvider(
+                    fallbackSource,
+                    log,
+                    cacheContext,
+                    ignoreFailedSources: false,
+                    ignoreWarning: false);
 
                 fallbackPackageFolders.Add(fallbackRepository);
                 localProviders.Add(provider);
@@ -110,11 +119,22 @@ namespace NuGet.Commands
 
             foreach (var source in sources)
             {
-                var provider = new SourceRepositoryDependencyProvider(source, log, cacheContext);
+                var provider = new SourceRepositoryDependencyProvider(
+                    source,
+                    log,
+                    cacheContext,
+                    cacheContext.IgnoreFailedSources,
+                    ignoreWarning: false);
+
                 remoteProviders.Add(provider);
             }
 
-            return new RestoreCommandProviders(globalPackages, fallbackPackageFolders, localProviders, remoteProviders, cacheContext);
+            return new RestoreCommandProviders(
+                globalPackages,
+                fallbackPackageFolders,
+                localProviders,
+                remoteProviders,
+                cacheContext);
         }
 
         public void Dispose()

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.DependencyResolver;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -43,7 +42,12 @@ namespace NuGet.Commands
                 var pathSource = Repository.Factory.GetCoreV3(path, FeedType.FileSystemV3);
 
                 // Do not throw or warn for global cache 
-                return new SourceRepositoryDependencyProvider(pathSource, log, cacheContext, ignoreFailedSources: true, ignoreWarning: true);
+                return new SourceRepositoryDependencyProvider(
+                    pathSource,
+                    log,
+                    cacheContext,
+                    ignoreFailedSources: true,
+                    ignoreWarning: true);
             });
 
             var localProviders = new List<IRemoteDependencyProvider>() { local };
@@ -60,7 +64,12 @@ namespace NuGet.Commands
                     var pathSource = Repository.Factory.GetCoreV3(path, FeedType.FileSystemV3);
 
                     // Throw for fallback package folders
-                    return new SourceRepositoryDependencyProvider(pathSource, log, cacheContext, ignoreFailedSources: false, ignoreWarning: false);
+                    return new SourceRepositoryDependencyProvider(
+                        pathSource,
+                        log,
+                        cacheContext,
+                        ignoreFailedSources: false,
+                        ignoreWarning: false);
                 });
 
                 localProviders.Add(localProvider);
@@ -70,7 +79,13 @@ namespace NuGet.Commands
 
             foreach (var source in sources)
             {
-                var remoteProvider = _remoteProviders.GetOrAdd(source, (sourceRepo) => new SourceRepositoryDependencyProvider(sourceRepo, log, cacheContext));
+                var remoteProvider = _remoteProviders.GetOrAdd(source, (sourceRepo) => new SourceRepositoryDependencyProvider(
+                    sourceRepo,
+                    log,
+                    cacheContext,
+                    cacheContext.IgnoreFailedSources,
+                    ignoreWarning: false));
+
                 remoteProviders.Add(remoteProvider);
             }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver/SourceRepositoryDependencyProvider.cs
@@ -38,23 +38,6 @@ namespace NuGet.DependencyResolver
         public SourceRepositoryDependencyProvider(
             SourceRepository sourceRepository,
             ILogger logger,
-            SourceCacheContext cacheContext)
-            : this(sourceRepository, logger, cacheContext, cacheContext.IgnoreFailedSources)
-        {
-        }
-
-        public SourceRepositoryDependencyProvider(
-           SourceRepository sourceRepository,
-           ILogger logger,
-           SourceCacheContext cacheContext,
-           bool ignoreFailedSources)
-           : this(sourceRepository, logger, cacheContext, ignoreFailedSources, false)
-        {
-        }
-
-        public SourceRepositoryDependencyProvider(
-            SourceRepository sourceRepository,
-            ILogger logger,
             SourceCacheContext cacheContext,
             bool ignoreFailedSources,
             bool ignoreWarning)
@@ -155,14 +138,15 @@ namespace NuGet.DependencyResolver
                     await _throttle.WaitAsync();
                 }
 
-                using (var nupkgStream = await _findPackagesByIdResource.GetNupkgStreamAsync(identity.Name, identity.Version, cancellationToken))
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
-                    // If the stream is already available, do not stop in the middle of copying the stream
-                    // Pass in CancellationToken.None
-                    await nupkgStream.CopyToAsync(stream, bufferSize: 8192, cancellationToken: CancellationToken.None);
-                }
+                // If the stream is already available, do not stop in the middle of copying the stream
+                // Pass in CancellationToken.None
+                await _findPackagesByIdResource.CopyNupkgToStreamAsync(
+                    identity.Name,
+                    identity.Version,
+                    stream,
+                    CancellationToken.None);
             }
             catch (FatalProtocolException e) when (_ignoreFailedSources)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement
 {
@@ -76,6 +77,7 @@ namespace NuGet.PackageManagement
         Task<PackageRestoreResult> RestoreMissingPackagesAsync(string solutionDirectory,
             NuGetProject nuGetProject,
             INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
             CancellationToken token);
 
         /// <summary>
@@ -97,6 +99,7 @@ namespace NuGet.PackageManagement
         Task<PackageRestoreResult> RestoreMissingPackagesAsync(string solutionDirectory,
             IEnumerable<PackageRestoreData> packages,
             INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
             CancellationToken token);
     }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -200,12 +200,55 @@ namespace NuGet.PackageManagement
         /// <paramref name="nuGetProject" /> <paramref name="resolutionContext" /> and
         /// <paramref name="nuGetProjectContext" /> are used in the process.
         /// </summary>
-        public Task InstallPackageAsync(NuGetProject nuGetProject, string packageId, ResolutionContext resolutionContext,
-            INuGetProjectContext nuGetProjectContext, SourceRepository primarySourceRepository,
-            IEnumerable<SourceRepository> secondarySources, CancellationToken token)
+        public Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            string packageId,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            SourceRepository primarySourceRepository,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
         {
-            return InstallPackageAsync(nuGetProject, packageId, resolutionContext, nuGetProjectContext,
-                new List<SourceRepository> { primarySourceRepository }, secondarySources, token);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var downloadContext = new PackageDownloadContext(sourceCacheContext);
+
+                return InstallPackageAsync(
+                    nuGetProject,
+                    packageId,
+                    resolutionContext,
+                    nuGetProjectContext,
+                    downloadContext,
+                    new List<SourceRepository> { primarySourceRepository },
+                    secondarySources,
+                    token);
+            }
+        }
+
+        /// <summary>
+        /// Installs the latest version of the given <paramref name="packageId" /> to NuGetProject
+        /// <paramref name="nuGetProject" /> <paramref name="resolutionContext" /> and
+        /// <paramref name="nuGetProjectContext" /> are used in the process.
+        /// </summary>
+        public Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            string packageId,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            SourceRepository primarySourceRepository,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
+        {
+            return InstallPackageAsync(
+                nuGetProject,
+                packageId,
+                resolutionContext,
+                nuGetProjectContext,
+                downloadContext,
+                new List<SourceRepository> { primarySourceRepository },
+                secondarySources,
+                token);
         }
 
         /// <summary>
@@ -216,6 +259,36 @@ namespace NuGet.PackageManagement
         public async Task InstallPackageAsync(NuGetProject nuGetProject, string packageId, ResolutionContext resolutionContext,
             INuGetProjectContext nuGetProjectContext, IEnumerable<SourceRepository> primarySources,
             IEnumerable<SourceRepository> secondarySources, CancellationToken token)
+        {
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var downloadContext = new PackageDownloadContext(sourceCacheContext);
+
+                await InstallPackageAsync(
+                    nuGetProject,
+                    packageId,
+                    resolutionContext,
+                    nuGetProjectContext,
+                    downloadContext,
+                    primarySources,
+                    secondarySources, token);
+            }
+        }
+
+        /// <summary>
+        /// Installs the latest version of the given
+        /// <paramref name="packageId" /> to NuGetProject <paramref name="nuGetProject" />
+        /// <paramref name="resolutionContext" /> and <paramref name="nuGetProjectContext" /> are used in the process.
+        /// </summary>
+        public async Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            string packageId,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            IEnumerable<SourceRepository> primarySources,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
         {
             var log = new LoggerAdapter(nuGetProjectContext);
 
@@ -234,29 +307,113 @@ namespace NuGet.PackageManagement
             }
 
             // Step-2 : Call InstallPackageAsync(project, packageIdentity)
-            await InstallPackageAsync(nuGetProject, new PackageIdentity(packageId, latestVersion), resolutionContext,
-                nuGetProjectContext, primarySources, secondarySources, token);
+            await InstallPackageAsync(
+                nuGetProject,
+                new PackageIdentity(packageId, latestVersion),
+                resolutionContext,
+                nuGetProjectContext,
+                downloadContext,
+                primarySources,
+                secondarySources,
+                token);
         }
 
         /// <summary>
         /// Installs given <paramref name="packageIdentity" /> to NuGetProject <paramref name="nuGetProject" />
         /// <paramref name="resolutionContext" /> and <paramref name="nuGetProjectContext" /> are used in the process.
         /// </summary>
-        public Task InstallPackageAsync(NuGetProject nuGetProject, PackageIdentity packageIdentity, ResolutionContext resolutionContext,
-            INuGetProjectContext nuGetProjectContext, SourceRepository primarySourceRepository,
-            IEnumerable<SourceRepository> secondarySources, CancellationToken token)
+        public Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            SourceRepository primarySourceRepository,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
         {
-            return InstallPackageAsync(nuGetProject, packageIdentity, resolutionContext, nuGetProjectContext,
-                new List<SourceRepository> { primarySourceRepository }, secondarySources, token);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var downloadContext = new PackageDownloadContext(sourceCacheContext);
+
+                return InstallPackageAsync(
+                    nuGetProject,
+                    packageIdentity,
+                    resolutionContext,
+                    nuGetProjectContext,
+                    downloadContext,
+                    new List<SourceRepository> { primarySourceRepository },
+                    secondarySources,
+                    token);
+            }
         }
 
         /// <summary>
         /// Installs given <paramref name="packageIdentity" /> to NuGetProject <paramref name="nuGetProject" />
         /// <paramref name="resolutionContext" /> and <paramref name="nuGetProjectContext" /> are used in the process.
         /// </summary>
-        public async Task InstallPackageAsync(NuGetProject nuGetProject, PackageIdentity packageIdentity, ResolutionContext resolutionContext,
-            INuGetProjectContext nuGetProjectContext, IEnumerable<SourceRepository> primarySources,
-            IEnumerable<SourceRepository> secondarySources, CancellationToken token)
+        public Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            SourceRepository primarySourceRepository,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
+        {
+            return InstallPackageAsync(
+                nuGetProject,
+                packageIdentity,
+                resolutionContext,
+                nuGetProjectContext,
+                downloadContext,
+                new List<SourceRepository> { primarySourceRepository },
+                secondarySources,
+                token);
+        }
+
+        /// <summary>
+        /// Installs given <paramref name="packageIdentity" /> to NuGetProject <paramref name="nuGetProject" />
+        /// <paramref name="resolutionContext" /> and <paramref name="nuGetProjectContext" /> are used in the process.
+        /// </summary>
+        public async Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<SourceRepository> primarySources,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
+        {
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var downloadContext = new PackageDownloadContext(sourceCacheContext);
+
+                await InstallPackageAsync(
+                    nuGetProject,
+                    packageIdentity,
+                    resolutionContext,
+                    nuGetProjectContext,
+                    downloadContext,
+                    primarySources,
+                    secondarySources,
+                    token);
+            }
+        }
+
+        /// <summary>
+        /// Installs given <paramref name="packageIdentity" /> to NuGetProject <paramref name="nuGetProject" />
+        /// <paramref name="resolutionContext" /> and <paramref name="nuGetProjectContext" /> are used in the process.
+        /// </summary>
+        public async Task InstallPackageAsync(
+            NuGetProject nuGetProject,
+            PackageIdentity packageIdentity,
+            ResolutionContext resolutionContext,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            IEnumerable<SourceRepository> primarySources,
+            IEnumerable<SourceRepository> secondarySources,
+            CancellationToken token)
         {
             ActivityCorrelationContext.StartNew();
 
@@ -267,7 +424,12 @@ namespace NuGet.PackageManagement
             SetDirectInstall(packageIdentity, nuGetProjectContext);
 
             // Step-2 : Execute all the nuGetProjectActions
-            await ExecuteNuGetProjectActionsAsync(nuGetProject, nuGetProjectActions, nuGetProjectContext, token);
+            await ExecuteNuGetProjectActionsAsync(
+                nuGetProject,
+                nuGetProjectActions,
+                nuGetProjectContext,
+                downloadContext,
+                token);
 
             ClearDirectInstall(nuGetProjectContext);
         }
@@ -1635,6 +1797,31 @@ namespace NuGet.PackageManagement
             INuGetProjectContext nuGetProjectContext,
             CancellationToken token)
         {
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var downloadContext = new PackageDownloadContext(sourceCacheContext);
+
+                await ExecuteNuGetProjectActionsAsync(nuGetProject,
+                    nuGetProjectActions,
+                    nuGetProjectContext,
+                    downloadContext,
+                    token);
+            }
+        }
+
+        /// <summary>
+        /// Executes the list of <paramref name="nuGetProjectActions" /> on <paramref name="nuGetProject" /> , which is
+        /// likely obtained by calling into
+        /// <see
+        ///     cref="PreviewInstallPackageAsync(NuGetProject,string,ResolutionContext,INuGetProjectContext,SourceRepository,IEnumerable{SourceRepository},CancellationToken)" />
+        /// <paramref name="nuGetProjectContext" /> is used in the process.
+        /// </summary>
+        public async Task ExecuteNuGetProjectActionsAsync(NuGetProject nuGetProject,
+            IEnumerable<NuGetProjectAction> nuGetProjectActions,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            CancellationToken token)
+        {
             if (nuGetProject == null)
             {
                 throw new ArgumentNullException(nameof(nuGetProject));
@@ -1702,12 +1889,13 @@ namespace NuGet.PackageManagement
                     {
                         // Make this independently cancelable.
                         downloadTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
-
+                        
                         // Download all packages up front in parallel
                         downloadTasks = await PackagePreFetcher.GetPackagesAsync(
                             actionsList,
                             PackagesFolderNuGetProject,
-                            Settings,
+                            downloadContext,
+                            SettingsUtility.GetGlobalPackagesFolder(Settings),
                             logger,
                             downloadTokenSource.Token);
 
@@ -1952,7 +2140,7 @@ namespace NuGet.PackageManagement
             // restores happening in this flow.
             using (var cacheContext = new SourceCacheContext())
             {
-                cacheContext.ListMaxAge = DateTimeOffset.UtcNow;
+                cacheContext.MaxAge = DateTimeOffset.UtcNow;
 
                 var providers = RestoreCommandProviders.Create(
                     pathContext.UserPackageFolder,
@@ -2149,7 +2337,7 @@ namespace NuGet.PackageManagement
                     referenceContext);
 
                 var now = DateTime.UtcNow;
-                Action<SourceCacheContext> cacheContextModifier = c => c.ListMaxAge = now;
+                Action<SourceCacheContext> cacheContextModifier = c => c.MaxAge = now;
 
                 foreach (var parent in parents)
                 {
@@ -2264,8 +2452,12 @@ namespace NuGet.PackageManagement
         /// packagesFolderPath from NuGetPackageManager
         /// to create a folderNuGetProject before calling into this method
         /// </summary>
-        public async Task<bool> RestorePackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext,
-            IEnumerable<SourceRepository> sourceRepositories, CancellationToken token)
+        public async Task<bool> RestorePackageAsync(
+            PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            PackageDownloadContext downloadContext,
+            IEnumerable<SourceRepository> sourceRepositories,
+            CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
             if (PackageExistsInPackagesFolder(packageIdentity, nuGetProjectContext.PackageExtractionContext.PackageSaveMode))
@@ -2274,21 +2466,21 @@ namespace NuGet.PackageManagement
             }
 
             token.ThrowIfCancellationRequested();
-            nuGetProjectContext.Log(ProjectManagement.MessageLevel.Info, string.Format(Strings.RestoringPackage, packageIdentity));
+            nuGetProjectContext.Log(MessageLevel.Info, string.Format(Strings.RestoringPackage, packageIdentity));
             var enabledSources = (sourceRepositories != null && sourceRepositories.Any()) ? sourceRepositories :
                 SourceRepositoryProvider.GetRepositories().Where(e => e.PackageSource.IsEnabled);
 
             token.ThrowIfCancellationRequested();
 
-            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(enabledSources,
+            using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(
+                enabledSources,
                 packageIdentity,
-                Settings,
+                downloadContext,
+                SettingsUtility.GetGlobalPackagesFolder(Settings),
                 new ProjectContextLogger(nuGetProjectContext),
                 token))
             {
-                packageIdentity = downloadResult.PackageReader.GetIdentity();
-
-                // If you already downloaded the package, just restore it, don't cancel the operation now
+                // Install package whether returned from the cache or a direct download
                 await PackagesFolderNuGetProject.InstallPackageAsync(packageIdentity, downloadResult, nuGetProjectContext, token);
             }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -25,10 +25,12 @@ namespace NuGet.PackageManagement
         /// Returns the <see cref="DownloadResourceResult"/> for a given <paramref name="packageIdentity" />
         /// from the given <paramref name="sources" />.
         /// </summary>
-        public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(IEnumerable<SourceRepository> sources,
+        public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            IEnumerable<SourceRepository> sources,
             PackageIdentity packageIdentity,
-            Configuration.ISettings settings,
-            Common.ILogger logger,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
+            ILogger logger,
             CancellationToken token)
         {
             if (sources == null)
@@ -41,9 +43,14 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(packageIdentity));
             }
 
-            if (settings == null)
+            if (downloadContext == null)
             {
-                throw new ArgumentNullException(nameof(settings));
+                throw new ArgumentNullException(nameof(downloadContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             var failedTasks = new List<Task<DownloadResourceResult>>();
@@ -81,7 +88,14 @@ namespace NuGet.PackageManagement
 
                     foreach (var source in sourceGroup)
                     {
-                        var task = GetDownloadResourceResultAsync(source, packageIdentity, settings, logger, linkedTokenSource.Token);
+                        var task = GetDownloadResourceResultAsync(
+                            source,
+                            packageIdentity,
+                            downloadContext,
+                            globalPackagesFolder,
+                            logger,
+                            linkedTokenSource.Token);
+
                         tasksLookup.Add(task, source);
                         tasks.Add(task);
                     }
@@ -165,10 +179,12 @@ namespace NuGet.PackageManagement
         /// Returns the <see cref="DownloadResourceResult"/> for a given <paramref name="packageIdentity" /> from the given
         /// <paramref name="sourceRepository" />.
         /// </summary>
-        public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(SourceRepository sourceRepository,
+        public static async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
+            SourceRepository sourceRepository,
             PackageIdentity packageIdentity,
-            Configuration.ISettings settings,
-            Common.ILogger logger,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
+            ILogger logger,
             CancellationToken token)
         {
             if (sourceRepository == null)
@@ -181,9 +197,14 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(packageIdentity));
             }
 
-            if (settings == null)
+            if (downloadContext == null)
             {
-                throw new ArgumentNullException(nameof(settings));
+                throw new ArgumentNullException(nameof(downloadContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             var downloadResource = await sourceRepository.GetResourceAsync<DownloadResource>(token);
@@ -200,7 +221,8 @@ namespace NuGet.PackageManagement
             {
                 result = await downloadResource.GetDownloadResourceResultAsync(
                    packageIdentity,
-                   settings,
+                   downloadContext,
+                   globalPackagesFolder,
                    logger,
                    token);
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackagePreFetcher.cs
@@ -8,8 +8,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement
 {
@@ -21,23 +23,14 @@ namespace NuGet.PackageManagement
         public static async Task<Dictionary<PackageIdentity, PackagePreFetcherResult>> GetPackagesAsync(
             IEnumerable<NuGetProjectAction> actions,
             FolderNuGetProject packagesFolder,
-            Configuration.ISettings settings,
-            Common.ILogger logger,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
+            ILogger logger,
             CancellationToken token)
         {
-            if (token == null)
+            if (actions == null)
             {
-                throw new ArgumentNullException(nameof(token));
-            }
-
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
+                throw new ArgumentNullException(nameof(actions));
             }
 
             if (packagesFolder == null)
@@ -45,9 +38,19 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(packagesFolder));
             }
 
-            if (actions == null)
+            if (downloadContext == null)
             {
-                throw new ArgumentNullException(nameof(actions));
+                throw new ArgumentNullException(nameof(downloadContext));
+            }
+
+            if (globalPackagesFolder == null)
+            {
+                throw new ArgumentNullException(nameof(globalPackagesFolder));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
             }
 
             var result = new Dictionary<PackageIdentity, PackagePreFetcherResult>();
@@ -127,7 +130,8 @@ namespace NuGet.PackageManagement
                     var task = Task.Run(async () => await PackageDownloader.GetDownloadResourceResultAsync(
                                         action.SourceRepository,
                                         action.PackageIdentity,
-                                        settings,
+                                        downloadContext,
+                                        globalPackagesFolder,
                                         logger,
                                         token));
 
@@ -152,7 +156,7 @@ namespace NuGet.PackageManagement
         public static void LogFetchMessages(
             IEnumerable<PackagePreFetcherResult> fetchResults,
             string packagesFolderRoot,
-            Common.ILogger logger)
+            ILogger logger)
         {
             if (fetchResults == null)
             {

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/FolderNuGetProject.cs
@@ -77,9 +77,11 @@ namespace NuGet.ProjectManagement
             {
                 throw new ArgumentException(Strings.PackageStreamShouldBeSeekable);
             }
-            var packageFile = PackagePathResolver.GetInstallPath(packageIdentity);
 
-            return ConcurrencyUtilities.ExecuteWithFileLockedAsync(packageFile,
+            var packageDirectory = PackagePathResolver.GetInstallPath(packageIdentity);
+
+            return ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                packageDirectory,
                 action: cancellationToken =>
                 {
                     // 1. Set a default package extraction context, if necessary.

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/PackageDownloadContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/PackageDownloadContext.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.Protocol.Core.Types
+{
+    public class PackageDownloadContext
+    {
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext) : this(
+            sourceCacheContext,
+            directDownloadDirectory: null)
+        {
+        }
+
+        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory)
+        {
+            if (sourceCacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(sourceCacheContext));
+            }
+
+            SourceCacheContext = sourceCacheContext;
+            DirectDownload = directDownloadDirectory != null;
+            DirectDownloadDirectory = directDownloadDirectory;
+        }
+
+        public SourceCacheContext SourceCacheContext { get; }
+        public bool DirectDownload { get; }
+        public string DirectDownloadDirectory { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/Resources/DownloadResource.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Protocol.Core.Types
@@ -23,8 +23,9 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public abstract Task<DownloadResourceResult> GetDownloadResourceResultAsync(
             PackageIdentity identity,
-            ISettings settings,
-            NuGet.Common.ILogger logger,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
+            ILogger logger,
             CancellationToken token);
 
         public event EventHandler<PackageProgressEventArgs> Progress;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheResult.cs
@@ -8,15 +8,15 @@ namespace NuGet.Protocol
 {
     public class HttpCacheResult
     {
-        public HttpCacheResult(TimeSpan maxAge, string newCacheFile, string cacheFile)
+        public HttpCacheResult(TimeSpan maxAge, string newFile, string cacheFule)
         {
             MaxAge = maxAge;
-            NewCacheFile = newCacheFile;
-            CacheFile = cacheFile;
+            NewFile = newFile;
+            CacheFile = cacheFule;
         }
 
         public TimeSpan MaxAge { get; }
-        public string NewCacheFile { get; }
+        public string NewFile { get; }
         public string CacheFile { get; }
         public Stream Stream { get; set; }
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpRetryHandlerRequest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Net.Http;
-using System.Threading;
 
 namespace NuGet.Protocol
 {
@@ -13,6 +12,7 @@ namespace NuGet.Protocol
     /// </summary>
     public class HttpRetryHandlerRequest
     {
+        public static readonly int DefaultMaxTries = 3;
         public static readonly TimeSpan DefaultDownloadTimeout = TimeSpan.FromSeconds(60);
 
         public HttpRetryHandlerRequest(HttpClient httpClient, Func<HttpRequestMessage> requestFactory)
@@ -20,7 +20,7 @@ namespace NuGet.Protocol
             HttpClient = httpClient;
             RequestFactory = requestFactory;
             CompletionOption = HttpCompletionOption.ResponseHeadersRead;
-            MaxTries = 3;
+            MaxTries = DefaultMaxTries;
             RequestTimeout = TimeSpan.FromSeconds(100);
             RetryDelay = TimeSpan.FromMilliseconds(200);
             DownloadTimeout = DefaultDownloadTimeout;
@@ -38,7 +38,6 @@ namespace NuGet.Protocol
         public HttpCompletionOption CompletionOption { get; set; }
 
         /// <summary>The maximum number of times to try the request. This value includes the initial attempt.</summary>
-        /// <remarks>This API is intended only for testing purposes and should not be used in product code.</remarks>
         public int MaxTries { get; set; }
 
         /// <summary>How long to wait on the request to come back with a response.</summary>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCachedRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceCachedRequest.cs
@@ -66,6 +66,9 @@ namespace NuGet.Protocol
         /// </summary>
         public bool IgnoreNotFounds { get; set; }
 
+        /// <summary>The maximum number of times to try the request. This value includes the initial attempt.</summary>
+        public int MaxTries { get; set; } = HttpRetryHandlerRequest.DefaultMaxTries;
+
         /// <summary>
         /// A method used to validate the response stream. This method should not
         /// dispose the stream and should throw an exception when the content is invalid.

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceRequest.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceRequest.cs
@@ -54,6 +54,9 @@ namespace NuGet.Protocol
         /// </summary>
         public TimeSpan RequestTimeout { get; set; } = DefaultRequestTimeout;
 
+        /// <summary>The maximum number of times to try the request. This value includes the initial attempt.</summary>
+        public int MaxTries { get; set; } = HttpRetryHandlerRequest.DefaultMaxTries;
+
         /// <summary>The timeout to apply to <see cref="DownloadTimeoutStream"/> instances.</summary>
         public TimeSpan DownloadTimeout { get; set; } = HttpRetryHandlerRequest.DefaultDownloadTimeout;
     }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResult.cs
@@ -10,20 +10,20 @@ namespace NuGet.Protocol
     {
         public Stream Stream { get; private set; }
         public HttpSourceResultStatus Status { get; }
-        public string CacheFileName { get; }
+        public string CacheFile { get; }
         
         public HttpSourceResult(HttpSourceResultStatus status)
         {
             Status = status;
             Stream = null;
-            CacheFileName = null;
+            CacheFile = null;
         }
 
         public HttpSourceResult(HttpSourceResultStatus status, string cacheFileName, Stream stream)
         {
             Status = status;
             Stream = stream;
-            CacheFileName = cacheFileName;
+            CacheFile = cacheFileName;
         }
 
         public void Dispose()

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSourceResultStatus.cs
@@ -7,6 +7,7 @@ namespace NuGet.Protocol
     {
         NotFound,
         NoContent,
-        OpenedFromDisk
+        OpenedFromDisk,
+        OpenedFromNetwork
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/DownloadResourceV2Feed.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -25,7 +24,8 @@ namespace NuGet.Protocol
 
         public override async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
             PackageIdentity identity,
-            ISettings settings,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
             ILogger logger,
             CancellationToken token)
         {
@@ -34,9 +34,9 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(identity));
             }
 
-            if (settings == null)
+            if (downloadContext == null)
             {
-                throw new ArgumentNullException(nameof(settings));
+                throw new ArgumentNullException(nameof(downloadContext));
             }
 
             if (logger == null)
@@ -57,12 +57,23 @@ namespace NuGet.Protocol
                     // If this is a SourcePackageDependencyInfo object with everything populated
                     // and it is from an online source, use the machine cache and download it using the
                     // given url.
-                    return await _feedParser.DownloadFromUrl(sourcePackage, sourcePackage.DownloadUri, settings, logger, token);
+                    return await _feedParser.DownloadFromUrl(
+                        sourcePackage,
+                        sourcePackage.DownloadUri,
+                        downloadContext,
+                        globalPackagesFolder,
+                        logger,
+                        token);
                 }
                 else
                 {
                     // Look up the package from the id and version and download it.
-                    return await _feedParser.DownloadFromIdentity(identity, settings, logger, token);
+                    return await _feedParser.DownloadFromIdentity(
+                        identity,
+                        downloadContext,
+                        globalPackagesFolder,
+                        logger,
+                        token);
                 }
             }
             catch (OperationCanceledException)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedParser.cs
@@ -233,17 +233,28 @@ namespace NuGet.Protocol
                 token: cancellationToken);
         }
 
-        public async Task<DownloadResourceResult> DownloadFromUrl(PackageIdentity package,
+        public async Task<DownloadResourceResult> DownloadFromUrl(
+            PackageIdentity package,
             Uri downloadUri,
-            ISettings settings,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
             ILogger log,
             CancellationToken token)
         {
-            return await GetDownloadResultUtility.GetDownloadResultAsync(_httpSource, package, downloadUri, settings, log, token);
+            return await GetDownloadResultUtility.GetDownloadResultAsync(
+                _httpSource,
+                package,
+                downloadUri,
+                downloadContext,
+                globalPackagesFolder,
+                log,
+                token);
         }
 
-        public async Task<DownloadResourceResult> DownloadFromIdentity(PackageIdentity package,
-            ISettings settings,
+        public async Task<DownloadResourceResult> DownloadFromIdentity(
+            PackageIdentity package,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
             ILogger log,
             CancellationToken token)
         {
@@ -254,7 +265,14 @@ namespace NuGet.Protocol
                 return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
             }
 
-            return await GetDownloadResultUtility.GetDownloadResultAsync(_httpSource, package, new Uri(packageInfo.DownloadUrl), settings, log, token);
+            return await GetDownloadResultUtility.GetDownloadResultAsync(
+                _httpSource,
+                package,
+                new Uri(packageInfo.DownloadUrl),
+                downloadContext,
+                globalPackagesFolder,
+                log,
+                token);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalDownloadResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalDownloadResource.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
-using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -28,10 +24,21 @@ namespace NuGet.Protocol
 
         public override Task<DownloadResourceResult> GetDownloadResourceResultAsync(
             PackageIdentity identity,
-            ISettings settings,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
             ILogger logger,
             CancellationToken token)
         {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             // Find the package from the local folder
             LocalPackageInfo packageInfo = null;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LocalRepositories/LocalV2FindPackageByIdResource.cs
@@ -49,15 +49,24 @@ namespace NuGet.Protocol
             return Task.FromResult<PackageIdentity>(null);
         }
 
-        public override Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken token)
+        public override async Task<bool> CopyNupkgToStreamAsync(
+            string id,
+            NuGetVersion version,
+            Stream destination,
+            CancellationToken token)
         {
             var info = GetPackageInfo(id, version);
+
             if (info != null)
             {
-                return Task.FromResult<Stream>(File.OpenRead(info.Path));
+                using (var fileStream = File.OpenRead(info.Path))
+                {
+                    await fileStream.CopyToAsync(destination, token);
+                    return true;
+                }
             }
 
-            return Task.FromResult<Stream>(null);
+            return false;
         }
 
         public override Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, NuGetVersion version, CancellationToken token)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/DownloadResourceV3.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -64,7 +63,7 @@ namespace NuGet.Protocol
         /// 2. A url will be constructed for the flat container location if the source has that resource.
         /// 3. The download url will be found in the registration blob as a fallback.
         /// </summary>
-        private async Task<Uri> GetDownloadUrl(PackageIdentity identity, Common.ILogger log, CancellationToken token)
+        private async Task<Uri> GetDownloadUrl(PackageIdentity identity, ILogger log, CancellationToken token)
         {
             Uri downloadUri = null;
             var sourcePackage = identity as SourcePackageDependencyInfo;
@@ -100,7 +99,8 @@ namespace NuGet.Protocol
 
         public override async Task<DownloadResourceResult> GetDownloadResourceResultAsync(
             PackageIdentity identity,
-            ISettings settings,
+            PackageDownloadContext downloadContext,
+            string globalPackagesFolder,
             ILogger logger,
             CancellationToken token)
         {
@@ -109,9 +109,9 @@ namespace NuGet.Protocol
                 throw new ArgumentNullException(nameof(identity));
             }
 
-            if (settings == null)
+            if (downloadContext == null)
             {
-                throw new ArgumentNullException(nameof(settings));
+                throw new ArgumentNullException(nameof(downloadContext));
             }
 
             if (logger == null)
@@ -123,7 +123,14 @@ namespace NuGet.Protocol
 
             if (uri != null)
             {
-                return await GetDownloadResultUtility.GetDownloadResultAsync(_client, identity, uri, settings, logger, token);
+                return await GetDownloadResultUtility.GetDownloadResultAsync(
+                    _client,
+                    identity,
+                    uri,
+                    downloadContext,
+                    globalPackagesFolder,
+                    logger,
+                    token);
             }
 
             return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -34,7 +33,11 @@ namespace NuGet.Protocol.Core.Types
         /// </returns>
         public abstract Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, NuGetVersion version, CancellationToken token);
 
-        public abstract Task<Stream> GetNupkgStreamAsync(string id, NuGetVersion version, CancellationToken token);
+        public abstract Task<bool> CopyNupkgToStreamAsync(
+            string id,
+            NuGetVersion version,
+            Stream destination,
+            CancellationToken token);
 
         /// <summary>
         /// Gets the original ID and version for a package. This is useful when finding the
@@ -61,17 +64,6 @@ namespace NuGet.Protocol.Core.Types
             return new FindPackageByIdDependencyInfo(
                 reader.GetDependencyGroups(),
                 reader.GetFrameworkReferenceGroups());
-        }
-
-        protected HttpSourceCacheContext CreateCacheContext(int retryCount)
-        {
-            if (CacheContext == null)
-            {
-                throw new InvalidOperationException(
-                    $"Must set cache context on {this.GetType().FullName} before consuming.");
-            }
-
-            return HttpSourceCacheContext.CreateCacheContext(CacheContext, retryCount);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FindPackagesByIdNupkgDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FindPackagesByIdNupkgDownloader.cs
@@ -1,0 +1,353 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol
+{
+    public class FindPackagesByIdNupkgDownloader
+    {
+        private readonly object _cacheEntriesLock = new object();
+        private readonly Dictionary<string, Task<CacheEntry>> _cacheEntries =
+            new Dictionary<string, Task<CacheEntry>>();
+
+        private readonly object _nuspecReadersLock = new object();
+        private readonly ConcurrentDictionary<string, NuspecReader> _nuspecReaders =
+            new ConcurrentDictionary<string, NuspecReader>();
+
+        private readonly HttpSource _httpSource;
+
+        public FindPackagesByIdNupkgDownloader(HttpSource httpSource)
+        {
+            if (httpSource == null)
+            {
+                throw new ArgumentNullException(nameof(httpSource));
+            }
+
+            _httpSource = httpSource;
+        }
+
+        /// <summary>
+        /// Gets a <see cref="NuspecReader"/> from a .nupkg. If the URL cannot be fetched or there is a problem
+        /// processing the .nuspec, an exception is throw. This method uses HTTP caching to avoid downloading the
+        /// package over and over (unless <see cref="SourceCacheContext.DirectDownload"/> is specified).
+        /// </summary>
+        /// <param name="identity">The package identity.</param>
+        /// <param name="url">The URL of the .nupkg.</param>
+        /// <param name="cacheContext">The cache context.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>The .nuspec reader.</returns>
+        public async Task<NuspecReader> GetNuspecReaderFromNupkgAsync(
+            PackageIdentity identity,
+            string url,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            NuspecReader reader = null;
+            
+            lock (_nuspecReadersLock)
+            {
+                if (_nuspecReaders.TryGetValue(url, out reader))
+                {
+                    return reader;
+                }
+            }
+
+            await ProcessNupkgStreamAsync(
+                identity,
+                url,
+                stream =>
+                {
+                    reader = PackageUtilities.OpenNuspecFromNupkg(identity.Id, stream, logger);
+
+                    return Task.FromResult(true);
+                },
+                cacheContext,
+                logger,
+                token);
+            
+            if (reader == null)
+            {
+                throw new FatalProtocolException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Log_FailedToGetNupkgStream,
+                    identity.Id));
+            }
+
+            lock (_nuspecReadersLock)
+            {
+                _nuspecReaders[url] = reader;
+            }
+
+            return reader;
+        }
+
+        /// <summary>
+        /// Copies a .nupkg stream to the <paramref name="destination"/> stream. If the .nupkg cannot be found or if
+        /// there is a network problem, no stream copy occurs.
+        /// </summary>
+        /// <param name="identity">The package identity.</param>
+        /// <param name="url">The URL of the .nupkg.</param>
+        /// <param name="destination">The destination stream. The .nupkg will be copied to this stream.</param>
+        /// <param name="cacheContext">The cache context.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>Returns true if the stream was copied, false otherwise.</returns>
+        public async Task<bool> CopyNupkgToStreamAsync(
+            PackageIdentity identity,
+            string url,
+            Stream destination,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            return await ProcessNupkgStreamAsync(
+                identity,
+                url,
+                stream => stream.CopyToAsync(destination, token),
+                cacheContext,
+                logger,
+                token);
+        }
+
+        /// <summary>
+        /// Manages the different ways of getting a .nupkg stream when using the global HTTP cache. When a stream is
+        /// found, the <paramref name="processStreamAsync"/> method is invoked on said stream. This deals with the
+        /// complexity of <see cref="SourceCacheContext.DirectDownload"/>.
+        /// </summary>
+        /// <param name="identity">The package identity.</param>
+        /// <param name="url">The URL of the .nupkg to fetch.</param>
+        /// <param name="processStreamAsync">The method to process the stream.</param>
+        /// <param name="cacheContext">The cache context.</param>
+        /// <param name="token">The cancellation token.</param>
+        /// <returns>
+        /// Returns true if the stream was processed, false if the stream could not fetched (either from the HTTP cache
+        /// or from the network).
+        /// </returns>
+        private async Task<bool> ProcessNupkgStreamAsync(
+            PackageIdentity identity,
+            string url,
+            Func<Stream, Task> processStreamAsync,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+
+            if (url == null)
+            {
+                throw new ArgumentNullException(nameof(url));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (cacheContext.DirectDownload)
+            {
+                // Don't read from the in-memory cache if we are doing a direct download.
+                var cacheEntry = await ProcessStreamAndGetCacheEntryAsync(
+                    identity,
+                    url,
+                    processStreamAsync,
+                    cacheContext,
+                    logger,
+                    token);
+
+                // If we get back a cache file result from the cache, we can save it to the in-memory cache.
+                lock (_cacheEntriesLock)
+                {
+                    if (cacheEntry.CacheFile != null && !_cacheEntries.ContainsKey(url))
+                    {
+                        _cacheEntries[url] = Task.FromResult(cacheEntry);
+                    }
+                }
+
+                // Process the NupkgEntry
+                return await ProcessCacheEntryAsync(cacheEntry, processStreamAsync, token);
+            }
+            else
+            {
+                // Try to get the NupkgEntry from the in-memory cache. If we find a match, we can open the cache file
+                // and use that as the source stream, instead of going to the package source.
+                Task<CacheEntry> nupkgEntryTask;
+                lock (_cacheEntriesLock)
+                {
+                    if (!_cacheEntries.TryGetValue(url, out nupkgEntryTask))
+                    {
+                        nupkgEntryTask = ProcessStreamAndGetCacheEntryAsync(
+                            identity,
+                            url,
+                            processStreamAsync,
+                            cacheContext,
+                            logger,
+                            token);
+
+                        _cacheEntries[url] = nupkgEntryTask;
+                    }
+                }
+
+                var nupkgEntry = await nupkgEntryTask;
+
+                return await ProcessCacheEntryAsync(nupkgEntry, processStreamAsync, token);
+            }
+        }
+
+        private async Task<CacheEntry> ProcessStreamAndGetCacheEntryAsync(
+            PackageIdentity identity,
+            string url,
+            Func<Stream, Task> processStreamAsync,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            return await ProcessHttpSourceResultAsync(
+                identity,
+                url,
+                async httpSourceResult =>
+                {
+                    if (httpSourceResult == null ||
+                        httpSourceResult.Stream == null)
+                    {
+                        return new CacheEntry(cacheFile: null, alreadyProcessed: false);
+                    }
+
+                    if (httpSourceResult.CacheFile != null)
+                    {
+                        // Return the cache file name so that the caller can open the cache file directly
+                        // and copy it to the destination stream.
+                        return new CacheEntry(httpSourceResult.CacheFile, alreadyProcessed: false);
+                    }
+                    else
+                    {
+                        await processStreamAsync(httpSourceResult.Stream);
+
+                        // When the stream came from the network directly, there is not cache file name. This
+                        // happens when the caller enables DirectDownload.
+                        return new CacheEntry(cacheFile: null, alreadyProcessed: true);
+                    }
+                },
+                cacheContext,
+                logger,
+                token);
+        }
+        
+        private async Task<T> ProcessHttpSourceResultAsync<T>(
+            PackageIdentity identity,
+            string url,
+            Func<HttpSourceResult, Task<T>> processAsync,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            for (var retry = 0; retry != 3; ++retry)
+            {
+                var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, retry);
+
+                try
+                {
+                    return await _httpSource.GetAsync(
+                        new HttpSourceCachedRequest(
+                            url,
+                            "nupkg_" + identity.Id + "." + identity.Version.ToNormalizedString(),
+                            httpSourceCacheContext)
+                        {
+                            EnsureValidContents = stream => HttpStreamValidation.ValidateNupkg(url, stream),
+                            IgnoreNotFounds = true
+                        },
+                        async httpSourceResult => await processAsync(httpSourceResult),
+                        logger,
+                        token);
+                }
+                catch (TaskCanceledException) when (retry < 2)
+                {
+                    // Requests can get cancelled if we got the data from elsewhere, no reason to warn.
+                    string message = string.Format(CultureInfo.CurrentCulture, Strings.Log_CanceledNupkgDownload, url);
+
+                    logger.LogMinimal(message);
+                }
+                catch (Exception ex) when (retry < 2)
+                {
+                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToDownloadPackage, url)
+                        + Environment.NewLine
+                        + ExceptionUtilities.DisplayMessage(ex);
+
+                    logger.LogMinimal(message);
+                }
+                catch (Exception ex) when (retry == 2)
+                {
+                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_FailedToDownloadPackage, url)
+                        + Environment.NewLine
+                        + ExceptionUtilities.DisplayMessage(ex);
+
+                    logger.LogError(message);
+                }
+            }
+
+            return await processAsync(null);
+        }
+
+        private async Task<bool> ProcessCacheEntryAsync(
+            CacheEntry cacheEntry,
+            Func<Stream, Task> processStreamAsync,
+            CancellationToken token)
+        {
+            if (cacheEntry.AlreadyProcessed)
+            {
+                return true;
+            }
+
+            if (cacheEntry.CacheFile == null)
+            {
+                return false;
+            }
+
+            // Acquire the lock on a file before we open it to prevent this process
+            // from opening a file deleted by another HTTP request.
+            using (var cacheStream = await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
+                cacheEntry.CacheFile,
+                lockedToken =>
+                {
+                    return Task.FromResult(new FileStream(
+                        cacheEntry.CacheFile,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.ReadWrite | FileShare.Delete,
+                        StreamExtensions.BufferSize,
+                        useAsync: true));
+                },
+                token))
+            {
+                await processStreamAsync(cacheStream);
+
+                return true;
+            }
+        }
+
+        private class CacheEntry
+        {
+            public CacheEntry(string cacheFile, bool alreadyProcessed)
+            {
+                CacheFile = cacheFile;
+                AlreadyProcessed = alreadyProcessed;
+            }
+            
+            public string CacheFile { get; }
+            public bool AlreadyProcessed { get; }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/GetDownloadResultUtility.cs
@@ -8,7 +8,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 
@@ -16,19 +15,24 @@ namespace NuGet.Protocol
 {
     public static class GetDownloadResultUtility
     {
+        private const int BufferSize = 8192;
+        private const string DirectDownloadExtension = ".nugetdirectdownload";
+        private const string DirectDownloadPattern = "*" + DirectDownloadExtension;
+
         public static async Task<DownloadResourceResult> GetDownloadResultAsync(
            HttpSource client,
            PackageIdentity identity,
            Uri uri,
-           ISettings settings,
+           PackageDownloadContext downloadContext,
+           string globalPackagesFolder,
            ILogger logger,
            CancellationToken token)
         {
-            // Uri is not null, so the package exists in the source
-            // Now, check if it is in the global packages folder, before, getting the package stream
-
-            // TODO: This code should respect no_cache settings and not write or read packages from the global packages folder
-            var packageFromGlobalPackages = GlobalPackagesFolderUtility.GetPackage(identity, settings);
+            // This code should respect -NoCache option and not read packages from the global
+            // packages folder: https://github.com/NuGet/Home/issues/1406
+            var packageFromGlobalPackages = GlobalPackagesFolderUtility.GetPackage(
+                identity,
+                globalPackagesFolder);
 
             if (packageFromGlobalPackages != null)
             {
@@ -51,12 +55,23 @@ namespace NuGet.Protocol
                                 return new DownloadResourceResult(DownloadResourceResultStatus.NotFound);
                             }
 
-                            return await GlobalPackagesFolderUtility.AddPackageAsync(
-                                identity,
-                                packageStream,
-                                settings,
-                                logger,
-                                token);
+                            if (downloadContext.DirectDownload)
+                            {
+                                return await DirectDownloadAsync(
+                                    identity,
+                                    packageStream,
+                                    downloadContext,
+                                    token);
+                            }
+                            else
+                            {
+                                return await GlobalPackagesFolderUtility.AddPackageAsync(
+                                    identity,
+                                    packageStream,
+                                    globalPackagesFolder,
+                                    logger,
+                                    token);
+                            }
                         },
                         logger,
                         token);
@@ -85,6 +100,95 @@ namespace NuGet.Protocol
             }
 
             throw new InvalidOperationException("Reached an unexpected point in the code");
+        }
+
+        /// <summary>
+        /// Allow explicit clean-up of direct download files. This is important because although direct downloads are
+        /// opened with the <see cref="FileOptions.DeleteOnClose"/> option, some systems (e.g. Linux) do not perform
+        /// the delete if the process dies. Additionally, if the system dies before the process dies (e.g. loss of
+        /// power), the direct download files will be left over.
+        /// </summary>
+        /// <param name="downloadContext">The download context.</param>
+        public static void CleanUpDirectDownloads(PackageDownloadContext downloadContext)
+        {
+            foreach (var file in Directory.EnumerateFiles(
+                downloadContext.DirectDownloadDirectory,
+                DirectDownloadPattern,
+                SearchOption.TopDirectoryOnly))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (Exception e) when (e is UnauthorizedAccessException ||
+                                          e is IOException)
+                {
+                    // Ignore exceptions indicating the file has permissions protecting it or if the file is in use.
+                }
+            }
+        }
+
+        private static async Task<DownloadResourceResult> DirectDownloadAsync(
+            PackageIdentity packageIdentity,
+            Stream packageStream,
+            PackageDownloadContext downloadContext,
+            CancellationToken token)
+        {
+            if (packageIdentity == null)
+            {
+                throw new ArgumentNullException(nameof(packageIdentity));
+            }
+
+            if (packageStream == null)
+            {
+                throw new ArgumentNullException(nameof(packageStream));
+            }
+
+            if (downloadContext == null)
+            {
+                throw new ArgumentNullException(nameof(downloadContext));
+            }
+
+            // Build a file name for the package that is being downloaded. The caller provided the directory that
+            // should be written to, but a random file name is used to avoid the necessity of locking. The caller
+            // provides a directory so that a high performance or local drive can be used (instead of the %TEMP%
+            // directory which can be different from the extraction location). The random file name is not just a
+            // performance optimization. This also means that future versions of NuGet can co-exist with this
+            // extraction code since the random component is specifically designed to avoid collisions.
+            var randomComponent = Path.GetRandomFileName();
+            var fileName = $"{randomComponent}{DirectDownloadExtension}";
+            var directDownloadPath = Path.Combine(downloadContext.DirectDownloadDirectory, fileName);
+
+            FileStream fileStream = null;
+
+            try
+            {
+                Directory.CreateDirectory(downloadContext.DirectDownloadDirectory);
+
+                // Use DeleteOnClose when opening this stream since this file is just used for for the package
+                // extraction. This file is meant to be ephemeral because package extraction does not always result
+                // in a .nupkg on disk. Even if a .nupkg is in the extraction result (via PackageSaveMode.Nupkg), it
+                // is not written to disk first, as is happening here.
+                fileStream = new FileStream(
+                   directDownloadPath,
+                   FileMode.Create,
+                   FileAccess.ReadWrite,
+                   FileShare.Read,
+                   BufferSize,
+                   FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+
+                await packageStream.CopyToAsync(fileStream, BufferSize, token);
+
+                fileStream.Seek(0, SeekOrigin.Begin);
+
+                return new DownloadResourceResult(fileStream);
+            }
+            catch
+            {
+                fileStream?.Dispose();
+
+                throw;
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/StreamExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NuGet.Protocol
+{
+    public static class StreamExtensions
+    {
+        public static readonly int BufferSize = 8192;
+
+        public static async Task CopyToAsync(this Stream stream, Stream destination, CancellationToken token)
+        {
+            await stream.CopyToAsync(destination, BufferSize, token);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -34,9 +34,29 @@ namespace Test.Utility
         {
         }
 
+        public bool DisableCaching { get; set; } = true;
+        public int CacheHits { get; private set; }
+        public int CacheMisses { get; private set; }
+
         protected override Stream TryReadCacheFile(string uri, TimeSpan maxAge, string cacheFile)
         {
-            return null;
+            if (DisableCaching)
+            {
+                return null;
+            }
+            
+            var result = base.TryReadCacheFile(uri, maxAge, cacheFile);
+            
+            if (result == null)
+            {
+                CacheMisses++;
+            }
+            else
+            {
+                CacheHits++;
+            }
+
+            return result;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestRunner.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTestRunner.cs
@@ -8,12 +8,18 @@ namespace NuGet.CommandLine.Test.Caching
     {
         public static async Task<CachingValidations> ExecuteAsync(ICachingTest test, ICachingCommand command, INuGetExe nuGetExe, CachingType caching, ServerType server)
         {
-            var testFolder = TestFileSystemUtility.CreateRandomTestFolder();
+            using (var testFolder = TestFileSystemUtility.CreateRandomTestFolder())
             using (var mockServer = new MockServer())
             {
                 var tc = new CachingTestContext(testFolder, mockServer, nuGetExe);
 
+                // Enable this flag to launch the debugger when the nuget.exe process starts. This also increases
+                // logging verbosity and command timeout.
+                //
+                // tc.Debug = true;
+
                 tc.NoCache = caching.HasFlag(CachingType.NoCache);
+                tc.DirectDownload = caching.HasFlag(CachingType.DirectDownload);
                 tc.CurrentSource = server == ServerType.V2 ? tc.V2Source : tc.V3Source;
 
                 tc.ClearHttpCache();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -7,9 +10,9 @@ namespace NuGet.CommandLine.Test.Caching
     /// <summary>
     /// The thought behind this test suite is to validate every permutation of test matrix comprised
     /// of the following variables:
-    /// - Installation command (implementations of ICachingCommand)
     /// - Caching aspect (implementation of ICachingTest)
-    /// - NoCache argument enabled or disabled
+    /// - Installation command (implementations of ICachingCommand)
+    /// - Caching options (NoCache or DirectDownload)
     /// - Server type (V2 or V3)
     /// </summary>
     public class CachingTests
@@ -22,19 +25,35 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
-        public async Task NuGetExe_Caching_InstallsToDestinationFolder(Type commandType, CachingType caching, ServerType server)
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
+        public async Task NuGetExe_Caching_InstallsToDestinationFolder(Type type, CachingType caching, ServerType server)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -42,7 +61,7 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(InstallsToDestinationFolderTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
@@ -61,19 +80,35 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, true, false)] // Should either fail or install?
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true, false)] // Should either fail or install?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, true)] // Should fail?
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, true)] // Should fail?
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, true, true)] // Should fail?
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
-        public async Task NuGetExe_Caching_AllowsMissingPackageOnSource(Type commandType, CachingType caching, ServerType server, bool success, bool installed)
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true, true)] // Should fail?
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, true)] // Should fail?
+        public async Task NuGetExe_Caching_AllowsMissingPackageOnSource(Type type, CachingType caching, ServerType server, bool success, bool installed)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -81,7 +116,7 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(AllowsMissingPackageOnSourceTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
@@ -92,26 +127,44 @@ namespace NuGet.CommandLine.Test.Caching
         }
 
         /// <summary>
-        /// There is currently no way to disable populating the global packages folder.
+        /// The -DirectDownload switch allows the users to skip the writing a package to the global packages directory.
+        /// This does not apply to a project.json restore since the global packages directory itself is considering the
+        /// destination directory.
         /// </summary>
         [Theory]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
-        public async Task NuGetExe_Caching_PopulatesGlobalPackagesFolder(Type commandType, CachingType caching, ServerType server)
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true)]
+        public async Task NuGetExe_Caching_PopulatesGlobalPackagesFolder(Type type, CachingType caching, ServerType server, bool success)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -119,14 +172,14 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(PopulatesGlobalPackagesFolderTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
 
             // Assert
             validations.Assert(CachingValidationType.CommandSucceeded, true);
-            validations.Assert(CachingValidationType.PackageInGlobalPackagesFolder, true);
+            validations.Assert(CachingValidationType.PackageInGlobalPackagesFolder, success);
         }
 
         /// <summary>
@@ -137,19 +190,35 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
-        public async Task NuGetExe_Caching_UsesGlobalPackagesFolderCopy(Type commandType, CachingType caching, ServerType server)
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
+        public async Task NuGetExe_Caching_UsesGlobalPackagesFolderCopy(Type type, CachingType caching, ServerType server)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -157,7 +226,7 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(UsesGlobalPackagesFolderCopyTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
@@ -179,19 +248,35 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, false)]
-        public async Task NuGetExe_Caching_UsesHttpCacheCopy(Type commandType, CachingType caching, ServerType server, bool success)
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        public async Task NuGetExe_Caching_UsesHttpCacheCopy(Type type, CachingType caching, ServerType server, bool success)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -199,7 +284,7 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(UsesHttpCacheCopyTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
@@ -221,19 +306,35 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, false)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, false)]
-        public async Task NuGetExe_Caching_WritesToHttpCacheTest(Type commandType, CachingType caching, ServerType server, bool success)
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        public async Task NuGetExe_Caching_WritesToHttpCache(Type type, CachingType caching, ServerType server, bool success)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -241,7 +342,7 @@ namespace NuGet.CommandLine.Test.Caching
             // Act
             var validations = await CachingTestRunner.ExecuteAsync(
                 typeof(WritesToHttpCacheTest),
-                commandType,
+                type,
                 nuGetExe,
                 caching,
                 server);
@@ -251,11 +352,68 @@ namespace NuGet.CommandLine.Test.Caching
             validations.Assert(CachingValidationType.PackageInHttpCache, success);
         }
 
+        /// <summary>
+        /// project.json restores do not use .nugetdirectdownload temporary files. Also, when you do not specify
+        /// -DirectDownload, .nugetdirectdownload files are not cleaned up.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        public async Task NuGetExe_Caching_CleansUpDirectDownload(Type type, CachingType caching, ServerType server, bool success)
+        {
+            // Arrange
+            var nuGetExe = await GetNuGetExeAsync();
+
+            // Act
+            var validations = await CachingTestRunner.ExecuteAsync(
+                typeof(CleansUpDirectDownloadTest),
+                type,
+                nuGetExe,
+                caching,
+                server);
+
+            // Assert
+            validations.Assert(CachingValidationType.CommandSucceeded, true);
+            validations.Assert(CachingValidationType.DirectDownloadFilesDoNotExist, success);
+        }
+
         private static async Task<INuGetExe> GetNuGetExeAsync()
         {
             await Task.Yield();
-            
-            return NuGetExe.GetBuiltNuGetExe();
+
+            var nuGetExe = NuGetExe.GetBuiltNuGetExe();
+
+            return nuGetExe;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingType.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingType.cs
@@ -6,6 +6,7 @@ namespace NuGet.CommandLine.Test.Caching
     public enum CachingType
     {
         Default = 0,
-        NoCache = 1
+        NoCache = 1,
+        DirectDownload = 2
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidation.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidation.cs
@@ -70,6 +70,14 @@ namespace NuGet.CommandLine.Test.Caching
                     True = "The package from the global packages folder was used.",
                     False = "The package from the global packages folder was not used."
                 }
+            },
+            {
+                CachingValidationType.DirectDownloadFilesDoNotExist,
+                new Messages
+                {
+                    True = "The direct download files were cleaned up.",
+                    False = "The direct download files were not cleaned up."
+                }
             }
         };
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidationType.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/CachingValidationType.cs
@@ -9,6 +9,7 @@
         PackageFromHttpCacheUsed,
         PackageFromSourceUsed,
         PackageFromSourceNotUsed,
-        PackageFromGlobalPackagesFolderUsed
+        PackageFromGlobalPackagesFolderUsed,
+        DirectDownloadFilesDoNotExist,
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/INuGetExe.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/INuGetExe.cs
@@ -5,6 +5,7 @@ namespace NuGet.CommandLine.Test.Caching
 {
     public interface INuGetExe
     {
+        void ClearHttpCache(CachingTestContext context);
         string GetHttpCachePath(CachingTestContext context);
         CommandRunnerResult Execute(CachingTestContext context, string args);
     }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/NuGetExe.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/NuGetExe/NuGetExe.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -11,114 +10,165 @@ namespace NuGet.CommandLine.Test.Caching
 {
     public class NuGetExe : INuGetExe
     {
-        private static ConcurrentDictionary<string, Task<NuGetExe>> _verifiedNuGetExe
-            = new ConcurrentDictionary<string, Task<NuGetExe>>();
+        private static ConcurrentDictionary<string, Task<string>> _verifiedPaths
+            = new ConcurrentDictionary<string, Task<string>>();
 
-        private NuGetExe(string pathToExe)
+        private readonly string _pathToExe;
+        private readonly bool _supportsIsolatedHttpCache;
+        private bool _hasExecuted;
+
+        private NuGetExe(string pathToExe, bool supportsIsolatedHttpCache)
         {
-            PathToExe = pathToExe;
-        }
-
-        public string PathToExe { get; }
-
-        public bool Debug { get; set; }
-
-        public CommandRunnerResult Execute(CachingTestContext context, string args)
-        {
-            var timeout = 60 * 1000 * 1;
-            if (Debug)
-            {
-                args += " --debug -Verbosity detailed";
-                timeout *= 60;
-            }
-
-            return CommandRunner.Run(
-                PathToExe,
-                context.WorkingPath,
-                args,
-                timeOutInMilliseconds: timeout,
-                waitForExit: true,
-                environmentVariables: new Dictionary<string, string>
-                {
-                    { "NUGET_PACKAGES", context.GlobalPackagesPath },
-                    { "NUGET_HTTP_CACHE_PATH", context.IsolatedHttpCachePath }
-                });
+            _pathToExe = pathToExe;
+            _supportsIsolatedHttpCache = supportsIsolatedHttpCache;
+            _hasExecuted = false;
         }
 
         public string GetHttpCachePath(CachingTestContext context)
         {
-            var result = Execute(context, "locals http-cache -list");
+            if (_supportsIsolatedHttpCache)
+            {
+                return context.IsolatedHttpCachePath;
+            }
+            else
+            {
+                var result = Execute(context, "locals http-cache -list", debug: false);
 
-            var stdout = result.Item2.Trim();
+                var stdout = result.Item2.Trim();
 
-            // Example:
-            //   stdout = http-cache: C:\Users\jver\AppData\Local\NuGet\v3-cache
-            //   path   = C:\Users\jver\AppData\Local\NuGet\v3-cache
-            var path = stdout.Split(new[] { ':' }, 2)[1].Trim();
+                // Example:
+                //   stdout = http-cache: C:\Users\jver\AppData\Local\NuGet\v3-cache
+                //   path   = C:\Users\jver\AppData\Local\NuGet\v3-cache
+                var path = stdout.Split(new[] { ':' }, 2)[1].Trim();
 
-            return path;
+                return path;
+            }
+        }
+
+        public void ClearHttpCache(CachingTestContext context)
+        {
+            if (_supportsIsolatedHttpCache)
+            {
+                if (_hasExecuted)
+                {
+                    Directory.Delete(context.IsolatedHttpCachePath, recursive: true);
+                }
+                else
+                {
+                    // Do nothing, the HTTP cache is still clean.
+                }
+            }
+            else
+            {
+                Execute(context, "locals http-cache -Clear", debug: false);
+            }
+        }
+
+        public CommandRunnerResult Execute(CachingTestContext context, string args)
+        {
+            return Execute(context, args, context.Debug);
+        }
+
+        private CommandRunnerResult Execute(CachingTestContext context, string args, bool debug)
+        {
+            _hasExecuted = true;
+
+            var timeout = 60 * 1000 * 1;
+            if (debug)
+            {
+                args += " -Verbosity detailed --debug";
+                timeout *= 60;
+            }
+
+            var environmentVariables = new Dictionary<string, string>
+            {
+                { "NUGET_PACKAGES", context.GlobalPackagesPath }
+            };
+
+            if (_supportsIsolatedHttpCache)
+            {
+                environmentVariables["NUGET_HTTP_CACHE_PATH"] = context.IsolatedHttpCachePath;
+            }
+
+            return CommandRunner.Run(
+                _pathToExe,
+                context.WorkingPath,
+                args,
+                timeOutInMilliseconds: timeout,
+                waitForExit: true,
+                environmentVariables: environmentVariables);
         }
 
         public static async Task<NuGetExe> Get320Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.2.0/nuget.exe",
-                "nuget.3.2.0.exe");
+                "nuget.3.2.0.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get330Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe",
-                "nuget.3.3.0.exe");
+                "nuget.3.3.0.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get340RcAsync()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.4.0-rc/nuget.exe",
-                "nuget.3.4.3-rc.exe");
+                "nuget.3.4.3-rc.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get343Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.4.3/nuget.exe",
-                "nuget.3.4.3.exe");
+                "nuget.3.4.3.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get344Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe",
-                "nuget.3.4.4.exe");
+                "nuget.3.4.4.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get350Beta2Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.5.0-beta2/NuGet.exe",
-                "nuget.3.5.0-beta2.exe");
+                "nuget.3.5.0-beta2.exe",
+                supportsIsolatedHttpCache: false);
         }
 
         public static async Task<NuGetExe> Get350Rc1Async()
         {
             return await DownloadNuGetExeAsync(
                 "https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe",
-                "nuget.3.5.0-rc1.exe");
+                "nuget.3.5.0-rc1.exe",
+                supportsIsolatedHttpCache: true);
         }
 
         public static NuGetExe GetBuiltNuGetExe()
         {
-            return new NuGetExe(Util.GetNuGetExePath());
+            return new NuGetExe(Util.GetNuGetExePath(), supportsIsolatedHttpCache: true);
         }
 
-        private static async Task<NuGetExe> DownloadNuGetExeAsync(string requestUri, string fileName)
+        private static async Task<NuGetExe> DownloadNuGetExeAsync(
+            string requestUri,
+            string fileName,
+            bool supportsIsolatedHttpCache)
         {
             var temp = NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp);
             var path = Path.Combine(temp, fileName);
 
-            return await _verifiedNuGetExe.GetOrAdd(
+            var verifiedPath = await _verifiedPaths.GetOrAdd(
                 path,
                 thisPath => ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                     thisPath,
@@ -128,14 +178,14 @@ namespace NuGet.CommandLine.Test.Caching
                         {
                             // Make sure we can run the executable.
                             var helpResult = CommandRunner.Run(
-                                    thisPath,
-                                    ".",
-                                    "help",
-                                    waitForExit: true);
+                                thisPath,
+                                ".",
+                                "help",
+                                waitForExit: true);
 
                             if (helpResult.Item1 == 0)
                             {
-                                return new NuGetExe(thisPath);
+                                return thisPath;
                             }
                         }
 
@@ -147,9 +197,11 @@ namespace NuGet.CommandLine.Test.Caching
                             await stream.CopyToAsync(fileStream);
                         }
 
-                        return new NuGetExe(thisPath);
+                        return thisPath;
                     },
                     CancellationToken.None));
+
+            return new NuGetExe(verifiedPath, supportsIsolatedHttpCache);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/CleansUpDirectDownloadTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Caching/Tests/CleansUpDirectDownloadTest.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Test.Utility;
+
+namespace NuGet.CommandLine.Test.Caching
+{
+    public class CleansUpDirectDownloadTest : ICachingTest
+    {
+        public string Description => "Cleans up leftover .nugetdirectdownload files in the destination directory";
+
+        public Task<string> PrepareTestAsync(CachingTestContext context, ICachingCommand command)
+        {
+            // Populate the output packages path with a leftover .directdownload file.
+            Directory.CreateDirectory(context.OutputPackagesPath);
+            var path = Path.Combine(context.OutputPackagesPath, $"leftover.nugetdirectdownload");
+            File.WriteAllText(path, string.Empty);
+
+            var args = command.PrepareArguments(context, context.PackageIdentityA);
+
+            return Task.FromResult(args);
+        }
+
+        public CachingValidations Validate(CachingTestContext context, ICachingCommand command, CommandRunnerResult result)
+        {
+            var validations = new CachingValidations();
+
+            validations.Add(
+                CachingValidationType.CommandSucceeded,
+                result.Item1 == 0);
+
+            validations.Add(
+                CachingValidationType.DirectDownloadFilesDoNotExist,
+                !Directory.EnumerateFiles(context.OutputPackagesPath, "*.nugetdirectdownload").Any());
+
+            return validations;
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Caching\Commands\RestorePackagesConfigCommand.cs" />
     <Compile Include="Caching\Commands\RestoreProjectJsonCommand.cs" />
     <Compile Include="Caching\Tests\ReadsFromHttpCacheTest.cs" />
+    <Compile Include="Caching\Tests\CleansUpDirectDownloadTest.cs" />
     <Compile Include="Caching\Tests\WritesToHttpCacheTest.cs" />
     <Compile Include="Caching\Tests\PopulatesGlobalPackagesFolderTest.cs" />
     <Compile Include="Caching\Tests\PopulatesDestinationFolderTest.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -13,6 +13,8 @@ using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using Xunit;
 using System.Text.RegularExpressions;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol;
 
 namespace NuGet.CommandLine.Test
 {

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1915,23 +1915,25 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var context = new SourceCacheContext();
-                context.IgnoreFailedSources = true;
-                var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
+                using (var context = new SourceCacheContext())
+                {
+                    context.IgnoreFailedSources = true;
+                    var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
-                var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
-                var request = new RestoreRequest(spec, provider, logger);
+                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
+                    var request = new RestoreRequest(spec, provider, logger);
 
-                request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+                    request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
-                var lockFileFormat = new LockFileFormat();
-                var command = new RestoreCommand(request);
+                    var lockFileFormat = new LockFileFormat();
+                    var command = new RestoreCommand(request);
 
-                // Act
-                var result = await command.ExecuteAsync();
+                    // Act
+                    var result = await command.ExecuteAsync();
 
-                // Assert
-                Assert.True(result.Success);
+                    // Assert
+                    Assert.True(result.Success);
+                }
             }
         }
 
@@ -1960,23 +1962,25 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var context = new SourceCacheContext();
-                context.IgnoreFailedSources = true;
-                var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
+                using (var context = new SourceCacheContext())
+                {
+                    context.IgnoreFailedSources = true;
+                    var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
-                var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
-                var request = new RestoreRequest(spec, provider, logger);
+                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
+                    var request = new RestoreRequest(spec, provider, logger);
 
-                request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
+                    request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
-                var lockFileFormat = new LockFileFormat();
-                var command = new RestoreCommand(request);
+                    var lockFileFormat = new LockFileFormat();
+                    var command = new RestoreCommand(request);
 
-                // Act
-                var result = await command.ExecuteAsync();
+                    // Act
+                    var result = await command.ExecuteAsync();
 
-                // Assert
-                Assert.True(result.Success);
+                    // Assert
+                    Assert.True(result.Success);
+                }
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/DownloadResourceV2FeedTests.cs
@@ -26,10 +26,14 @@ namespace NuGet.Protocol.FuncTest
             var package = new SourcePackageDependencyInfo("WindowsAzure.Storage", new NuGetVersion("6.2.0"), null, true, repo, new Uri($@"{TestServers.NuGetV2}/package/WindowsAzure.Storage/6.2.0"), "");
 
             // Act & Assert
-            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None))
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
                 var packageReader = downloadResult.PackageReader;
                 var files = packageReader.GetFiles();
@@ -49,10 +53,14 @@ namespace NuGet.Protocol.FuncTest
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0"));
 
             // Act & Assert
-            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(package,
-                                                              NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None))
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await downloadResource.GetDownloadResourceResultAsync(
+                package,
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
             {
                 var packageReader = downloadResult.PackageReader;
                 var files = packageReader.GetFiles();
@@ -71,16 +79,21 @@ namespace NuGet.Protocol.FuncTest
 
             var package = new SourcePackageDependencyInfo("not-found", new NuGetVersion("6.2.0"), null, true, repo, new Uri($@"{TestServers.NuGetV2}/package/not-found/6.2.0"), "");
 
-            // Act 
-            var actual = await downloadResource.GetDownloadResourceResultAsync(
-                package,
-                NullSettings.Instance,
-                NullLogger.Instance,
-                CancellationToken.None);
+            // Act
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var actual = await downloadResource.GetDownloadResourceResultAsync(
+                    package,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None);
 
-            // Assert
-            Assert.NotNull(actual);
-            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+                // Assert
+                Assert.NotNull(actual);
+                Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+            }
         }
 
         [Fact]

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
@@ -21,16 +21,19 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("1.0", packages.FirstOrDefault().ToString());
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
+
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("1.0", packages.FirstOrDefault().ToString());
+            }
         }
 
         [Theory]
@@ -43,16 +46,19 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("1.3.3.0", packages.FirstOrDefault().ToString());
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
+
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("1.3.3.0", packages.FirstOrDefault().ToString());
+            }
         }
 
         [Theory]
@@ -65,21 +71,23 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("8.0.3", packages.FirstOrDefault().ToString());
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("8.0.3", packages.FirstOrDefault().ToString());
+            }
         }
 
         [Theory]
         [InlineData(TestServers.NuGetServer, "NuGetServer")]
-        [InlineData(TestServers.Vsts,"Vsts")]
+        [InlineData(TestServers.Vsts, "Vsts")]
         public async Task FindPackageByIdResource_Credential(string packageSource, string feedName)
         {
             // Arrange
@@ -89,16 +97,19 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("8.0.3", packages.FirstOrDefault().ToString());
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
+
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("8.0.3", packages.FirstOrDefault().ToString());
+            }
         }
 
         [Theory]
@@ -113,16 +124,18 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("1.3.3.0", packages.FirstOrDefault().ToString());
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("1.3.3.0", packages.FirstOrDefault().ToString());
+            }
         }
 
         [Theory]
@@ -137,16 +150,18 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var context = new SourceCacheContext();
-            context.NoCache = true;
-            findPackageByIdResource.CacheContext = context;
+            using (var context = new SourceCacheContext())
+            {
+                context.NoCache = true;
+                findPackageByIdResource.CacheContext = context;
 
-            // Act
-            var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
+                // Act
+                var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
 
-            // Assert
-            Assert.Equal(1, packages.Count());
-            Assert.Equal("1.0", packages.FirstOrDefault().ToString());
+                // Assert
+                Assert.Equal(1, packages.Count());
+                Assert.Equal("1.0", packages.FirstOrDefault().ToString());
+            }
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.FuncTest
         [Fact]
         public async Task V2FeedParser_DownloadFromInvalidUrl()
         {
-            // Arrange
+        // Arrange
             var randomName = Guid.NewGuid().ToString();
             var repo = Repository.Factory.GetCoreV3(TestServers.NuGetV2);
 
@@ -26,15 +26,22 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, TestServers.NuGetV2);
 
             // Act 
-            Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(async () => await parser.DownloadFromUrl(new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
-                                                              new Uri($"https://www.{randomName}.org/api/v2/"),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None));
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                Exception ex = await Assert.ThrowsAsync<FatalProtocolException>(
+                    async () => await parser.DownloadFromUrl(
+                        new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
+                        new Uri($"https://www.{randomName}.org/api/v2/"),
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        NullLogger.Instance,
+                        CancellationToken.None));
 
-            // Assert
-            Assert.NotNull(ex);
-            Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
+                // Assert
+                Assert.NotNull(ex);
+                Assert.Equal($"Error downloading 'not-found.6.2.0' from 'https://www.{randomName}.org/api/v2/'.", ex.Message);
+            }
         }
 
         [Fact]
@@ -48,15 +55,21 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, TestServers.NuGetV2);
 
             // Act 
-            var actual = await parser.DownloadFromUrl(new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
-                new Uri($@"{TestServers.NuGetV2}/package/not-found/6.2.0"),
-                Configuration.NullSettings.Instance,
-                NullLogger.Instance,
-                CancellationToken.None);
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var actual = await parser.DownloadFromUrl(
+                    new PackageIdentity("not-found", new NuGetVersion("6.2.0")),
+                    new Uri($@"{TestServers.NuGetV2}/package/not-found/6.2.0"),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None);
 
-            // Assert
-            Assert.NotNull(actual);
-            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+                // Assert
+                Assert.NotNull(actual);
+                Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+            }
         }
 
         [Fact]
@@ -70,15 +83,21 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, TestServers.NuGetV2);
 
             // Act & Assert
-            using (var downloadResult = await parser.DownloadFromIdentity(new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None))
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                using (var downloadResult = await parser.DownloadFromIdentity(
+                    new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
 
-                Assert.Equal(11, files.Count());
+                    Assert.Equal(11, files.Count());
+                }
             }
         }
 
@@ -118,15 +137,21 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, packageSource);
 
             // Act & Assert
-            using (var downloadResult = await parser.DownloadFromIdentity(new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None))
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                using (var downloadResult = await parser.DownloadFromIdentity(
+                    new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
 
-                Assert.Equal(15, files.Count());
+                    Assert.Equal(15, files.Count());
+                }
             }
         }
 
@@ -254,15 +279,21 @@ namespace NuGet.Protocol.FuncTest
             V2FeedParser parser = new V2FeedParser(httpSource, packageSource);
 
             // Act & Assert
-            using (var downloadResult = await parser.DownloadFromIdentity(new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
-                                                              Configuration.NullSettings.Instance,
-                                                              NullLogger.Instance,
-                                                              CancellationToken.None))
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
             {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
+                using (var downloadResult = await parser.DownloadFromIdentity(
+                    new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None))
+                {
+                    var packageReader = downloadResult.PackageReader;
+                    var files = packageReader.GetFiles();
 
-                Assert.Equal(15, files.Count());
+                    Assert.Equal(15, files.Count());
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
@@ -81,16 +81,19 @@ namespace NuGet.Commands.Test
                 File.WriteAllText(p3, EmptyProjectJson);
 
                 var context = new RestoreArgs();
-                context.CacheContext = new SourceCacheContext();
-                context.Log = new TestLogger();
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    context.CacheContext = cacheContext;
+                    context.Log = new TestLogger();
 
-                // Act
-                var supports = await provider.Supports(workingDir);
-                var requests = await provider.CreateRequests(workingDir, context);
+                    // Act
+                    var supports = await provider.Supports(workingDir);
+                    var requests = await provider.CreateRequests(workingDir, context);
 
-                // Assert
-                Assert.Equal(true, supports);
-                Assert.Equal(3, requests.Count);
+                    // Assert
+                    Assert.Equal(true, supports);
+                    Assert.Equal(3, requests.Count);
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -57,29 +57,32 @@ namespace NuGet.Commands.Test
 
                 var providerCache = new RestoreCommandProvidersCache();
 
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    GlobalPackagesFolder = packagesDir.FullName,
-                    Sources = new List<string>() { packageSource.FullName },
-                    Inputs = new List<string>() { specPath1 },
-                    Log = logger,
-                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        GlobalPackagesFolder = packagesDir.FullName,
+                        Sources = new List<string>() { packageSource.FullName },
+                        Inputs = new List<string>() { specPath1 },
+                        Log = logger,
+                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                            new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
-                var summary = summaries.Single();
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summary = summaries.Single();
 
-                // Assert
-                Assert.True(summary.Success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.Equal(1, summary.FeedsUsed.Count);
-                Assert.True(File.Exists(lockPath), lockPath);
+                    // Assert
+                    Assert.True(summary.Success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                    Assert.Equal(1, summary.FeedsUsed.Count);
+                    Assert.True(File.Exists(lockPath), lockPath);
+                }
             }
         }
 
@@ -133,29 +136,32 @@ namespace NuGet.Commands.Test
 
                 var providerCache = new RestoreCommandProvidersCache();
 
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    GlobalPackagesFolder = packagesDir.FullName,
-                    ConfigFile = configPath,
-                    Inputs = new List<string>() { specPath1 },
-                    Log = logger,
-                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(new List<PackageSource>())),
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        GlobalPackagesFolder = packagesDir.FullName,
+                        ConfigFile = configPath,
+                        Inputs = new List<string>() { specPath1 },
+                        Log = logger,
+                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(new List<PackageSource>())),
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                            new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
-                var summary = summaries.Single();
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summary = summaries.Single();
 
-                // Assert
-                Assert.True(summary.Success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.Equal(1, summary.FeedsUsed.Count);
-                Assert.True(File.Exists(lockPath), lockPath);
+                    // Assert
+                    Assert.True(summary.Success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                    Assert.Equal(1, summary.FeedsUsed.Count);
+                    Assert.True(File.Exists(lockPath), lockPath);
+                }
             }
         }
 
@@ -236,36 +242,38 @@ namespace NuGet.Commands.Test
 
                 var providerCache = new RestoreCommandProvidersCache();
 
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    GlobalPackagesFolder = packagesDir.FullName,
-                    Sources = new List<string>() { packageSource.FullName },
-                    Inputs = new List<string>() { dgPath },
-                    Log = logger,
-                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new MSBuildP2PRestoreRequestProvider(providerCache),
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        GlobalPackagesFolder = packagesDir.FullName,
+                        Sources = new List<string>() { packageSource.FullName },
+                        Inputs = new List<string>() { dgPath },
+                        Log = logger,
+                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                            new MSBuildP2PRestoreRequestProvider(providerCache),
+                            new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
-                var success = summaries.All(s => s.Success);
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var success = summaries.All(s => s.Success);
 
-                var lockFormat = new LockFileFormat();
-                var lockFile1 = lockFormat.Read(lockPath1);
-                var project2Lib = lockFile1.Libraries.First();
+                    var lockFormat = new LockFileFormat();
+                    var lockFile1 = lockFormat.Read(lockPath1);
+                    var project2Lib = lockFile1.Libraries.First();
 
-                // Assert
-                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.True(File.Exists(lockPath1), lockPath1);
-                Assert.True(File.Exists(lockPath2), lockPath2);
-                Assert.Equal("project2", project2Lib.Name);
+                    // Assert
+                    Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                    Assert.True(File.Exists(lockPath1), lockPath1);
+                    Assert.True(File.Exists(lockPath2), lockPath2);
+                    Assert.Equal("project2", project2Lib.Name);
+                }
             }
         }
 
@@ -332,31 +340,33 @@ namespace NuGet.Commands.Test
 
                 var providerCache = new RestoreCommandProvidersCache();
 
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    GlobalPackagesFolder = packagesDir.FullName,
-                    Sources = new List<string>() { packageSource.FullName },
-                    Inputs = new List<string>() { workingDir },
-                    Log = logger,
-                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new MSBuildP2PRestoreRequestProvider(providerCache),
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        GlobalPackagesFolder = packagesDir.FullName,
+                        Sources = new List<string>() { packageSource.FullName },
+                        Inputs = new List<string>() { workingDir },
+                        Log = logger,
+                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                            new MSBuildP2PRestoreRequestProvider(providerCache),
+                            new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
-                var success = summaries.All(s => s.Success);
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var success = summaries.All(s => s.Success);
 
-                // Assert
-                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.True(File.Exists(lockPath1), lockPath1);
-                Assert.True(File.Exists(lockPath2), lockPath2);
+                    // Assert
+                    Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                    Assert.True(File.Exists(lockPath1), lockPath1);
+                    Assert.True(File.Exists(lockPath2), lockPath2);
+                }
             }
         }
 
@@ -402,33 +412,36 @@ namespace NuGet.Commands.Test
 
                 var providerCache = new RestoreCommandProvidersCache();
 
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    GlobalPackagesFolder = packagesDir.FullName,
-                    Sources = new List<string>() { packageSource.FullName },
-                    Inputs = new List<string>() { specPath1 },
-                    Log = logger,
-                    CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        GlobalPackagesFolder = packagesDir.FullName,
+                        Sources = new List<string>() { packageSource.FullName },
+                        Inputs = new List<string>() { specPath1 },
+                        Log = logger,
+                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                             new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                restoreContext.Runtimes.Add("linux-x86");
+                    restoreContext.Runtimes.Add("linux-x86");
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
-                var success = summaries.All(s => s.Success);
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var success = summaries.All(s => s.Success);
 
-                var lockFormat = new LockFileFormat();
-                var lockFile = lockFormat.Read(lockPath1);
+                    var lockFormat = new LockFileFormat();
+                    var lockFile = lockFormat.Read(lockPath1);
 
-                // Assert
-                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.True(lockFile.Targets.Any(graph => graph.RuntimeIdentifier == "linux-x86"));
+                    // Assert
+                    Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                    Assert.True(lockFile.Targets.Any(graph => graph.RuntimeIdentifier == "linux-x86"));
+                }
             }
         }
 
@@ -443,25 +456,28 @@ namespace NuGet.Commands.Test
                 // Arrange
                 var logger = new TestLogger();
                 var providerCache = new RestoreCommandProvidersCache();
-                var restoreContext = new RestoreArgs()
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    CacheContext = new SourceCacheContext(),
-                    DisableParallel = true,
-                    Inputs = new List<string>() { workingDir },
-                    Log = logger,
-                    RequestProviders = new List<IRestoreRequestProvider>()
+                    var restoreContext = new RestoreArgs()
                     {
-                        new ProjectJsonRestoreRequestProvider(providerCache)
-                    }
-                };
+                        CacheContext = cacheContext,
+                        DisableParallel = true,
+                        Inputs = new List<string>() { workingDir },
+                        Log = logger,
+                        RequestProviders = new List<IRestoreRequestProvider>()
+                        {
+                            new ProjectJsonRestoreRequestProvider(providerCache)
+                        }
+                    };
 
-                // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
+                    // Act
+                    var summaries = await RestoreRunner.Run(restoreContext);
 
-                // Assert
-                Assert.Equal(0, summaries.Count);
-                var matchingError = logger.Messages.ToList().Find(error => error.Contains(workingDir));
-                Assert.NotNull(matchingError);
+                    // Assert
+                    Assert.Equal(0, summaries.Count);
+                    var matchingError = logger.Messages.ToList().Find(error => error.Contains(workingDir));
+                    Assert.NotNull(matchingError);
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackagePreFetcherTests.cs
@@ -23,6 +23,7 @@ namespace NuGet.PackageManagement.Test
         public async Task PackagePreFetcher_NoActionsInput()
         {
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -31,15 +32,18 @@ namespace NuGet.PackageManagement.Test
                 var logger = new TestLogger();
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    testSettings,
-                    logger,
-                    CancellationToken.None);
-
-                // Assert
-                Assert.Equal(0, result.Count);
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
+                    // Assert
+                    Assert.Equal(0, result.Count);
+                }
             }
         }
 
@@ -47,6 +51,7 @@ namespace NuGet.PackageManagement.Test
         public async Task PackagePreFetcher_NoInstallActionsInput()
         {
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -61,15 +66,19 @@ namespace NuGet.PackageManagement.Test
                 actions.Add(NuGetProjectAction.CreateUninstallProjectAction(target2));
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                // Assert
-                Assert.Equal(0, result.Count);
+                    // Assert
+                    Assert.Equal(0, result.Count);
+                }
             }
         }
 
@@ -78,6 +87,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -94,24 +104,28 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(target, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                var downloadResult = await result[target].GetResultAsync();
+                    var downloadResult = await result[target].GetResultAsync();
 
-                // Assert
-                Assert.Equal(1, result.Count);
-                Assert.True(result[target].InPackagesFolder);
-                Assert.Null(result[target].Source);
-                Assert.Equal(target, result[target].Package);
-                Assert.True(result[target].IsComplete);
-                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                Assert.NotNull(downloadResult.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    // Assert
+                    Assert.Equal(1, result.Count);
+                    Assert.True(result[target].InPackagesFolder);
+                    Assert.Null(result[target].Source);
+                    Assert.Equal(target, result[target].Package);
+                    Assert.True(result[target].IsComplete);
+                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                    Assert.NotNull(downloadResult.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                }
             }
         }
 
@@ -120,6 +134,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -137,24 +152,28 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(target, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
-                    actions,
-                    packagesFolder,
-                    testSettings,
-                    logger,
-                    CancellationToken.None);
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
+                        actions,
+                        packagesFolder,
+                        new PackageDownloadContext(cacheContext),
+                        globalPackagesFolder,
+                        logger,
+                        CancellationToken.None);
 
-                var downloadResult = await result[target].GetResultAsync();
+                    var downloadResult = await result[target].GetResultAsync();
 
-                // Assert
-                Assert.Equal(1, result.Count);
-                Assert.False(result[target].InPackagesFolder);
-                Assert.Equal(source.PackageSource, result[target].Source);
-                Assert.Equal(target, result[target].Package);
-                Assert.True(result[target].IsComplete);
-                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                Assert.NotNull(downloadResult.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    // Assert
+                    Assert.Equal(1, result.Count);
+                    Assert.False(result[target].InPackagesFolder);
+                    Assert.Equal(source.PackageSource, result[target].Source);
+                    Assert.Equal(target, result[target].Package);
+                    Assert.True(result[target].IsComplete);
+                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                    Assert.NotNull(downloadResult.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                }
             }
         }
 
@@ -163,6 +182,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -197,43 +217,47 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(targetC2, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                var resultA2 = await result[targetA2].GetResultAsync();
-                var resultB2 = await result[targetB2].GetResultAsync();
-                var resultC2 = await result[targetC2].GetResultAsync();
+                    var resultA2 = await result[targetA2].GetResultAsync();
+                    var resultB2 = await result[targetB2].GetResultAsync();
+                    var resultC2 = await result[targetC2].GetResultAsync();
 
-                // Assert
-                Assert.Equal(3, result.Count);
+                    // Assert
+                    Assert.Equal(3, result.Count);
 
-                Assert.True(result[targetA2].InPackagesFolder);
-                Assert.Null(result[targetA2].Source);
-                Assert.Equal(targetA2, result[targetA2].Package);
-                Assert.True(result[targetA2].IsComplete);
-                Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
-                Assert.NotNull(resultA2.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
+                    Assert.True(result[targetA2].InPackagesFolder);
+                    Assert.Null(result[targetA2].Source);
+                    Assert.Equal(targetA2, result[targetA2].Package);
+                    Assert.True(result[targetA2].IsComplete);
+                    Assert.Equal(targetA2, resultA2.PackageReader.GetIdentity());
+                    Assert.NotNull(resultA2.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, resultA2.Status);
 
-                Assert.False(result[targetB2].InPackagesFolder);
-                Assert.Equal(source.PackageSource, result[targetB2].Source);
-                Assert.Equal(targetB2, result[targetB2].Package);
-                Assert.True(result[targetB2].IsComplete);
-                Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
-                Assert.NotNull(resultB2.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
+                    Assert.False(result[targetB2].InPackagesFolder);
+                    Assert.Equal(source.PackageSource, result[targetB2].Source);
+                    Assert.Equal(targetB2, result[targetB2].Package);
+                    Assert.True(result[targetB2].IsComplete);
+                    Assert.Equal(targetB2, resultB2.PackageReader.GetIdentity());
+                    Assert.NotNull(resultB2.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, resultB2.Status);
 
-                Assert.False(result[targetC2].InPackagesFolder);
-                Assert.Equal(source.PackageSource, result[targetC2].Source);
-                Assert.Equal(targetC2, result[targetC2].Package);
-                Assert.True(result[targetC2].IsComplete);
-                Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
-                Assert.NotNull(resultC2.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                    Assert.False(result[targetC2].InPackagesFolder);
+                    Assert.Equal(source.PackageSource, result[targetC2].Source);
+                    Assert.Equal(targetC2, result[targetC2].Package);
+                    Assert.True(result[targetC2].IsComplete);
+                    Assert.Equal(targetC2, resultC2.PackageReader.GetIdentity());
+                    Assert.NotNull(resultC2.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, resultC2.Status);
+                }
             }
         }
 
@@ -242,6 +266,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -259,23 +284,27 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(targetNonNormalized, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                var downloadResult = await result[target].GetResultAsync();
+                    var downloadResult = await result[target].GetResultAsync();
 
-                // Assert
-                Assert.Equal(1, result.Count);
-                Assert.True(result[target].InPackagesFolder);
-                Assert.Null(result[target].Source);
-                Assert.Equal(target, result[target].Package);
-                Assert.True(result[target].IsComplete);
-                Assert.NotNull(downloadResult.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    // Assert
+                    Assert.Equal(1, result.Count);
+                    Assert.True(result[target].InPackagesFolder);
+                    Assert.Null(result[target].Source);
+                    Assert.Equal(target, result[target].Package);
+                    Assert.True(result[target].IsComplete);
+                    Assert.NotNull(downloadResult.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                }
             }
         }
 
@@ -284,6 +313,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -301,23 +331,27 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(target, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                var downloadResult = await result[target].GetResultAsync();
+                    var downloadResult = await result[target].GetResultAsync();
 
-                // Assert
-                Assert.Equal(1, result.Count);
-                Assert.True(result[target].InPackagesFolder);
-                Assert.Null(result[target].Source);
-                Assert.Equal(target, result[target].Package);
-                Assert.True(result[target].IsComplete);
-                Assert.NotNull(downloadResult.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    // Assert
+                    Assert.Equal(1, result.Count);
+                    Assert.True(result[target].InPackagesFolder);
+                    Assert.Null(result[target].Source);
+                    Assert.Equal(target, result[target].Package);
+                    Assert.True(result[target].IsComplete);
+                    Assert.NotNull(downloadResult.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                }
             }
         }
 
@@ -326,6 +360,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -339,24 +374,28 @@ namespace NuGet.PackageManagement.Test
                 AddToSource(target, sourceDir);
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                var downloadResult = await result[target].GetResultAsync();
+                    var downloadResult = await result[target].GetResultAsync();
 
-                // Assert
-                Assert.Equal(1, result.Count);
-                Assert.False(result[target].InPackagesFolder);
-                Assert.Equal(source.PackageSource, result[target].Source);
-                Assert.Equal(target, result[target].Package);
-                Assert.True(result[target].IsComplete);
-                Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
-                Assert.NotNull(downloadResult.PackageStream);
-                Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                    // Assert
+                    Assert.Equal(1, result.Count);
+                    Assert.False(result[target].InPackagesFolder);
+                    Assert.Equal(source.PackageSource, result[target].Source);
+                    Assert.Equal(target, result[target].Package);
+                    Assert.True(result[target].IsComplete);
+                    Assert.Equal(target, downloadResult.PackageReader.GetIdentity());
+                    Assert.NotNull(downloadResult.PackageStream);
+                    Assert.Equal(DownloadResourceResultStatus.Available, downloadResult.Status);
+                }
             }
         }
 
@@ -365,6 +404,7 @@ namespace NuGet.PackageManagement.Test
         {
             using (var sourceDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var packagesFolderDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
             {
                 // Arrange
                 var actions = new List<NuGetProjectAction>();
@@ -377,27 +417,31 @@ namespace NuGet.PackageManagement.Test
                 actions.Add(NuGetProjectAction.CreateInstallProjectAction(target, source));
 
                 // Act
-                var result = await PackagePreFetcher.GetPackagesAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await PackagePreFetcher.GetPackagesAsync(
                     actions,
                     packagesFolder,
-                    testSettings,
+                    new PackageDownloadContext(cacheContext),
+                    globalPackagesFolder,
                     logger,
                     CancellationToken.None);
 
-                Exception exception = null;
+                    Exception exception = null;
 
-                try
-                {
-                    var downloadResult = await result[target].GetResultAsync();
-                    Assert.True(false);
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
+                    try
+                    {
+                        var downloadResult = await result[target].GetResultAsync();
+                        Assert.True(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
+                    }
 
-                // Assert
-                Assert.StartsWith("Package 'packageA.1.0.0' is not found on source", exception.Message);
+                    // Assert
+                    Assert.StartsWith("Package 'packageA.1.0.0' is not found on source", exception.Message);
+                }
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Configuration;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
@@ -33,15 +33,21 @@ namespace NuGet.Protocol.Tests
 
             var downloadResource = await repo.GetResourceAsync<DownloadResource>();
 
-            // Act 
-            var actual = await downloadResource.GetDownloadResourceResultAsync(new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
-                NullSettings.Instance,
-                NullLogger.Instance,
-                CancellationToken.None);
+            // Act
+            using (var packagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var actual = await downloadResource.GetDownloadResourceResultAsync(
+                    new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound")),
+                    new PackageDownloadContext(sourceCacheContext),
+                    packagesFolder,
+                    NullLogger.Instance,
+                    CancellationToken.None);
 
-            // Assert
-            Assert.NotNull(actual);
-            Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+                // Assert
+                Assert.NotNull(actual);
+                Assert.Equal(DownloadResourceResultStatus.NotFound, actual.Status);
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LocalResourceTests/LocalDownloadResourceTests.cs
@@ -1,11 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using NuGet.Configuration;
-using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -17,7 +13,6 @@ namespace NuGet.Protocol.Core.v3.Tests
 {
     public class LocalDownloadResourceTests
     {
-
         [Fact]
         public async Task LocalDownloadResource_PackageIsReturned()
         {
@@ -46,25 +41,30 @@ namespace NuGet.Protocol.Core.v3.Tests
                 };
 
                 SimpleTestPackageUtility.CreatePackages(root, packageContexts);
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
-                    packageA.Identity,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                using (var reader = result.PackageReader)
-                using (var stream = result.PackageStream)
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    // Assert
-                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                    Assert.Equal("a", reader.GetIdentity().Id);
-                    Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                    Assert.True(stream.CanSeek);
+                    var result = await resource.GetDownloadResourceResultAsync(
+                        packageA.Identity,
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    using (var reader = result.PackageReader)
+                    using (var stream = result.PackageStream)
+                    {
+                        // Assert
+                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                        Assert.Equal("a", reader.GetIdentity().Id);
+                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
+                        Assert.True(stream.CanSeek);
+                    }
                 }
             }
         }
@@ -103,37 +103,46 @@ namespace NuGet.Protocol.Core.v3.Tests
                 };
 
                 SimpleTestPackageUtility.CreatePackages(root, packageContexts);
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result1 = await resource.GetDownloadResourceResultAsync(
-                    packageA1.Identity,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                var result2 = await resource.GetDownloadResourceResultAsync(
-                    packageA2.Identity,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                var result3 = await resource.GetDownloadResourceResultAsync(
-                    packageA3.Identity,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                using (var reader1 = result1.PackageReader)
-                using (var reader2 = result2.PackageReader)
-                using (var reader3 = result3.PackageReader)
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    // Assert
-                    Assert.Equal("1.0", reader1.GetIdentity().Version.ToString());
-                    Assert.Equal("1.0.0", reader2.GetIdentity().Version.ToString());
-                    Assert.Equal("1.0.0.0", reader3.GetIdentity().Version.ToString());
+                    var downloadContext = new PackageDownloadContext(cacheContext);
+
+                    var result1 = await resource.GetDownloadResourceResultAsync(
+                        packageA1.Identity,
+                        downloadContext,
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    var result2 = await resource.GetDownloadResourceResultAsync(
+                        packageA2.Identity,
+                        downloadContext,
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    var result3 = await resource.GetDownloadResourceResultAsync(
+                        packageA3.Identity,
+                        downloadContext,
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    using (var reader1 = result1.PackageReader)
+                    using (var reader2 = result2.PackageReader)
+                    using (var reader3 = result3.PackageReader)
+                    {
+                        // Assert
+                        Assert.Equal("1.0", reader1.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0", reader2.GetIdentity().Version.ToString());
+                        Assert.Equal("1.0.0.0", reader3.GetIdentity().Version.ToString());
+                    }
                 }
             }
         }
@@ -166,25 +175,30 @@ namespace NuGet.Protocol.Core.v3.Tests
                 };
 
                 SimpleTestPackageUtility.CreatePackages(root, packageContexts);
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
-                    packageA.Identity,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                using (var reader = result.PackageReader)
-                using (var stream = result.PackageStream)
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    // Assert
-                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                    Assert.Equal("a", reader.GetIdentity().Id);
-                    Assert.Equal("1.0.0-alpha.1.2+b", reader.GetIdentity().Version.ToFullString());
-                    Assert.True(stream.CanSeek);
+                    var result = await resource.GetDownloadResourceResultAsync(
+                        packageA.Identity,
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    using (var reader = result.PackageReader)
+                    using (var stream = result.PackageStream)
+                    {
+                        // Assert
+                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                        Assert.Equal("a", reader.GetIdentity().Id);
+                        Assert.Equal("1.0.0-alpha.1.2+b", reader.GetIdentity().Version.ToFullString());
+                        Assert.True(stream.CanSeek);
+                    }
                 }
             }
         }
@@ -217,19 +231,24 @@ namespace NuGet.Protocol.Core.v3.Tests
                 };
 
                 SimpleTestPackageUtility.CreatePackages(root, packageContexts);
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
-                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await resource.GetDownloadResourceResultAsync(
+                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                }
             }
         }
 
@@ -240,19 +259,24 @@ namespace NuGet.Protocol.Core.v3.Tests
             {
                 // Arrange
                 var testLogger = new TestLogger();
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
-                    new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await resource.GetDownloadResourceResultAsync(
+                        new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
 
-                // Assert
-                Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                }
             }
         }
 
@@ -263,6 +287,7 @@ namespace NuGet.Protocol.Core.v3.Tests
             {
                 // Arrange
                 var testLogger = new TestLogger();
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceV2(root);
                 var resource = new LocalDownloadResource(localResource);
@@ -270,14 +295,18 @@ namespace NuGet.Protocol.Core.v3.Tests
                 Directory.Delete(root);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var result = await resource.GetDownloadResourceResultAsync(
                     new PackageIdentity("a", NuGetVersion.Parse("1.0.0-beta.1.2.3+a.b")),
-                    NullSettings.Instance,
+                    new PackageDownloadContext(cacheContext),
+                    packagesFolder,
                     testLogger,
                     CancellationToken.None);
 
-                // Assert
-                Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                    // Assert
+                    Assert.Equal(DownloadResourceResultStatus.NotFound, result.Status);
+                }
             }
         }
 
@@ -291,26 +320,31 @@ namespace NuGet.Protocol.Core.v3.Tests
 
                 var id = new PackageIdentity("a", NuGetVersion.Parse("1.0.0"));
                 SimpleTestPackageUtility.CreateFolderFeedUnzip(root, id);
+                string packagesFolder = null; // This is unused by the implementation.
 
                 var localResource = new FindLocalPackagesResourceUnzipped(root);
                 var resource = new LocalDownloadResource(localResource);
 
                 // Act
-                var result = await resource.GetDownloadResourceResultAsync(
-                    id,
-                    NullSettings.Instance,
-                    testLogger,
-                    CancellationToken.None);
-
-                using (var reader = result.PackageReader)
-                using (var stream = result.PackageStream)
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    // Assert
-                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
-                    Assert.Equal("a", reader.GetIdentity().Id);
-                    Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
-                    Assert.True(stream.CanSeek);
-                    Assert.True(reader is PackageFolderReader);
+                    var result = await resource.GetDownloadResourceResultAsync(
+                        id,
+                        new PackageDownloadContext(cacheContext),
+                        packagesFolder,
+                        testLogger,
+                        CancellationToken.None);
+
+                    using (var reader = result.PackageReader)
+                    using (var stream = result.PackageStream)
+                    {
+                        // Assert
+                        Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                        Assert.Equal("a", reader.GetIdentity().Id);
+                        Assert.Equal("1.0.0", reader.GetIdentity().Version.ToFullString());
+                        Assert.True(stream.CanSeek);
+                        Assert.True(reader is PackageFolderReader);
+                    }
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -29,16 +29,19 @@ namespace NuGet.Protocol.Tests
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-            var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            resource.Logger = NullLogger.Instance;
-            resource.CacheContext = new SourceCacheContext();
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                resource.Logger = NullLogger.Instance;
+                resource.CacheContext = cacheContext;
 
-            // Act
-            var versions = await resource.GetAllVersionsAsync("a", CancellationToken.None);
+                // Act
+                var versions = await resource.GetAllVersionsAsync("a", CancellationToken.None);
 
-            // Assert
-            // Verify no items returned, and no exceptions were thrown above
-            Assert.Equal(0, versions.Count());
+                // Assert
+                // Verify no items returned, and no exceptions were thrown above
+                Assert.Equal(0, versions.Count());
+            }
         }
 
         [Fact]
@@ -78,20 +81,23 @@ namespace NuGet.Protocol.Tests
 
                 var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                resource.Logger = NullLogger.Instance;
-                resource.CacheContext = new SourceCacheContext();
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                    resource.Logger = NullLogger.Instance;
+                    resource.CacheContext = cacheContext;
 
-                // Act
-                var identity = await resource.GetOriginalIdentityAsync(
-                    "XUNIT",
-                    new NuGetVersion("2.2.0-BETA1-build3239"),
-                    CancellationToken.None);
+                    // Act
+                    var identity = await resource.GetOriginalIdentityAsync(
+                        "XUNIT",
+                        new NuGetVersion("2.2.0-BETA1-build3239"),
+                        CancellationToken.None);
 
-                // Assert
-                Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
-                Assert.Equal("xunit", identity.Id);
-                Assert.Equal("2.2.0-beta1-build3239", identity.Version.ToNormalizedString());
+                    // Assert
+                    Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
+                    Assert.Equal("xunit", identity.Id);
+                    Assert.Equal("2.2.0-beta1-build3239", identity.Version.ToNormalizedString());
+                }
             }
         }
 
@@ -132,20 +138,23 @@ namespace NuGet.Protocol.Tests
 
                 var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
-                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                resource.Logger = NullLogger.Instance;
-                resource.CacheContext = new SourceCacheContext();
+                using (var cacheContext = new SourceCacheContext())
+                {
+                    var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                    resource.Logger = NullLogger.Instance;
+                    resource.CacheContext = cacheContext;
 
-                // Act
-                var identity = await resource.GetOriginalIdentityAsync(
-                    "WINDOWSAZURE.STORAGE",
-                    new NuGetVersion("6.2.2-PREVIEW"),
-                    CancellationToken.None);
+                    // Act
+                    var identity = await resource.GetOriginalIdentityAsync(
+                        "WINDOWSAZURE.STORAGE",
+                        new NuGetVersion("6.2.2-PREVIEW"),
+                        CancellationToken.None);
 
-                // Assert
-                Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
-                Assert.Equal("WindowsAzure.Storage", identity.Id);
-                Assert.Equal("6.2.2-preview", identity.Version.ToNormalizedString());
+                    // Assert
+                    Assert.IsType<RemoteV2FindPackageByIdResource>(resource);
+                    Assert.Equal("WindowsAzure.Storage", identity.Id);
+                    Assert.Equal("6.2.2-preview", identity.Version.ToNormalizedString());
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/SourceCacheContextTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/SourceCacheContextTests.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using NuGet.Protocol.Core.Types;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class SourceCacheContextTests
+    {
+        [Fact]
+        public void SourceCacheContext_StoresGeneratedTempFolder()
+        {
+            // Arrange
+            using (var target = new SourceCacheContext())
+            {
+                // Act
+                var folderA = target.GeneratedTempFolder;
+                var folderB = target.GeneratedTempFolder;
+
+                // Assert
+                Assert.Equal(folderA, folderB);
+            }
+        }
+
+        [Fact]
+        public void SourceCacheContext_DisposeDeletesGeneratedTempFolder()
+        {
+            // Arrange
+            string directoryPath;
+            using (var target = new SourceCacheContext())
+            {
+                directoryPath = target.GeneratedTempFolder;
+                Directory.CreateDirectory(directoryPath);
+                var filePath = Path.Combine(directoryPath, "test.txt");
+                File.WriteAllText(filePath, string.Empty);
+
+                // Act
+                target.Dispose();
+                target.Dispose();
+
+                // Assert
+                Assert.False(Directory.Exists(directoryPath));
+                Assert.False(File.Exists(filePath));
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/FindPackagesByIdNupkgDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/FindPackagesByIdNupkgDownloaderTests.cs
@@ -1,0 +1,377 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class FindPackagesByIdNupkgDownloaderTests
+    {
+        [Theory]
+        [InlineData(HttpStatusCode.NoContent, 1)]
+        [InlineData(HttpStatusCode.NotFound, 1)]
+        [InlineData(HttpStatusCode.InternalServerError, 9)] // There are two levels of retry (3 x 3).
+        public async Task CopyNupkgToStreamAsync_DoesNothingWithDestinationStreamWhenNupkgIsNotFound(
+            HttpStatusCode statusCode,
+            int expectedRequests)
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+                tc.StatusCode = statusCode;
+
+                // Act
+                var copied = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.False(copied);
+                var actualContent = tc.DestinationStream.ToArray();
+                Assert.Empty(actualContent);
+                Assert.Equal(expectedRequests, tc.RequestCount);
+            }
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.NoContent, 1)]
+        [InlineData(HttpStatusCode.NotFound, 1)]
+        [InlineData(HttpStatusCode.InternalServerError, 9)] // There are two levels of retry (3 x 3).
+        public async Task GetNuspecReaderFromNupkgAsync_ThrowsWhenNupkgIsNotFound(
+            HttpStatusCode statusCode,
+            int expectedRequests)
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+                tc.StatusCode = statusCode;
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<FatalProtocolException>(
+                    () => tc.Target.GetNuspecReaderFromNupkgAsync(
+                        tc.Identity,
+                        tc.NupkgUrl,
+                        cacheContext,
+                        tc.Logger,
+                        CancellationToken.None));
+                Assert.Contains(tc.Identity.Id, exception.Message);
+                Assert.Equal(expectedRequests, tc.RequestCount);
+            }
+        }
+
+        [Fact]
+        public async Task GetNuspecReaderFromNupkgAsync_GetsNuspecReader()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+
+                // Act
+                var nuspecReader = await tc.Target.GetNuspecReaderFromNupkgAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.NotNull(nuspecReader);
+                Assert.Equal(tc.Identity.Id, nuspecReader.GetId());
+                Assert.Equal(tc.Identity.Version.ToFullString(), nuspecReader.GetVersion().ToFullString());
+                Assert.Equal(1, tc.RequestCount);
+            }
+        }
+
+        [Fact]
+        public async Task GetNuspecReaderFromNupkgAsync_DoesNotWriteCacheFileWithDirectDownload()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+                cacheContext.DirectDownload = true;
+
+                // Act
+                // This should not write to the disk cache.
+                var nuspecReaderA = await tc.Target.GetNuspecReaderFromNupkgAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // This also should not write to the disk cache but the .nuspec should be cached in memory.
+                var nuspecReaderB = await tc.Target.GetNuspecReaderFromNupkgAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.Equal(tc.Identity, nuspecReaderA.GetIdentity());
+                Assert.Equal(tc.Identity, nuspecReaderB.GetIdentity());
+                Assert.Equal(1, tc.RequestCount);
+                Assert.False(Directory.Exists(tc.HttpCacheDirectory));
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgToStreamAsync_CopiesNupkgToDestinationStream()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+
+                // Act
+                var copied = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.True(copied);
+                var actualContent = tc.DestinationStream.ToArray();
+                Assert.Equal(tc.ExpectedContent, actualContent);
+                Assert.Equal(1, tc.RequestCount);
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgToStreamAsync_RemembersCacheFileLocationWithoutDirectDownload()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+
+                // Act
+                // This should record the cache entry in memory.
+                var copiedA = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentA = tc.DestinationStream.ToArray();
+                tc.DestinationStream.SetLength(0);
+
+                // This should find that in-memory cache entry.
+                var copiedB = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentB = tc.DestinationStream.ToArray();
+
+                // Assert
+                Assert.True(copiedA);
+                Assert.True(copiedB);
+                Assert.Equal(tc.ExpectedContent, actualContentA);
+                Assert.Equal(tc.ExpectedContent, actualContentB);
+                Assert.Equal(1, tc.RequestCount);
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgToStreamAsync_DoesNotWriteCacheFileWithDirectDownload()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+                cacheContext.DirectDownload = true;
+
+                // Act
+                // This should not write to the disk cache.
+                var copiedA = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentA = tc.DestinationStream.ToArray();
+                tc.DestinationStream.SetLength(0);
+
+                // This also should not write to the disk cache.
+                var copiedB = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentB = tc.DestinationStream.ToArray();
+
+                // Assert
+                Assert.True(copiedA);
+                Assert.True(copiedB);
+                Assert.Equal(tc.ExpectedContent, actualContentA);
+                Assert.Equal(tc.ExpectedContent, actualContentB);
+                Assert.Equal(2, tc.RequestCount);
+                Assert.False(Directory.Exists(tc.HttpCacheDirectory));
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgToStreamAsync_DirectDownloadPopulatesInMemoryCache()
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
+            {
+                var tc = new TestContext(testDirectory);
+
+                // Populate the disk cache.
+                await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    new MemoryStream(),
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+
+                tc.Initialize();
+
+                // Act
+                // This should find an entry on the disk cache.
+                cacheContext.DirectDownload = true;
+                var copiedA = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentA = tc.DestinationStream.ToArray();
+                tc.DestinationStream.SetLength(0);
+
+                // This should find an cache entry in memory.
+                cacheContext.DirectDownload = false;
+                var copiedB = await tc.Target.CopyNupkgToStreamAsync(
+                    tc.Identity,
+                    tc.NupkgUrl,
+                    tc.DestinationStream,
+                    cacheContext,
+                    tc.Logger,
+                    CancellationToken.None);
+                var actualContentB = tc.DestinationStream.ToArray();
+
+                // Assert
+                Assert.True(copiedA);
+                Assert.True(copiedB);
+                Assert.Equal(tc.ExpectedContent, actualContentA);
+                Assert.Equal(tc.ExpectedContent, actualContentB);
+                Assert.Equal(0, tc.RequestCount);
+                Assert.Equal(1, tc.HttpSource.CacheHits);
+                Assert.Equal(0, tc.HttpSource.CacheMisses);
+            }
+        }
+
+        private class TestContext
+        {
+
+            public TestContext(TestDirectory testDirectory)
+            {
+                TestDirectory = testDirectory;
+                Identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0-Beta"));
+
+                var packageDirectory = Path.Combine(testDirectory, "packages");
+                var package = SimpleTestPackageUtility.CreateFullPackage(
+                    packageDirectory,
+                    Identity.Id,
+                    Identity.Version.ToString());
+                ExpectedContent = File.ReadAllBytes(package.FullName);
+
+                PackageSource = new PackageSource("http://foo/index.json");
+                NupkgUrl = "http://foo/package.nupkg";
+                RequestCount = 0;
+                HttpCacheDirectory = Path.Combine(testDirectory, "httpCache");
+                StatusCode = HttpStatusCode.OK;
+
+                Logger = new TestLogger();
+                DestinationStream = new MemoryStream();
+
+                Initialize();
+            }
+
+            public void Initialize()
+            {
+                HttpSource = new TestHttpSource(
+                    PackageSource,
+                    new Dictionary<string, Func<HttpRequestMessage, Task<HttpResponseMessage>>>()
+                    {
+                        {
+                            NupkgUrl,
+                            request =>
+                            {
+                                RequestCount++;
+
+                                return Task.FromResult(new HttpResponseMessage
+                                {
+                                    StatusCode = StatusCode,
+                                    Content = new ByteArrayContent(ExpectedContent)
+                                });
+                            }
+                        }
+                    });
+
+                HttpSource.HttpCacheDirectory = HttpCacheDirectory;
+                HttpSource.DisableCaching = false;
+
+                RequestCount = 0;
+
+                Target = new FindPackagesByIdNupkgDownloader(HttpSource);                
+            }
+
+            public byte[] ExpectedContent { get; }
+            public PackageIdentity Identity { get; }
+            public TestLogger Logger { get; }
+            public TestDirectory TestDirectory { get; }
+            public MemoryStream DestinationStream { get; }
+            public string NupkgUrl { get; }
+            public int RequestCount { get; private set; }
+            public string HttpCacheDirectory { get; }
+            public PackageSource PackageSource { get; }
+            public TestHttpSource HttpSource { get; private set; }
+            public HttpStatusCode StatusCode { get; set; }
+            public FindPackagesByIdNupkgDownloader Target { get; private set; }
+        }
+
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/GetDownloadResultUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/GetDownloadResultUtilityTests.cs
@@ -1,0 +1,176 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class GetDownloadResultUtilityTests
+    {
+        [Fact]
+        public async Task GetDownloadResultUtility_WithSingleDirectDownload_ReturnsTemporaryDownloadResult()
+        {
+            // Arrange
+            var uri = new Uri("http://fake/content.nupkg");
+            var expectedContent = "TestContent";
+            var identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0-Beta"));
+            var testHttpSource = new TestHttpSource(
+                new PackageSource("http://fake"),
+                new Dictionary<string, string>
+                {
+                    { uri.ToString(), expectedContent }
+                });
+            var logger = new TestLogger();
+            var token = CancellationToken.None;
+
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var downloadContext = new PackageDownloadContext(
+                    cacheContext,
+                    downloadDirectory);
+
+                // Act
+                using (var result = await GetDownloadResultUtility.GetDownloadResultAsync(
+                    testHttpSource,
+                    identity,
+                    uri,
+                    downloadContext,
+                    globalPackagesFolder,
+                    logger,
+                    token))
+                {
+                    // Assert
+                    Assert.Null(result.PackageReader);
+                    Assert.Equal(DownloadResourceResultStatus.Available, result.Status);
+                    Assert.NotNull(result.PackageStream);
+                    Assert.True(result.PackageStream.CanSeek);
+                    Assert.True(result.PackageStream.CanRead);
+                    Assert.Equal(0, result.PackageStream.Position);
+
+                    var files = Directory.EnumerateFileSystemEntries(downloadDirectory).ToArray();
+                    Assert.Equal(1, files.Length);
+                    Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[0]));
+
+                    Assert.Equal(0, Directory.EnumerateFileSystemEntries(globalPackagesFolder).Count());
+
+                    var actualContent = new StreamReader(result.PackageStream).ReadToEnd();
+                    Assert.Equal(expectedContent, actualContent);
+                }
+
+                Assert.Equal(0, Directory.EnumerateFileSystemEntries(downloadDirectory).Count());
+                Assert.Equal(0, Directory.EnumerateFileSystemEntries(globalPackagesFolder).Count());
+            }
+        }
+
+        [Fact]
+        public async Task GetDownloadResultUtility_WithTwoOfTheSameDownloads_DoesNotCollide()
+        {
+            // Arrange
+            var uri = new Uri("http://fake/content.nupkg");
+            var expectedContent = "TestContent";
+            var identity = new PackageIdentity("PackageA", NuGetVersion.Parse("1.0.0-Beta"));
+            var testHttpSource = new TestHttpSource(
+                new PackageSource("http://fake"),
+                new Dictionary<string, string>
+                {
+                    { uri.ToString(), expectedContent }
+                });
+            var logger = new TestLogger();
+            var token = CancellationToken.None;
+
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var globalPackagesFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var downloadContext = new PackageDownloadContext(
+                    cacheContext,
+                    downloadDirectory);
+
+                // Act
+                using (var resultA = await GetDownloadResultUtility.GetDownloadResultAsync(
+                    testHttpSource,
+                    identity,
+                    uri,
+                    downloadContext,
+                    globalPackagesFolder,
+                    logger,
+                    token))
+                using (var resultB = await GetDownloadResultUtility.GetDownloadResultAsync(
+                    testHttpSource,
+                    identity,
+                    uri,
+                    downloadContext,
+                    globalPackagesFolder,
+                    logger,
+                    token))
+                {
+                    // Assert
+                    var files = Directory.EnumerateFileSystemEntries(downloadDirectory).ToArray();
+                    Assert.Equal(2, files.Length);
+                    Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[0]));
+                    Assert.EndsWith(".nugetdirectdownload", Path.GetFileName(files[1]));
+
+                    var actualContentA = new StreamReader(resultA.PackageStream).ReadToEnd();
+                    Assert.Equal(expectedContent, actualContentA);
+
+                    var actualContentB = new StreamReader(resultB.PackageStream).ReadToEnd();
+                    Assert.Equal(expectedContent, actualContentB);
+                }
+
+                Assert.Equal(0, Directory.EnumerateFileSystemEntries(downloadDirectory).Count());
+                Assert.Equal(0, Directory.EnumerateFileSystemEntries(globalPackagesFolder).Count());
+            }
+        }
+
+        [Fact]
+        public void GetDownloadResultUtility_OnlyCleansUpDirectDownloadFilesItCanAccess()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var downloadContext = new PackageDownloadContext(
+                    cacheContext,
+                    downloadDirectory);
+
+                var deletePathA = Path.Combine(downloadDirectory, "packageA.nugetdirectdownload");
+                File.WriteAllText(deletePathA, string.Empty);
+
+                var deletePathB = Path.Combine(downloadDirectory, "packageB.nugetdirectdownload");
+                File.WriteAllText(deletePathB, string.Empty);
+
+                // Ignored because it's in a child directory.
+                var nestedPath = Path.Combine(downloadDirectory, "nested", "packageB.nugetdirectdownload");
+                Directory.CreateDirectory(Path.GetDirectoryName(nestedPath));
+                File.WriteAllText(nestedPath, string.Empty);
+
+                // Ignored because it doesn't match the file pattern.
+                var ignorePath = Path.Combine(downloadDirectory, "something-else-entirely");
+                File.WriteAllText(ignorePath, string.Empty);
+
+                // Act
+                GetDownloadResultUtility.CleanUpDirectDownloads(downloadContext);
+
+                // Assert
+                Assert.False(File.Exists(deletePathA), "The first direct download file should be deleted.");
+                Assert.False(File.Exists(deletePathB), "The second direct download file should be deleted.");
+                Assert.True(File.Exists(nestedPath), "Nested files should not be deleted.");
+                Assert.True(File.Exists(ignorePath), "Files with the wrong extension should not be deleted.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
([the diff is best viewed with GitHub's `w=1` switch](https://github.com/NuGet/NuGet.Client/pull/839/files?w=1))
### Motivation

This adds `-DirectDownload` switch conforming to [the spec](https://github.com/NuGet/Home/wiki/Aggressive-No-Caching-option-for-nuget.exe). The key points are that `-DirectDownload`:
- packages.config install/restore should skip writing to the HTTP cache and to the global packages folder. 
- project.json restore should skip writing to the HTTP cache. The global packages folder should still be written to.
### Implementation

This is achieved by plumbing down the install directory to the `GetDownloadResultUtility`. This is the guy that installs packages to the global packages folder during a packages.config restore. Also, a `DirectDownload` switch is plumbed into `HttpSource` so that we can choose not to write to the HTTP cache.

Originally we were thinking that adding another resource here would be the best option. However I came to the conclusion that a fork this early in our install/restore flow would lead to a lot of duplicated code paths. The number of operations that actually hard code writing to the global packages folder or HTTP cache is rather low (just `HttpSource` and `GetDownloadResultUtility`).

The biggest challenge in the route I picked (that is, choosing to plumb these flags down to existing resources) was that `HttpSource.GetAsync` (the caching `GET`) now would have two types of streams it could return: opened from a cache file on disk or opened from the network directly. This was solved by inverting control of this method so that it accepts a `Func<HttpSourceResult, Task<T>>`. This is consistent with the other (non-caching) methods on `HttpSource`. The benefit of this pattern is that `HttpResponseMessage` lifetime can be controlled just by `HttpSource` and not permeate to the rest of the code base.

An added benefit of my chosen approach is that we are now in a much better position to address https://github.com/NuGet/Home/issues/3132 and https://github.com/NuGet/Home/issues/3244. This is because our code base now in general has better access to the current `SourceCacheContext`.

For commands that install to a directory outside of the global packages folder (e.g. a solution `packages` folder), the destination directory is plumbed down in a new `PackageDownloadContext` type. `GetDownloadResultUtility` then downloads the package to this directory. The caller gets the `DownloadResourceResult` and does whatever he wants with it. Right now that's installing it to a `FolderNuGetProject`. This does the extraction.

I also consolidated and tested the .nupkg and .nuspec reader acquisition code currently duplicated between the three remote `FindPackagesByIdResource` implementations. This code previously did not have good direct test coverage.

I also blew up my caching tests to try out `-DirectDownload` and `-DirectDownload -NoCache` switch combinations. These tests are not very fast so I am considering moving them to a `NuGet.CommandLine.FuncTest` project mimicking our "slow test" pattern in the NuGet.Core solution as a follow-up PR.
### Example

<pre>
C:\Users\joelv\Desktop>nuget.exe locals -Clear all
Clearing NuGet HTTP cache: C:\Users\joelv\AppData\Local\NuGet\v3-cache
Clearing NuGet cache: C:\Users\joelv\AppData\Local\NuGet\Cache
Clearing NuGet global packages cache: C:\Users\joelv\.nuget\packages\
Local resources cleared.

C:\Users\joelv\Desktop>dir /b
C:\Users\joelv\Desktop\nuget.exe

C:\Users\joelv\Desktop><b>nuget.exe install WindowsAzure.Storage -DirectDownload</b> -Verbosity quiet -Source https://www.nuget.org/api/v2

C:\Users\joelv\Desktop>dir /b
Microsoft.Data.Edm.5.6.4
Microsoft.Data.OData.5.6.4
Newtonsoft.Json.6.0.8
nuget.exe
System.Spatial.5.6.4
WindowsAzure.Storage.7.2.0

C:\Users\joelv\Desktop>dir /s /b C:\Users\joelv\AppData\Local\nuget\v3-cache
File Not Found

C:\Users\joelv\Desktop>dir /s /b C:\Users\joelv\AppData\Local\NuGet\Cache
File Not Found

C:\Users\joelv\Desktop>dir /s /b C:\Users\joelv\.nuget\packages
File Not Found
</pre>


/cc @emgarten @alpaix @yishaigalatzer @MarkOsborneMS 
