### PR TITLE
Provide constant for codeLanguage fixed value 'any'

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagingConstants.cs
@@ -6,6 +6,7 @@ namespace NuGet.Packaging
     public static class PackagingConstants
     {
         public static readonly string AnyFramework = "any";
+        public static readonly string AnyCodeLanguage = "any";
         public static readonly string AgnosticFramework = "agnostic";
 
         public static readonly string TargetFrameworkPropertyKey = "targetframework";


### PR DESCRIPTION
Since `AnyFramework` is provided, for consistency, `AnyCodeLanguage` should 
exist too, since either one could change in the future. 

Alternatively, the `AnyFramework` could be renamed to just `Any`, but that would 
be a breaking change.
