### PR TITLE
Make -NoCache skip reading packages from the global packages folder

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -190,9 +190,7 @@ namespace NuGet.CommandLine
                 cacheContext.NoCache = NoCache;
                 cacheContext.DirectDownload = DirectDownload;
 
-                var downloadContext = new PackageDownloadContext(
-                    cacheContext,
-                    directDownloadDirectory: DirectDownload ? installPath : null);
+                var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload);
 
                 await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
@@ -292,9 +290,7 @@ namespace NuGet.CommandLine
                     cacheContext.NoCache = NoCache;
                     cacheContext.DirectDownload = DirectDownload;
 
-                    var downloadContext = new PackageDownloadContext(
-                        cacheContext,
-                        directDownloadDirectory: DirectDownload ? installPath : null);
+                    var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload);
 
                     await packageManager.InstallPackageAsync(
                         folderProject,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -339,9 +339,7 @@ namespace NuGet.CommandLine
                 cacheContext.NoCache = NoCache;
                 cacheContext.DirectDownload = DirectDownload;
 
-                var downloadContext = new PackageDownloadContext(
-                    cacheContext,
-                    directDownloadDirectory: DirectDownload ? packagesFolderPath : null);
+                var downloadContext = new PackageDownloadContext(cacheContext, packagesFolderPath, DirectDownload);
 
                 var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,

--- a/src/NuGet.Core/NuGet.Protocol.Core.Types/PackageDownloadContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.Types/PackageDownloadContext.cs
@@ -9,19 +9,30 @@ namespace NuGet.Protocol.Core.Types
     {
         public PackageDownloadContext(SourceCacheContext sourceCacheContext) : this(
             sourceCacheContext,
-            directDownloadDirectory: null)
+            directDownloadDirectory: null,
+            directDownload: false)
         {
         }
 
-        public PackageDownloadContext(SourceCacheContext sourceCacheContext, string directDownloadDirectory)
+        public PackageDownloadContext(
+            SourceCacheContext sourceCacheContext,
+            string directDownloadDirectory,
+            bool directDownload)
         {
             if (sourceCacheContext == null)
             {
                 throw new ArgumentNullException(nameof(sourceCacheContext));
             }
 
+            if (directDownloadDirectory == null && (directDownload || sourceCacheContext.NoCache))
+            {
+                // If NoCache is specified on the source cache context, it's possible that we will perform a direct
+                // download (even if the PackageDownloadContext.DirectDownload property is false).
+                throw new ArgumentNullException(nameof(directDownloadDirectory));
+            }
+
             SourceCacheContext = sourceCacheContext;
-            DirectDownload = directDownloadDirectory != null;
+            DirectDownload = directDownload;
             DirectDownloadDirectory = directDownloadDirectory;
         }
 

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTests.cs
@@ -79,11 +79,11 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, true, false)] // Should either fail or install?
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, false)] // Should either fail or install?
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true, false)] // Should either fail or install?
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, false)] // Should either fail or install?
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false, false)]
@@ -95,11 +95,11 @@ namespace NuGet.CommandLine.Test.Caching
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false, false)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false, false)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
         [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false, false)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, true)] // Should fail?
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false, false)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, true, true)] // Should fail?
@@ -183,42 +183,42 @@ namespace NuGet.CommandLine.Test.Caching
         }
 
         /// <summary>
-        /// There is currently no way to disable getting the package from the global packages folder.
+        /// -NoCache disables reading from the global packages folder.
         /// </summary>
         [Theory]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2)]
-        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3)]
-        public async Task NuGetExe_Caching_UsesGlobalPackagesFolderCopy(Type type, CachingType caching, ServerType server)
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache, ServerType.V3, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false)]
+        [InlineData(typeof(RestorePackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.Default, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.DirectDownload, ServerType.V3, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true)]
+        [InlineData(typeof(RestoreProjectJsonCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true)]
+        public async Task NuGetExe_Caching_UsesGlobalPackagesFolderCopy(Type type, CachingType caching, ServerType server, bool success)
         {
             // Arrange
             var nuGetExe = await GetNuGetExeAsync();
@@ -234,8 +234,8 @@ namespace NuGet.CommandLine.Test.Caching
             // Assert
             validations.Assert(CachingValidationType.CommandSucceeded, true);
             validations.Assert(CachingValidationType.PackageInstalled, true);
-            validations.Assert(CachingValidationType.PackageFromGlobalPackagesFolderUsed, true);
-            validations.Assert(CachingValidationType.PackageFromSourceNotUsed, true);
+            validations.Assert(CachingValidationType.PackageFromGlobalPackagesFolderUsed, success);
+            validations.Assert(CachingValidationType.PackageFromSourceNotUsed, success);
         }
 
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4820,7 +4820,10 @@ namespace NuGet.Test
                 // Act
                 using (var cacheContext = new SourceCacheContext())
                 {
-                    var downloadContext = new PackageDownloadContext(cacheContext, directDownloadDirectory);
+                    var downloadContext = new PackageDownloadContext(
+                        cacheContext,
+                        directDownloadDirectory,
+                        directDownload: true);
 
                     await nuGetPackageManager.RestorePackageAsync(
                         packageIdentity,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/PackageDownloaderTests.cs
@@ -263,7 +263,10 @@ namespace NuGet.PackageManagement
             using (var directDownloadDirectory = TestFileSystemUtility.CreateRandomTestFolder())
             using (var cacheContext = new SourceCacheContext())
             {
-                var downloadContext = new PackageDownloadContext(cacheContext, directDownloadDirectory);
+                var downloadContext = new PackageDownloadContext(
+                    cacheContext,
+                    directDownloadDirectory,
+                    directDownload: true);
 
                 // Act
                 using (var downloadResult = await PackageDownloader.GetDownloadResourceResultAsync(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/GetDownloadResultUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/Utility/GetDownloadResultUtilityTests.cs
@@ -41,7 +41,8 @@ namespace NuGet.Protocol.Tests
             {
                 var downloadContext = new PackageDownloadContext(
                     cacheContext,
-                    downloadDirectory);
+                    downloadDirectory,
+                    directDownload: true);
 
                 // Act
                 using (var result = await GetDownloadResultUtility.GetDownloadResultAsync(
@@ -98,7 +99,8 @@ namespace NuGet.Protocol.Tests
             {
                 var downloadContext = new PackageDownloadContext(
                     cacheContext,
-                    downloadDirectory);
+                    downloadDirectory,
+                    directDownload: true);
 
                 // Act
                 using (var resultA = await GetDownloadResultUtility.GetDownloadResultAsync(
@@ -145,7 +147,8 @@ namespace NuGet.Protocol.Tests
             {
                 var downloadContext = new PackageDownloadContext(
                     cacheContext,
-                    downloadDirectory);
+                    downloadDirectory,
+                    directDownload: true);
 
                 var deletePathA = Path.Combine(downloadDirectory, "packageA.nugetdirectdownload");
                 File.WriteAllText(deletePathA, string.Empty);


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1406 and https://github.com/NuGet/Home/issues/3074.

This PR brings `-NoCache` closer to sanity. Other related caching issues are tracked here:
- https://github.com/NuGet/Home/issues/3132: packages.config scenarios should use the HTTP cache.
- https://github.com/NuGet/Home/issues/3244: `-NoCache` with a package missing on all sources should cause the operation to fail.
- https://github.com/NuGet/Home/issues/3389: Caching of version lists in the HTTP cache should be smarter.
- https://github.com/NuGet/Home/issues/3390: Packages in the HTTP cache should last for much longer than 30 minutes.
- https://github.com/NuGet/Home/issues/3392: HTTP cache should be checked before multi-source HTTP requests.

Check the `CachingTests.cs` file for assertions on current caching functionality.

To summarize, the caching switches should behave as follows:

`-NoCache` means "don't read from the cache". If something is in the global packages folder and you are restoring packages.config (that is, the destination folder is something other than a global packages folder), don't use it. Use the version from the source. Same goes for the HTTP cache but the behavior should be consistent between packages.config and project.json.

`-DirectDownload` means "don't write to the cache". If something is in the global packages folder or HTTP cache, you can use it. The main idea here is to minimize disk usage.

`-NoCache` and `-DirectDownload` together should be "isolated mode". You neither read from nor write to the global packages folder (for packages.config) or HTTP cache (for both packages.config and project.json).

/cc @emgarten @yishaigalatzer @MarkOsborneMS @zarenner @zjrunner @pspill 
