### PR TITLE
Adding target and prop imports in topological sort for transitive dependencies

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging.Core;
+
+namespace NuGet.Packaging
+{
+    public static class TopologicalSortUtility
+    {
+        /// <summary>
+        /// Order dependencies by children first.
+        /// </summary>
+        public static IReadOnlyList<PackageDependencyInfo> SortPackagesByDependencyOrder(
+            IEnumerable<PackageDependencyInfo> packages)
+        {
+            var sorted = new List<PackageDependencyInfo>();
+            var toSort = packages.Distinct().ToList();
+
+            while (toSort.Count > 0)
+            {
+                // Order packages by parent count, take the child with the lowest number of parents
+                // and remove it from the list
+                var nextPackage = toSort.OrderBy(package => GetParentCount(toSort, package.Id))
+                    .ThenBy(package => package.Id, StringComparer.OrdinalIgnoreCase).First();
+
+                sorted.Add(nextPackage);
+                toSort.Remove(nextPackage);
+            }
+
+            // the list is ordered by parents first, reverse to run children first
+            sorted.Reverse();
+
+            return sorted;
+        }
+
+        private static int GetParentCount(List<PackageDependencyInfo> packages, string id)
+        {
+            int count = 0;
+
+            foreach (var package in packages)
+            {
+                if (package.Dependencies != null
+                    && package.Dependencies.Any(dependency =>
+                        string.Equals(id, dependency.Id, StringComparison.OrdinalIgnoreCase)))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -135,7 +135,7 @@ namespace NuGet.ProjectManagement
             }
 
             // Sort dependencies
-            var sortedDependencies = SortPackagesByDependencyOrder(dependencies);
+            var sortedDependencies = TopologicalSortUtility.SortPackagesByDependencyOrder(dependencies);
 
             foreach (var dependency in sortedDependencies)
             {
@@ -145,49 +145,6 @@ namespace NuGet.ProjectManagement
             }
 
             return results;
-        }
-
-        /// <summary>
-        /// Order dependencies by children first.
-        /// </summary>
-        private static IReadOnlyList<PackageDependencyInfo> SortPackagesByDependencyOrder(
-            IEnumerable<PackageDependencyInfo> packages)
-        {
-            var sorted = new List<PackageDependencyInfo>();
-            var toSort = packages.Distinct().ToList();
-
-            while (toSort.Count > 0)
-            {
-                // Order packages by parent count, take the child with the lowest number of parents
-                // and remove it from the list
-                var nextPackage = toSort.OrderBy(package => GetParentCount(toSort, package.Id))
-                    .ThenBy(package => package.Id, StringComparer.OrdinalIgnoreCase).First();
-
-                sorted.Add(nextPackage);
-                toSort.Remove(nextPackage);
-            }
-
-            // the list is ordered by parents first, reverse to run children first
-            sorted.Reverse();
-
-            return sorted;
-        }
-
-        private static int GetParentCount(List<PackageDependencyInfo> packages, string id)
-        {
-            int count = 0;
-
-            foreach (var package in packages)
-            {
-                if (package.Dependencies != null
-                    && package.Dependencies.Any(dependency =>
-                        string.Equals(id, dependency.Id, StringComparison.OrdinalIgnoreCase)))
-                {
-                    count++;
-                }
-            }
-
-            return count;
         }
     }
 }


### PR DESCRIPTION
Instead of adding these target and prop imports in alphabetical order, it now adds them in topological sort for transitive dependency nupkgs which allows it to resolve all targets and props correctly.

Fixes https://github.com/NuGet/Home/issues/3342

@emgarten @rrelyea @joelverhagen @rohit21agrawal 
