### PR TITLE
LibraryDependencyTarget should be able to parse mixed values

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
@@ -14,35 +14,19 @@ namespace NuGet.LibraryModel
         /// <summary>
         /// Convert flag string into a LibraryTypeFlag.
         /// </summary>
-        public static LibraryDependencyTarget Parse(string flag)
+        public static LibraryDependencyTarget Parse(string flags)
         {
             // If the LibraryDependency does not have a flag value it is considered all
-            if (string.IsNullOrEmpty(flag))
+            if (string.IsNullOrEmpty(flags))
             {
                 return LibraryDependencyTarget.All;
             }
 
-            switch (flag.ToLowerInvariant())
-            {
-                case "package":
-                    return LibraryDependencyTarget.Package;
-                case "project":
-                    return LibraryDependencyTarget.Project;
-                case "externalproject":
-                    return LibraryDependencyTarget.ExternalProject;
-                case "reference":
-                    return LibraryDependencyTarget.Reference;
-                case "assembly":
-                    return LibraryDependencyTarget.Assembly;
-                case "winmd":
-                    return LibraryDependencyTarget.WinMD;
-                case "all":
-                    return LibraryDependencyTarget.All;
+            LibraryDependencyTarget target;
+            // None is a noop here
+            Enum.TryParse(flags, out target);
 
-                    // None is a noop here
-            }
-
-            return LibraryDependencyTarget.None;
+            return target;
         }
 
         /// <summary>


### PR DESCRIPTION
I discovered this issue when trying to parse a json file written by JsonPackageSpecWriter

JsonPackageSpecWriter sets the LibraryDependencyTarget to ~LibraryDependencyTarget.Reference when target is not GAC or framework reference which is has multiple values "PackageProjectExternal, Assembly, WinMD" that LibraryDependencyTargetUtils was unable to parse.
