### PR TITLE
Clear HTTP cache before running V3 mock server test (index.json is cached)

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -300,6 +300,7 @@ namespace NuGet.CommandLine.Test
         public void DeleteCommand_WithApiKeyFromConfig(string configKeyFormatString)
         {
             // Arrange
+            Util.ClearWebCache();
             var testApiKey = Guid.NewGuid().ToString();
 
             using (var testFolder = TestFileSystemUtility.CreateRandomTestFolder())
@@ -340,7 +341,7 @@ namespace NuGet.CommandLine.Test
                     var config = $@"<?xml version='1.0' encoding='utf-8'?>
 <configuration>
     <packageSources>
-        <add key='nuget.org' value='{server.Uri}index.json' protocolVersion='3' />
+        <add key='MockServer' value='{server.Uri}index.json' protocolVersion='3' />
     </packageSources>
     <apikeys>
         <add key='{configKey}' value='{Configuration.EncryptionUtility.EncryptString(testApiKey)}' />
@@ -357,7 +358,7 @@ namespace NuGet.CommandLine.Test
                         "testPackage1",
                         "1.1.0",
                         "-Source",
-                        "nuget.org",
+                        "MockServer",
                         "-ConfigFile",
                         configFileName,
                         "-NonInteractive"


### PR DESCRIPTION
HTTP caching of index.json was causing flakiness in this test theory.

/cc @drewgil @emgarten @alpaix
