### PR TITLE
Properly request DTE service from the components service provider

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -82,11 +82,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public event EventHandler<ActionsExecutedEventArgs> ActionsExecuted;
 
-        public VSSolutionManager()
+        public VSSolutionManager([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
         {
-            _dte = ServiceLocator.GetInstance<DTE>();
-            _vsSolution = ServiceLocator.GetGlobalService<SVsSolution, IVsSolution>();
-            _vsMonitorSelection = ServiceLocator.GetGlobalService<SVsShellMonitorSelection, IVsMonitorSelection>();
+            _dte = (DTE)serviceProvider.GetService(typeof(DTE));
+            _vsSolution = (IVsSolution)serviceProvider.GetService(typeof(SVsSolution));
+            _vsMonitorSelection = (IVsMonitorSelection)serviceProvider.GetService(typeof(SVsShellMonitorSelection));
 
             // Keep a reference to SolutionEvents so that it doesn't get GC'ed. Otherwise, we won't receive events.
             _solutionEvents = _dte.Events.SolutionEvents;
@@ -103,7 +103,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             UserAgent.SetUserAgentString(
-                new UserAgentStringBuilder().WithVisualStudioSKU(VSVersionHelper.GetFullVsVersionString()));
+                new UserAgentStringBuilder().WithVisualStudioSKU(VSVersionHelper.GetFullVsVersionString(_dte)));
 
             _solutionEvents.BeforeClosing += OnBeforeClosing;
             _solutionEvents.AfterClosing += OnAfterClosing;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSVersionHelper.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSVersionHelper.cs
@@ -9,11 +9,8 @@ namespace NuGet.PackageManagement.VisualStudio
 {
     internal static class VSVersionHelper
     {
-        public static string GetSKU()
+        public static string GetSKU(DTE dte)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            DTE dte = ServiceLocator.GetInstance<DTE>();
             string sku = dte.Edition;
             if (sku.Equals("Ultimate", StringComparison.OrdinalIgnoreCase)
                 ||
@@ -27,12 +24,8 @@ namespace NuGet.PackageManagement.VisualStudio
             return sku;
         }
 
-        public static string GetFullVsVersionString()
+        public static string GetFullVsVersionString(DTE dte)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            DTE dte = ServiceLocator.GetInstance<DTE>();
-
             // On Dev14, dte.Edition just returns SKU, such as "Enterprise"
             // Add "VS" to the string so that in user agent header, it will be "VS Enterprise/14.0".
             string edition = dte.Edition;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using EnvDTE;
@@ -15,8 +16,8 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly AsyncLazy<IEnumerable<Configuration.Settings>> _settings;
 
         [ImportingConstructor]
-        public VsMachineWideSettings()
-            : this(ServiceLocator.GetInstance<DTE>())
+        public VsMachineWideSettings([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider)
+            : this((DTE)serviceProvider.GetService(typeof(DTE)))
         {
         }
 
@@ -30,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         baseDirectory,
                         "VisualStudio",
                         dte.Version,
-                        VSVersionHelper.GetSKU());
+                        VSVersionHelper.GetSKU(dte));
                 }, ThreadHelper.JoinableTaskFactory);
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -3,6 +3,7 @@
     "NuGet.PackageManagement": "3.6.0-*",
     "NuGet.Protocol.VisualStudio": "3.6.0-*",
     "NuGet.Common": "3.6.0-*",
+    "Microsoft.VisualStudio.Shell.Immutable.10.0":  "10.0.30319",
     "Microsoft.VisualStudio.Shell.Interop": "7.10.6071",
     "Microsoft.VisualStudio.Shell.Interop.10.0": "10.0.30319",
     "Microsoft.VisualStudio.Shell.Interop.11.0": "11.0.61030",


### PR DESCRIPTION
The previous approach failed if the MEF component happened to be
instantiated from a background thread (i.e. another MEF component
requested in a background thread depended these exports). Since
MEF components aren't guaranteed to initialize on the UI thread,
this caused heard to track and unfriendly errors, such as
NuGet/Home#3419.

The requirement came from the helper class which used a static
service locator and therefore had no way of knowing if it was
being properly invoked, and therefore resorted to just throwing
if not.

This fix changes the way these services are requested from the
MEF components so that they use the built-in mechanism provided
by VSMEF to retrieve VS services properly from a MEF component:
the IServiceProvider import.

Since the helper does not need to retrieve the service itself
anymore, it receives the DTE as a parameter instead.

This fixes NuGet/Home#3419

The previous issue can be easily reproduced with the following
VS package code:

```
[ProvideAutoLoad(UIContextGuids.SolutionExists)]
[PackageRegistration(UseManagedResourcesOnly = true)]
[Guid(PackageGuidString)]
public sealed class NuGetBreakingPackage : Package
{
    public const string PackageGuidString = "3FF684D3-61BF-417C-A1C0-17CD9B81BFE6";

    protected override void Initialize()
    {
        base.Initialize();

        var components = (IComponentModel)GetService(typeof(SComponentModel));

        System.Threading.Tasks.Task.Run(() =>
        {
            try
            {
                var solution = components.DefaultExportProvider.GetExportedValue<object>("NuGet.PackageManagement.ISolutionManager");
            }
            catch (Exception ex)
            {
                Debug.Fail(ex.ToString());
            }
        });
    }
}
```
