### PR TITLE
Add method to VersionFolderPathResolver to get just the hash file name

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -55,7 +55,12 @@ namespace NuGet.Packaging
         {
             return Path.Combine(
                 GetInstallPath(packageId, version),
-                $"{Normalize(packageId)}.{Normalize(version)}.nupkg.sha512");
+                GetHashFileName(packageId, version));
+        }
+
+        public string GetHashFileName(string packageId, NuGetVersion version)
+        {
+            return $"{Normalize(packageId)}.{Normalize(version)}.nupkg.sha512";
         }
 
         public string GetVersionListDirectory(string packageId)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
@@ -76,6 +76,21 @@ namespace NuGet.Packaging.Test
         }
 
         [Theory]
+        [InlineData("nuget.packaging.3.4.3-beta.nupkg.sha512", true)]
+        [InlineData("NuGet.Packaging.3.4.3-Beta.nupkg.sha512", false)]
+        public void VersionFolderPathResolver_GetHashFileName(string file, bool isLowercase)
+        {
+            // Arrange
+            var tc = new TestContext { IsLowercase = isLowercase };
+
+            // Act
+            var actual = tc.Target.GetHashFileName(tc.Id, tc.Version);
+
+            // Assert
+            Assert.Equal(file, actual);
+        }
+
+        [Theory]
         [InlineData("nuget.packaging", "3.4.3-beta", true)]
         [InlineData("NuGet.Packaging", "3.4.3-Beta", false)]
         public void VersionFolderPathResolver_GetPackageDirectory(string id, string version, bool isLowercase)


### PR DESCRIPTION
DotNetHost currently builds the hash file name from `{id}.{version}.nupkg.{hash-algorithm}`. `{hash-algorithm}` is hard coded to be `sha512` by NuGet and by .NET CLI. Currently, .NET CLI in the `feature/msbuild` branch is using `VersionFolderPathResolver`. This PR adds a method to generate this hash file name so it can be serialized into the .deps.json file for use by DotNetHost (so that it does not have it's own logic to build this file name).

/cc @emgarten
