### PR TITLE
Fix bug where subsequent restores do not warn about bumped up dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -174,16 +174,12 @@ namespace NuGet.Commands
             var result = RestoreTargetGraph.Create(runtimeGraph, graphs, context, _logger, framework, runtimeIdentifier);
 
             // Check if the dependencies got bumped up
-            if (_request.ExistingLockFile == null)
-            {
-                // No lock file, so check dependencies
-                CheckDependencies(result, _request.Project.Dependencies);
+            CheckDependencies(result, _request.Project.Dependencies);
 
-                var fxInfo = _request.Project.GetTargetFramework(framework);
-                if (fxInfo != null)
-                {
-                    CheckDependencies(result, fxInfo.Dependencies);
-                }
+            var fxInfo = _request.Project.GetTargetFramework(framework);
+            if (fxInfo != null)
+            {
+                CheckDependencies(result, fxInfo.Dependencies);
             }
 
             return result;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -43,7 +43,7 @@ namespace NuGet.DependencyResolver
 
             // Downgrade
 
-            // A -> B -> C -> D 2.0 (downgrage)
+            // A -> B -> C -> D 2.0 (downgrade)
             //        -> D 1.0
 
             // Potential downgrade that turns out to not downgrade


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/3373.

This regressed when we removed the `"locked"` property from the lock file.

/cc @emgarten @jainaashish

@rrelyea, should this be 3.5.0 RTM?
