### PR TITLE
Improving test coverage and small fixes for xplat locals 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,10 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+# build xplat dll
+echo "$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0"
+$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0
+
 # run tests
 for testProject in `find test/NuGet.Core.Tests -type f -name project.json`
 do

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ fi
 
 # build xplat dll
 echo "$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0"
-$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0
+$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --framework netcoreapp1.0
 
 # run tests
 for testProject in `find test/NuGet.Core.Tests -type f -name project.json`

--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ fi
 
 # build xplat dll
 echo "$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0"
-$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --framework netcoreapp1.0
+$DOTNET build src/NuGet.Core/NuGet.CommandLine.XPlat --configuration release --framework netcoreapp1.0
 
 # run tests
 for testProject in `find test/NuGet.Core.Tests -type f -name project.json`

--- a/src/NuGet.Clients/Options/Resources.Designer.cs
+++ b/src/NuGet.Clients/Options/Resources.Designer.cs
@@ -117,7 +117,7 @@ namespace NuGet.Options {
         /// <summary>
         ///   Looks up a localized string similar to NuGet cache(s) clear failed at {0}. 
         ///Error: {1}
-        ///Please see http://example.com/help/locals for more help..
+        ///Please see https://aka.ms/troubleshoot_nuget_cache for more help..
         /// </summary>
         public static string ShowMessage_LocalsCommandFailure {
             get {

--- a/src/NuGet.Clients/Options/Resources.resx
+++ b/src/NuGet.Clients/Options/Resources.resx
@@ -138,7 +138,7 @@
   <data name="ShowMessage_LocalsCommandFailure" xml:space="preserve">
     <value>NuGet cache(s) clear failed at {0}. 
 Error: {1}
-Please see http://example.com/help/locals for more help.</value>
+Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <comment>{0} :error message;
 {1}: date and time
 </comment>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
@@ -43,7 +43,8 @@ namespace NuGet.CommandLine.XPlat
                 {
                     var logger = getLogger();
                     var setting = Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null);
-                    if (((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0])) || (clear.HasValue() && list.HasValue()) || (!clear.HasValue() && !list.HasValue()))
+                    if (((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0]))
+                        || (clear.HasValue() && list.HasValue()) || (!clear.HasValue() && !list.HasValue()))
                     {
                         // Using both -clear and -list command options, or neither one of them, is not supported.
                         // We use MinArgs = 0 even though the first argument is required,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
@@ -43,14 +43,13 @@ namespace NuGet.CommandLine.XPlat
                 {
                     var logger = getLogger();
                     var setting = Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null);
-                    if (((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0]))
-                        || (clear.HasValue() && list.HasValue()) || (!clear.HasValue() && !list.HasValue()))
+                    if (((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0])) || (clear.HasValue() && list.HasValue()) || (!clear.HasValue() && !list.HasValue()))
                     {
                         // Using both -clear and -list command options, or neither one of them, is not supported.
                         // We use MinArgs = 0 even though the first argument is required,
                         // to avoid throwing a command argument validation exception and
                         // immediately show usage help for this command instead.
-                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
+                        throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
@@ -17,6 +17,7 @@ namespace NuGet.CommandLine.XPlat
             app.Command("locals", locals =>
             {
                 locals.Description = Strings.LocalsCommand_Description;
+                locals.HelpOption(XPlatUtility.HelpOption);
 
                 locals.Option(
                     CommandConstants.ForceEnglishOutputOption,
@@ -48,7 +49,7 @@ namespace NuGet.CommandLine.XPlat
                         // We use MinArgs = 0 even though the first argument is required,
                         // to avoid throwing a command argument validation exception and
                         // immediately show usage help for this command instead.
-                        throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/LocalsCommand.cs
@@ -43,13 +43,21 @@ namespace NuGet.CommandLine.XPlat
                 {
                     var logger = getLogger();
                     var setting = Settings.LoadDefaultSettings(root: null, configFileName: null, machineWideSettings: null);
-                    if (((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0])) || (clear.HasValue() && list.HasValue()) || (!clear.HasValue() && !list.HasValue()))
+                    // Using both -clear and -list command options, or neither one of them, is not supported.
+                    // We use MinArgs = 0 even though the first argument is required,
+                    // to avoid throwing a command argument validation exception and
+                    // immediately show usage help for this command instead.
+                    if ((arguments.Values.Count < 1) || string.IsNullOrWhiteSpace(arguments.Values[0]))
                     {
-                        // Using both -clear and -list command options, or neither one of them, is not supported.
-                        // We use MinArgs = 0 even though the first argument is required,
-                        // to avoid throwing a command argument validation exception and
-                        // immediately show usage help for this command instead.
-                        throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_NoArguments));
+                    }
+                    else if (clear.HasValue() && list.HasValue())
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_MultipleOperations));
+                    }
+                    else if (!clear.HasValue() && !list.HasValue())
+                    {
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_NoOperation));
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -260,6 +260,39 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
+        /// </summary>
+        public static string LocalsCommand_MultipleOperations {
+            get {
+                return ResourceManager.GetString("LocalsCommand_MultipleOperations", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to No Cache Type was specified.
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
+        /// </summary>
+        public static string LocalsCommand_NoArguments {
+            get {
+                return ResourceManager.GetString("LocalsCommand_NoArguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Please specify an operation i.e. --list or --clear.
+        ///usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
+        /// </summary>
+        public static string LocalsCommand_NoOperation {
+            get {
+                return ResourceManager.GetString("LocalsCommand_NoOperation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Committing restore....
         /// </summary>
         public static string Log_Committing {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -331,4 +331,19 @@
     <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
+  <data name="LocalsCommand_MultipleOperations" xml:space="preserve">
+    <value>Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.
+usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
+  </data>
+  <data name="LocalsCommand_NoArguments" xml:space="preserve">
+    <value>No Cache Type was specified.
+usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
+  </data>
+  <data name="LocalsCommand_NoOperation" xml:space="preserve">
+    <value>Please specify an operation i.e. --list or --clear.
+usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
@@ -77,7 +77,17 @@ namespace NuGet.Commands
         /// </summary>
         /// <returns></returns>
         public void ExecuteCommand()
-        {           
+        {
+            if (((Arguments.Count < 1) || string.IsNullOrWhiteSpace(Arguments[0]))
+                || (Clear && List) || (!Clear && !List))
+            {
+                // Using both -clear and -list command options, or neither one of them, is not supported.
+                // We use MinArgs = 0 even though the first argument is required,
+                // to avoid throwing a command argument validation exception and
+                // immediately show usage help for this command instead.
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_Help));
+            }
+
             var localResourceName = GetLocalResourceName(Arguments[0]);
 
             if (Clear)

--- a/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
@@ -31,9 +31,9 @@ namespace NuGet.Commands
         private const string AllResourceName = "all";
         private const string TempResourceName = "temp";
 
-        public bool Clear { get; set; }
+        private bool Clear { get; set; }
 
-        public bool List { get; set; }
+        private bool List { get; set; }
 
         private IList<string> Arguments { get; set; }
 
@@ -77,7 +77,7 @@ namespace NuGet.Commands
         /// </summary>
         /// <returns></returns>
         public void ExecuteCommand()
-        {
+        {           
             var localResourceName = GetLocalResourceName(Arguments[0]);
 
             if (Clear)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -294,6 +294,16 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+        ///For more information, visit http://docs.nuget.org/docs/reference/command-line-reference.
+        /// </summary>
+        public static string LocalsCommand_Help {
+            get {
+                return ResourceManager.GetString("LocalsCommand_Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to An invalid local resource name was provided. Please provide one of the following values: http-cache, temp, global-packages, all..
         /// </summary>
         public static string LocalsCommand_InvalidLocalResourceName {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -444,4 +444,8 @@
   <data name="LocalsCommand_LocalsPartiallyCleared" xml:space="preserve">
     <value>Local resources partially cleared.</value>
   </data>
+  <data name="LocalsCommand_Help" xml:space="preserve">
+    <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
+For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -28,8 +28,7 @@ namespace NuGet.XPlat.FuncTest
         /// </returns>
         public static string GetDotnetCli()
         {
-            var funcTestLocation = typeof(XPlatLocalsTests).GetTypeInfo().Assembly.Location;
-            var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(funcTestLocation));
+            var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
             var parentDirInfo = currentDirInfo.Parent;
             while (parentDirInfo != null)
             {
@@ -106,8 +105,7 @@ namespace NuGet.XPlat.FuncTest
         /// </returns>
         public static string GetXplatDll()
         {
-            var funcTestLocation = typeof(XPlatLocalsTests).GetTypeInfo().Assembly.Location;
-            var currentDirInfo = new DirectoryInfo(Path.GetDirectoryName(funcTestLocation));
+            var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
             var parentDirInfo = currentDirInfo.Parent;
             while (parentDirInfo != null)
             {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using NuGet.Test.Utility;
 using Xunit;
@@ -11,8 +12,11 @@ namespace NuGet.XPlat.FuncTest
     {
         private const string _dotnetCliBinary = @"dotnet";
         private const string _dotnetCliExe = @"dotnet.exe";
+
         private static string _xplatDll = Path.Combine("NuGet.Core", "NuGet.CommandLine.XPlat", "bin",
                                                        "release", "netcoreapp1.0", "NuGet.CommandLine.XPlat.dll");
+
+        private static List<string> _fileNames = new List<string> { "file1.txt", "file2.txt" };
 
         /// <summary>
         /// Provides the path to dotnet cli on the test machine.
@@ -58,11 +62,37 @@ namespace NuGet.XPlat.FuncTest
         /// <param name="path">Path which needs to be populated with dummy files</param>
         public static void CreateTestFiles(string path)
         {
-            var fileNames = new List<string> { "file1.txt", "file2.txt" };
-            foreach (var fileName in fileNames)
+            foreach (var fileName in _fileNames)
             {
                 File.Create(Path.Combine(path, fileName)).Dispose();
             }
+        }
+
+        /// <summary>
+        /// Verifies the dummy text files at the specified path for testing nuget locals --clear
+        /// </summary>
+        /// <param name="path">Path which needs to be tested for the dummy files</param>
+        public static void VerifyClearSuccess(string path)
+        {
+            Assert.False(Directory.Exists(path));
+        }
+
+        /// <summary>
+        /// Verifies the dummy text files at the specified path for testing nuget locals --clear
+        /// </summary>
+        /// <param name="path">Path which needs to be tested for the dummy files</param>
+        public static void VerifyNoClear(string path)
+        {
+            Assert.True(Directory.Exists(path));
+            var files = Directory.GetFiles(path)
+                                 .Select(filepath => Path.GetFileName(filepath))
+                                 .ToArray();
+            foreach (var filename in _fileNames)
+            {
+                Assert.True(Array.Exists(files, element => element == filename));
+            }
+
+            Assert.Equal(files.Count(), _fileNames.Count);
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -20,8 +20,8 @@ namespace NuGet.XPlat.FuncTest
         {
             DotnetCliBinary = @"dotnet";
             DotnetCliExe = @"dotnet.exe";
-            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\debug\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
-            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/debug/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
+            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\release\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
+            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/release/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
         }
 
         public static string GetDotnetCli()

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
@@ -50,6 +51,15 @@ namespace NuGet.XPlat.FuncTest
                 parentDirInfo = currentDirInfo.Parent;
             }
             return dotnetCli;
+        }
+
+        public static void createTestFiles(string path)
+        {
+            var fileNames = new List<string> { "file1.txt", "file2.txt" };
+            foreach (var fileName in fileNames)
+            {
+                File.Create(Path.Combine(path, fileName)).Dispose();
+            }
         }
 
         public static string GetXplatDll()

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
-    public class Util
+    internal class Util
     {
         private static string DotnetCliBinary { get; set; }
 
@@ -24,13 +24,21 @@ namespace NuGet.XPlat.FuncTest
             XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/release/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
         }
 
+        /// <summary>
+        /// Provides the path to dotnet cli on the test machine.
+        /// It traverses in the directory tree going one step up at a time and looks for cli folder.
+        /// </summary>
+        /// <returns>
+        /// <code>String</code> containing the path to the dotnet cli within the local repository.
+        /// Can return <code>null</code> if no cli directory or dotnet cli is found, in which case the tests can fail.
+        /// </returns>
         public static string GetDotnetCli()
         {
             var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
             var parentDirInfo = currentDirInfo.Parent;
-            var dotnetCli = "";
             while (parentDirInfo != null)
             {
+                var dotnetCli = "";
                 foreach (var dir in parentDirInfo.EnumerateDirectories())
                 {
                     if (StringComparer.OrdinalIgnoreCase.Equals(dir.Name, "cli"))
@@ -53,6 +61,10 @@ namespace NuGet.XPlat.FuncTest
             return null;
         }
 
+        /// <summary>
+        /// Adds a few dummy text files at the specified path for testing nuget locals --clear
+        /// </summary>
+        /// <param name="path">Path which needs to be populated with dummy files</param>
         public static void createTestFiles(string path)
         {
             var fileNames = new List<string> { "file1.txt", "file2.txt" };
@@ -62,13 +74,22 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        /// <summary>
+        /// Provides the path to Xplat dll on the test machine.
+        /// It traverses in the directory tree going one step up at a time and looks for src folder.
+        /// Once in src, it looks for the xplat dll in the location specified by <code>XplatDll</code> or <code>XplatDllShell</code>.
+        /// </summary>
+        /// <returns>
+        /// <code>String</code> containing the path to the dotnet cli within the local repository.
+        /// Can return <code>null</code> if no src directory or xplat dll is found, in which case the tests can fail.
+        /// </returns>
         public static string GetXplatDll()
         {
             var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
             var parentDirInfo = currentDirInfo.Parent;
-            var xplatDll = "";
             while (parentDirInfo != null)
             {
+                var xplatDll = "";
                 foreach (var dir in parentDirInfo.EnumerateDirectories())
                 {
                     if (StringComparer.OrdinalIgnoreCase.Equals(dir.Name, "src"))
@@ -91,6 +112,11 @@ namespace NuGet.XPlat.FuncTest
             return null;
         }
 
+        /// <summary>
+        /// Used to verify the success of positive test cases
+        /// </summary>
+        /// <param name="result">The actual result of the test</param>
+        /// <param name="expectedOutputMessage"> The expected result of the test</param>
         public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)
         {
             Assert.True(
@@ -105,6 +131,11 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        /// <summary>
+        /// Used to verify the failure of negitive test cases
+        /// </summary>
+        /// <param name="result">The actual result of the test</param>
+        /// <param name="expectedOutputMessage"> The expected result of the test</param>
         public static void VerifyResultFailure(CommandRunnerResult result,
                                                string expectedErrorMessage)
         {

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -20,8 +20,8 @@ namespace NuGet.XPlat.FuncTest
         {
             DotnetCliBinary = @"dotnet";
             DotnetCliExe = @"dotnet.exe";
-            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\release\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
-            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/release/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
+            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\debug\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
+            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/debug/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
         }
 
         public static string GetDotnetCli()
@@ -50,7 +50,7 @@ namespace NuGet.XPlat.FuncTest
                 currentDirInfo = new DirectoryInfo(parentDirInfo.FullName);
                 parentDirInfo = currentDirInfo.Parent;
             }
-            return dotnetCli;
+            return null;
         }
 
         public static void createTestFiles(string path)
@@ -88,7 +88,7 @@ namespace NuGet.XPlat.FuncTest
                 currentDirInfo = new DirectoryInfo(parentDirInfo.FullName);
                 parentDirInfo = currentDirInfo.Parent;
             }
-            return xplatDll;
+            return null;
         }
 
         public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -6,18 +7,78 @@ namespace NuGet.XPlat.FuncTest
 {
     public class Util
     {
-        private static string DotnetCliExec { get; set; }
+        private static string DotnetCliBinary { get; set; }
+
+        private static string DotnetCliExe { get; set; }
+
+        private static string XplatDll { get; set; }
+
+        private static string XplatDllShell { get; set; }
 
         static Util()
         {
-            DotnetCliExec = @"../../../cli/dotnet";
+            DotnetCliBinary = @"dotnet";
+            DotnetCliExe = @"dotnet.exe";
+            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\debug\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
+            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/Debug/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
         }
 
         public static string GetDotnetCli()
         {
-            var currentDir = Directory.GetCurrentDirectory();
-            var dotnetCli = Path.Combine(currentDir, DotnetCliExec);
+            var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var parentDirInfo = currentDirInfo.Parent;
+            var dotnetCli = "";
+            while (parentDirInfo != null)
+            {
+                foreach (var dir in parentDirInfo.EnumerateDirectories())
+                {
+                    if (StringComparer.OrdinalIgnoreCase.Equals(dir.Name, "cli"))
+                    {
+                        dotnetCli = Path.Combine(dir.FullName, DotnetCliExe);
+                        if (File.Exists(dotnetCli))
+                        {
+                            return dotnetCli;
+                        }
+                        dotnetCli = Path.Combine(dir.FullName, DotnetCliBinary);
+                        if (File.Exists(dotnetCli))
+                        {
+                            return dotnetCli;
+                        }
+                    }
+                }
+                currentDirInfo = new DirectoryInfo(parentDirInfo.FullName);
+                parentDirInfo = currentDirInfo.Parent;
+            }
             return dotnetCli;
+        }
+
+        public static string GetXplatDll()
+        {
+            var currentDirInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var parentDirInfo = currentDirInfo.Parent;
+            var xplatDll = "";
+            while (parentDirInfo != null)
+            {
+                foreach (var dir in parentDirInfo.EnumerateDirectories())
+                {
+                    if (StringComparer.OrdinalIgnoreCase.Equals(dir.Name, "src"))
+                    {
+                        xplatDll = Path.Combine(dir.FullName, XplatDll);
+                        if (File.Exists(xplatDll))
+                        {
+                            return xplatDll;
+                        }
+                        xplatDll = Path.Combine(dir.FullName, XplatDllShell);
+                        if (File.Exists(xplatDll))
+                        {
+                            return xplatDll;
+                        }
+                    }
+                }
+                currentDirInfo = new DirectoryInfo(parentDirInfo.FullName);
+                parentDirInfo = currentDirInfo.Parent;
+            }
+            return xplatDll;
         }
 
         public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class Util
+    {
+        private static string DotnetCliExec { get; set; }
+
+        static Util()
+        {
+            DotnetCliExec = @"../../../cli/dotnet";
+        }
+
+        public static string GetDotnetCli()
+        {
+            var currentDir = Directory.GetCurrentDirectory();
+            var dotnetCli = Path.Combine(currentDir, DotnetCliExec);
+            return dotnetCli;
+        }
+
+        public static void VerifyResultSuccess(CommandRunnerResult result, string expectedOutputMessage = null)
+        {
+            Assert.True(
+                result.Item1 == 0,
+                "nuget.exe DID NOT SUCCEED: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+
+            if (!string.IsNullOrEmpty(expectedOutputMessage))
+            {
+                Assert.Contains(
+                    expectedOutputMessage,
+                    result.Item2);
+            }
+        }
+
+        public static void VerifyResultFailure(CommandRunnerResult result,
+                                               string expectedErrorMessage)
+        {
+            Assert.True(
+                result.Item1 != 0,
+                "nuget.exe DID NOT FAIL: Ouput is " + result.Item2 + ". Error is " + result.Item3);
+
+            Assert.True(
+                result.Item2.Contains(expectedErrorMessage),
+                "Expected error is " + expectedErrorMessage + ". Actual error is " + result.Item2);
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/Util.cs
@@ -20,8 +20,8 @@ namespace NuGet.XPlat.FuncTest
         {
             DotnetCliBinary = @"dotnet";
             DotnetCliExe = @"dotnet.exe";
-            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\debug\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
-            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/Debug/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
+            XplatDll = @"NuGet.Core\NuGet.CommandLine.XPlat\bin\release\netcoreapp1.0\NuGet.CommandLine.XPlat.dll";
+            XplatDllShell = @"NuGet.Core/NuGet.CommandLine.XPlat/bin/release/netcoreapp1.0/NuGet.CommandLine.XPlat.dll";
         }
 
         public static string GetDotnetCli()

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using NuGet.CommandLine.XPlat;
+using System.IO;
+using NuGet.Test.Utility;
 using Xunit;
 
 namespace NuGet.XPlat.FuncTest
@@ -10,90 +11,90 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatLocalsTests
     {
         [Theory]
-        [InlineData("locals all --list")]
-        [InlineData("locals all -l")]
-        [InlineData("locals --list all")]
-        [InlineData("locals -l all")]
-        [InlineData("locals http-cache --list")]
-        [InlineData("locals http-cache -l")]
-        [InlineData("locals --list http-cache")]
-        [InlineData("locals -l http-cache")]
-        [InlineData("locals temp --list")]
-        [InlineData("locals temp -l")]
-        [InlineData("locals --list temp")]
-        [InlineData("locals -l temp")]
-        [InlineData("locals global-packages --list")]
-        [InlineData("locals global-packages -l")]
-        [InlineData("locals --list global-packages")]
-        [InlineData("locals -l global-packages")]
-        // [InlineData("locals --clear all")]
-        // [InlineData("locals -c all")]
-        public static void Locals_Succeeds(String args)
+        [InlineData("nuget locals all --list")]
+        [InlineData("nuget locals all -l")]
+        [InlineData("nuget locals --list all")]
+        [InlineData("nuget locals -l all")]
+        [InlineData("nuget locals http-cache --list")]
+        [InlineData("nuget locals http-cache -l")]
+        [InlineData("nuget locals --list http-cache")]
+        [InlineData("nuget locals -l http-cache")]
+        [InlineData("nuget locals temp --list")]
+        [InlineData("nuget locals temp -l")]
+        [InlineData("nuget locals --list temp")]
+        [InlineData("nuget locals -l temp")]
+        [InlineData("nuget locals global-packages --list")]
+        [InlineData("nuget locals global-packages -l")]
+        [InlineData("nuget locals --list global-packages")]
+        [InlineData("nuget locals -l global-packages")]
+        // [InlineData("nuget locals --clear all")]
+        // [InlineData("nuget locals -c all")]
+        public static void Locals_Succeeds(string args)
         {
-            // Arrange
-            var log = new TestCommandOutputLogger();
-
             // Act
-            var exitCode = Program.MainInternal(args.Split(null), log);
+            var result = CommandRunner.Run(
+              Util.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              args,
+              waitForExit: true);
 
             // Assert
-            Assert.Equal(string.Empty, log.ShowErrors());
-            Assert.Equal(0, exitCode);
+            Util.VerifyResultSuccess(result, string.Empty);
         }
 
         [Theory]
-        [InlineData("locals")]
-        [InlineData("locals --list")]
-        [InlineData("locals -l")]
-        [InlineData("locals --clear")]
-        [InlineData("locals -c")]
-        public static void Locals_Success_InvalidArguments_HelpMessage(String args)
+        [InlineData("nuget locals")]
+        [InlineData("nuget locals --list")]
+        [InlineData("nuget locals -l")]
+        [InlineData("nuget locals --clear")]
+        [InlineData("nuget locals -c")]
+        public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
-            // Arrange
-            var log = new TestCommandOutputLogger();
-
             // Act
-            var exitCode = Program.MainInternal(args.Split(null), log);
+            var result = CommandRunner.Run(
+              Util.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              args,
+              waitForExit: true);
 
             // Assert
-            Assert.Equal("usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]" + Environment.NewLine + "For more information, visit http://docs.nuget.org/docs/reference/command-line-reference", log.ShowErrors());
-            Assert.Equal(1, exitCode);
+            Util.VerifyResultFailure(result, "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]" + Environment.NewLine + "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
         }
 
         [Theory]
-        [InlineData("locals --list unknownResource")]
-        [InlineData("locals -l unknownResource")]
-        [InlineData("locals --clear unknownResource")]
-        [InlineData("locals -c unknownResource")]
-        public static void Locals_Success_InvalidResourceName_HelpMessage(String args)
+        [InlineData("nuget locals --list unknownResource")]
+        [InlineData("nuget locals -l unknownResource")]
+        [InlineData("nuget locals --clear unknownResource")]
+        [InlineData("nuget locals -c unknownResource")]
+        public static void Locals_Success_InvalidResourceName_HelpMessage(string args)
         {
-            // Arrange
-            var log = new TestCommandOutputLogger();
-
             // Act
-            var exitCode = Program.MainInternal(args.Split(null), log);
+            var result = CommandRunner.Run(
+              Util.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              args,
+              waitForExit: true);
 
             // Assert
-            Assert.Equal("An invalid local resource name was provided. Please provide one of the following values: http-cache, temp, global-packages, all.", log.ShowErrors());
-            Assert.Equal(1, exitCode);
+            Util.VerifyResultFailure(result, "error: An invalid local resource name was provided. Please provide one of the following values: http-cache, temp, global-packages, all.");
         }
 
         [Theory]
-        [InlineData("locals -list")]
-        [InlineData("locals -clear")]
-        [InlineData("locals --l")]
-        [InlineData("locals --c")]
-        public static void Locals_Success_InvalidFlags_HelpMessage(String args)
+        [InlineData("nuget locals -list")]
+        [InlineData("nuget locals -clear")]
+        [InlineData("nuget locals --l")]
+        [InlineData("nuget locals --c")]
+        public static void Locals_Success_InvalidFlags_HelpMessage(string args)
         {
-            // Arrange
-            var log = new TestCommandOutputLogger();
-
             // Act
-            var exitCode = Program.MainInternal(args.Split(null), log);
+            var result = CommandRunner.Run(
+              Util.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              args,
+              waitForExit: true);
 
             // Assert
-            Assert.Equal("Unrecognized option '" + args.Split(null)[1] + "'", log.ShowErrors());
-            Assert.Equal(1, exitCode);
+            Util.VerifyResultFailure(result, "Specify --help for a list of available options and commands." + Environment.NewLine + "error: Unrecognized option '" + args.Split(null)[2] + "'");
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -115,24 +115,30 @@ namespace NuGet.XPlat.FuncTest
                 }
                 else if (cacheType == "global-packages")
                 {
-                    // Only the global packages cache should be cleared
-                    Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
-                    Assert.True(Directory.Exists(mockHttpCacheDirectory.FullName));
-                    Assert.True(Directory.Exists(mockTmpCacheDirectory.FullName));
+                    // Global packages cache should be cleared
+                    DotnetCliUtil.VerifyClearSuccess(mockGlobalPackagesDirectory.FullName);
+
+                    // Http cache and Temp cahce should be untouched
+                    DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
                 }
                 else if (cacheType == "http-cache")
                 {
-                    // Only the http cache should be cleared
-                    Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
-                    Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
-                    Assert.True(Directory.Exists(mockTmpCacheDirectory.FullName));
+                    // Http cache should be cleared
+                    DotnetCliUtil.VerifyClearSuccess(mockHttpCacheDirectory.FullName);
+
+                    // Global packages cache and temp cache should be untouched
+                    DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
                 }
                 else if (cacheType == "temp")
                 {
-                    // Only the temp cache should be cleared
-                    Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
-                    Assert.True(Directory.Exists(mockHttpCacheDirectory.FullName));
-                    Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
+                    // Temp cache should be cleared
+                    DotnetCliUtil.VerifyClearSuccess(mockTmpCacheDirectory.FullName);
+
+                    // Global packages cache and Http cache should be un touched
+                    DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
+                    DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
                 }
                 DotnetCliUtil.VerifyResultSuccess(result, string.Empty);
             }
@@ -146,9 +152,9 @@ namespace NuGet.XPlat.FuncTest
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Arrange
-            var expectedResult = string.Concat("error: No Cache Type was specified. ", 
+            var expectedResult = string.Concat("error: No Cache Type was specified. ",
                                                Environment.NewLine,
-                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]", 
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
                                                Environment.NewLine,
                                                "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -11,31 +11,31 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatLocalsTests
     {
         [Theory]
-        [InlineData("nuget locals all --list")]
-        [InlineData("nuget locals all -l")]
-        [InlineData("nuget locals --list all")]
-        [InlineData("nuget locals -l all")]
-        [InlineData("nuget locals http-cache --list")]
-        [InlineData("nuget locals http-cache -l")]
-        [InlineData("nuget locals --list http-cache")]
-        [InlineData("nuget locals -l http-cache")]
-        [InlineData("nuget locals temp --list")]
-        [InlineData("nuget locals temp -l")]
-        [InlineData("nuget locals --list temp")]
-        [InlineData("nuget locals -l temp")]
-        [InlineData("nuget locals global-packages --list")]
-        [InlineData("nuget locals global-packages -l")]
-        [InlineData("nuget locals --list global-packages")]
-        [InlineData("nuget locals -l global-packages")]
-        // [InlineData("nuget locals --clear all")]
-        // [InlineData("nuget locals -c all")]
+        [InlineData("locals all --list")]
+        [InlineData("locals all -l")]
+        [InlineData("locals --list all")]
+        [InlineData("locals -l all")]
+        [InlineData("locals http-cache --list")]
+        [InlineData("locals http-cache -l")]
+        [InlineData("locals --list http-cache")]
+        [InlineData("locals -l http-cache")]
+        [InlineData("locals temp --list")]
+        [InlineData("locals temp -l")]
+        [InlineData("locals --list temp")]
+        [InlineData("locals -l temp")]
+        [InlineData("locals global-packages --list")]
+        [InlineData("locals global-packages -l")]
+        [InlineData("locals --list global-packages")]
+        [InlineData("locals -l global-packages")]
+        // [InlineData("locals --clear all")]
+        // [InlineData("locals -c all")]
         public static void Locals_Succeeds(string args)
         {
             // Act
             var result = CommandRunner.Run(
               Util.GetDotnetCli(),
               Directory.GetCurrentDirectory(),
-              args,
+              Util.GetXplatDll() + " " + args,
               waitForExit: true);
 
             // Assert
@@ -43,18 +43,18 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("nuget locals")]
-        [InlineData("nuget locals --list")]
-        [InlineData("nuget locals -l")]
-        [InlineData("nuget locals --clear")]
-        [InlineData("nuget locals -c")]
+        [InlineData("locals")]
+        [InlineData("locals --list")]
+        [InlineData("locals -l")]
+        [InlineData("locals --clear")]
+        [InlineData("locals -c")]
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Act
             var result = CommandRunner.Run(
               Util.GetDotnetCli(),
               Directory.GetCurrentDirectory(),
-              args,
+              Util.GetXplatDll() + " " + args,
               waitForExit: true);
 
             // Assert
@@ -62,17 +62,17 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("nuget locals --list unknownResource")]
-        [InlineData("nuget locals -l unknownResource")]
-        [InlineData("nuget locals --clear unknownResource")]
-        [InlineData("nuget locals -c unknownResource")]
+        [InlineData("locals --list unknownResource")]
+        [InlineData("locals -l unknownResource")]
+        [InlineData("locals --clear unknownResource")]
+        [InlineData("locals -c unknownResource")]
         public static void Locals_Success_InvalidResourceName_HelpMessage(string args)
         {
             // Act
             var result = CommandRunner.Run(
               Util.GetDotnetCli(),
               Directory.GetCurrentDirectory(),
-              args,
+              Util.GetXplatDll() + " " + args,
               waitForExit: true);
 
             // Assert
@@ -80,21 +80,21 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("nuget locals -list")]
-        [InlineData("nuget locals -clear")]
-        [InlineData("nuget locals --l")]
-        [InlineData("nuget locals --c")]
+        [InlineData("locals -list")]
+        [InlineData("locals -clear")]
+        [InlineData("locals --l")]
+        [InlineData("locals --c")]
         public static void Locals_Success_InvalidFlags_HelpMessage(string args)
         {
             // Act
             var result = CommandRunner.Run(
               Util.GetDotnetCli(),
               Directory.GetCurrentDirectory(),
-              args,
+              Util.GetXplatDll() + " " + args,
               waitForExit: true);
 
             // Assert
-            Util.VerifyResultFailure(result, "Specify --help for a list of available options and commands." + Environment.NewLine + "error: Unrecognized option '" + args.Split(null)[2] + "'");
+            Util.VerifyResultFailure(result, "Specify --help for a list of available options and commands." + Environment.NewLine + "error: Unrecognized option '" + args.Split(null)[1] + "'");
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -152,7 +152,7 @@ namespace NuGet.XPlat.FuncTest
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Arrange
-            var expectedResult = string.Concat("error: No Cache Type was specified. ",
+            var expectedResult = string.Concat("No Cache Type was specified. ",
                                                Environment.NewLine,
                                                "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
                                                Environment.NewLine,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -152,7 +152,7 @@ namespace NuGet.XPlat.FuncTest
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Arrange
-            var expectedResult = string.Concat("No Cache Type was specified. ",
+            var expectedResult = string.Concat("error: No Cache Type was specified. ",
                                                Environment.NewLine,
                                                "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
                                                Environment.NewLine,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -82,7 +82,8 @@ namespace NuGet.XPlat.FuncTest
                 // Arrange
                 var mockGlobalPackagesDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"global-packages"));
                 var mockHttpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"http-cache"));
-                var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"temp"));
+                var mockTmpDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"temp"));
+                var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"NuGetScratch"));
 
                 DotnetCliUtil.CreateTestFiles(mockGlobalPackagesDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockHttpCacheDirectory.FullName);
@@ -100,7 +101,7 @@ namespace NuGet.XPlat.FuncTest
                     {
                         { "NUGET_PACKAGES", mockGlobalPackagesDirectory.FullName },
                         { "NUGET_HTTP_CACHE_PATH", mockHttpCacheDirectory.FullName },
-                        { RuntimeEnvironmentHelper.IsWindows ? "TMP" : "TMPDIR", mockTmpCacheDirectory.FullName }
+                        { RuntimeEnvironmentHelper.IsWindows ? "TMP" : "TMPDIR", mockTmpDirectory.FullName }
                     });
                 // Unix uses TMPDIR as environment variable as opposed to TMP on windows
 
@@ -108,9 +109,19 @@ namespace NuGet.XPlat.FuncTest
                 if (StringComparer.Ordinal.Equals(cacheType, "all"))
                 {
                     Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
-                    var x = Directory.EnumerateFileSystemEntries(mockGlobalPackagesDirectory.FullName);
-                    //Assert.Equal(Directory.EnumerateFileSystemEntries(mockGlobalPackagesDirectory.FullName), IEnumerable<String>);
                     Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
+                    Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
+                }
+                else if (StringComparer.Ordinal.Equals(cacheType, "global-packages"))
+                {
+                    Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
+                }
+                else if (StringComparer.Ordinal.Equals(cacheType, "http-cache"))
+                {
+                    Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
+                }
+                else
+                {
                     Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
                 DotnetCliUtil.VerifyResultSuccess(result, string.Empty);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -109,9 +109,9 @@ namespace NuGet.XPlat.FuncTest
                 // Assert
                 if (cacheType == "all")
                 {
-                    Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
-                    Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
-                    Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
+                    DotnetCliUtil.VerifyClearSuccess(mockGlobalPackagesDirectory.FullName);
+                    DotnetCliUtil.VerifyClearSuccess(mockHttpCacheDirectory.FullName);
+                    DotnetCliUtil.VerifyClearSuccess(mockTmpCacheDirectory.FullName);
                 }
                 else if (cacheType == "global-packages")
                 {
@@ -152,7 +152,7 @@ namespace NuGet.XPlat.FuncTest
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Arrange
-            var expectedResult = string.Concat("error: No Cache Type was specified. ",
+            var expectedResult = string.Concat("error: No Cache Type was specified.",
                                                Environment.NewLine,
                                                "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
                                                Environment.NewLine,

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -122,12 +122,12 @@ namespace NuGet.XPlat.FuncTest
                 }
                 else if (cacheType == "http-cache")
                 {
-                    // Only the http cache cache should be cleared
+                    // Only the http cache should be cleared
                     Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
                     Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
                     Assert.True(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
-                else
+                else if (cacheType == "temp")
                 {
                     // Only the temp cache should be cleared
                     Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
@@ -139,7 +139,6 @@ namespace NuGet.XPlat.FuncTest
         }
 
         [Theory]
-        [InlineData("locals")]
         [InlineData("locals --list")]
         [InlineData("locals -l")]
         [InlineData("locals --clear")]
@@ -147,7 +146,9 @@ namespace NuGet.XPlat.FuncTest
         public static void Locals_Success_InvalidArguments_HelpMessage(string args)
         {
             // Arrange
-            var expectedResult = string.Concat("error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+            var expectedResult = string.Concat("error: No Cache Type was specified. ", 
+                                               Environment.NewLine,
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]", 
                                                Environment.NewLine,
                                                "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 
@@ -194,6 +195,60 @@ namespace NuGet.XPlat.FuncTest
             // Arrange
             var expectedResult = string.Concat("Specify --help for a list of available options and commands.",
                                                Environment.NewLine, "error: Unrecognized option '", args.Split(null)[1], "'");
+
+            // Act
+            var result = CommandRunner.Run(
+              DotnetCliUtil.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              DotnetCliUtil.GetXplatDll() + " " + args,
+              waitForExit: true);
+
+            // Assert
+            DotnetCliUtil.VerifyResultFailure(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData("locals all")]
+        [InlineData("locals http-cache")]
+        [InlineData("locals global-packages")]
+        [InlineData("locals temp")]
+        public static void Locals_Success_NoFlags_HelpMessage(string args)
+        {
+            // Arrange
+            var expectedResult = string.Concat("error: Please specify an operation i.e. --list or --clear.",
+                                               Environment.NewLine,
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+                                               Environment.NewLine,
+                                               "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
+
+            // Act
+            var result = CommandRunner.Run(
+              DotnetCliUtil.GetDotnetCli(),
+              Directory.GetCurrentDirectory(),
+              DotnetCliUtil.GetXplatDll() + " " + args,
+              waitForExit: true);
+
+            // Assert
+            DotnetCliUtil.VerifyResultFailure(result, expectedResult);
+        }
+
+        [Theory]
+        [InlineData("locals -c -l all")]
+        [InlineData("locals -c -l global-packages")]
+        [InlineData("locals -c -l http-cache")]
+        [InlineData("locals -c -l temp")]
+        [InlineData("locals --clear --list all")]
+        [InlineData("locals --clear --list global-packages")]
+        [InlineData("locals --clear --list http-cache")]
+        [InlineData("locals --clear --list temp")]
+        public static void Locals_Success_BothFlags_HelpMessage(string args)
+        {
+            // Arrange
+            var expectedResult = string.Concat("error: Both operations, --list and --clear, are not supported in the same command. Please specify only one operation.",
+                                               Environment.NewLine,
+                                               "error: usage: NuGet locals <all | http-cache | global-packages | temp> [--clear | -c | --list | -l]",
+                                               Environment.NewLine,
+                                               "error: For more information, visit http://docs.nuget.org/docs/reference/command-line-reference");
 
             // Act
             var result = CommandRunner.Run(

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -84,7 +84,7 @@ namespace NuGet.XPlat.FuncTest
                 var mockGlobalPackagesDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"global-packages"));
                 var mockHttpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"http-cache"));
                 var mockTmpDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"temp"));
-                var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockBaseDirectory.Path, @"NuGetScratch"));
+                var mockTmpCacheDirectory = Directory.CreateDirectory(Path.Combine(mockTmpDirectory.FullName, @"NuGetScratch"));
 
                 DotnetCliUtil.CreateTestFiles(mockGlobalPackagesDirectory.FullName);
                 DotnetCliUtil.CreateTestFiles(mockHttpCacheDirectory.FullName);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -61,6 +61,7 @@ namespace NuGet.XPlat.FuncTest
             }
         }
 
+        [Theory]
         [InlineData("locals --clear all")]
         [InlineData("locals -c all")]
         [InlineData("locals http-cache --clear")]
@@ -106,22 +107,31 @@ namespace NuGet.XPlat.FuncTest
                 // Unix uses TMPDIR as environment variable as opposed to TMP on windows
 
                 // Assert
-                if (StringComparer.Ordinal.Equals(cacheType, "all"))
+                if (cacheType == "all")
                 {
                     Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
                     Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
                     Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
-                else if (StringComparer.Ordinal.Equals(cacheType, "global-packages"))
+                else if (cacheType == "global-packages")
                 {
+                    // Only the global packages cache should be cleared
                     Assert.False(Directory.Exists(mockGlobalPackagesDirectory.FullName));
+                    Assert.True(Directory.Exists(mockHttpCacheDirectory.FullName));
+                    Assert.True(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
-                else if (StringComparer.Ordinal.Equals(cacheType, "http-cache"))
+                else if (cacheType == "http-cache")
                 {
+                    // Only the http cache cache should be cleared
+                    Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
                     Assert.False(Directory.Exists(mockHttpCacheDirectory.FullName));
+                    Assert.True(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
                 else
                 {
+                    // Only the temp cache should be cleared
+                    Assert.True(Directory.Exists(mockGlobalPackagesDirectory.FullName));
+                    Assert.True(Directory.Exists(mockHttpCacheDirectory.FullName));
                     Assert.False(Directory.Exists(mockTmpCacheDirectory.FullName));
                 }
                 DotnetCliUtil.VerifyResultSuccess(result, string.Empty);


### PR DESCRIPTION
PR contains code for the following - 
1. Improve test coverage for xplat locals by adding test cases for --clear | -c and adding Utils.cs to get the dotnet cli path, etc.
2. Add the troubleshooting link to the Package Manager Settings UI.
3. Better error detection in LocalsCommandRunner.
4. Enable Help option in xplat locals.

Fixes :  https://github.com/NuGet/Home/issues/3348 https://github.com/NuGet/Home/issues/3347

//cc : @joelverhagen @rohit21agrawal @emgarten @jainaashish @drewgil 
