### PR TITLE
Enable SemVer 2.0.0 support for pack

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.Designer.cs
@@ -168,6 +168,33 @@ namespace NuGet.Commands.Rules {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The package version &apos;{0}&apos; uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. This message can be ignored if the package is not intended for older clients..
+        /// </summary>
+        public static string LegacyVersionDescription {
+            get {
+                return ResourceManager.GetString("LegacyVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter..
+        /// </summary>
+        public static string LegacyVersionSolution {
+            get {
+                return ResourceManager.GetString("LegacyVersionSolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Package version not supported on legacy clients..
+        /// </summary>
+        public static string LegacyVersionTitle {
+            get {
+                return ResourceManager.GetString("LegacyVersionTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to The file &apos;{0}&apos; will be ignored by NuGet because it is not directly under &apos;tools&apos; folder..
         /// </summary>
         public static string MisplacedInitScriptDescription {

--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
@@ -153,6 +153,15 @@
   <data name="InvalidFrameworkTitle" xml:space="preserve">
     <value>Invalid framework folder.</value>
   </data>
+  <data name="LegacyVersionDescription" xml:space="preserve">
+    <value>The package version '{0}' uses SemVer 2.0.0 or components of SemVer 1.0.0 that are not supported on legacy clients. This message can be ignored if the package is not intended for older clients.</value>
+  </data>
+  <data name="LegacyVersionSolution" xml:space="preserve">
+    <value>Change the package version to a SemVer 1.0.0 string. If the version contains a release label it must start with a letter.</value>
+  </data>
+  <data name="LegacyVersionTitle" xml:space="preserve">
+    <value>Package version not supported on legacy clients.</value>
+  </data>
   <data name="MisplacedInitScriptDescription" xml:space="preserve">
     <value>The file '{0}' will be ignored by NuGet because it is not directly under 'tools' folder.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/Rules/DefaultPackageRuleSet.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/DefaultPackageRuleSet.cs
@@ -16,7 +16,8 @@ namespace NuGet.Commands.Rules
                 new InitScriptNotUnderToolsRule(),
                 new WinRTNameIsObsoleteRule(),
                 new DefaultManifestValuesRule(),
-                new InvalidPlaceholderFileRule()
+                new InvalidPlaceholderFileRule(),
+                new LegacyVersionRule()
             }
         );
 

--- a/src/NuGet.Core/NuGet.Commands/Rules/LegacyVersionRule.cs
+++ b/src/NuGet.Core/NuGet.Commands/Rules/LegacyVersionRule.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using NuGet.Packaging;
+
+namespace NuGet.Commands.Rules
+{
+    /// <summary>
+    /// Warn if the version is not parsable by older nuget clients.
+    /// </summary>
+    /// <remarks>This rule should be removed once more users move to SemVer 2.0.0 capable clients.</remarks>
+    internal class LegacyVersionRule : IPackageRule
+    {
+        // NuGet 2.12 regex for version parsing.
+        private const string LegacyRegex = @"^(?<Version>\d+(\s*\.\s*\d+){0,3})(?<Release>-[a-z][0-9a-z-]*)?$";
+
+        public IEnumerable<PackageIssue> Validate(PackageBuilder builder)
+        {
+            var regex = new Regex(LegacyRegex);
+
+            if (!regex.IsMatch(builder.Version.ToFullString()))
+            {
+                yield return new PackageIssue(
+                    AnalysisResources.LegacyVersionTitle,
+                    string.Format(CultureInfo.CurrentCulture, AnalysisResources.LegacyVersionDescription, builder.Version.ToFullString()),
+                    AnalysisResources.LegacyVersionSolution);
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -328,11 +328,6 @@ namespace NuGet.Packaging
                 throw new InvalidOperationException(NuGetResources.SemVerSpecialVersionTooLong);
             }
 
-            if (Version != null && Version.IsSemVer2)
-            {
-                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, NuGetResources.SemVer2VersionsNotSupported, Version));
-            }
-
             ValidateDependencyGroups(Version, DependencyGroups);
             ValidateReferenceAssemblies(Files, PackageAssemblyReferences);
 
@@ -455,19 +450,6 @@ namespace NuGet.Packaging
             foreach (var dep in dependencies.SelectMany(s => s.Packages))
             {
                 PackageIdValidator.ValidatePackageId(dep.Id);
-
-                if (dep.VersionRange != null)
-                {
-                    if (dep.VersionRange.HasLowerBound && dep.VersionRange.MinVersion.IsSemVer2)
-                    {
-                        throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, NuGetResources.SemVer2VersionsNotSupported, dep.VersionRange.MinVersion));
-                    }
-
-                    if (dep.VersionRange.HasUpperBound && dep.VersionRange.MaxVersion.IsSemVer2)
-                    {
-                        throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, NuGetResources.SemVer2VersionsNotSupported, dep.VersionRange.MaxVersion));
-                    }
-                }
             }
 
             if (!version.IsPrerelease)

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.Designer.cs
@@ -249,15 +249,6 @@ namespace NuGet.Packaging.PackageCreation.Resources {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Versions using SemVer 2.0.0 are not supported: {0}..
-        /// </summary>
-        public static string SemVer2VersionsNotSupported {
-            get {
-                return ResourceManager.GetString("SemVer2VersionsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///    Looks up a localized string similar to The special version part cannot exceed 20 characters..
         /// </summary>
         public static string SemVerSpecialVersionTooLong {

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Resources/NuGetResources.resx
@@ -186,7 +186,4 @@
   <data name="Manifest_ReferencesIsEmpty" xml:space="preserve">
     <value>The element package\metadata\references\group must contain at least one &lt;reference&gt; child element.</value>
   </data>
-  <data name="SemVer2VersionsNotSupported" xml:space="preserve">
-    <value>Versions using SemVer 2.0.0 are not supported: {0}.</value>
-  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Xml/PackageMetadataXmlExtensions.cs
@@ -33,7 +33,7 @@ namespace NuGet.Packaging.Xml
             }
 
             elem.Add(new XElement(ns + "id", metadata.Id));
-            AddElementIfNotNull(elem, ns, "version", metadata.Version?.ToNormalizedString());
+            AddElementIfNotNull(elem, ns, "version", metadata.Version?.ToFullString());
             AddElementIfNotNull(elem, ns, "title", metadata.Title);
             AddElementIfNotNull(elem, ns, "authors", metadata.Authors, authors => string.Join(",", authors));
             AddElementIfNotNull(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));


### PR DESCRIPTION
Enable SemVer 2.0.0 support for pack
- Remove the pack check for SemVer 2.0.0 that block pack.
- Include metadata when writing the version to the nuspec file. Metadata is not used anywhere in NuGet, but it should be persisted in the nuspec file for readers who choose to consume it.

Fixes https://github.com/NuGet/Home/issues/3356
