### PR TITLE
Reversed order to log nuget action messages

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -80,14 +80,14 @@ namespace NuGet.PackageManagement
                 var added = BuildIntegratedRestoreUtility.GetAddedPackages(OriginalLockFile, RestoreResult.LockFile);
                 var removed = BuildIntegratedRestoreUtility.GetAddedPackages(RestoreResult.LockFile, OriginalLockFile);
 
-                foreach (var package in added)
-                {
-                    actions.Add(NuGetProjectAction.CreateInstallProjectAction(package, sourceRepository: null, project: Project));
-                }
-
                 foreach (var package in removed)
                 {
                     actions.Add(NuGetProjectAction.CreateUninstallProjectAction(package, Project));
+                }
+
+                foreach (var package in added)
+                {
+                    actions.Add(NuGetProjectAction.CreateInstallProjectAction(package, sourceRepository: null, project: Project));
                 }
             }
 


### PR DESCRIPTION
Reversed order to log nuget action messages to first log uninstall actions and then install actions.

Fix https://github.com/NuGet/Home/issues/3446

@joelverhagen @zhili1208 @rrelyea 
