### PR TITLE
Enable Visual Studio project mutation event batching per package for MSBuild projects

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2051,11 +2051,6 @@ namespace NuGet.PackageManagement
 
                     if (msbuildProject != null)
                     {
-                        // Leaving it as comment for future reference
-                        // Don't use batch API for whole install or uninstall which also includes adding/ removing references
-                        // from project, since it could then create problems while adding binding redirects.
-                        // msbuildProject.MSBuildNuGetProjectSystem.BeginProcessing();
-
                         // raise Nuget batch start event
                         var batchId = Guid.NewGuid().ToString();
                         string name;

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -275,64 +275,73 @@ namespace NuGet.ProjectManagement
             }
             PackageEventsProvider.Instance.NotifyInstalled(packageEventArgs);
 
-            // Step-8: MSBuildNuGetProjectSystem operations
-            // Step-8.1: Add references to project
-            if (!IsSkipAssemblyReferences(nuGetProjectContext) &&
-                MSBuildNuGetProjectSystemUtility.IsValid(compatibleReferenceItemsGroup))
+            try
             {
-                foreach (var referenceItem in compatibleReferenceItemsGroup.Items)
-                {
-                    if (IsAssemblyReference(referenceItem))
-                    {
-                        var referenceItemFullPath = Path.Combine(packageInstallPath, referenceItem);
-                        var referenceName = Path.GetFileName(referenceItem);
+                MSBuildNuGetProjectSystem.BeginProcessing();
 
-                        if (MSBuildNuGetProjectSystem.ReferenceExists(referenceName))
+                // Step-8: MSBuildNuGetProjectSystem operations
+                // Step-8.1: Add references to project
+                if (!IsSkipAssemblyReferences(nuGetProjectContext) &&
+                    MSBuildNuGetProjectSystemUtility.IsValid(compatibleReferenceItemsGroup))
+                {
+                    foreach (var referenceItem in compatibleReferenceItemsGroup.Items)
+                    {
+                        if (IsAssemblyReference(referenceItem))
                         {
-                            MSBuildNuGetProjectSystem.RemoveReference(referenceName);
+                            var referenceItemFullPath = Path.Combine(packageInstallPath, referenceItem);
+                            var referenceName = Path.GetFileName(referenceItem);
+
+                            if (MSBuildNuGetProjectSystem.ReferenceExists(referenceName))
+                            {
+                                MSBuildNuGetProjectSystem.RemoveReference(referenceName);
+                            }
+
+                            MSBuildNuGetProjectSystem.AddReference(referenceItemFullPath);
                         }
-
-                        MSBuildNuGetProjectSystem.AddReference(referenceItemFullPath);
                     }
                 }
-            }
 
-            // Step-8.2: Add Frameworkreferences to project
-            if (!IsSkipAssemblyReferences(nuGetProjectContext) &&
-                MSBuildNuGetProjectSystemUtility.IsValid(compatibleFrameworkReferencesGroup))
-            {
-                foreach (var frameworkReference in compatibleFrameworkReferencesGroup.Items)
+                // Step-8.2: Add Frameworkreferences to project
+                if (!IsSkipAssemblyReferences(nuGetProjectContext) &&
+                    MSBuildNuGetProjectSystemUtility.IsValid(compatibleFrameworkReferencesGroup))
                 {
-                    if (!MSBuildNuGetProjectSystem.ReferenceExists(frameworkReference))
+                    foreach (var frameworkReference in compatibleFrameworkReferencesGroup.Items)
                     {
-                        MSBuildNuGetProjectSystem.AddFrameworkReference(frameworkReference, packageIdentity.Id);
+                        if (!MSBuildNuGetProjectSystem.ReferenceExists(frameworkReference))
+                        {
+                            MSBuildNuGetProjectSystem.AddFrameworkReference(frameworkReference, packageIdentity.Id);
+                        }
                     }
                 }
-            }
 
-            // Step-8.3: Add Content Files
-            if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleContentFilesGroup))
-            {
-                MSBuildNuGetProjectSystemUtility.AddFiles(MSBuildNuGetProjectSystem,
-                    packageReader, compatibleContentFilesGroup, FileTransformers);
-            }
-
-            // Step-8.4: Add Build imports
-            if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleBuildFilesGroup))
-            {
-                foreach (var buildImportFile in compatibleBuildFilesGroup.Items)
+                // Step-8.3: Add Content Files
+                if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleContentFilesGroup))
                 {
-                    var fullImportFilePath = Path.Combine(packageInstallPath, buildImportFile);
-                    MSBuildNuGetProjectSystem.AddImport(fullImportFilePath,
-                        fullImportFilePath.EndsWith(".props", StringComparison.OrdinalIgnoreCase) ? ImportLocation.Top : ImportLocation.Bottom);
+                    MSBuildNuGetProjectSystemUtility.AddFiles(MSBuildNuGetProjectSystem,
+                        packageReader, compatibleContentFilesGroup, FileTransformers);
                 }
+
+                // Step-8.4: Add Build imports
+                if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleBuildFilesGroup))
+                {
+                    foreach (var buildImportFile in compatibleBuildFilesGroup.Items)
+                    {
+                        var fullImportFilePath = Path.Combine(packageInstallPath, buildImportFile);
+                        MSBuildNuGetProjectSystem.AddImport(fullImportFilePath,
+                            fullImportFilePath.EndsWith(".props", StringComparison.OrdinalIgnoreCase) ? ImportLocation.Top : ImportLocation.Bottom);
+                    }
+                }
+
+                // Step-9: Install package to PackagesConfigNuGetProject
+                await PackagesConfigNuGetProject.InstallPackageAsync(packageIdentity, downloadResourceResult, nuGetProjectContext, token);
+
+                // Step-10: Add packages.config to MSBuildNuGetProject
+                MSBuildNuGetProjectSystem.AddExistingFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
             }
-
-            // Step-9: Install package to PackagesConfigNuGetProject
-            await PackagesConfigNuGetProject.InstallPackageAsync(packageIdentity, downloadResourceResult, nuGetProjectContext, token);
-
-            // Step-10: Add packages.config to MSBuildNuGetProject
-            MSBuildNuGetProjectSystem.AddExistingFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
+            finally
+            {
+                MSBuildNuGetProjectSystem.EndProcessing();
+            }
 
             // Step 11: Raise PackageReferenceAdded event
             PackageReferenceAdded?.Invoke(this, packageEventArgs);
@@ -446,61 +455,70 @@ namespace NuGet.ProjectManagement
                 compatibleBuildFilesGroup
                     = MSBuildNuGetProjectSystemUtility.Normalize(compatibleBuildFilesGroup);
 
-                // Step-5: Remove package reference from packages.config
-                await PackagesConfigNuGetProject.UninstallPackageAsync(packageIdentity, nuGetProjectContext, token);
+                try
+                {
+                    MSBuildNuGetProjectSystem.BeginProcessing();
 
-                // Step-6: Remove packages.config from MSBuildNuGetProject if there are no packages
-                //         OR Add it again (to ensure that Source Control works), when there are some packages
-                if (!(await PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).Any())
-                {
-                    MSBuildNuGetProjectSystem.RemoveFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
-                }
-                else
-                {
-                    MSBuildNuGetProjectSystem.AddExistingFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
-                }
+                    // Step-5: Remove package reference from packages.config
+                    await PackagesConfigNuGetProject.UninstallPackageAsync(packageIdentity, nuGetProjectContext, token);
 
-                // Step-7: Uninstall package from the msbuild project
-                // Step-7.1: Remove references
-                if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleReferenceItemsGroup))
-                {
-                    foreach (var item in compatibleReferenceItemsGroup.Items)
+                    // Step-6: Remove packages.config from MSBuildNuGetProject if there are no packages
+                    //         OR Add it again (to ensure that Source Control works), when there are some packages
+                    if (!(await PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).Any())
                     {
-                        if (IsAssemblyReference(item))
+                        MSBuildNuGetProjectSystem.RemoveFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
+                    }
+                    else
+                    {
+                        MSBuildNuGetProjectSystem.AddExistingFile(Path.GetFileName(PackagesConfigNuGetProject.FullPath));
+                    }
+
+                    // Step-7: Uninstall package from the msbuild project
+                    // Step-7.1: Remove references
+                    if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleReferenceItemsGroup))
+                    {
+                        foreach (var item in compatibleReferenceItemsGroup.Items)
                         {
-                            MSBuildNuGetProjectSystem.RemoveReference(Path.GetFileName(item));
+                            if (IsAssemblyReference(item))
+                            {
+                                MSBuildNuGetProjectSystem.RemoveReference(Path.GetFileName(item));
+                            }
                         }
                     }
-                }
 
-                // Step-7.2: Framework references are never removed. This is a no-op
+                    // Step-7.2: Framework references are never removed. This is a no-op
 
-                // Step-7.3: Remove content files
-                if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleContentFilesGroup))
-                {
-                    var packagesPaths = (await GetInstalledPackagesAsync(token))
-                        .Select(pr => FolderNuGetProject.GetInstalledPackageFilePath(pr.PackageIdentity));
-
-                    MSBuildNuGetProjectSystemUtility.DeleteFiles(MSBuildNuGetProjectSystem,
-                        zipArchive,
-                        packagesPaths,
-                        compatibleContentFilesGroup,
-                        FileTransformers);
-                }
-
-                // Step-7.4: Remove build imports
-                if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleBuildFilesGroup))
-                {
-                    foreach (var buildImportFile in compatibleBuildFilesGroup.Items)
+                    // Step-7.3: Remove content files
+                    if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleContentFilesGroup))
                     {
-                        var fullImportFilePath = Path.Combine(FolderNuGetProject.GetInstalledPath(packageIdentity), buildImportFile);
-                        MSBuildNuGetProjectSystem.RemoveImport(fullImportFilePath);
-                    }
-                }
+                        var packagesPaths = (await GetInstalledPackagesAsync(token))
+                            .Select(pr => FolderNuGetProject.GetInstalledPackageFilePath(pr.PackageIdentity));
 
-                // Step-7.5: Remove binding redirects. This is a no-op
-                // Binding redirects will be removed when all packages have finished
-                // uninstalling for performance reasons
+                        MSBuildNuGetProjectSystemUtility.DeleteFiles(MSBuildNuGetProjectSystem,
+                            zipArchive,
+                            packagesPaths,
+                            compatibleContentFilesGroup,
+                            FileTransformers);
+                    }
+
+                    // Step-7.4: Remove build imports
+                    if (MSBuildNuGetProjectSystemUtility.IsValid(compatibleBuildFilesGroup))
+                    {
+                        foreach (var buildImportFile in compatibleBuildFilesGroup.Items)
+                        {
+                            var fullImportFilePath = Path.Combine(FolderNuGetProject.GetInstalledPath(packageIdentity), buildImportFile);
+                            MSBuildNuGetProjectSystem.RemoveImport(fullImportFilePath);
+                        }
+                    }
+
+                    // Step-7.5: Remove binding redirects. This is a no-op
+                    // Binding redirects will be removed when all packages have finished
+                    // uninstalling for performance reasons
+                }
+                finally
+                {
+                    MSBuildNuGetProjectSystem.EndProcessing();
+                }
 
                 // Step-8: Raise PackageReferenceRemoved event
                 if (PackageReferenceRemoved != null)

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -144,65 +144,58 @@ namespace NuGet.ProjectManagement
 
             var packageItemListAsArchiveEntryNames = frameworkSpecificGroup.Items.ToList();
             packageItemListAsArchiveEntryNames.Sort(new PackageItemComparer());
+
             try
             {
-                try
-                {
-                    var paths =
-                        packageItemListAsArchiveEntryNames.Select(
-                            file => ResolvePath(fileTransformers, fte => fte.InstallExtension,
-                                GetEffectivePathForContentFile(packageTargetFramework, file)));
-                    paths = paths.Where(p => !string.IsNullOrEmpty(p));
+                var paths =
+                    packageItemListAsArchiveEntryNames.Select(
+                        file => ResolvePath(fileTransformers, fte => fte.InstallExtension,
+                            GetEffectivePathForContentFile(packageTargetFramework, file)));
+                paths = paths.Where(p => !string.IsNullOrEmpty(p));
 
-                    msBuildNuGetProjectSystem.BeginProcessing();
-                    msBuildNuGetProjectSystem.RegisterProcessedFiles(paths);
-                }
-                catch (Exception)
-                {
-                    // Ignore all exceptions for now
-                }
-
-                foreach (var file in packageItemListAsArchiveEntryNames)
-                {
-                    if (IsEmptyFolder(file))
-                    {
-                        continue;
-                    }
-
-                    var effectivePathForContentFile = GetEffectivePathForContentFile(packageTargetFramework, file);
-
-                    // Resolve the target path
-                    IPackageFileTransformer installTransformer;
-                    var path = ResolveTargetPath(msBuildNuGetProjectSystem,
-                        fileTransformers,
-                        fte => fte.InstallExtension, effectivePathForContentFile, out installTransformer);
-
-                    if (msBuildNuGetProjectSystem.IsSupportedFile(path))
-                    {
-                        if (installTransformer != null)
-                        {
-                            installTransformer.TransformFile(() => packageReader.GetStream(file), path,
-                                msBuildNuGetProjectSystem);
-                        }
-                        else
-                        {
-                            // Ignore uninstall transform file during installation
-                            string truncatedPath;
-                            var uninstallTransformer =
-                                FindFileTransformer(fileTransformers, fte => fte.UninstallExtension,
-                                    effectivePathForContentFile, out truncatedPath);
-                            if (uninstallTransformer != null)
-                            {
-                                continue;
-                            }
-                            TryAddFile(msBuildNuGetProjectSystem, path, () => packageReader.GetStream(file));
-                        }
-                    }
-                }
+                msBuildNuGetProjectSystem.RegisterProcessedFiles(paths);
             }
-            finally
+            catch (Exception)
             {
-                msBuildNuGetProjectSystem.EndProcessing();
+                // Ignore all exceptions for now
+            }
+
+            foreach (var file in packageItemListAsArchiveEntryNames)
+            {
+                if (IsEmptyFolder(file))
+                {
+                    continue;
+                }
+
+                var effectivePathForContentFile = GetEffectivePathForContentFile(packageTargetFramework, file);
+
+                // Resolve the target path
+                IPackageFileTransformer installTransformer;
+                var path = ResolveTargetPath(msBuildNuGetProjectSystem,
+                    fileTransformers,
+                    fte => fte.InstallExtension, effectivePathForContentFile, out installTransformer);
+
+                if (msBuildNuGetProjectSystem.IsSupportedFile(path))
+                {
+                    if (installTransformer != null)
+                    {
+                        installTransformer.TransformFile(() => packageReader.GetStream(file), path,
+                            msBuildNuGetProjectSystem);
+                    }
+                    else
+                    {
+                        // Ignore uninstall transform file during installation
+                        string truncatedPath;
+                        var uninstallTransformer =
+                            FindFileTransformer(fileTransformers, fte => fte.UninstallExtension,
+                                effectivePathForContentFile, out truncatedPath);
+                        if (uninstallTransformer != null)
+                        {
+                            continue;
+                        }
+                        TryAddFile(msBuildNuGetProjectSystem, path, () => packageReader.GetStream(file));
+                    }
+                }
             }
         }
 
@@ -216,135 +209,127 @@ namespace NuGet.ProjectManagement
             var packageTargetFramework = frameworkSpecificGroup.TargetFramework;
             IPackageFileTransformer transformer;
 
-            try
+            var directoryLookup = frameworkSpecificGroup.Items.ToLookup(
+                p => Path.GetDirectoryName(ResolveTargetPath(projectSystem,
+                    fileTransformers,
+                    fte => fte.UninstallExtension,
+                    GetEffectivePathForContentFile(packageTargetFramework, p),
+                    out transformer)));
+
+            // Get all directories that this package may have added
+            var directories = from grouping in directoryLookup
+                from directory in FileSystemUtility.GetDirectories(grouping.Key, altDirectorySeparator: false)
+                orderby directory.Length descending
+                select directory;
+
+            string projectFullPath = projectSystem.ProjectFullPath;
+
+            // Remove files from every directory
+            foreach (var directory in directories)
             {
-                projectSystem.BeginProcessing();
-                var directoryLookup = frameworkSpecificGroup.Items.ToLookup(
-                    p => Path.GetDirectoryName(ResolveTargetPath(projectSystem,
-                        fileTransformers,
-                        fte => fte.UninstallExtension,
-                        GetEffectivePathForContentFile(packageTargetFramework, p),
-                        out transformer)));
+                var directoryFiles = directoryLookup.Contains(directory)
+                    ? directoryLookup[directory]
+                    : Enumerable.Empty<string>();
 
-                // Get all directories that this package may have added
-                var directories = from grouping in directoryLookup
-                    from directory in FileSystemUtility.GetDirectories(grouping.Key, altDirectorySeparator: false)
-                    orderby directory.Length descending
-                    select directory;
-
-                string projectFullPath = projectSystem.ProjectFullPath;
-
-                // Remove files from every directory
-                foreach (var directory in directories)
+                if (!Directory.Exists(Path.Combine(projectFullPath, directory)))
                 {
-                    var directoryFiles = directoryLookup.Contains(directory)
-                        ? directoryLookup[directory]
-                        : Enumerable.Empty<string>();
+                    continue;
+                }
 
-                    if (!Directory.Exists(Path.Combine(projectFullPath, directory)))
+                foreach (var file in directoryFiles)
+                {
+                    if (IsEmptyFolder(file))
                     {
                         continue;
                     }
 
-                    foreach (var file in directoryFiles)
+                    // Resolve the path
+                    var path = ResolveTargetPath(projectSystem,
+                        fileTransformers,
+                        fte => fte.UninstallExtension,
+                        GetEffectivePathForContentFile(packageTargetFramework, file),
+                        out transformer);
+
+                    if (projectSystem.IsSupportedFile(path))
                     {
-                        if (IsEmptyFolder(file))
+                        // Register the file being uninstalled (used by web site project system).
+                        projectSystem.RegisterProcessedFiles(new[] {path});
+
+                        if (transformer != null)
                         {
-                            continue;
-                        }
+                            // TODO: use the framework from packages.config instead of the current framework
+                            // which may have changed during re-targeting
+                            var projectFramework = projectSystem.TargetFramework;
 
-                        // Resolve the path
-                        var path = ResolveTargetPath(projectSystem,
-                            fileTransformers,
-                            fte => fte.UninstallExtension,
-                            GetEffectivePathForContentFile(packageTargetFramework, file),
-                            out transformer);
-
-                        if (projectSystem.IsSupportedFile(path))
-                        {
-                            // Register the file being uninstalled (used by web site project system).
-                            projectSystem.RegisterProcessedFiles(new[] {path});
-
-                            if (transformer != null)
+                            var matchingFiles = new List<InternalZipFileInfo>();
+                            foreach (var otherPackagePath in otherPackagesPath)
                             {
-                                // TODO: use the framework from packages.config instead of the current framework
-                                // which may have changed during re-targeting
-                                var projectFramework = projectSystem.TargetFramework;
-
-                                var matchingFiles = new List<InternalZipFileInfo>();
-                                foreach (var otherPackagePath in otherPackagesPath)
+                                using (var otherPackageZipReader = new PackageArchiveReader(otherPackagePath))
                                 {
-                                    using (var otherPackageZipReader = new PackageArchiveReader(otherPackagePath))
-                                    {
-                                        // use the project framework to find the group that would have been installed
-                                        var mostCompatibleContentFilesGroup = GetMostCompatibleGroup(
-                                            projectFramework,
-                                            otherPackageZipReader.GetContentItems());
+                                    // use the project framework to find the group that would have been installed
+                                    var mostCompatibleContentFilesGroup = GetMostCompatibleGroup(
+                                        projectFramework,
+                                        otherPackageZipReader.GetContentItems());
 
-                                        if (IsValid(mostCompatibleContentFilesGroup))
+                                    if (IsValid(mostCompatibleContentFilesGroup))
+                                    {
+                                        // Should not normalize content files group.
+                                        // It should be like a ZipFileEntry with a forward slash.
+                                        foreach (var otherPackageItem in mostCompatibleContentFilesGroup.Items)
                                         {
-                                            // Should not normalize content files group.
-                                            // It should be like a ZipFileEntry with a forward slash.
-                                            foreach (var otherPackageItem in mostCompatibleContentFilesGroup.Items)
+                                            if (GetEffectivePathForContentFile(packageTargetFramework,
+                                                otherPackageItem)
+                                                .Equals(
+                                                    GetEffectivePathForContentFile(packageTargetFramework, file),
+                                                    StringComparison.OrdinalIgnoreCase))
                                             {
-                                                if (GetEffectivePathForContentFile(packageTargetFramework,
-                                                    otherPackageItem)
-                                                    .Equals(
-                                                        GetEffectivePathForContentFile(packageTargetFramework, file),
-                                                        StringComparison.OrdinalIgnoreCase))
-                                                {
-                                                    matchingFiles.Add(new InternalZipFileInfo(otherPackagePath,
-                                                        otherPackageItem));
-                                                }
+                                                matchingFiles.Add(new InternalZipFileInfo(otherPackagePath,
+                                                    otherPackageItem));
                                             }
                                         }
                                     }
                                 }
+                            }
 
-                                try
+                            try
+                            {
+                                var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
+                                if (zipArchiveFileEntry != null)
                                 {
-                                    var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
-                                    if (zipArchiveFileEntry != null)
-                                    {
-                                        transformer.RevertFile(zipArchiveFileEntry.Open, path, matchingFiles,
-                                            projectSystem);
-                                    }
-                                }
-                                catch (Exception e)
-                                {
-                                    projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
+                                    transformer.RevertFile(zipArchiveFileEntry.Open, path, matchingFiles,
+                                        projectSystem);
                                 }
                             }
-                            else
+                            catch (Exception e)
                             {
-                                try
-                                {
-                                    var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
-                                    if (zipArchiveFileEntry != null)
-                                    {
-                                        DeleteFileSafe(path, zipArchiveFileEntry.Open, projectSystem);
-                                    }
-                                }
-                                catch (Exception e)
-                                {
-                                    projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
-                                }
-
+                                projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
                             }
                         }
-                    }
+                        else
+                        {
+                            try
+                            {
+                                var zipArchiveFileEntry = PathUtility.GetEntry(zipArchive, file);
+                                if (zipArchiveFileEntry != null)
+                                {
+                                    DeleteFileSafe(path, zipArchiveFileEntry.Open, projectSystem);
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                projectSystem.NuGetProjectContext.Log(MessageLevel.Warning, e.Message);
+                            }
 
-                    // If the directory is empty then delete it
-                    if (!GetFilesSafe(projectSystem, directory).Any()
-                        && !GetDirectoriesSafe(projectSystem, directory).Any())
-                    {
-                        DeleteDirectorySafe(projectSystem, directory);
+                        }
                     }
                 }
-            }
-            finally
-            {
-                projectSystem.EndProcessing();
+
+                // If the directory is empty then delete it
+                if (!GetFilesSafe(projectSystem, directory).Any()
+                    && !GetDirectoriesSafe(projectSystem, directory).Any())
+                {
+                    DeleteDirectorySafe(projectSystem, directory);
+                }
             }
         }
 

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -25,6 +25,7 @@ namespace Test.Utility
         public Dictionary<string, int> ScriptsExecuted { get; }
         public int BindingRedirectsCallCount { get; private set; }
         public INuGetProjectContext NuGetProjectContext { get; private set; }
+        public int BatchCount { get; private set; }
 
         public TestMSBuildNuGetProjectSystem(NuGetFramework targetFramework, INuGetProjectContext nuGetProjectContext,
             string projectFullPath = null, string projectName = null)
@@ -193,6 +194,7 @@ namespace Test.Utility
 
         public void EndProcessing()
         {
+            ++BatchCount;
             ProcessedFiles = FilesInProcessing;
             FilesInProcessing = null;
         }

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -26,6 +26,8 @@ namespace Test.Utility
         public int BindingRedirectsCallCount { get; private set; }
         public INuGetProjectContext NuGetProjectContext { get; private set; }
         public int BatchCount { get; private set; }
+        public Action<string> AddReferenceAction { get; set; }
+        public Action<string> RemoveReferenceAction { get; set; }
 
         public TestMSBuildNuGetProjectSystem(NuGetFramework targetFramework, INuGetProjectContext nuGetProjectContext,
             string projectFullPath = null, string projectName = null)
@@ -40,6 +42,8 @@ namespace Test.Utility
             ScriptsExecuted = new Dictionary<string, int>();
             ProcessedFiles = new HashSet<string>();
             ProjectName = projectName ?? TestProjectName;
+            AddReferenceAction = AddReferenceImplementation;
+            RemoveReferenceAction = RemoveReferenceImplementation;
         }
 
         public void AddFile(string path, Stream stream)
@@ -75,12 +79,7 @@ namespace Test.Utility
 
         public void AddReference(string referencePath)
         {
-            var referenceAssemblyName = Path.GetFileName(referencePath);
-            if (References.ContainsKey(referenceAssemblyName))
-            {
-                throw new InvalidOperationException("Cannot add existing reference. That would be a COMException in VS");
-            }
-            References.Add(referenceAssemblyName, referencePath);
+            AddReferenceAction(referencePath);
         }
 
         public void RemoveFile(string path)
@@ -114,10 +113,7 @@ namespace Test.Utility
 
         public void RemoveReference(string name)
         {
-            if (References.ContainsKey(name))
-            {
-                References.Remove(name);
-            }
+            RemoveReferenceAction(name);
         }
 
         public NuGetFramework TargetFramework { get; }
@@ -221,6 +217,24 @@ namespace Test.Utility
         public IEnumerable<string> GetDirectories(string path)
         {
             return GetFiles(path, "*.*", recursive: true);
+        }
+
+        private void AddReferenceImplementation(string referencePath)
+        {
+            var referenceAssemblyName = Path.GetFileName(referencePath);
+            if (References.ContainsKey(referenceAssemblyName))
+            {
+                throw new InvalidOperationException("Cannot add existing reference. That would be a COMException in VS");
+            }
+            References.Add(referenceAssemblyName, referencePath);
+        }
+
+        private void RemoveReferenceImplementation(string name)
+        {
+            if (References.ContainsKey(name))
+            {
+                References.Remove(name);
+            }
         }
     }
 }

--- a/src/NuGet.Core/Test.Utility/TestPackages.cs
+++ b/src/NuGet.Core/Test.Utility/TestPackages.cs
@@ -49,6 +49,18 @@ namespace Test.Utility
                 });
         }
 
+        public static FileInfo GetLegacyTestPackageWithMultipleReferences(string path,
+            string packageId = "packageA",
+            string packageVersion = "2.0.3")
+        {
+            return GeneratePackage(path, packageId, packageVersion,
+                new[]
+                {
+                    "lib/net45/a.dll",
+                    "lib/net45/b.dll"
+                });
+        }
+
         public static FileInfo GetNet45TestPackage(string path,
             string packageId = "packageA",
             string packageVersion = "2.0.3")

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
@@ -242,6 +242,55 @@ namespace ProjectManagement.Test
         }
 
         [Fact]
+        public async Task TestMSBuildNuGetProjectInstallReferencesFailureEventBatching()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+
+            using (var randomTestPackageSourcePath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesConfigFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var randomPackagesConfigPath = Path.Combine(randomPackagesConfigFolderPath, "packages.config");
+                var token = CancellationToken.None;
+
+                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
+                var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
+
+                msBuildNuGetProjectSystem.AddReferenceAction = (string referenceName) => { throw new InvalidOperationException(); };
+
+                // Pre-Assert
+                // Check that the packages.config file does not exist
+                Assert.False(File.Exists(randomPackagesConfigPath));
+                // Check that there are no packages returned by PackagesConfigProject
+                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
+
+                var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
+                    packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
+                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                {
+                    // Act
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    {
+                        await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                    });
+                }
+
+                // Assert
+                Assert.False(File.Exists(randomPackagesConfigPath));
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
+            }
+        }
+
+        [Fact]
         public async Task TestMSBuildNuGetProjectUninstallReferencesEventBatching()
         {
             // Arrange
@@ -299,6 +348,73 @@ namespace ProjectManagement.Test
                 Assert.Equal(0, packagesInPackagesConfig.Count);
                 // Check that the reference has been added to MSBuildNuGetProjectSystem
                 Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(2, msBuildNuGetProjectSystem.BatchCount);
+            }
+        }
+
+        [Fact]
+        public async Task TestMSBuildNuGetProjectUninstallReferencesFailureEventBatching()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("packageA", new NuGetVersion("1.0.0"));
+
+            using (var randomTestPackageSourcePath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            using (var randomPackagesConfigFolderPath = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var randomPackagesConfigPath = Path.Combine(randomPackagesConfigFolderPath, "packages.config");
+                var token = CancellationToken.None;
+
+                var projectTargetFramework = NuGetFramework.Parse("net45");
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
+                var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
+
+                msBuildNuGetProjectSystem.RemoveReferenceAction = (string referenceName) => { throw new InvalidOperationException(); };
+
+                // Pre-Assert
+                // Check that the packages.config file does not exist
+                Assert.False(File.Exists(randomPackagesConfigPath));
+                // Check that there are no packages returned by PackagesConfigProject
+                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
+
+                var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
+                    packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
+                using (var packageStream = GetDownloadResourceResult(packageFileInfo))
+                {
+                    // Act
+                    await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                }
+
+                // Assert
+                // Check that the packages.config file exists after the installation
+                Assert.True(File.Exists(randomPackagesConfigPath));
+                // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(1, packagesInPackagesConfig.Count);
+                // Check that the reference has been added to MSBuildNuGetProjectSystem
+                Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
+                Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
+                Assert.Equal("a.dll", msBuildNuGetProjectSystem.References.First().Key);
+                Assert.Equal("b.dll", msBuildNuGetProjectSystem.References.Skip(1).First().Key);
+                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
+                    "lib\\net45\\a.dll"), msBuildNuGetProjectSystem.References.First().Value);
+                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
+                    "lib\\net45\\b.dll"), msBuildNuGetProjectSystem.References.Skip(1).First().Value);
+
+                // Main Act
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    await msBuildNuGetProject.UninstallPackageAsync(packageIdentity, testNuGetProjectContext, token);
+                });
+
+                // Check the number of packages and packages returned by PackagesConfigProject after the installation
+                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
+                Assert.Equal(0, packagesInPackagesConfig.Count);
+                Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(2, msBuildNuGetProjectSystem.BatchCount);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
@@ -206,12 +206,6 @@ namespace ProjectManagement.Test
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
                 var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
 
-                // Pre-Assert
-                // Check that the packages.config file does not exist
-                Assert.False(File.Exists(randomPackagesConfigPath));
-                // Check that there are no packages returned by PackagesConfigProject
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
                 Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
 
@@ -224,12 +218,6 @@ namespace ProjectManagement.Test
                 }
 
                 // Assert
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(randomPackagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(1, packagesInPackagesConfig.Count);
-                // Check that the reference has been added to MSBuildNuGetProjectSystem
                 Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
                 Assert.Equal("a.dll", msBuildNuGetProjectSystem.References.First().Key);
@@ -261,12 +249,6 @@ namespace ProjectManagement.Test
 
                 msBuildNuGetProjectSystem.AddReferenceAction = (string referenceName) => { throw new InvalidOperationException(); };
 
-                // Pre-Assert
-                // Check that the packages.config file does not exist
-                Assert.False(File.Exists(randomPackagesConfigPath));
-                // Check that there are no packages returned by PackagesConfigProject
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
                 Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
 
@@ -282,9 +264,6 @@ namespace ProjectManagement.Test
                 }
 
                 // Assert
-                Assert.False(File.Exists(randomPackagesConfigPath));
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
                 Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
             }
@@ -308,45 +287,20 @@ namespace ProjectManagement.Test
                 var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext);
                 var msBuildNuGetProject = new MSBuildNuGetProject(msBuildNuGetProjectSystem, randomPackagesFolderPath, randomPackagesConfigFolderPath);
 
-                // Pre-Assert
-                // Check that the packages.config file does not exist
-                Assert.False(File.Exists(randomPackagesConfigPath));
-                // Check that there are no packages returned by PackagesConfigProject
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
-                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
-                Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
-
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
                 }
 
-                // Assert
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(randomPackagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(1, packagesInPackagesConfig.Count);
-                // Check that the reference has been added to MSBuildNuGetProjectSystem
                 Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
-                Assert.Equal("a.dll", msBuildNuGetProjectSystem.References.First().Key);
-                Assert.Equal("b.dll", msBuildNuGetProjectSystem.References.Skip(1).First().Key);
-                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
-                    "lib\\net45\\a.dll"), msBuildNuGetProjectSystem.References.First().Value);
-                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
-                    "lib\\net45\\b.dll"), msBuildNuGetProjectSystem.References.Skip(1).First().Value);
 
-                // Main Act
+                // Act
                 await msBuildNuGetProject.UninstallPackageAsync(packageIdentity, testNuGetProjectContext, token);
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
-                // Check that the reference has been added to MSBuildNuGetProjectSystem
+
+                // Assert
                 Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(2, msBuildNuGetProjectSystem.BatchCount);
             }
@@ -372,48 +326,23 @@ namespace ProjectManagement.Test
 
                 msBuildNuGetProjectSystem.RemoveReferenceAction = (string referenceName) => { throw new InvalidOperationException(); };
 
-                // Pre-Assert
-                // Check that the packages.config file does not exist
-                Assert.False(File.Exists(randomPackagesConfigPath));
-                // Check that there are no packages returned by PackagesConfigProject
-                var packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
-                Assert.Equal(0, msBuildNuGetProjectSystem.References.Count);
-                Assert.Equal(0, msBuildNuGetProjectSystem.BatchCount);
-
                 var packageFileInfo = TestPackagesGroupedByFolder.GetLegacyTestPackageWithMultipleReferences(randomTestPackageSourcePath,
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    // Act
                     await msBuildNuGetProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
                 }
 
-                // Assert
-                // Check that the packages.config file exists after the installation
-                Assert.True(File.Exists(randomPackagesConfigPath));
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(1, packagesInPackagesConfig.Count);
-                // Check that the reference has been added to MSBuildNuGetProjectSystem
                 Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(1, msBuildNuGetProjectSystem.BatchCount);
-                Assert.Equal("a.dll", msBuildNuGetProjectSystem.References.First().Key);
-                Assert.Equal("b.dll", msBuildNuGetProjectSystem.References.Skip(1).First().Key);
-                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
-                    "lib\\net45\\a.dll"), msBuildNuGetProjectSystem.References.First().Value);
-                Assert.Equal(Path.Combine(msBuildNuGetProject.FolderNuGetProject.GetInstalledPath(packageIdentity),
-                    "lib\\net45\\b.dll"), msBuildNuGetProjectSystem.References.Skip(1).First().Value);
 
-                // Main Act
+                // Act
                 await Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 {
                     await msBuildNuGetProject.UninstallPackageAsync(packageIdentity, testNuGetProjectContext, token);
                 });
 
-                // Check the number of packages and packages returned by PackagesConfigProject after the installation
-                packagesInPackagesConfig = (await msBuildNuGetProject.PackagesConfigNuGetProject.GetInstalledPackagesAsync(token)).ToList();
-                Assert.Equal(0, packagesInPackagesConfig.Count);
+                // Assert
                 Assert.Equal(2, msBuildNuGetProjectSystem.References.Count);
                 Assert.Equal(2, msBuildNuGetProjectSystem.BatchCount);
             }


### PR DESCRIPTION
Improve performance of package installation/uninstallation operations for packages with lots of MSBuild project mutations.

For the scenario in Nuget/Home#3428 these changes improved installation performance by ~40% (not including download or extraction times) and uninstall performance by ~50%.

@joelverhagen @jainaashish @alpaix @rohit21agrawal @drewgil @zhili1208
