### PR TITLE
Emitting nuget telemetry events for VS15

### DIFF
--- a/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetrySession.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Telemetry/TelemetrySession.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if VS14
 using System;
 using Microsoft.VisualStudio.Telemetry;
 using VsTelemetryEvent = Microsoft.VisualStudio.Telemetry.TelemetryEvent;
-#endif
 
 namespace NuGet.VisualStudio.Facade.Telemetry
 {
-#if VS14
     public class TelemetrySession : ITelemetrySession
     {
         public void PostEvent(TelemetryEvent telemetryEvent)
@@ -29,13 +26,4 @@ namespace NuGet.VisualStudio.Facade.Telemetry
             TelemetryService.DefaultSession.PostEvent(vsTelemetryEvent);
         }
     }
-#elif VS15
-    public class TelemetrySession : ITelemetrySession
-    {
-        public void PostEvent(TelemetryEvent telemetryEvent)
-        {
-            // Do nothing.
-        }
-    }
-#endif
 }

--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
@@ -14,7 +14,8 @@
     "Microsoft.VisualStudio.Text.UI": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Threading": "15.0.20-pre",
-    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
+    "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4",
+    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920"
   },
   "frameworks": {
     "net46": {}

--- a/src/NuGet.Clients/VsExtension/.vsixignore.vs15
+++ b/src/NuGet.Clients/VsExtension/.vsixignore.vs15
@@ -1,6 +1,10 @@
 # assemblies not to be included in VSIX
 ICSharpCode.SharpZipLib.dll
+Microsoft.ApplicationInsights.dll
+Microsoft.ApplicationInsights.PersistenceChannel.dll
+Microsoft.ApplicationInsights.UniversalTelemetryChannel.dll
 Microsoft.CSharp.dll
+Microsoft.Diagnostics.Tracing.EventSource.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.dll
 Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll
 Microsoft.ServiceBus.dll
@@ -38,15 +42,22 @@ Microsoft.TeamFoundation.WorkItemTracking.Client.QueryLanguage.dll
 Microsoft.TeamFoundation.WorkItemTracking.Common.dll
 Microsoft.TeamFoundation.WorkItemTracking.Proxy.dll
 Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll
+Microsoft.Threading.Tasks.dll
+Microsoft.Threading.Tasks.Extensions.Desktop.dll
+Microsoft.Threading.Tasks.Extensions.dll
+Microsoft.VisualStudio.RemoteControl.dll
 Microsoft.VisualStudio.Services.Client.dll
 Microsoft.VisualStudio.Services.Common.dll
 Microsoft.VisualStudio.Services.WebApi.dll
+Microsoft.VisualStudio.Telemetry.dll
+Microsoft.VisualStudio.Utilities.Internal.dll
 Microsoft.WindowsAzure.Configuration.dll
 Newtonsoft.Json.dll
 System.dll
 System.IdentityModel.dll
 System.IdentityModel.Tokens.Jwt.dll
 System.IO.Compression.dll
+System.Net.dll
 System.Net.Http.dll
 System.Net.Http.Formatting.dll
 System.Net.Http.WebRequest.dll


### PR DESCRIPTION
We already emit nuget telemetry events for dev14, this code change is to also emit these events for dev15.

@joelverhagen @rrelyea @emgarten @alpaix @harikmenon 
