### PR TITLE
Get project information for telemetry without using JTF (saves a context switch)

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -578,6 +578,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Finally, try to add the project to the cache.
             var added = _nuGetAndEnvDTEProjectCache.AddProject(newEnvDTEProjectName, envDTEProject, nuGetProject);
+
+            /* TODO: Enable this in such a way that it does not effect project load time.
             if (added)
             {
                 // Emit project specific telemetry as we are adding the project to the cache.
@@ -585,6 +587,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 // open.
                 NuGetProjectTelemetryService.Instance.EmitNuGetProject(envDTEProject, nuGetProject);
             }
+            */
 
             if (string.IsNullOrEmpty(DefaultNuGetProjectName) ||
                 newEnvDTEProjectName.ShortName.Equals(DefaultNuGetProjectName, StringComparison.OrdinalIgnoreCase))

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
@@ -59,16 +59,14 @@ namespace NuGet.PackageManagement.Telemetry
         private async Task EmitNuGetProjectAsync(EnvDTEProject vsProject, NuGetProject nuGetProject)
         {
             // Get the project details.
-            ProjectDetails projectDetails = null;
+            var projectUniqueName = nuGetProject.GetMetadata<string>(NuGetProjectMetadataKeys.UniqueName);
+            var projectId = Guid.Empty;
             try
             {
-                projectDetails = ThreadHelper.JoinableTaskFactory.Run(async delegate
+                projectId = await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
                 {
                     await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                    // Get the project name.
-                    var name = vsProject.Name;
-
+                    
                     // Get the project ID.
                     var vsHierarchyItem = VsHierarchyUtility.GetHierarchyItemForProject(vsProject);
                     Guid id;
@@ -77,7 +75,7 @@ namespace NuGet.PackageManagement.Telemetry
                         id = Guid.Empty;
                     }
 
-                    return new ProjectDetails(id, name);
+                    return id;
                 });
             }
             catch (Exception ex)
@@ -112,7 +110,7 @@ namespace NuGet.PackageManagement.Telemetry
 
                 var projectInformation = new ProjectInformation(
                     NuGetVersion.Value,
-                    projectDetails.Id,
+                    projectId,
                     projectType);
 
                 _nuGetTelemetryService.EmitProjectInformation(projectInformation);
@@ -120,7 +118,7 @@ namespace NuGet.PackageManagement.Telemetry
             catch (Exception ex)
             {
                 var message =
-                    $"Failed to emit project information for project '{projectDetails.Name}'. Exception:" +
+                    $"Failed to emit project information for project '{projectUniqueName}'. Exception:" +
                     Environment.NewLine +
                     ex.ToString();
 
@@ -136,7 +134,7 @@ namespace NuGet.PackageManagement.Telemetry
 
                 var projectDependencyStatistics = new ProjectDependencyStatistics(
                     NuGetVersion.Value,
-                    projectDetails.Id,
+                    projectId,
                     installedPackagesCount);
 
                 _nuGetTelemetryService.EmitProjectDependencyStatistics(projectDependencyStatistics);
@@ -144,25 +142,13 @@ namespace NuGet.PackageManagement.Telemetry
             catch (Exception ex)
             {
                 var message =
-                    $"Failed to emit project dependency statistics for project '{projectDetails.Name}'. Exception:" +
+                    $"Failed to emit project dependency statistics for project '{projectUniqueName}'. Exception:" +
                     Environment.NewLine +
                     ex.ToString();
 
                 ActivityLog.LogWarning(message, ExceptionHelper.LogEntrySource);
                 Debug.Fail(message);
             }
-        }
-
-        private class ProjectDetails
-        {
-            public ProjectDetails(Guid id, string name)
-            {
-                Id = id;
-                Name = name;
-            }
-
-            public Guid Id { get; }
-            public string Name { get; }
         }
     }
 }


### PR DESCRIPTION
Regarding VS bug 267648 and NuGet bug https://github.com/NuGet/Home/issues/3500.

Get project information while still on the UI thread, thus avoiding the need for JTF entirely.

/cc @jainaashish 
