### PR TITLE
Plumb SourceCacheContext and ILogger parameter down to FindPackageByIdResource

### DIFF
--- a/NuGet.Core.sln
+++ b/NuGet.Core.sln
@@ -134,6 +134,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Repositories.Test", "
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.Commands.Test.Utility", "test\NuGet.Core.Tests\NuGet.Commands.Test.Utility\NuGet.Commands.Test.Utility.xproj", "{975924FA-3B4F-46AD-AA3B-F7C066D3955C}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NuGet.DependencyResolver.Core.Tests.Utility", "test\NuGet.Core.Tests\NuGet.DependencyResolver.Core.Tests.Utility\NuGet.DependencyResolver.Core.Tests.Utility.xproj", "{23C35C81-55E5-4E21-9E67-CCDEE901072B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -360,6 +362,10 @@ Global
 		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{975924FA-3B4F-46AD-AA3B-F7C066D3955C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23C35C81-55E5-4E21-9E67-CCDEE901072B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23C35C81-55E5-4E21-9E67-CCDEE901072B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23C35C81-55E5-4E21-9E67-CCDEE901072B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23C35C81-55E5-4E21-9E67-CCDEE901072B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -420,5 +426,6 @@ Global
 		{2034C981-C938-4F0F-8F3B-528B83CB8F7D} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{93D1D30C-45F8-4DCE-8EAD-7C7C504713B6} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{975924FA-3B4F-46AD-AA3B-F7C066D3955C} = {7323F93B-D141-4001-BB9E-7AF14031143E}
+		{23C35C81-55E5-4E21-9E67-CCDEE901072B} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/OriginalCaseGlobalPackageFolder.cs
@@ -160,7 +160,12 @@ namespace NuGet.Commands
             else
             {
                 // Otherwise, get it from the provider.
-                await remoteMatch.Provider.CopyToAsync(remoteMatch.Library, destination, token);
+                await remoteMatch.Provider.CopyToAsync(
+                    remoteMatch.Library,
+                    destination,
+                    _request.CacheContext,
+                    _request.Log,
+                    token);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -28,9 +28,9 @@ namespace NuGet.Commands
 
         private readonly ProjectRestoreRequest _request;
 
-        public ProjectRestoreCommand(ILogger logger, ProjectRestoreRequest request)
+        public ProjectRestoreCommand(ProjectRestoreRequest request)
         {
-            _logger = logger;
+            _logger = request.Log;
             _request = request;
         }
 
@@ -272,7 +272,12 @@ namespace NuGet.Commands
                 _request.XmlDocFileSaveMode);
 
             await PackageExtractor.InstallFromSourceAsync(
-                stream => installItem.Provider.CopyToAsync(installItem.Library, stream, token),
+                stream => installItem.Provider.CopyToAsync(
+                    installItem.Library,
+                    stream,
+                    _request.CacheContext,
+                    _logger,
+                    token),
                 versionFolderPathContext,
                 token);
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -3,10 +3,12 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
 using NuGet.RuntimeModel;
 
 namespace NuGet.Commands
@@ -20,6 +22,8 @@ namespace NuGet.Commands
             Dictionary<NuGetFramework, RuntimeGraph> runtimeGraphCache,
             ConcurrentDictionary<PackageIdentity, RuntimeGraph> runtimeGraphCacheByPackage)
         {
+            CacheContext = request.CacheContext;
+            Log = request.Log;
             PackagesDirectory = request.PackagesDirectory;
             ExistingLockFile = existingLockFile;
             RuntimeGraphCache = runtimeGraphCache;
@@ -30,6 +34,8 @@ namespace NuGet.Commands
             XmlDocFileSaveMode = request.XmlDocFileSaveMode;
         }
 
+        public SourceCacheContext CacheContext { get; }
+        public ILogger Log { get; }
         public string PackagesDirectory { get; }
         public int MaxDegreeOfConcurrency { get; }
         public LockFile ExistingLockFile { get; }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildP2PRestoreRequestProvider.cs
@@ -91,6 +91,7 @@ namespace NuGet.Commands
             var request = new RestoreRequest(
                 project.PackageSpec,
                 sharedCache,
+                restoreContext.CacheContext,
                 restoreContext.Log);
 
             restoreContext.ApplyStandardProperties(request);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/ProjectJsonRestoreRequestProvider.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.ProjectModel;
 
 namespace NuGet.Commands
@@ -84,6 +83,7 @@ namespace NuGet.Commands
             var request = new RestoreRequest(
                 project,
                 sharedCache,
+                restoreContext.CacheContext,
                 restoreContext.Log);
 
             restoreContext.ApplyStandardProperties(request);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -388,7 +388,7 @@ namespace NuGet.Commands
                     existingToolLockFile,
                     new Dictionary<NuGetFramework, RuntimeGraph>(),
                     _runtimeGraphCacheByPackage);
-                var projectRestoreCommand = new ProjectRestoreCommand(_logger, projectRestoreRequest);
+                var projectRestoreCommand = new ProjectRestoreCommand(projectRestoreRequest);
                 var result = await projectRestoreCommand.TryRestore(
                     tool.LibraryRange,
                     projectFrameworkRuntimePairs,
@@ -556,7 +556,7 @@ namespace NuGet.Commands
                 _request.ExistingLockFile,
                 _runtimeGraphCache,
                 _runtimeGraphCacheByPackage);
-            var projectRestoreCommand = new ProjectRestoreCommand(_logger, projectRestoreRequest);
+            var projectRestoreCommand = new ProjectRestoreCommand(projectRestoreRequest);
             var result = await projectRestoreCommand.TryRestore(
                 projectRange,
                 projectFrameworkRuntimePairs,
@@ -660,7 +660,9 @@ namespace NuGet.Commands
 
         private static RemoteWalkContext CreateRemoteWalkContext(RestoreRequest request)
         {
-            var context = new RemoteWalkContext();
+            var context = new RemoteWalkContext(
+                request.CacheContext,
+                request.Log);
 
             foreach (var provider in request.DependencyProviders.LocalProviders)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -8,6 +8,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
 using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -18,6 +19,7 @@ namespace NuGet.Commands
         public RestoreRequest(
             PackageSpec project,
             RestoreCommandProviders dependencyProviders,
+            SourceCacheContext cacheContext,
             ILogger log)
         {
             if (project == null)
@@ -28,6 +30,11 @@ namespace NuGet.Commands
             if (dependencyProviders == null)
             {
                 throw new ArgumentNullException(nameof(dependencyProviders));
+            }
+
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
             }
 
             if (log == null)
@@ -43,10 +50,13 @@ namespace NuGet.Commands
             PackagesDirectory = dependencyProviders.GlobalPackages.RepositoryRoot;
             IsLowercasePackagesDirectory = true;
 
+            CacheContext = cacheContext;
             Log = log;
 
             DependencyProviders = dependencyProviders;
         }
+
+        public SourceCacheContext CacheContext { get; set; }
 
         public ILogger Log { get; set; }
 

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -5,8 +5,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.DependencyResolver
 {
@@ -14,10 +16,25 @@ namespace NuGet.DependencyResolver
     {
         bool IsHttp { get; }
 
-        Task<LibraryIdentity> FindLibraryAsync(LibraryRange libraryRange, NuGetFramework targetFramework, CancellationToken cancellationToken);
+        Task<LibraryIdentity> FindLibraryAsync(
+            LibraryRange libraryRange,
+            NuGetFramework targetFramework,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken);
 
-        Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(LibraryIdentity match, NuGetFramework targetFramework, CancellationToken cancellationToken);
+        Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(
+            LibraryIdentity match,
+            NuGetFramework targetFramework,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken);
 
-        Task CopyToAsync(LibraryIdentity match, Stream stream, CancellationToken cancellationToken);
+        Task CopyToAsync(
+            LibraryIdentity match,
+            Stream stream,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.DependencyResolver
 {
@@ -22,7 +24,12 @@ namespace NuGet.DependencyResolver
 
         public bool IsHttp { get; private set; }
 
-        public Task<LibraryIdentity> FindLibraryAsync(LibraryRange libraryRange, NuGetFramework targetFramework, CancellationToken cancellationToken)
+        public Task<LibraryIdentity> FindLibraryAsync(
+            LibraryRange libraryRange,
+            NuGetFramework targetFramework,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var library = _dependencyProvider.GetLibrary(libraryRange, targetFramework);
 
@@ -34,14 +41,24 @@ namespace NuGet.DependencyResolver
             return Task.FromResult(library.Identity);
         }
 
-        public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(LibraryIdentity library, NuGetFramework targetFramework, CancellationToken cancellationToken)
+        public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(
+            LibraryIdentity library,
+            NuGetFramework targetFramework,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             var description = _dependencyProvider.GetLibrary(library, targetFramework);
 
             return Task.FromResult(description.Dependencies);
         }
 
-        public Task CopyToAsync(LibraryIdentity match, Stream stream, CancellationToken cancellationToken)
+        public Task CopyToAsync(
+            LibraryIdentity match,
+            Stream stream,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteWalkContext.cs
@@ -1,18 +1,33 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using NuGet.LibraryModel;
+using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.DependencyResolver
 {
     public class RemoteWalkContext
     {
-        public RemoteWalkContext()
+        public RemoteWalkContext(SourceCacheContext cacheContext, ILogger logger)
         {
+            if (cacheContext == null)
+            {
+                throw new ArgumentNullException(nameof(cacheContext));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            CacheContext = cacheContext;
+            Logger = logger;
+
             ProjectLibraryProviders = new List<IProjectDependencyProvider>();
             LocalLibraryProviders = new List<IRemoteDependencyProvider>();
             RemoteLibraryProviders = new List<IRemoteDependencyProvider>();
@@ -20,6 +35,9 @@ namespace NuGet.DependencyResolver
             FindLibraryEntryCache = new ConcurrentDictionary<LibraryRangeCacheKey, Task<GraphItem<RemoteResolveResult>>>();
             PackageFileCache = new ConcurrentDictionary<PackageIdentity, IList<string>>(PackageIdentity.Comparer);
         }
+
+        public SourceCacheContext CacheContext { get; }
+        public ILogger Logger { get; }
 
         public IList<IProjectDependencyProvider> ProjectLibraryProviders { get; }
         public IList<IRemoteDependencyProvider> LocalLibraryProviders { get; }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -75,6 +75,7 @@ namespace NuGet.PackageManagement
                     project.PackageSpec,
                     context,
                     providers,
+                    cacheContext,
                     token);
 
                 // Throw before writing if this has been canceled
@@ -95,6 +96,7 @@ namespace NuGet.PackageManagement
             PackageSpec packageSpec,
             ExternalProjectReferenceContext context,
             RestoreCommandProviders providers,
+            SourceCacheContext cacheContext,
             CancellationToken token)
         {
             // Restoring packages
@@ -103,7 +105,7 @@ namespace NuGet.PackageManagement
                 Strings.BuildIntegratedPackageRestoreStarted,
                 project.ProjectName));
 
-            var request = new RestoreRequest(packageSpec, providers, logger);
+            var request = new RestoreRequest(packageSpec, providers, cacheContext, logger);
             request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
 
             // Add the existing lock file if it exists

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2256,7 +2256,6 @@ namespace NuGet.PackageManagement
             }
 
             var logger = new ProjectContextLogger(nuGetProjectContext);
-            var buildIntegratedContext = new ExternalProjectReferenceContext(logger);
 
             var pathContext = NuGetPathContext.Create(Settings);
 
@@ -2268,6 +2267,8 @@ namespace NuGet.PackageManagement
             using (var cacheContext = new SourceCacheContext())
             {
                 cacheContext.MaxAge = DateTimeOffset.UtcNow;
+
+                var buildIntegratedContext = new ExternalProjectReferenceContext(logger);
 
                 var providers = RestoreCommandProviders.Create(
                     pathContext.UserPackageFolder,
@@ -2289,6 +2290,7 @@ namespace NuGet.PackageManagement
                         originalPackageSpec,
                         buildIntegratedContext,
                         providers,
+                        cacheContext,
                         token);
 
                     originalLockFile = originalRestoreResult.LockFile;
@@ -2318,6 +2320,7 @@ namespace NuGet.PackageManagement
                     packageSpec,
                     buildIntegratedContext,
                     providers,
+                    cacheContext,
                     token);
 
                 InstallationCompatibility.EnsurePackageCompatibility(

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedProjectReferenceContext.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedProjectReferenceContext.cs
@@ -8,14 +8,6 @@ namespace NuGet.ProjectManagement
     public class ExternalProjectReferenceContext
     {
         /// <summary>
-        /// Create a new build integrated project reference context and cache.
-        /// </summary>
-        public ExternalProjectReferenceContext()
-            : this(NullLogger.Instance)
-        {
-        }
-
-        /// <summary>
         /// Create a new build integrated project reference context and caches.
         /// </summary>
         public ExternalProjectReferenceContext(ILogger logger)
@@ -32,34 +24,6 @@ namespace NuGet.ProjectManagement
 
             SpecCache = new Dictionary<string, PackageSpec>(
                 StringComparer.OrdinalIgnoreCase);
-        }
-
-        /// <summary>
-        /// Create a new build integrated project reference context with the given caches.
-        /// </summary>
-        public ExternalProjectReferenceContext(
-            ILogger logger,
-            IDictionary<string, IReadOnlyList<ExternalProjectReference>> cache,
-            IDictionary<string, PackageSpec> specCache)
-        {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            if (cache == null)
-            {
-                throw new ArgumentNullException(nameof(cache));
-            }
-
-            if (specCache == null)
-            {
-                throw new ArgumentNullException(nameof(specCache));
-            }
-
-            Logger = logger;
-            Cache = cache;
-            SpecCache = specCache;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/FindPackageByIdResource.cs
@@ -14,29 +14,38 @@ namespace NuGet.Protocol.Core.Types
 {
     public abstract class FindPackageByIdResource : INuGetResource
     {
-        public virtual SourceCacheContext CacheContext { get; set; }
-
-        public virtual ILogger Logger { get; set; } = new NullLogger();
-
-        public abstract Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, CancellationToken token);
+        public abstract Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
+            string id,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token);
 
         /// <summary>
         /// Gets the <see cref="FindPackageByIdDependencyInfo" /> for a specific package.
         /// </summary>
         /// <param name="id">The packag id.</param>
         /// <param name="version">The package version.</param>
+        /// <param name="cacheContext">The source cache context.</param>
+        /// <param name="logger">The logger.</param>
         /// <param name="token">The <see cref="CancellationToken" />.</param>
         /// <returns>
         /// A <see cref="Task" /> that on completion returns a <see cref="FindPackageByIdDependencyInfo" /> of the
         /// package, if found,
         /// <c>null</c> otherwise.
         /// </returns>
-        public abstract Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(string id, NuGetVersion version, CancellationToken token);
+        public abstract Task<FindPackageByIdDependencyInfo> GetDependencyInfoAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token);
 
         public abstract Task<bool> CopyNupkgToStreamAsync(
             string id,
             NuGetVersion version,
             Stream destination,
+            SourceCacheContext cacheContext,
+            ILogger logger,
             CancellationToken token);
 
         /// <summary>
@@ -46,9 +55,16 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         /// <param name="id">The package ID. This value is case insensitive.</param>
         /// <param name="version">The version.</param>
+        /// <param name="cacheContext">The source cache context.</param>
+        /// <param name="logger">The logger.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns>The package identity, with the ID having the case provided by the package author.</returns>
-        public abstract Task<PackageIdentity> GetOriginalIdentityAsync(string id, NuGetVersion version, CancellationToken token);
+        public abstract Task<PackageIdentity> GetOriginalIdentityAsync(
+            string id,
+            NuGetVersion version,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token);
 
         /// <summary>
         /// Read dependency info from a nuspec.

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestSourceCacheContext.cs
@@ -4,7 +4,7 @@
 using System;
 using NuGet.Protocol.Core.Types;
 
-namespace NuGet.Protocol.Test.Utility
+namespace NuGet.Protocol.Test
 {
     /// <summary>
     /// This is a test source cache context that should be used in places where it is not convenient to dispose the

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1956,7 +1956,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
-                    var request = new RestoreRequest(spec, provider, logger);
+                    var request = new RestoreRequest(spec, provider, context, logger);
 
                     request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 
@@ -2003,7 +2003,7 @@ namespace NuGet.Commands.FuncTest
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
                     var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
-                    var request = new RestoreRequest(spec, provider, logger);
+                    var request = new RestoreRequest(spec, provider, context, logger);
 
                     request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/FindPackageByIdResourceTests.cs
@@ -21,14 +21,18 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "owin",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());
@@ -46,14 +50,18 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "costura.fody",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());
@@ -71,13 +79,18 @@ namespace NuGet.Protocol.FuncTest
             // Arrange
             var repo = Repository.Factory.GetCoreV3(packageSource);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
+            
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "Newtonsoft.json",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());
@@ -97,14 +110,18 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
 
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("Newtonsoft.json", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "Newtonsoft.json",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());
@@ -124,13 +141,18 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
+
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("costura.fody", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "costura.fody",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());
@@ -150,13 +172,18 @@ namespace NuGet.Protocol.FuncTest
             source.Credentials = sourceCredential;
             var repo = Repository.Factory.GetCoreV2(source);
             var findPackageByIdResource = await repo.GetResourceAsync<FindPackageByIdResource>();
+            var logger = new TestLogger();
+
             using (var context = new SourceCacheContext())
             {
                 context.NoCache = true;
-                findPackageByIdResource.CacheContext = context;
 
                 // Act
-                var packages = await findPackageByIdResource.GetAllVersionsAsync("owin", CancellationToken.None);
+                var packages = await findPackageByIdResource.GetAllVersionsAsync(
+                    "owin",
+                    context,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 Assert.Equal(1, packages.Count());

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/TestRestoreRequest.cs
@@ -8,7 +8,7 @@ using NuGet.Configuration;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol.Test.Utility;
+using NuGet.Protocol.Test;
 
 namespace NuGet.Commands.Test
 {
@@ -106,6 +106,7 @@ namespace NuGet.Commands.Test
                     sources: sources,
                     cacheContext: cacheContext,
                     log: log),
+                cacheContext,
                 log)
         {
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/project.json
@@ -10,6 +10,9 @@
     "NuGet.Commands.Test.Utility": {
       "target": "project"
     },
+    "NuGet.DependencyResolver.Core.Tests.Utility": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/NuGet.DependencyResolver.Core.Tests.Utility.xproj
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/NuGet.DependencyResolver.Core.Tests.Utility.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>23c35c81-55e5-4e21-9e67-ccdee901072b</ProjectGuid>
+    <RootNamespace>NuGet.DependencyResolver.Core.Tests.Utility</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/TestRestoreWalkContext.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/TestRestoreWalkContext.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Common;
+using NuGet.Protocol.Test;
+
+namespace NuGet.DependencyResolver.Tests
+{
+    public class TestRemoteWalkContext : RemoteWalkContext
+    {
+        public TestRemoteWalkContext() : base(new TestSourceCacheContext(), NullLogger.Instance)
+        {
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests.Utility/project.json
@@ -1,0 +1,48 @@
+﻿{
+  "version": "1.0.0-*",
+  "copyright": "Copyright .NET Foundation. All rights reserved.",
+  "packOptions": {
+    "licenseUrl": "https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt",
+    "projectUrl": "https://github.com/NuGet/NuGet.Client"
+  },
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": [
+      "CS1591"
+    ],
+    "compile": {
+      "include": [
+        "../../../Shared/*.cs"
+      ]
+    }
+  },
+  "dependencies": {
+    "NuGet.DependencyResolver.Core": {
+      "target": "project"
+    },
+    "NuGet.Protocol.Test.Utility": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net46": {
+      "dependencies": {},
+      "buildOptions": {
+        "define": [
+          "IS_DESKTOP"
+        ]
+      }
+    },
+    "netstandard1.3": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      },
+      "buildOptions": {
+        "define": [
+          "IS_CORECLR"
+        ]
+      }
+    }
+  }
+}

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
@@ -4,8 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.DependencyResolver.Tests;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
 
@@ -31,7 +34,7 @@ namespace NuGet.DependencyResolver.Core.Tests
                 Version = new NuGetVersion("1.0.0")
             });
 
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             context.RemoteLibraryProviders.Add(slowProvider);
             context.RemoteLibraryProviders.Add(fastProvider);
 
@@ -71,7 +74,7 @@ namespace NuGet.DependencyResolver.Core.Tests
                 Version = new NuGetVersion("1.1.0")
             });
 
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             context.RemoteLibraryProviders.Add(slowProvider);
             context.RemoteLibraryProviders.Add(fastProvider);
 
@@ -110,12 +113,22 @@ namespace NuGet.DependencyResolver.Core.Tests
 
             public bool IsHttp => true;
 
-            public Task CopyToAsync(LibraryIdentity match, Stream stream, CancellationToken cancellationToken)
+            public Task CopyToAsync(
+                LibraryIdentity match,
+                Stream stream,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
 
-            public async Task<LibraryIdentity> FindLibraryAsync(LibraryRange libraryRange, NuGetFramework targetFramework, CancellationToken cancellationToken)
+            public async Task<LibraryIdentity> FindLibraryAsync(
+                LibraryRange libraryRange,
+                NuGetFramework targetFramework,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 if (_delay != TimeSpan.Zero)
                 {
@@ -125,7 +138,12 @@ namespace NuGet.DependencyResolver.Core.Tests
                 return _libraries.FindBestMatch(libraryRange.VersionRange, l => l?.Version);
             }
 
-            public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(LibraryIdentity match, NuGetFramework targetFramework, CancellationToken cancellationToken)
+            public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(
+                LibraryIdentity match,
+                NuGetFramework targetFramework,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 return Task.FromResult(Enumerable.Empty<LibraryDependency>());
             }

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/project.json
@@ -4,6 +4,15 @@
     "NuGet.DependencyResolver.Core": {
       "target": "project"
     },
+    "NuGet.DependencyResolver.Core.Tests.Utility": {
+      "target": "project"
+    },
+    "NuGet.Protocol.Test.Utility": {
+      "target": "project"
+    },
+    "NuGet.Test.Utility": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/RemoteDependencyWalkerTests.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Xunit;
 
@@ -16,7 +18,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task AllowPreleaseVersionNoConflict()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0-beta")
                     .DependsOn("B", "1.0")
@@ -44,7 +46,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task CyclesAreDetected()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0");
@@ -68,7 +70,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task CyclesAreDetectedIf2VersionsOfTheSamePackageId()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0");
@@ -92,7 +94,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DeepCycleCheck()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0");
@@ -124,7 +126,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DependencyRangesButNoConflict()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -157,7 +159,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task SingleConflict()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -191,7 +193,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task SingleConflictWhereConflictingDependenyIsUnresolved()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -224,7 +226,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task StrictDependenciesButNoConflict()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -251,7 +253,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task ConflictAtDifferentLevel()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -295,7 +297,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task TryResolveConflicts_ThrowsIfPackageConstraintCannotBeResolved()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("Root", "1.0")
                     .DependsOn("A", "1.0")
@@ -329,7 +331,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task TryResolveConflicts_WorksWhenVersionRangeIsNotSpecified()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("Root", "1.0")
                     .DependsOn("A", "1.0")
@@ -368,7 +370,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task NearestWinsOverridesStrictDependency()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -398,7 +400,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task NearestWinsOverridesStrictDependencyButDowngradeWarns()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -433,7 +435,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DowngradeSkippedIfEqual()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -456,7 +458,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DowngradeAtRootIsDetected()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -485,7 +487,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DowngradeNotAtRootIsDetected()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0");
@@ -516,7 +518,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DowngradeOverddienByCousinCheck()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "1.0")
@@ -548,7 +550,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task PotentialDowngradeThenUpgrade()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "1.2")
@@ -579,7 +581,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DowngradeThenUpgradeThenDowngrade()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "1.0")
@@ -613,7 +615,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task UpgradeThenDowngradeThenEqual()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "2.0")
@@ -642,7 +644,7 @@ namespace NuGet.DependencyResolver.Tests
         [Fact]
         public async Task DoubleDowngrade()
         {
-            var context = new RemoteWalkContext();
+            var context = new TestRemoteWalkContext();
             var provider = new DependencyProvider();
             provider.Package("A", "1.0")
                     .DependsOn("B", "0.7")
@@ -823,19 +825,34 @@ namespace NuGet.DependencyResolver.Tests
                 }
             }
 
-            public Task CopyToAsync(LibraryIdentity match, Stream stream, CancellationToken cancellationToken)
+            public Task CopyToAsync(
+                LibraryIdentity match,
+                Stream stream,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<LibraryIdentity> FindLibraryAsync(LibraryRange libraryRange, NuGetFramework targetFramework, CancellationToken cancellationToken)
+            public Task<LibraryIdentity> FindLibraryAsync(
+                LibraryRange libraryRange,
+                NuGetFramework targetFramework,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 var packages = _graph.Keys.Where(p => p.Name == libraryRange.Name);
 
                 return Task.FromResult(packages.FindBestMatch(libraryRange.VersionRange, i => i?.Version));
             }
 
-            public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(LibraryIdentity match, NuGetFramework targetFramework, CancellationToken cancellationToken)
+            public Task<IEnumerable<LibraryDependency>> GetDependenciesAsync(
+                LibraryIdentity match,
+                NuGetFramework targetFramework,
+                SourceCacheContext cacheContext,
+                ILogger logger,
+                CancellationToken cancellationToken)
             {
                 List<LibraryDependency> dependencies;
                 if (_graph.TryGetValue(match, out dependencies))

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Tests/project.json
@@ -4,6 +4,9 @@
     "NuGet.DependencyResolver": {
       "target": "project"
     },
+    "NuGet.DependencyResolver.Core.Tests.Utility": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -9,6 +9,7 @@ using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.DependencyResolver;
+using NuGet.DependencyResolver.Tests;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
@@ -435,7 +436,7 @@ namespace NuGet.PackageManagement.Test
 
                 var graph = RestoreTargetGraph.Create(
                     new[] { node },
-                    new RemoteWalkContext(),
+                    new TestRemoteWalkContext(),
                     NullLogger.Instance,
                     FrameworkConstants.CommonFrameworks.NetStandard10);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/project.json
@@ -8,6 +8,9 @@
     "Test.Utility": {
       "target": "project"
     },
+    "NuGet.DependencyResolver.Core.Tests.Utility": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpFileSystemBasedFindPackageByIdResourceTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -52,16 +51,18 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(source, Repository.Provider.GetCoreV3(), responses);
+                var logger = new TestLogger();
+
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                    resource.Logger = NullLogger.Instance;
-                    resource.CacheContext = cacheContext;
 
                     // Act
                     var identity = await resource.GetOriginalIdentityAsync(
                         "DEEPEQUAL",
                         new NuGetVersion("1.4.0.1-RC"),
+                        cacheContext,
+                        logger,
                         CancellationToken.None);
 
                     // Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV2FindPackageByIdResourceTests.cs
@@ -28,15 +28,18 @@ namespace NuGet.Protocol.Tests
             responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+            var logger = new TestLogger();
 
             using (var cacheContext = new SourceCacheContext())
             {
                 var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                resource.Logger = NullLogger.Instance;
-                resource.CacheContext = cacheContext;
 
                 // Act
-                var versions = await resource.GetAllVersionsAsync("a", CancellationToken.None);
+                var versions = await resource.GetAllVersionsAsync(
+                    "a",
+                    cacheContext,
+                    logger,
+                    CancellationToken.None);
 
                 // Assert
                 // Verify no items returned, and no exceptions were thrown above
@@ -80,17 +83,18 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+                var logger = new TestLogger();
 
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                    resource.Logger = NullLogger.Instance;
-                    resource.CacheContext = cacheContext;
 
                     // Act
                     var identity = await resource.GetOriginalIdentityAsync(
                         "XUNIT",
                         new NuGetVersion("2.2.0-BETA1-build3239"),
+                        cacheContext,
+                        logger,
                         CancellationToken.None);
 
                     // Assert
@@ -137,17 +141,18 @@ namespace NuGet.Protocol.Tests
                 };
 
                 var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
+                var logger = new TestLogger();
 
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-                    resource.Logger = NullLogger.Instance;
-                    resource.CacheContext = cacheContext;
 
                     // Act
                     var identity = await resource.GetOriginalIdentityAsync(
                         "WINDOWSAZURE.STORAGE",
                         new NuGetVersion("6.2.2-PREVIEW"),
+                        cacheContext,
+                        logger,
                         CancellationToken.None);
 
                     // Assert

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RemoteV3FindPackageByIdResourceTests.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
@@ -19,18 +20,24 @@ namespace NuGet.Protocol.Tests
             responses.Add("https://api.nuget.org/v3/registration0/deepequal/index.json", JsonData.DeepEqualRegistationIndex);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var logger = new TestLogger();
 
-            // Act
-            var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
-            var identity = await resource.GetOriginalIdentityAsync(
-                "DEEPEQUAL",
-                new NuGetVersion("1.4.0.1-RC"),
-                CancellationToken.None);
+            using (var cacheContext = new SourceCacheContext())
+            {
+                // Act
+                var resource = await repo.GetResourceAsync<FindPackageByIdResource>();
+                var identity = await resource.GetOriginalIdentityAsync(
+                    "DEEPEQUAL",
+                    new NuGetVersion("1.4.0.1-RC"),
+                    cacheContext,
+                    logger,
+                    CancellationToken.None);
 
-            // Assert
-            Assert.IsType<RemoteV3FindPackageByIdResource>(resource);
-            Assert.Equal("DeepEqual", identity.Id);
-            Assert.Equal("1.4.0.1-rc", identity.Version.ToNormalizedString());
+                // Assert
+                Assert.IsType<RemoteV3FindPackageByIdResource>(resource);
+                Assert.Equal("DeepEqual", identity.Id);
+                Assert.Equal("1.4.0.1-rc", identity.Version.ToNormalizedString());
+            }
         }
     }
 }


### PR DESCRIPTION
Previously `FindPackageByIdResource` had an `ILogger` property and `SourceCacheContext` property. It was the callers responsibility to set these properties before using any methods.

Fixes https://github.com/NuGet/Home/issues/1357 and https://github.com/NuGet/Home/issues/2216.

/cc @emgarten @jainaashish @rohit21agrawal @drewgil 
