### PR TITLE
fix to add an extra backslash so it doesn't unwantedly escape any quotes in msbuild command line

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -402,14 +402,8 @@ namespace NuGet.CommandLine
             string properties = string.Empty;
             foreach (var property in ProjectProperties)
             {
-                if (property.Value.Contains(" "))
-                {
-                    properties += $" /p:{property.Key}=\"{property.Value}\"";
-                }
-                else
-                {
-                    properties += $" /p:{property.Key}={property.Value}";
-                }
+                string escapedValue = MsBuildUtility.Escape(property.Value);
+                properties += $" /p:{property.Key}={escapedValue}";
             }
 
             int result = MsBuildUtility.Build(_msbuildDirectory, $"\"{_project.FullPath}\" {properties} /toolsversion:{_project.ToolsVersion}");

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Evaluation;
 using NuGet.Commands;
 using NuGet.Common;
@@ -624,7 +625,7 @@ namespace NuGet.CommandLine
                 // Try to find msbuild.exe from hard code path.
                 var path = new[] { CommandLineConstants.MsbuildPathOnMac15, CommandLineConstants.MsbuildPathOnMac14 }.
                     Select(p => Path.Combine(p, "msbuild.exe")).FirstOrDefault(File.Exists);
-                
+
                 if (path != null)
                 {
                     return path;
@@ -639,6 +640,27 @@ namespace NuGet.CommandLine
                 return Path.Combine(msbuildDirectory, "msbuild.exe");
             }
 
+        }
+
+        /// <summary>
+        /// Escapes a string so that it can be safely passed as a command line argument when starting a msbuild process.
+        /// Source: http://stackoverflow.com/a/12364234
+        /// </summary>
+        public static string Escape(string argument)
+        {
+            if (argument == string.Empty)
+            {
+                return "\"\"";
+            }
+
+            var escaped = Regex.Replace(argument, @"(\\*)""", @"$1\$0");
+
+            escaped = Regex.Replace(
+                escaped,
+                @"^(.*\s.*?)(\\*)$", @"""$1$2$2""",
+                RegexOptions.Singleline);
+
+            return escaped;
         }
     }
 }


### PR DESCRIPTION
This PR fixes : https://github.com/NuGet/Home/issues/3432

The issue is that while adding SolutionDir as a property, we add a '\' in front of the path for Visual Studio Macro Compatibility (I am not sure what that means but that is what the code comment says). 

If there is a space somewhere in the path, then we surround the path with quotes (" " ). However, the extra backslash ends up escaping the ending quote when msbuild is invoked and the remaining properties are not read properly.

This fix check for an unescaped backslash at the end of the property value which also has a space in it, and adds an extra backslash if necessary.

CC: @rrelyea @joelverhagen @drewgil @alpaix @mishra14 @zhili1208 
