### PR TITLE
Fixed NuGet Solution UI selected package version should be keep when it's still valid

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -270,14 +270,13 @@ namespace NuGet.PackageManagement.UI
         {
             DisplayVersion versionToSelect = null;
 
-            if (_versions.Count > 0)
+            if (_versions.Count > 0 && !_versions.Contains(SelectedVersion))
             {
                 // it should always select the top version from versions list to install or update
                 // which has a valid version. If find none, then just set to null.
                 versionToSelect = _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
+                SelectedVersion = versionToSelect;
             }
-
-            SelectedVersion = versionToSelect;
         }
 
         internal async Task LoadPackageMetadaAsync(IPackageMetadataProvider metadataProvider, CancellationToken token)

--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -268,14 +268,15 @@ namespace NuGet.PackageManagement.UI
         // Calculate the version to select among _versions and select it
         protected void SelectVersion()
         {
-            DisplayVersion versionToSelect = null;
-
-            if (_versions.Count > 0 && !_versions.Contains(SelectedVersion))
+            if (_versions.Count == 0)
+            {
+                SelectedVersion = null;
+            }
+            else if (!_versions.Contains(SelectedVersion))
             {
                 // it should always select the top version from versions list to install or update
                 // which has a valid version. If find none, then just set to null.
-                versionToSelect = _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
-                SelectedVersion = versionToSelect;
+                SelectedVersion = _versions.FirstOrDefault(v => v != null && v.IsValidVersion);
             }
         }
 


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/3371

the issue here is nuget will refresh selected version when selected project is changed because different selected projects have different allowed version range.

the fix here is check if the previous selected version is still in allowed version range, if yes, keep it. otherwise update it to latest version.

@rrelyea @jainaashish 
