### PR TITLE
Add error handling and logging around credential provider initializaton in the VSIX

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -158,7 +158,7 @@ namespace NuGet.CommandLine
         /// </summary>
         protected void SetDefaultCredentialProvider()
         {
-            CredentialService = new CredentialService(GetCredentialProviders(), Console.WriteError, NonInteractive);
+            CredentialService = new CredentialService(GetCredentialProviders(), NonInteractive);
 
             HttpClient.DefaultCredentialProvider = new CredentialServiceAdapter(CredentialService);
 

--- a/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
@@ -30,31 +30,19 @@ namespace NuGet.Credentials
         /// </summary>
         private static readonly Semaphore ProviderSemaphore = new Semaphore(1, 1);
 
-        private Action<string> ErrorDelegate { get; }
-
         /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="providers">All available credential providers.</param>
-        /// <param name="errorDelegate">Used to write error messages to the user</param>
         /// <param name="nonInteractive">If true, the nonInteractive flag will be passed to providers.
         /// NonInteractive requests must not promt the user for credentials.</param>
-        public CredentialService(
-            IEnumerable<ICredentialProvider> providers,
-            Action<string> errorDelegate,
-            bool nonInteractive)
+        public CredentialService(IEnumerable<ICredentialProvider> providers, bool nonInteractive)
         {
             if (providers == null)
             {
                 throw new ArgumentNullException(nameof(providers));
             }
-
-            if (errorDelegate == null)
-            {
-                throw new ArgumentNullException(nameof(errorDelegate));
-            }
-
-            ErrorDelegate = errorDelegate;
+            
             _nonInteractive = nonInteractive;
             Providers = new List<ICredentialProvider>(providers);
         }

--- a/src/NuGet.Clients/VsExtension/Resources.Designer.cs
+++ b/src/NuGet.Clients/VsExtension/Resources.Designer.cs
@@ -115,6 +115,33 @@ namespace NuGetVSExtension {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The legacy NuGet credential provider failed to load..
+        /// </summary>
+        internal static string CredentialProviderFailed_LegacyCredentialProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_LegacyCredentialProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Visual Studio or VSTS account provider failed to load..
+        /// </summary>
+        internal static string CredentialProviderFailed_VisualStudioAccountProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_VisualStudioAccountProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Visual Studio credential provider failed to load..
+        /// </summary>
+        internal static string CredentialProviderFailed_VisualStudioCredentialProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_VisualStudioCredentialProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet Package Manager.
         /// </summary>
         internal static string DialogTitle {
@@ -357,24 +384,6 @@ namespace NuGetVSExtension {
         internal static string SolutionIsNotSavedPromptReopen {
             get {
                 return ResourceManager.GetString("SolutionIsNotSavedPromptReopen", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error getting the credential provider.  {0}.
-        /// </summary>
-        internal static string VsCredentialProviderImport_GenericError {
-            get {
-                return ResourceManager.GetString("VsCredentialProviderImport_GenericError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error loading VisualStudioAcountProvider. {0}.
-        /// </summary>
-        internal static string VsCredentialProviderImporter_LoadErrorFormat {
-            get {
-                return ResourceManager.GetString("VsCredentialProviderImporter_LoadErrorFormat", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/VsExtension/Resources.resx
+++ b/src/NuGet.Clients/VsExtension/Resources.resx
@@ -219,10 +219,13 @@ To prevent NuGet from restoring packages during build, open the Visual Studio Op
   <data name="SolutionIsNotSavedPromptReopen" xml:space="preserve">
     <value>Solution is not saved. Please save your solution and re-open solution before managing NuGet packages.</value>
   </data>
-  <data name="VsCredentialProviderImporter_LoadErrorFormat" xml:space="preserve">
-    <value>Error loading VisualStudioAcountProvider. {0}</value>
+  <data name="CredentialProviderFailed_LegacyCredentialProvider" xml:space="preserve">
+    <value>The legacy NuGet credential provider failed to load.</value>
   </data>
-  <data name="VsCredentialProviderImport_GenericError" xml:space="preserve">
-    <value>Error getting the credential provider.  {0}</value>
+  <data name="CredentialProviderFailed_VisualStudioCredentialProvider" xml:space="preserve">
+    <value>The Visual Studio credential provider failed to load.</value>
+  </data>
+  <data name="CredentialProviderFailed_VisualStudioAccountProvider" xml:space="preserve">
+    <value>The Visual Studio or VSTS account provider failed to load.</value>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/CredentialServiceTests.cs
@@ -16,8 +16,6 @@ namespace NuGet.Credentials.Test
     
     public class CredentialServiceTests
     {
-        private readonly StringBuilder _testErrorOutput = new StringBuilder();
-
         private readonly Mock<ICredentialProvider> _mockProvider;
 
         public CredentialServiceTests()
@@ -36,18 +34,12 @@ namespace NuGet.Credentials.Test
             _mockProvider.Setup(x => x.Id).Returns("1");
         }
 
-        private void TestableErrorWriter(string s)
-        {
-            _testErrorOutput.AppendLine(s);
-        }
-
         [Fact]
         public async Task GetCredentials_PassesAllParametersToProviders()
         {
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: true);
             var webProxy = new WebProxy();
             var uri = new Uri("http://uri");
@@ -77,7 +69,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(
                 x => x.GetAsync(
@@ -132,7 +123,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider.Setup(
                 x => x.GetAsync(
@@ -187,7 +177,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: true);
             var webProxy = new WebProxy();
             var uri = new Uri("http://uri");
@@ -231,7 +220,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider
                 .Setup(x => x.GetAsync(
@@ -280,7 +268,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider
                 .Setup(x => x.GetAsync(
@@ -353,7 +340,6 @@ namespace NuGet.Credentials.Test
             mockProvider2.Setup(x => x.Id).Returns("2");
             var service = new CredentialService(
                 new[] {mockProvider1.Object, mockProvider2.Object},
-                TestableErrorWriter,
                 nonInteractive: false);
             var uri1 = new Uri("http://host/some/path");
 
@@ -395,7 +381,6 @@ namespace NuGet.Credentials.Test
             // Arrange
             var service = new CredentialService(
                 new[] { _mockProvider.Object },
-                TestableErrorWriter,
                 nonInteractive: false);
             _mockProvider
                 .Setup(x => x.GetAsync(


### PR DESCRIPTION
Addresses https://github.com/NuGet/Home/issues/2422.

This adds resiliency around credential provider initialization in the VSIX so that if they fail to load, the whole extension is not brought down. In the case of credential provider failure, an exception is written to the activity log.

/cc @emgarten @alpaix @drewgil @pspill @xavierdecoster 
