### PR TITLE
allow nuspec files element to override what content files are added while packing using csproj

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -264,7 +264,14 @@ namespace NuGet.CommandLine
             ApplyAction(p => p.AddOutputFiles(builder));
 
             // Add content files if there are any. They could come from a project or nuspec file
-            ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));
+            // In order to be compliant with the documented behavior, if the nuspec file has an 
+            // empty <files> element, we do not add any content files at all. If the <files> element
+            // has one or more files specified, then those files are added to the package along with
+            // any files of type Content from the csproj file.
+            if (manifest == null || !manifest.HasFilesNode || manifest.Files.Count > 0)
+            {
+                ApplyAction(p => p.AddFiles(builder, ContentItemType, ContentFolder));
+            }
 
             // Add sources if this is a symbol package
             if (IncludeSymbols)
@@ -1160,7 +1167,7 @@ namespace NuGet.CommandLine
                 Packaging.Manifest manifest = Packaging.Manifest.ReadFrom(stream, GetPropertyValue, validateSchema: true);
                 builder.Populate(manifest.Metadata);
 
-                if (manifest.Files != null)
+                if (manifest.HasFilesNode)
                 {
                     basePath = String.IsNullOrEmpty(basePath) ? Path.GetDirectoryName(nuspecFile) : basePath;
                     builder.PopulateFiles(basePath, manifest.Files);


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/3257

This bug was introduced because of fixing the bug  from https://github.com/NuGet/Home/issues/2658 commit https://github.com/NuGet/NuGet.Client/commit/10a986f0959638cf975688619b720a1a0eec193a

manifest.Files != null was not a good enough check as Files was always initialized to an empty list upon creation of a Manifest object. This replaces that check with the better manifest.HasFilesNode which knows if the <files> element is present or not in the nuspec. If an empty files element is present in the nuspec, then content is not added at all .

Since this is a regression, this fix will also go into 3.5-rtm branch.

CC: @joelverhagen @emgarten @alpaix @zhili1208 @jainaashish @mishra14 @rrelyea 
