### PR TITLE
Reverted namespace change which broke jetbrains runner

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/CommandAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/CommandAttribute.cs
@@ -1,6 +1,7 @@
 using System;
+using NuGet.CommandLine;
 
-namespace NuGet.CommandLine
+namespace NuGet
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public sealed class CommandAttribute : Attribute

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/OptionAttribute.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/OptionAttribute.cs
@@ -1,6 +1,7 @@
 using System;
+using NuGet.CommandLine;
 
-namespace NuGet.CommandLine
+namespace NuGet
 {
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     public sealed class OptionAttribute : Attribute


### PR DESCRIPTION
Reverted namespace change since jetbrains runner uses some public APIs which uses this class. And it got broken because of updated namespace.

Fix https://github.com/NuGet/Home/issues/3464

@rrelyea @emgarten @joelverhagen 
