### PR TITLE
Fix GetFeedType perf issue, https://github.com/NuGet/Home/issues/3355

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
@@ -26,18 +26,21 @@ namespace NuGet.Protocol
 
             if (source.FeedTypeOverride == FeedType.Undefined)
             {
-                // Check the feed type
-                var feedType = FeedTypeUtility.GetFeedType(source.PackageSource);
+                if (!_feedTypeCache.TryGetValue(source.PackageSource, out curResource))
+                {
+                    // Check the feed type
+                    var feedType = FeedTypeUtility.GetFeedType(source.PackageSource);
 
-                if (feedType == FeedType.FileSystemUnknown)
-                {
-                    // Do not cache unknown folder types
-                    curResource = new FeedTypeResource(FeedType.FileSystemUnknown);
-                }
-                else
-                {
-                    curResource = _feedTypeCache.GetOrAdd(source.PackageSource,
-                        (packageSource) => new FeedTypeResource(feedType));
+                    if (feedType == FeedType.FileSystemUnknown)
+                    {
+                        // Do not cache unknown folder types
+                        curResource = new FeedTypeResource(FeedType.FileSystemUnknown);
+                    }
+                    else
+                    {
+                        curResource = _feedTypeCache.GetOrAdd(source.PackageSource,
+                            (packageSource) => new FeedTypeResource(feedType));
+                    }
                 }
             }
             else

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
@@ -15,6 +15,8 @@ namespace NuGet.Protocol
         private readonly ConcurrentDictionary<PackageSource, FeedTypeResource> _feedTypeCache
             = new ConcurrentDictionary<PackageSource, FeedTypeResource>();
 
+        private object accessLock = new object();
+
         public FeedTypeResourceProvider()
             : base(typeof(FeedTypeResource), nameof(FeedTypeResourceProvider))
         {
@@ -28,18 +30,24 @@ namespace NuGet.Protocol
             {
                 if (!_feedTypeCache.TryGetValue(source.PackageSource, out curResource))
                 {
-                    // Check the feed type
-                    var feedType = FeedTypeUtility.GetFeedType(source.PackageSource);
+                    lock (accessLock)
+                    {
+                        if (!_feedTypeCache.TryGetValue(source.PackageSource, out curResource))
+                        {
+                            // Check the feed type
+                            var feedType = FeedTypeUtility.GetFeedType(source.PackageSource);
 
-                    if (feedType == FeedType.FileSystemUnknown)
-                    {
-                        // Do not cache unknown folder types
-                        curResource = new FeedTypeResource(FeedType.FileSystemUnknown);
-                    }
-                    else
-                    {
-                        curResource = _feedTypeCache.GetOrAdd(source.PackageSource,
-                            (packageSource) => new FeedTypeResource(feedType));
+                            if (feedType == FeedType.FileSystemUnknown)
+                            {
+                                // Do not cache unknown folder types
+                                curResource = new FeedTypeResource(FeedType.FileSystemUnknown);
+                            }
+                            else
+                            {
+                                curResource = new FeedTypeResource(feedType);
+                                _feedTypeCache.TryAdd(source.PackageSource, curResource);
+                            }
+                        }
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/FeedTypeResourceProvider.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol
         private readonly ConcurrentDictionary<PackageSource, FeedTypeResource> _feedTypeCache
             = new ConcurrentDictionary<PackageSource, FeedTypeResource>();
 
-        private object accessLock = new object();
+        private object _accessLock = new object();
 
         public FeedTypeResourceProvider()
             : base(typeof(FeedTypeResource), nameof(FeedTypeResourceProvider))
@@ -30,7 +30,7 @@ namespace NuGet.Protocol
             {
                 if (!_feedTypeCache.TryGetValue(source.PackageSource, out curResource))
                 {
-                    lock (accessLock)
+                    lock (_accessLock)
                     {
                         if (!_feedTypeCache.TryGetValue(source.PackageSource, out curResource))
                         {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
@@ -39,14 +39,7 @@ namespace NuGet.Protocol
                 else
                 {
                     // Try to determine the actual folder feed type by looking for nupkgs
-                    if (LocalFolderUtility.GetNupkgsFromFlatFolder(path, NullLogger.Instance).Any())
-                    {
-                        type = FeedType.FileSystemV2;
-                    }
-                    else if (LocalFolderUtility.GetPackagesV3(path, NullLogger.Instance).Any())
-                    {
-                        type = FeedType.FileSystemV3;
-                    }
+                    type = LocalFolderUtility.GetLocalFeedType(path);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/FeedTypeUtility.cs
@@ -39,7 +39,7 @@ namespace NuGet.Protocol
                 else
                 {
                     // Try to determine the actual folder feed type by looking for nupkgs
-                    type = LocalFolderUtility.GetLocalFeedType(path);
+                    type = LocalFolderUtility.GetLocalFeedType(path, NullLogger.Instance);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/LocalFolderUtility.cs
@@ -668,7 +668,7 @@ namespace NuGet.Protocol
             yield break;
         }
 
-        public static FeedType GetLocalFeedType(string root)
+        public static FeedType GetLocalFeedType(string root, ILogger log)
         {
             if (root == null)
             {
@@ -686,24 +686,24 @@ namespace NuGet.Protocol
             try
             {
 
-                if (Directory.EnumerateFiles(root, NupkgFilter, SearchOption.TopDirectoryOnly).Any())
+                if (rootDirectoryInfo.EnumerateFiles(NupkgFilter, SearchOption.TopDirectoryOnly).Any())
                 {
                     return FeedType.FileSystemV2;
                 }
 
-                foreach (var dir in Directory.EnumerateDirectories(root))
+                foreach (var idDir in rootDirectoryInfo.EnumerateDirectories())
                 {
-                    if (Directory.EnumerateFiles(dir, NupkgFilter, SearchOption.TopDirectoryOnly).Any())
+                    if (idDir.EnumerateFiles(NupkgFilter, SearchOption.TopDirectoryOnly).Any())
                     {
                         return FeedType.FileSystemV2;
                     }
 
-                    foreach (var versionDir in Directory.EnumerateDirectories(dir))
+                    foreach (var versionDir in idDir.EnumerateDirectories())
                     {
                         NuGetVersion version;
-                        if (NuGetVersion.TryParse(versionDir, out version))
+                        if (NuGetVersion.TryParse(versionDir.Name, out version))
                         {
-                            var identity = new PackageIdentity(dir, version);
+                            var identity = new PackageIdentity(idDir.Name, version);
 
                             // Read the package, this may be null if files are missing
                             var package = GetPackageV3(root, identity, log);


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/3355

Fixed FeedType cache and GetFeedType perf.

Perf with this fix:

First access for one package time: 2.15 second (2.11 second for gathering package information, around 5 ms for determining source feed type)
Then 10 times access for same package time: 73 ms ( around 7 ms for each, used gather cache for gathering package information)
