### PR TITLE
Remove unused SourceCacheContext property from RestoreCommandProviders

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -132,6 +132,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{DE23D0
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Repositories.Test", "test\NuGet.Core.Tests\NuGet.Repositories.Test\NuGet.Repositories.Test.xproj", "{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Commands.Test.Utility", "test\NuGet.Core.Tests\NuGet.Commands.Test.Utility\NuGet.Commands.Test.Utility.xproj", "{975924FA-3B4F-46AD-AA3B-F7C066D3955C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -354,6 +356,10 @@ Global
 		{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -413,5 +419,6 @@ Global
 		{626E0086-1375-4ABE-A0F8-412786D315FA} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{2034C981-C938-4F0F-8F3B-528B83CB8F7D} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{975924FA-3B4F-46AD-AA3B-F7C066D3955C} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
@@ -91,8 +91,7 @@ namespace NuGet.Commands
             var request = new RestoreRequest(
                 project.PackageSpec,
                 sharedCache,
-                restoreContext.Log,
-                disposeProviders: false);
+                restoreContext.Log);
 
             restoreContext.ApplyStandardProperties(request);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
@@ -84,8 +84,7 @@ namespace NuGet.Commands
             var request = new RestoreRequest(
                 project,
                 sharedCache,
-                restoreContext.Log,
-                disposeProviders: false);
+                restoreContext.Log);
 
             restoreContext.ApplyStandardProperties(request);
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -11,7 +11,7 @@ namespace NuGet.Commands
     /// <summary>
     /// Feed providers
     /// </summary>
-    public class RestoreCommandProviders : IDisposable
+    public class RestoreCommandProviders
     {
         /// <summary>
         /// Providers used by the restore command. These can be shared across restores.
@@ -20,13 +20,11 @@ namespace NuGet.Commands
         /// <param name="fallbackPackageFolders">Path to any fallback package folders.</param>
         /// <param name="localProviders">This is typically just a provider for the global packages folder.</param>
         /// <param name="remoteProviders">All dependency providers.</param>
-        /// <param name="cacheContext">Web cache context.</param>
         public RestoreCommandProviders(
             NuGetv3LocalRepository globalPackages,
             IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
             IReadOnlyList<IRemoteDependencyProvider> localProviders,
-            IReadOnlyList<IRemoteDependencyProvider> remoteProviders,
-            SourceCacheContext cacheContext)
+            IReadOnlyList<IRemoteDependencyProvider> remoteProviders)
         {
             if (globalPackages == null)
             {
@@ -48,15 +46,9 @@ namespace NuGet.Commands
                 throw new ArgumentNullException(nameof(remoteProviders));
             }
 
-            if (cacheContext == null)
-            {
-                throw new ArgumentNullException(nameof(cacheContext));
-            }
-
             GlobalPackages = globalPackages;
             LocalProviders = localProviders;
             RemoteProviders = remoteProviders;
-            CacheContext = cacheContext;
             FallbackPackageFolders = fallbackPackageFolders;
         }
 
@@ -72,8 +64,6 @@ namespace NuGet.Commands
         public IReadOnlyList<IRemoteDependencyProvider> LocalProviders { get; }
 
         public IReadOnlyList<IRemoteDependencyProvider> RemoteProviders { get; }
-
-        public SourceCacheContext CacheContext { get; }
 
         public static RestoreCommandProviders Create(
             string globalFolderPath,
@@ -133,13 +123,7 @@ namespace NuGet.Commands
                 globalPackages,
                 fallbackPackageFolders,
                 localProviders,
-                remoteProviders,
-                cacheContext);
-        }
-
-        public void Dispose()
-        {
-            CacheContext.Dispose();
+                remoteProviders);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -89,7 +89,7 @@ namespace NuGet.Commands
                 remoteProviders.Add(remoteProvider);
             }
 
-            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, cacheContext);
+            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -3,94 +3,22 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
-using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
-    public class RestoreRequest : IDisposable
+    public class RestoreRequest
     {
         public static readonly int DefaultDegreeOfConcurrency = 16;
-        private readonly bool _disposeProviders;
-
-        /// <summary>
-        /// This overload should only be used by tests.
-        /// </summary>
-        public RestoreRequest(
-            PackageSpec project,
-            IEnumerable<PackageSource> sources,
-            string packagesDirectory,
-            ILogger log)
-            : this(
-                  project,
-                  sources,
-                  packagesDirectory,
-                  new List<string>(),
-                  log)
-        {
-        }
-
-        /// <summary>
-        /// This overload should only be used by tests.
-        /// </summary>
-        public RestoreRequest(
-            PackageSpec project,
-            IEnumerable<PackageSource> sources,
-            string packagesDirectory,
-            IEnumerable<string> fallbackPackageFolders,
-            ILogger log)
-            : this(
-                  project,
-                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
-                  packagesDirectory,
-                  fallbackPackageFolders,
-                  log)
-        {
-        }
         
-        /// <summary>
-        /// This overload should only be used by tests.
-        /// </summary>
-        public RestoreRequest(
-            PackageSpec project,
-            IEnumerable<SourceRepository> sources,
-            string packagesDirectory,
-            IEnumerable<string> fallbackPackageFolders,
-            ILogger log) : this(
-                project,
-                RestoreCommandProviders.Create(
-                    packagesDirectory,
-                    fallbackPackageFolderPaths: fallbackPackageFolders,
-                    sources: sources,
-                    cacheContext: new SourceCacheContext(),
-                    log: log),
-                log)
-        {
-        }
-
-        /// <summary>
-        /// This overload should only be used by tests.
-        /// </summary>
         public RestoreRequest(
             PackageSpec project,
             RestoreCommandProviders dependencyProviders,
             ILogger log)
-            : this(project, dependencyProviders, log, disposeProviders: true)
-        {
-        }
-
-        public RestoreRequest(
-            PackageSpec project,
-            RestoreCommandProviders dependencyProviders,
-            ILogger log,
-            bool disposeProviders)
         {
             if (project == null)
             {
@@ -118,8 +46,6 @@ namespace NuGet.Commands
             Log = log;
 
             DependencyProviders = dependencyProviders;
-
-            _disposeProviders = disposeProviders;
         }
 
         public ILogger Log { get; set; }
@@ -202,13 +128,5 @@ namespace NuGet.Commands
         /// This includes both remote and local package providers.
         /// </summary>
         public RestoreCommandProviders DependencyProviders { get; set; }
-
-        public void Dispose()
-        {
-            if (_disposeProviders)
-            {
-                DependencyProviders.Dispose();
-            }
-        }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpSourceCacheContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 
 namespace NuGet.Protocol.Core.Types
 {
@@ -9,6 +10,20 @@ namespace NuGet.Protocol.Core.Types
     {
         private HttpSourceCacheContext(string rootTempFolder, TimeSpan maxAge, bool directDownload)
         {
+            if (maxAge == TimeSpan.Zero)
+            {
+                if (rootTempFolder == null)
+                {
+                    throw new ArgumentNullException(nameof(rootTempFolder));
+                }
+            }
+            else
+            {
+                Debug.Assert(
+                    rootTempFolder == null,
+                    $"{nameof(rootTempFolder)} should be null when {nameof(maxAge)} is not zero.");
+            }
+
             RootTempFolder = rootTempFolder;
             MaxAge = maxAge;
             DirectDownload = directDownload;
@@ -34,9 +49,9 @@ namespace NuGet.Protocol.Core.Types
             if (retryCount == 0)
             {
                 return new HttpSourceCacheContext(
-                    cacheContext.GeneratedTempFolder,
-                    cacheContext.MaxAgeTimeSpan,
-                    cacheContext.DirectDownload);
+                    rootTempFolder: null,
+                    maxAge: cacheContext.MaxAgeTimeSpan,
+                    directDownload: cacheContext.DirectDownload);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/HttpSourceCacheContext.cs
@@ -10,7 +10,7 @@ namespace NuGet.Protocol.Core.Types
     {
         private HttpSourceCacheContext(string rootTempFolder, TimeSpan maxAge, bool directDownload)
         {
-            if (maxAge == TimeSpan.Zero)
+            if (maxAge <= TimeSpan.Zero)
             {
                 if (rootTempFolder == null)
                 {
@@ -46,7 +46,7 @@ namespace NuGet.Protocol.Core.Types
                 throw new ArgumentNullException(nameof(cacheContext));
             }
 
-            if (retryCount == 0)
+            if (retryCount == 0 && cacheContext.MaxAgeTimeSpan > TimeSpan.Zero)
             {
                 return new HttpSourceCacheContext(
                     rootTempFolder: null,

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/SourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/SourceCacheContext.cs
@@ -79,7 +79,7 @@ namespace NuGet.Protocol.Core.Types
             return timeSpan;
         }
 
-        public string GeneratedTempFolder
+        public virtual string GeneratedTempFolder
         {
             get
             {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpCacheUtility.cs
@@ -23,20 +23,17 @@ namespace NuGet.Protocol
             string cacheKey,
             HttpSourceCacheContext context)
         {
-            var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(sourceUri.OriginalString));
-            var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
-            var cacheFolder = Path.Combine(httpCacheDirectory, baseFolderName);
-            var cacheFile = Path.Combine(cacheFolder, baseFileName);
-            var newCacheFile = cacheFile + "-new";
-
-            var temporaryFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
-            var newTemporaryFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
-
             // When the MaxAge is TimeSpan.Zero, this means the caller is passing is using a temporary directory for
             // cache files, instead of the global HTTP cache used by default. Additionally, the cleaning up of this
             // directory is the responsibility of the caller.
-            if (!context.MaxAge.Equals(TimeSpan.Zero))
+            if (context.MaxAge > TimeSpan.Zero)
             {
+                var baseFolderName = RemoveInvalidFileNameChars(ComputeHash(sourceUri.OriginalString));
+                var baseFileName = RemoveInvalidFileNameChars(cacheKey) + ".dat";
+                var cacheFolder = Path.Combine(httpCacheDirectory, baseFolderName);
+                var cacheFile = Path.Combine(cacheFolder, baseFileName);
+                var newCacheFile = cacheFile + "-new";
+
                 return new HttpCacheResult(
                     context.MaxAge,
                     newCacheFile,
@@ -44,6 +41,9 @@ namespace NuGet.Protocol
             }
             else
             {
+                var temporaryFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
+                var newTemporaryFile = Path.Combine(context.RootTempFolder, Path.GetRandomFileName());
+
                 return new HttpCacheResult(
                     context.MaxAge,
                     newTemporaryFile,

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestSourceCacheContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Protocol.Core.Types;
+
+namespace NuGet.Protocol.Test.Utility
+{
+    /// <summary>
+    /// This is a test source cache context that should be used in places where it is not convenient to dispose the
+    /// <see cref="SourceCacheContext"/>. Since <see cref="SourceCacheContext.GeneratedTempFolder"/> must be called
+    /// before <see cref="SourceCacheContext.Dispose"/> does anything meaningful, this implementation disables that
+    /// property.
+    /// </summary>
+    public class TestSourceCacheContext : SourceCacheContext
+    {
+        public override string GeneratedTempFolder
+        {
+            get
+            {
+                throw new NotSupportedException(
+                    "The test source cache context does not support building a generated temp folder.");
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using NuGet.Commands.Test;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -43,7 +43,7 @@ namespace NuGet.Commands.FuncTest
 
                 AddDependency(spec, "ENTITYFRAMEWORK", "6.1.3-BETA1");
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, new[] { sourceRepository }, packagesDir, Enumerable.Empty<string>(), logger);
+                var request = new TestRestoreRequest(spec, new[] { sourceRepository }, packagesDir, Enumerable.Empty<string>(), logger);
                 var command = new RestoreCommand(request);
                 // Act
                 var result = await command.ExecuteAsync();
@@ -94,7 +94,7 @@ namespace NuGet.Commands.FuncTest
                 JsonPackageSpecWriter.WritePackageSpec(referenceSpec, referenceSpecPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(projectSpec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(projectSpec, sources, packagesDir, logger);
                 var command = new RestoreCommand(request);
 
                 // Act
@@ -143,7 +143,7 @@ namespace NuGet.Commands.FuncTest
                 JsonPackageSpecWriter.WritePackageSpec(referenceSpec, referenceSpecPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(projectSpec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(projectSpec, sources, packagesDir, logger);
                 var command = new RestoreCommand(request);
 
                 // Act
@@ -219,7 +219,7 @@ namespace NuGet.Commands.FuncTest
                 var specA = JsonPackageSpecReader.GetPackageSpec("a", specPathA);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(specA, sources, packagesDir, logger)
+                var request = new TestRestoreRequest(specA, sources, packagesDir, logger)
                 {
                     LockFilePath = Path.Combine(specDirA, "project.lock.json")
                 };
@@ -253,7 +253,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "TestPackage.MinClientVersion", "1.0.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -295,7 +295,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "TestPackage.MinClientVersion", "1.0.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -339,7 +339,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "packageA", "1.0.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -393,7 +393,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "packageA", "1.0.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -471,7 +471,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -525,7 +525,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -581,7 +581,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -593,7 +593,7 @@ namespace NuGet.Commands.FuncTest
                 logger.Clear();
 
                 // Act
-                request = new RestoreRequest(spec, sources, packagesDir, logger);
+                request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 request.ExistingLockFile = result.LockFile;
@@ -654,7 +654,7 @@ namespace NuGet.Commands.FuncTest
                 Assert.True(fileSize == 0, "Dummy nupkg file bigger than expected");
 
                 // create the request
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 var command = new RestoreCommand(request);
 
@@ -695,7 +695,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -745,7 +745,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -797,7 +797,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -841,7 +841,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "json-ld.net", "1.0.4");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -892,7 +892,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "dotNetRDF", "1.0.8.3533");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -926,7 +926,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -943,7 +943,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFormat = new LockFileFormat();
                 lockFormat.Write(File.OpenWrite(lockFilePath), modifiedLockFile);
 
-                request = new RestoreRequest(spec, sources, packagesDir, logger);
+                request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -978,7 +978,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -994,7 +994,7 @@ namespace NuGet.Commands.FuncTest
                 File.AppendAllText(lockFilePath, whitespace);
 
                 // Act
-                request = new RestoreRequest(spec, sources, packagesDir, logger);
+                request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 var previousLockFile = result.LockFile;
@@ -1028,7 +1028,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1042,7 +1042,7 @@ namespace NuGet.Commands.FuncTest
                 // Act
                 var lastDate = File.GetLastWriteTime(lockFilePath);
 
-                request = new RestoreRequest(spec, sources, packagesDir, logger);
+                request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 var previousLockFile = result.LockFile;
@@ -1091,7 +1091,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1134,7 +1134,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "WebGrease", "1.6.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1198,7 +1198,7 @@ namespace NuGet.Commands.FuncTest
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1254,7 +1254,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "Moon.Owin.Localization", "1.3.1");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1296,7 +1296,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1304,7 +1304,7 @@ namespace NuGet.Commands.FuncTest
                 var firstRun = await command.ExecuteAsync();
 
                 // Act
-                request = new RestoreRequest(spec, sources, packagesDir, logger);
+                request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 command = new RestoreCommand(request);
                 var result = await command.ExecuteAsync();
                 var installed = result.GetAllInstalled();
@@ -1335,7 +1335,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Versioning", "1.0.7");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1368,7 +1368,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "owin", "1.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1399,7 +1399,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "Newtonsoft.Json", "7.0.0"); // 7.0.0 does not exist so we'll bump up to 7.0.1
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1434,13 +1434,13 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "Newtonsoft.Json", "7.0.0"); // 7.0.0 does not exist so we'll bump up to 7.0.1
                 
                 // Execute the first restore
-                var requestA = new RestoreRequest(spec, sources, packagesDir, new TestLogger());
+                var requestA = new TestRestoreRequest(spec, sources, packagesDir, new TestLogger());
                 requestA.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 var commandA = new RestoreCommand(requestA);
                 var resultA = await commandA.ExecuteAsync();
 
                 var logger = new TestLogger();
-                var requestB = new RestoreRequest(spec, sources, packagesDir, logger);
+                var requestB = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 requestB.LockFilePath = Path.Combine(projectDir, "project.lock.json");
                 requestB.ExistingLockFile = resultA.LockFile;
                 var commandB = new RestoreCommand(requestB);
@@ -1470,7 +1470,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "Newtonsoft.Json", "7.0.1");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1513,7 +1513,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NuGet.Core", "2.8.3");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1561,7 +1561,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NotARealPackage.ThisShouldNotExists.DontCreateIt.Seriously.JustDontDoIt.Please", "2.8.3");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1609,7 +1609,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1656,7 +1656,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1701,7 +1701,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(project, "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1789,7 +1789,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFile = lockFileFormat.Parse(lockFileContent, "In Memory");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.ExistingLockFile = lockFile;
 
@@ -1833,7 +1833,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1873,7 +1873,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1911,7 +1911,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1858,6 +1858,7 @@ namespace NuGet.Commands.FuncTest
 
             using (var packagesDir = TestFileSystemUtility.CreateRandomTestFolder())
             using (var projectDir = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var cacheContext = new SourceCacheContext())
             {
                 var configJson = JObject.Parse(@"
                 {
@@ -1873,7 +1874,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, cacheContext, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/UWPRestoreTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using NuGet.Commands.Test;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -88,7 +89,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
@@ -141,7 +142,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger)
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger)
                 {
                     XmlDocFileSaveMode = Packaging.XmlDocFileSaveMode.None
                 };
@@ -192,7 +193,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
@@ -233,7 +234,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
@@ -284,7 +285,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
@@ -349,7 +350,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 // Set the lock file version to v1 to force a downgrade
@@ -417,7 +418,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();
@@ -475,7 +476,7 @@ namespace NuGet.Commands.FuncTest
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var lockFileFormat = new LockFileFormat();

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/project.json
@@ -4,6 +4,9 @@
     "NuGet.Commands": {
       "target": "project"
     },
+    "NuGet.Commands.Test.Utility": {
+      "target": "project"
+    },
     "NuGet.Test.Utility": {
       "target": "project"
     },

--- a/test/NuGet.Core.FuncTests/global.json
+++ b/test/NuGet.Core.FuncTests/global.json
@@ -1,6 +1,7 @@
 {
   "projects": [
     "../../src/NuGet.Core",
+    "../../test/NuGet.Core.Tests",
     "../../lib"
   ]
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/NuGet.Commands.Test.Utility.xproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/NuGet.Commands.Test.Utility.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>975924fa-3b4f-46ad-aa3b-f7c066d3955c</ProjectGuid>
+    <RootNamespace>NuGet.Commands.Test.Utility</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Protocol.Test.Utility;
+
+namespace NuGet.Commands.Test
+{
+    public class TestRestoreRequest : RestoreRequest
+    {
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
+            ILogger log)
+            : this(
+                  project,
+                  sources,
+                  packagesDirectory,
+                  new List<string>(),
+                  log)
+        {
+        }
+        
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
+            IEnumerable<string> fallbackPackageFolders,
+            ILogger log)
+            : this(
+                  project,
+                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  packagesDirectory,
+                  fallbackPackageFolders,
+                  log)
+        {
+        }
+        
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<SourceRepository> sources,
+            string packagesDirectory,
+            IEnumerable<string> fallbackPackageFolders,
+            ILogger log) : base(
+                project,
+                RestoreCommandProviders.Create(
+                    packagesDirectory,
+                    fallbackPackageFolderPaths: fallbackPackageFolders,
+                    sources: sources,
+                    cacheContext: new TestSourceCacheContext(),
+                    log: log),
+                log)
+        {
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
@@ -23,11 +23,27 @@ namespace NuGet.Commands.Test
                   project,
                   sources,
                   packagesDirectory,
-                  new List<string>(),
+                  new TestSourceCacheContext(),
                   log)
         {
         }
-        
+
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
+            SourceCacheContext cacheContext,
+            ILogger log)
+            : this(
+                  project,
+                  sources,
+                  packagesDirectory,
+                  new List<string>(),
+                  cacheContext,
+                  log)
+        {
+        }
+
         public TestRestoreRequest(
             PackageSpec project,
             IEnumerable<PackageSource> sources,
@@ -36,25 +52,59 @@ namespace NuGet.Commands.Test
             ILogger log)
             : this(
                   project,
-                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  sources,
                   packagesDirectory,
                   fallbackPackageFolders,
+                  new TestSourceCacheContext(),
                   log)
         {
         }
-        
+
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<PackageSource> sources,
+            string packagesDirectory,
+            IEnumerable<string> fallbackPackageFolders,
+            SourceCacheContext cacheContext,
+            ILogger log)
+            : this(
+                  project,
+                  sources.Select(source => Repository.Factory.GetCoreV3(source.Source)),
+                  packagesDirectory,
+                  fallbackPackageFolders,
+                  cacheContext,
+                  log)
+        {
+        }
+
         public TestRestoreRequest(
             PackageSpec project,
             IEnumerable<SourceRepository> sources,
             string packagesDirectory,
             IEnumerable<string> fallbackPackageFolders,
+            ILogger log) : this(
+                project,
+                sources,
+                packagesDirectory,
+                fallbackPackageFolders,
+                new TestSourceCacheContext(),
+                log)
+        {
+        }
+
+        public TestRestoreRequest(
+            PackageSpec project,
+            IEnumerable<SourceRepository> sources,
+            string packagesDirectory,
+            IEnumerable<string> fallbackPackageFolders,
+            SourceCacheContext cacheContext,
             ILogger log) : base(
                 project,
                 RestoreCommandProviders.Create(
                     packagesDirectory,
                     fallbackPackageFolderPaths: fallbackPackageFolders,
                     sources: sources,
-                    cacheContext: new TestSourceCacheContext(),
+                    cacheContext: cacheContext,
                     log: log),
                 log)
         {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/project.json
@@ -1,0 +1,48 @@
+﻿{
+  "version": "1.0.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "packOptions": {
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+  },
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ],
+    "compile": {
+      "include": [
+        "../../../Shared/*.cs"
+      ]
+    }
+  },
+  "dependencies": {
+    "NuGet.Commands": {
+      "target": "project"
+    },
+    "NuGet.Protocol.Test.Utility": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net46": {
+      "dependencies": {},
+      "buildOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      },
+      "buildOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
+    }
+  }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -54,7 +54,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -126,7 +126,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -194,7 +194,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -261,7 +261,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -329,7 +329,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -396,7 +396,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -475,7 +475,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -553,7 +553,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ContentFilesTests.cs
@@ -68,7 +68,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -137,7 +137,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -206,7 +206,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -281,7 +281,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -377,7 +377,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -476,7 +476,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -572,7 +572,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -661,7 +661,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var format = new LockFileFormat();
@@ -736,7 +736,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var format = new LockFileFormat();
@@ -807,7 +807,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -877,7 +877,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -947,7 +947,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -1024,7 +1024,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1099,7 +1099,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1177,7 +1177,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1256,7 +1256,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1336,7 +1336,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1417,7 +1417,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1500,7 +1500,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1583,7 +1583,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1660,7 +1660,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1732,7 +1732,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1787,7 +1787,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -1944,7 +1944,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -2001,7 +2001,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DependencyTypeConstraintTests.cs
@@ -59,7 +59,7 @@ namespace NuGet.Commands.Test
                 await GlobalFolderUtility.AddPackageToGlobalFolderAsync(project1PackagePath, packagesDir);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -152,7 +152,7 @@ namespace NuGet.Commands.Test
                 await GlobalFolderUtility.AddPackageToGlobalFolderAsync(packageAPath, packagesDir);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -258,7 +258,7 @@ namespace NuGet.Commands.Test
                 await GlobalFolderUtility.AddPackageToGlobalFolderAsync(packageAPath, packagesDir);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.ExternalProjects.Add(
                     new ExternalProjectReference("project1", spec1, project1CSProjPath, new string[] { "packageA" }));
@@ -372,7 +372,7 @@ namespace NuGet.Commands.Test
                 await GlobalFolderUtility.AddPackageToGlobalFolderAsync(packageAPath, packagesDir);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -475,7 +475,7 @@ namespace NuGet.Commands.Test
                 await GlobalFolderUtility.AddPackageToGlobalFolderAsync(packageAPath, packagesDir);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/IncludeTypeTests.cs
@@ -1665,7 +1665,7 @@ namespace NuGet.Commands.Test
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource(repository));
 
-            var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+            var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
             request.LockFilePath = Path.Combine(testProject1Dir, "project.lock.json");
 
             request.ExternalProjects = new List<ExternalProjectReference>()
@@ -1737,7 +1737,7 @@ namespace NuGet.Commands.Test
             var sources = new List<PackageSource>();
             sources.Add(new PackageSource(repository));
 
-            var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+            var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
             request.LockFilePath = Path.Combine(testProject1Dir, "project.lock.json");
             request.ExternalProjects = new List<ExternalProjectReference>()
             {
@@ -1776,7 +1776,7 @@ namespace NuGet.Commands.Test
             var specPath = Path.Combine(testProjectDir, "project.json");
             var spec = JsonPackageSpecReader.GetPackageSpec(configJson, "TestProject", specPath);
 
-            var request = new RestoreRequest(spec, sources, packagesDir, logger);
+            var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
             request.LockFilePath = Path.Combine(testProjectDir, "project.lock.json");
 
             request.ExternalProjects.Add(

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MinClientVersionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MinClientVersionTests.cs
@@ -50,7 +50,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/PackagesWithResourcesTests.cs
@@ -72,7 +72,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/Project2ProjectInLockFileTests.cs
@@ -68,7 +68,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 var format = new LockFileFormat();
@@ -154,7 +154,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 var format = new LockFileFormat();
@@ -261,7 +261,7 @@ namespace NuGet.Commands.Test
                 var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
                 request.ExternalProjects.Add(new ExternalProjectReference(
                     "project1",
                     spec1,
@@ -364,7 +364,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
                 request.ExternalProjects.Add(new ExternalProjectReference(
                     "project1",
                     spec1,
@@ -441,7 +441,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
                 request.ExternalProjects.Add(new ExternalProjectReference(
                     "project1",
                     spec1,
@@ -521,7 +521,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
                 request.ExternalProjects.Add(new ExternalProjectReference(
                     "project1",
                     spec1,
@@ -630,7 +630,7 @@ namespace NuGet.Commands.Test
                 var spec3 = JsonPackageSpecReader.GetPackageSpec(projectJson, "project3", specPath3);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir, logger);
                 request.ExternalProjects.Add(new ExternalProjectReference(
                     "project1",
                     spec1,
@@ -768,7 +768,7 @@ namespace NuGet.Commands.Test
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 var format = new LockFileFormat();
@@ -895,7 +895,7 @@ namespace NuGet.Commands.Test
                 var specPath3 = Path.Combine(project3.FullName, "project.json");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.LockFileVersion = 1;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -77,7 +77,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -152,7 +152,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -224,7 +224,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -302,7 +302,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -387,7 +387,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -468,7 +468,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -535,7 +535,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -605,7 +605,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -678,7 +678,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -753,7 +753,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -828,7 +828,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -945,7 +945,7 @@ namespace NuGet.Commands.Test
                 var spec3 = JsonPackageSpecReader.GetPackageSpec(project3Json, "project3", specPath3);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1015,7 +1015,7 @@ namespace NuGet.Commands.Test
                     "1.0.0");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1087,7 +1087,7 @@ namespace NuGet.Commands.Test
                     "build/net45/packageA.props");
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1177,7 +1177,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1255,7 +1255,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1316,7 +1316,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1404,7 +1404,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1489,7 +1489,7 @@ namespace NuGet.Commands.Test
                 var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/FallbackFolderRestoreTests.cs
@@ -53,7 +53,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,
@@ -149,7 +149,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,
@@ -237,7 +237,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,
@@ -330,7 +330,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,
@@ -414,7 +414,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,
@@ -488,7 +488,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec1,
                     sources,
                     packagesDir.FullName,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackagesFolderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommand/OriginalCaseGlobalPackagesFolderTests.cs
@@ -271,7 +271,7 @@ namespace NuGet.Commands.Test
 
         private static RestoreRequest GetRestoreRequest(string packagesDirectory, TestLogger logger, params string[] fallbackDirectories)
         {
-            return new RestoreRequest(
+            return new TestRestoreRequest(
                 new PackageSpec(new JObject()),
                 Enumerable.Empty<PackageSource>(),
                 packagesDirectory,

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -60,7 +60,7 @@ namespace NuGet.Commands.Test
                 var spec = JsonPackageSpecReader.GetPackageSpec(projectJson, "project1", specPath);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(
+                var request = new TestRestoreRequest(
                     spec,
                     sources.Select(x => Repository.Factory.GetCoreV3(x)),
                     packagesDir.FullName,
@@ -148,7 +148,7 @@ namespace NuGet.Commands.Test
 
                 // Act
                 // Execute the first restore with the opposite lowercase setting.
-                var requestA = new RestoreRequest(
+                var requestA = new TestRestoreRequest(
                     spec,
                     sources.Select(x => Repository.Factory.GetCoreV3(x)),
                     packagesDir.FullName,
@@ -163,7 +163,7 @@ namespace NuGet.Commands.Test
                 await resultA.CommitAsync(logger, CancellationToken.None);
 
                 // Execute the second restore with the request lowercase setting.
-                var requestB = new RestoreRequest(
+                var requestB = new TestRestoreRequest(
                     spec,
                     sources.Select(x => Repository.Factory.GetCoreV3(x)),
                     packagesDir.FullName,
@@ -258,7 +258,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -319,7 +319,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -378,7 +378,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -437,7 +437,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "PROJECT1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -503,7 +503,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -572,7 +572,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -641,7 +641,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -710,7 +710,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -772,7 +772,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
                 var packageAContext = new SimpleTestPackageContext("packageA");
@@ -833,7 +833,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -896,7 +896,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -950,7 +950,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -1441,7 +1441,7 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(Project.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(ProjectJson, "project1", specPath1);
-                Request = new RestoreRequest(spec1, Sources, PackagesDir.FullName, Logger);
+                Request = new TestRestoreRequest(spec1, Sources, PackagesDir.FullName, Logger);
 
                 Request.LockFilePath = Path.Combine(Project.FullName, "project.lock.json");
                 Command = new RestoreCommand(Request);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreSemVerTests.cs
@@ -55,7 +55,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -171,7 +171,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -243,7 +243,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -315,7 +315,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -387,7 +387,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -458,7 +458,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimePackageTests.cs
@@ -134,7 +134,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);
@@ -201,7 +201,7 @@ namespace NuGet.Commands.Test
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(configJson.ToString(), "TestProject", specPath);
 
-                var request = new RestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
                 var command = new RestoreCommand(request);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
@@ -52,7 +52,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
 
@@ -124,7 +124,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -218,7 +218,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");
@@ -309,7 +309,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new RestoreRequest(spec1, sources, packagesDir.FullName, logger);
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
 
                 request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
                 request.RequestedRuntimes.Add("win7-x86");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -7,6 +7,9 @@
     "NuGet.Test.Utility": {
       "target": "project"
     },
+    "NuGet.Commands.Test.Utility": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {


### PR DESCRIPTION
This is a code clean-up with no functional impact.
1. Remove unused `SourceCacheContext` property from `RestoreCommandProviders`.
2. Move test-only constructors on `RestoreRequest` to `TestRestoreRequest`. These constructors should not be used from product code.
3. Introduce `TestSourceCacheContext` which does not have to be disposed (for convenience in tests).

This is a clean-up prior to addressing https://github.com/NuGet/Home/issues/1357 and https://github.com/NuGet/Home/issues/2216.

/cc @emgarten @jainaashish @rohit21agrawal @drewgil
