### PR TITLE
handled solution project file full path check failure, warn for website with http URI

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -707,7 +707,7 @@ namespace NuGet.CommandLine
                 restoreInputs.PackagesConfigFiles.Add(solutionLevelPackagesConfig);
             }
 
-            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, _msbuildDirectory.Value); // normalize path
+            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, _msbuildDirectory.Value);
 
             foreach (var projectFile in projectFiles)
             {


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/3235

keep the v2 behavior, when nuget can't find project file, it will not fail and send warning.

Warning message :
MSBuild auto-detection: using msbuild version '14.0' from 'C:\Program Files (x86
)\MSBuild\14.0\bin'.
WARNING: Project file C:\Users\lzhi\Documents\3235\http://localhost:51302 cannot
 be found.
Nothing to do. None of the projects in this solution specify any packages for Nu
Get to restore.

@rrelyea @emgarten 
