### PR TITLE
Improve Update tab UI performance

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/IPackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/IPackageItemLoader.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// This enhance IItemLoader by adding package specific methods.
+    /// </summary>
+    internal interface IPackageItemLoader : IItemLoader<PackageItemListViewModel>
+    {
+        Task<SearchResult<IPackageSearchMetadata>> SearchAsync(ContinuationToken continuationToken,
+            CancellationToken cancellationToken);
+
+        Task UpdateStateAndReportAsync(SearchResult<IPackageSearchMetadata> searchResult,
+            IProgress<IItemLoaderState> progress, CancellationToken cancellationToken);
+
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Converters\EnumDescriptionValueConverter.cs" />
     <Compile Include="Converters\NotNullOrTrueToBooleanConverter.cs" />
     <Compile Include="DisplayVersion.cs" />
+    <Compile Include="IPackageItemLoader.cs" />
     <Compile Include="Models\DeprecatedFrameworkModel.cs" />
     <Compile Include="Models\LoadingStatusViewModel.cs" />
     <Compile Include="Models\PackageSearchMetadataCache.cs" />

--- a/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageItemLoader.cs
@@ -13,7 +13,7 @@ using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI
 {
-    internal class PackageItemLoader : IItemLoader<PackageItemListViewModel>
+    internal class PackageItemLoader : IPackageItemLoader
     {
         private readonly PackageLoadContext _context;
         private readonly string _searchText;
@@ -238,7 +238,7 @@ namespace NuGet.PackageManagement.UI
             NuGetEventTrigger.Instance.TriggerEvent(NuGetEvent.PackageLoadEnd);
         }
 
-        private async Task<SearchResult<IPackageSearchMetadata>> SearchAsync(ContinuationToken continuationToken, CancellationToken cancellationToken)
+        public async Task<SearchResult<IPackageSearchMetadata>> SearchAsync(ContinuationToken continuationToken, CancellationToken cancellationToken)
         {
             if (continuationToken != null)
             {
@@ -248,7 +248,7 @@ namespace NuGet.PackageManagement.UI
             return await _packageFeed.SearchAsync(_searchText, SearchFilter, cancellationToken);
         }
 
-        private async Task UpdateStateAndReportAsync(SearchResult<IPackageSearchMetadata> searchResult, IProgress<IItemLoaderState> progress, CancellationToken cancellationToken)
+        public async Task UpdateStateAndReportAsync(SearchResult<IPackageSearchMetadata> searchResult, IProgress<IItemLoaderState> progress, CancellationToken cancellationToken)
         {
             // cache installed packages here for future use
             _installedPackages = await _context.GetInstalledPackagesAsync();

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -122,8 +122,7 @@ namespace NuGet.PackageManagement.UI
 
             Loaded += (_, __) =>
             {
-                SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
-                RefreshAvailableUpdatesCount();
+                SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
                 RefreshConsolidatablePackagesCount();
             };
 
@@ -306,8 +305,7 @@ namespace NuGet.PackageManagement.UI
                 if (prevSelectedItem != SelectedSource)
                 {
                     SaveSettings();
-                    SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
-                    RefreshAvailableUpdatesCount();
+                    SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
                 }
             }
             finally
@@ -528,7 +526,7 @@ namespace NuGet.PackageManagement.UI
         /// <summary>
         /// This method is called from several event handlers. So, consolidating the use of JTF.Run in this method
         /// </summary>
-        private void SearchPackageInActivePackageSource(string searchText, bool useCache)
+        private void SearchPackagesAndRefreshUpdateCount(string searchText, bool useCache)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -549,7 +547,35 @@ namespace NuGet.PackageManagement.UI
                     ? Resx.Resources.Text_Loading
                     : string.Format(CultureInfo.CurrentCulture, Resx.Resources.Text_Searching, searchText);
 
-                _packageList.LoadItems(loader, loadingMessage, _uiLogger);
+                // start SearchAsync task for initial loading of packages
+                var searchResultTask = loader.SearchAsync(continuationToken:null, cancellationToken:CancellationToken.None);
+
+                // this will wait for searchResultTask to complete instead of creating a new task
+                _packageList.LoadItems(loader, loadingMessage, _uiLogger, searchResultTask);
+
+                // We only refresh update count, when we don't use cache so check it it's false
+                if (!useCache)
+                {
+                    if (_topPanel.Filter.Equals(ItemFilter.UpdatesAvailable))
+                    {
+                        // it means selected tab is update itself, so just wait for searchAsyncTask to complete
+                        // without making another call to loader to get all packages.
+                        _topPanel._labelUpgradeAvailable.Count = 0;
+
+                        var searchResult = await searchResultTask;
+                        Model.CachedUpdates = new PackageSearchMetadataCache
+                        {
+                            Packages = searchResult.Items,
+                            IncludePrerelease = IncludePrerelease
+                        };
+
+                        _topPanel._labelUpgradeAvailable.Count = Model.CachedUpdates.Packages.Count;
+                    }
+                    else
+                    {
+                        RefreshAvailableUpdatesCount();
+                    }
+                }
             });
         }
 
@@ -695,8 +721,7 @@ namespace NuGet.PackageManagement.UI
 
                 //Model.Context.SourceProvider.PackageSourceProvider.SaveActivePackageSource(ActiveSource.PackageSource);
                 SaveSettings();
-                SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
-                RefreshAvailableUpdatesCount();
+                SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
             }
         }
 
@@ -705,7 +730,7 @@ namespace NuGet.PackageManagement.UI
             if (_initialized)
             {
                 _packageList.CheckBoxesEnabled = _topPanel.Filter == ItemFilter.UpdatesAvailable;
-                SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: true);
+                SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: true);
 
                 _detailModel.OnFilterChanged(e.PreviousFilter, _topPanel.Filter);
             }
@@ -719,7 +744,7 @@ namespace NuGet.PackageManagement.UI
             if (_topPanel.Filter != ItemFilter.All)
             {
                 // refresh the whole package list
-                SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
+                SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
             }
             else
             {
@@ -730,9 +755,10 @@ namespace NuGet.PackageManagement.UI
                         CancellationToken.None);
                     _packageList.UpdatePackageStatus(installedPackages.ToArray());
                 });
+
+                RefreshAvailableUpdatesCount();
             }
 
-            RefreshAvailableUpdatesCount();
             RefreshConsolidatablePackagesCount();
 
             _packageDetail?.Refresh();
@@ -753,7 +779,7 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: true);
+            SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: true);
         }
 
         private void CheckboxPrerelease_CheckChanged(object sender, EventArgs e)
@@ -766,8 +792,7 @@ namespace NuGet.PackageManagement.UI
             RegistrySettingUtility.SetBooleanSetting(
                 Constants.IncludePrereleaseRegistryName,
                 _topPanel.CheckboxPrerelease.IsChecked == true);
-            SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
-            RefreshAvailableUpdatesCount();
+            SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
         }
 
         internal class SearchQuery : IVsSearchQuery
@@ -792,12 +817,12 @@ namespace NuGet.PackageManagement.UI
 
         public void ClearSearch()
         {
-            SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: true);
+            SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: true);
         }
 
         public IVsSearchTask CreateSearch(uint dwCookie, IVsSearchQuery pSearchQuery, IVsSearchCallback pSearchCallback)
         {
-            SearchPackageInActivePackageSource(pSearchQuery.SearchString, useCache: true);
+            SearchPackagesAndRefreshUpdateCount(pSearchQuery.SearchString, useCache: true);
             return null;
         }
 
@@ -1010,8 +1035,7 @@ namespace NuGet.PackageManagement.UI
 
         private void ExecuteRestartSearchCommand(object sender, ExecutedRoutedEventArgs e)
         {
-            SearchPackageInActivePackageSource(_windowSearchHost.SearchQuery.SearchString, useCache: false);
-            RefreshAvailableUpdatesCount();
+            SearchPackagesAndRefreshUpdateCount(_windowSearchHost.SearchQuery.SearchString, useCache: false);
             RefreshConsolidatablePackagesCount();
         }
     }


### PR DESCRIPTION
The fix consolidates SearchPackages and RefreshUpdateCount into one api and improve Update tab ui performance by having single SearchAsync task. Other than improving cpu time by ~30%, it also optimize network resource by avoiding duplicate network calls.

Fixes https://github.com/NuGet/Home/issues/1493
