### PR TITLE
Refactoring around init.ps1 execution, minor refactoring, and additional testing

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -211,7 +211,7 @@ namespace NuGet.Common
             FileSystemUtility.DeleteDirectory(path, recursive, NuGetProjectContext);
         }
 
-        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure)
+        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure)
         {
             // No-op
             return Task.FromResult(0);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IScriptExecutor.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IScriptExecutor.cs
@@ -17,7 +17,6 @@ namespace NuGet.PackageManagement.VisualStudio
             string packageInstallPath,
             string scriptRelativePath,
             EnvDTEProject envDTEProject,
-            NuGetProject nuGetProject,
             INuGetProjectContext nuGetProjectContext,
             bool throwOnFailure);
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/PackageInitPS1State.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/PackageInitPS1State.cs
@@ -1,4 +1,7 @@
-﻿namespace NuGet.PackageManagement.VisualStudio
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.PackageManagement.VisualStudio
 {
     public enum PackageInitPS1State
     {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -90,6 +90,7 @@
     <Compile Include="IDE\NuGetAndEnvDTEProjectCache.cs" />
     <Compile Include="IDE\EnvDTEProjectName.cs" />
     <Compile Include="IDE\IScriptExecutor.cs" />
+    <Compile Include="ScriptExecutionRequest.cs" />
     <Compile Include="Telemetry\ProjectTelemetryEvent.cs" />
     <Compile Include="IDE\PackageInitPS1State.cs" />
     <Compile Include="IDE\VsCommonOperations.cs" />

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/BuildIntegratedProjectSystem.cs
@@ -350,7 +350,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return pathToProject;
         }
 
-        public override async Threading.Task<bool> ExecuteInitScriptAsync(
+        public override async Task<bool> ExecuteInitScriptAsync(
             PackageIdentity identity,
             string packageInstallPath,
             INuGetProjectContext projectContext,
@@ -389,7 +389,6 @@ namespace NuGet.PackageManagement.VisualStudio
                                 packageInstallPath,
                                 initPS1RelativePath,
                                 EnvDTEProject,
-                                this,
                                 projectContext,
                                 throwOnFailure);
                         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -810,12 +810,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #endregion
 
-        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure)
+        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure)
         {
             if (ScriptExecutor != null)
             {
-                return ScriptExecutor.ExecuteAsync(identity, packageInstallPath, scriptRelativePath, EnvDTEProject, nuGetProject, NuGetProjectContext, throwOnFailure);
+                return ScriptExecutor.ExecuteAsync(identity, packageInstallPath, scriptRelativePath, EnvDTEProject, NuGetProjectContext, throwOnFailure);
             }
+
             return Task.FromResult(false);
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ScriptExecutionRequest.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ScriptExecutionRequest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using EnvDTEProject = EnvDTE.Project;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public class ScriptExecutionRequest
+    {
+        public ScriptExecutionRequest(string scriptPath, PackageIdentity identity, EnvDTEProject project)
+        {
+            if (scriptPath == null)
+            {
+                throw new ArgumentNullException(nameof(scriptPath));
+            }
+
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+            
+            Identity = identity;
+            ScriptPath = scriptPath;
+
+            ToolsPath = Path.GetDirectoryName(ScriptPath);
+            InstallPath = Path.GetDirectoryName(ToolsPath);
+            ScriptPackage = new ScriptPackage(Identity.Id, Identity.Version.ToString(), InstallPath);
+            Project = project;
+        }
+
+        public PackageIdentity Identity { get; }
+        public string InstallPath { get; }
+        public string ToolsPath { get; }
+        public string ScriptPath { get; }
+        public ScriptPackage ScriptPackage { get; }
+        public EnvDTEProject Project { get; }
+
+        public string BuildCommand()
+        {
+            var escapedScriptPath = PathUtility.EscapePSPath(ScriptPath);
+            var command = new StringBuilder(
+                "$__pc_args=@(); " +
+                "$input|%{$__pc_args+=$_}; " +
+                "& " + escapedScriptPath + " $__pc_args[0] $__pc_args[1] $__pc_args[2]");
+            command.Append(Project != null ? " $__pc_args[3]; " : "; ");
+            command.Append("Remove-Variable __pc_args -Scope 0");
+
+            return command.ToString();
+        }
+
+        public object[] BuildInput()
+        {
+            var input = new List<object>
+            {
+                InstallPath,
+                ToolsPath,
+                ScriptPackage
+            };
+
+            if (Project != null)
+            {
+                input.Add(Project);
+            }
+
+            return input.ToArray();
+        }
+    }
+}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/RunspaceDispatcher.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/RunspaceDispatcher.cs
@@ -6,14 +6,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading;
 using Microsoft.PowerShell;
 using NuGet;
-using NuGet.PackageManagement.VisualStudio;
-using NuGet.Packaging.Core;
 using PathUtility = NuGet.ProjectManagement.PathUtility;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
@@ -178,21 +175,6 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             string command = string.Format(CultureInfo.InvariantCulture, "Set-ExecutionPolicy {0} -Scope {1} -Force", policy, scope);
 
             Invoke(command, inputs: null, outputResults: false);
-        }
-
-        // Was passing in IPackage
-        public void ExecuteScript(string installPath, string scriptPath, ScriptPackage package)
-        {
-            if (File.Exists(scriptPath))
-            {
-                string folderPath = Path.GetDirectoryName(scriptPath);
-
-                Invoke(
-                    "$__pc_args=@(); $input|%{$__pc_args+=$_}; & " + PathUtility.EscapePSPath(scriptPath)
-                    + " $__pc_args[0] $__pc_args[1] $__pc_args[2]; Remove-Variable __pc_args -Scope 0",
-                    new object[] { installPath, folderPath, package },
-                    outputResults: true);
-            }
         }
 
         public void ImportModule(string modulePath)

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -523,11 +523,11 @@ namespace NuGetVSExtension
 
             var projectName = NuGetProject.GetUniqueNameOrName(project);
 
-            var nugetPathContext = NuGetPathContext.Create(Settings);
+            var pathContext = NuGetPathContext.Create(Settings);
 
             providerCache.GetOrCreate(
-                nugetPathContext.UserPackageFolder,
-                nugetPathContext.FallbackPackageFolders,
+                pathContext.UserPackageFolder,
+                pathContext.FallbackPackageFolders,
                 enabledSources,
                 cacheContext,
                 context.Logger);
@@ -536,8 +536,8 @@ namespace NuGetVSExtension
             var restoreResult = await BuildIntegratedRestoreUtility.RestoreAsync(project,
                 context,
                 enabledSources,
-                nugetPathContext.UserPackageFolder,
-                 nugetPathContext.FallbackPackageFolders,
+                pathContext.UserPackageFolder,
+                pathContext.FallbackPackageFolders,
                 token);
 
             if (!restoreResult.Success)

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -71,16 +71,6 @@ namespace NuGet.PackageManagement
             CancellationToken token);
 
         /// <summary>
-        /// Restores the missing packages for a project. Returns true if atleast one package was restored.
-        /// </summary>
-        /// <remarks>Best use case is 'nuget.exe restore packages.config'</remarks>
-        Task<PackageRestoreResult> RestoreMissingPackagesAsync(string solutionDirectory,
-            NuGetProject nuGetProject,
-            INuGetProjectContext nuGetProjectContext,
-            PackageDownloadContext downloadContext,
-            CancellationToken token);
-
-        /// <summary>
         /// Restores the package references if they are missing
         /// </summary>
         /// <param name="packages">

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreContext.cs
@@ -18,13 +18,6 @@ namespace NuGet.PackageManagement
         public IEnumerable<SourceRepository> SourceRepositories { get; }
         public int MaxNumberOfParallelTasks { get; }
 
-        /// <summary>
-        /// WasRestored is set to true in this class, if one or more packages were restored or that satellite files
-        /// were copied
-        /// Note that this property is not read-only unlike other properties
-        /// </summary>
-        public bool WasRestored { get; private set; }
-
         public PackageRestoreContext(NuGetPackageManager nuGetPackageManager,
             IEnumerable<PackageRestoreData> packages,
             CancellationToken token,
@@ -55,28 +48,6 @@ namespace NuGet.PackageManagement
             PackageRestoreFailedEvent = packageRestoreFailedEvent;
             SourceRepositories = sourceRepositories;
             MaxNumberOfParallelTasks = maxNumberOfParallelTasks;
-        }
-
-        public PackageRestoreContext(NuGetPackageManager nuGetPackageManager,
-            IEnumerable<PackageRestoreData> packages,
-            CancellationToken token)
-            : this(nuGetPackageManager,
-                packages,
-                token,
-                packageRestoredEvent: null,
-                packageRestoreFailedEvent: null,
-                sourceRepositories: null,
-                maxNumberOfParallelTasks: PackageManagementConstants.DefaultMaxDegreeOfParallelism)
-        {
-        }
-
-        /// <summary>
-        /// Sets that one or more packages were restored or that satellite files were copied
-        /// If this has been called at least once, WasRestored returns true. Otherwise, it returns false
-        /// </summary>
-        public void SetRestored()
-        {
-            WasRestored = true;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreResult.cs
@@ -1,15 +1,20 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using NuGet.Packaging.Core;
+
 namespace NuGet.PackageManagement
 {
     public class PackageRestoreResult
     {
-        public bool Restored { get; }
-
-        public PackageRestoreResult(bool restored)
+        public PackageRestoreResult(bool restored, IEnumerable<PackageIdentity> restoredPackages)
         {
             Restored = restored;
+            RestoredPackages = restoredPackages;
         }
+
+        public bool Restored { get; }
+        public IEnumerable<PackageIdentity> RestoredPackages { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
@@ -43,7 +43,7 @@ namespace NuGet.ProjectManagement
         string ResolvePath(string path);
         bool IsSupportedFile(string path);
         void AddBindingRedirects();
-        Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure);
+        Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure);
         void BeginProcessing();
         /// <summary>
         /// This method can be called multiple times during a batch operation in between a single BeginProcessing/EndProcessing calls.

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -347,7 +347,7 @@ namespace NuGet.ProjectManagement
                 if (!string.IsNullOrEmpty(initPS1RelativePath))
                 {
                     initPS1RelativePath = PathUtility.ReplaceAltDirSeparatorWithDirSeparator(initPS1RelativePath);
-                    await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, initPS1RelativePath, this, throwOnFailure: true);
+                    await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, initPS1RelativePath, throwOnFailure: true);
                 }
             }
 
@@ -357,7 +357,7 @@ namespace NuGet.ProjectManagement
                     p => p.EndsWith(Path.DirectorySeparatorChar + PowerShellScripts.Install, StringComparison.OrdinalIgnoreCase));
                 if (!string.IsNullOrEmpty(installPS1RelativePath))
                 {
-                    await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, installPS1RelativePath, this, throwOnFailure: true);
+                    await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, installPS1RelativePath, throwOnFailure: true);
                 }
             }
             return true;
@@ -419,7 +419,7 @@ namespace NuGet.ProjectManagement
                     if (!string.IsNullOrEmpty(uninstallPS1RelativePath))
                     {
                         var packageInstallPath = FolderNuGetProject.GetInstalledPath(packageIdentity);
-                        await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, uninstallPS1RelativePath, this, throwOnFailure: false);
+                        await MSBuildNuGetProjectSystem.ExecuteScriptAsync(packageIdentity, packageInstallPath, uninstallPS1RelativePath, throwOnFailure: false);
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Common;
-using NuGet.Configuration;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -20,17 +18,6 @@ namespace NuGet.ProjectManagement
     /// </summary>
     public static class BuildIntegratedProjectUtility
     {
-        /// <summary>
-        /// Get the root path of a package from the global folder.
-        /// </summary>
-        public static string GetPackagePathFromGlobalSource(
-            string effectiveGlobalPackagesFolder,
-            PackageIdentity identity)
-        {
-            var pathResolver = new VersionFolderPathResolver(effectiveGlobalPackagesFolder);
-            return pathResolver.GetInstallPath(identity.Id, identity.Version);
-        }
-
         /// <summary>
         /// Orders all package dependencies in a project.
         /// Project must be restored.

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -156,7 +156,7 @@ namespace Test.Utility
             BindingRedirectsCallCount++;
         }
 
-        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, NuGetProject nuGetProject, bool throwOnFailure)
+        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure)
         {
             var scriptFullPath = Path.Combine(packageInstallPath, scriptRelativePath);
             if (!File.Exists(scriptFullPath) && throwOnFailure)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -133,13 +133,13 @@ namespace NuGet.Protocol.Tests
         {
             // Arrange
 
-            // 20 requests that take 50ms each for a total of 1 second (plus noise).
-            var requestDuration = TimeSpan.FromMilliseconds(50);
+            // 20 requests that take 250ms each for a total of 5 seconds (plus noise).
+            var requestDuration = TimeSpan.FromMilliseconds(250);
             var maxTries = 20;
 
             // Make the request timeout longer than each request duration but less than the total
             // duration of all attempts.
-            var requestTimeout = TimeSpan.FromMilliseconds(500);
+            var requestTimeout = TimeSpan.FromMilliseconds(4000);
 
             int hits = 0;
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverUtilityTests.cs
@@ -4,17 +4,46 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 using Xunit;
-using NuGet.Configuration;
 
 namespace NuGet.Resolver.Test
 {
     public class ResolverUtilityTests
     {
+        [Fact]
+        public void ResolverUtility_TopologicalSort()
+        {
+            // Arrange
+            var packages = new List<ResolverPackage>()
+            {
+                CreatePackage("A", "1.0.0", "B", "1.0.0"),
+                CreatePackage("B", "1.0.0", "C", "1.0.0"),
+                CreatePackage("C", "1.0.0", "D", "1.0.0"),
+                CreatePackage("D", "1.0.0"),
+                CreatePackage("E1", "1.0.0"),
+                CreatePackage("E3", "1.0.0"),
+                CreatePackage("E2", "1.0.0")
+            };
+
+            // Act
+            var sorted = ResolverUtility.TopologicalSort(packages).ToList();
+
+            // Assert
+            Assert.Equal(7, sorted.Count);
+            Assert.Equal("D", sorted[0].Id);
+            Assert.Equal("C", sorted[1].Id);
+            Assert.Equal("B", sorted[2].Id);
+            Assert.Equal("A", sorted[3].Id);
+            Assert.Equal("E1", sorted[4].Id);
+            Assert.Equal("E2", sorted[5].Id);
+            Assert.Equal("E3", sorted[6].Id);
+        }
+
         [Fact]
         public void ResolverUtility_GetLowestDistanceFromTargetMultiplePaths()
         {


### PR DESCRIPTION
I have been working through the init.ps1 on restore problem and made the following changes to set the groundwork:
1. Remove unused overloads and parameters.
2. Add tests to assert topological sort behavior.
3. Make the list of restore packages available for packages.config and UWP project.json cases.
4. Move init.ps1 execution logic for UWP project.json available in a shared location.

This PR should have no functional impact. 

/cc @emgarten @alpaix @drewgil @jainaashish 
