### PR TITLE
Improve paths in restore warnings and avoid invalid downgrade warning from bump-up

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -287,33 +287,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Reading project file {0}..
-        /// </summary>
-        public static string Log_ReadingProject {
-            get {
-                return ResourceManager.GetString("Log_ReadingProject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to Restore completed in {0}ms..
-        /// </summary>
-        public static string Log_RestoreComplete {
-            get {
-                return ResourceManager.GetString("Log_RestoreComplete", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to Restore failed in {0}ms..
-        /// </summary>
-        public static string Log_RestoreFailed {
-            get {
-                return ResourceManager.GetString("Log_RestoreFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///    Looks up a localized string similar to Running non-parallel restore..
         /// </summary>
         public static string Log_RunningNonParallelRestore {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -153,15 +153,6 @@
   <data name="Log_LoadedProject" xml:space="preserve">
     <value>Loaded project {0} from {1}.</value>
   </data>
-  <data name="Log_ReadingProject" xml:space="preserve">
-    <value>Reading project file {0}.</value>
-  </data>
-  <data name="Log_RestoreComplete" xml:space="preserve">
-    <value>Restore completed in {0}ms.</value>
-  </data>
-  <data name="Log_RestoreFailed" xml:space="preserve">
-    <value>Restore failed in {0}ms.</value>
-  </data>
   <data name="Log_RunningNonParallelRestore" xml:space="preserve">
     <value>Running non-parallel restore.</value>
   </data>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -147,21 +147,19 @@ namespace NuGet.Commands
 
             if (result.Success)
             {
-                log.LogMinimal(
-                    summaryRequest.InputPath + Environment.NewLine +
-                        string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.Log_RestoreComplete,
-                        sw.ElapsedMilliseconds));
+                log.LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Log_RestoreComplete,
+                    sw.ElapsedMilliseconds,
+                    summaryRequest.InputPath));
             }
             else
             {
-                log.LogMinimal(
-                    summaryRequest.InputPath + Environment.NewLine +
-                        string.Format(
-                        CultureInfo.CurrentCulture,
-                        Strings.Log_RestoreFailed,
-                        sw.ElapsedMilliseconds));
+                log.LogMinimal(string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Log_RestoreFailed,
+                    sw.ElapsedMilliseconds,
+                    summaryRequest.InputPath));
             }
 
             // Build the summary

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -690,7 +690,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Restore completed in {0}ms..
+        ///    Looks up a localized string similar to Restore completed in {0}ms for {1}..
         /// </summary>
         public static string Log_RestoreComplete {
             get {
@@ -699,7 +699,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Restore failed in {0}ms..
+        ///    Looks up a localized string similar to Restore failed in {0}ms for {1}..
         /// </summary>
         public static string Log_RestoreFailed {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -235,14 +235,15 @@
   <data name="Log_LoadedProject" xml:space="preserve">
     <value>Loaded project {0} from {1}.</value>
   </data>
-  <data name="Log_ReadingProject" xml:space="preserve">
-    <value>Reading project file {0}.</value>
-  </data>
   <data name="Log_RestoreComplete" xml:space="preserve">
-    <value>Restore completed in {0}ms.</value>
+    <value>Restore completed in {0}ms for {1}.</value>
+    <comment>{0} is the restore duration in milliseconds.
+{1} is the path to the project file.</comment>
   </data>
   <data name="Log_RestoreFailed" xml:space="preserve">
-    <value>Restore failed in {0}ms.</value>
+    <value>Restore failed in {0}ms for {1}.</value>
+    <comment>{0} is the restore duration in milliseconds.
+{1} is the path to the project file.</comment>
   </data>
   <data name="Log_RunningNonParallelRestore" xml:space="preserve">
     <value>Running non-parallel restore.</value>
@@ -443,5 +444,8 @@
   </data>
   <data name="LocalsCommand_LocalsPartiallyCleared" xml:space="preserve">
     <value>Local resources partially cleared.</value>
+  </data>
+  <data name="Log_ReadingProject" xml:space="preserve">
+    <value>Reading project file {0}.</value>
   </data>
 </root>


### PR DESCRIPTION
Addresses https://github.com/NuGet/Home/issues/2142.

This PR fixes two problems:
1. When reporting a downgrade warning about a bumped up package, the path showed the requested version, not the resolved version, which made debugging more confusing. Now we report the resolved version (if available).
2. When a package was both bumped up and downgraded, an invalid downgrade warning could appear. This case is now handled.

I also cleaned up some minor logging things.

/cc @emgarten @davidfowl @jainaashish 
