### PR TITLE
Fixed End-to-End packaging

### DIFF
--- a/scripts/cibuild/CreateEndToEndTestPackage.ps1
+++ b/scripts/cibuild/CreateEndToEndTestPackage.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+Creates end-to-end test package for test pass
+
+.PARAMETER Configuration
+API.Test build configuration to place in test package. Debug by default.
+
+.PARAMETER ToolsetVersion
+Toolset version
+
+.PARAMETER OutputDirectory
+Output directory where EndToEnd.zip package file will be created.
+Will use current directory if not provided.
+
+.PARAMETER NuGetRoot
+Optional. NuGet.Client repository root
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$False)]
+    [Alias('c')]
+    [string]$Configuration = 'Debug',
+    [Parameter(Mandatory=$False)]
+    [ValidateSet(14,15)]
+    [Alias('tv')]
+    [int]$ToolsetVersion = 14,
+    [Parameter(Mandatory=$False)]
+    [Alias('out')]
+    [string]$OutputDirectory = $PWD,
+    [Parameter(Mandatory=$False)]
+    [string]$NuGetRoot
+)
+
+. "$PSScriptRoot\..\common.ps1"
+
+if (-not $NuGetRoot -and (Test-Path Env:\NuGetRoot)) {
+    $NuGetRoot = $env:NuGetRoot
+}
+
+if (-not $NuGetRoot) {
+    $NuGetRoot = Join-Path $PSScriptRoot '..\..\' -Resolve
+}
+
+$WorkingDirectory = New-TempDir
+
+$opts = '/s', '/z', '/r:3', '/w:30', '/np', '/nfl'
+
+if ($VerbosePreference) {
+    $opts += '/v'
+}
+
+try {
+    $TestSource = Join-Path $NuGetRoot test\EndToEnd -Resolve
+    Write-Verbose "Copying all test files from '$TestSource' to '$WorkingDirectory'"
+    & robocopy $TestSource $WorkingDirectory $opts
+
+    $TestExtension = Join-Path $NuGetRoot "artifacts\API.Test\${ToolsetVersion}.0\${Configuration}\API.Test.dll" -Resolve
+    Write-Verbose "Copying test extension from '$TestExtension' to '$WorkingDirectory'"
+    Copy-Item $TestExtension $WorkingDirectory
+
+    $ScriptsDirectory = Join-Path $WorkingDirectory scripts
+    New-Item -ItemType Directory -Force -Path $ScriptsDirectory | Out-Null
+
+    $ScriptsSource = Join-Path $NuGetRoot Scripts\e2etests -Resolve
+    Write-Verbose "Copying test scripts from '$ScriptsSource' to '$ScriptsDirectory'"
+    & robocopy $ScriptsSource $ScriptsDirectory "*.ps1" $opts
+
+    if (-not (Test-Path $OutputDirectory)) {
+        md $OutputDirectory | Out-Null
+    }
+
+    $TestPackage = Join-Path $OutputDirectory EndToEnd.zip
+    Write-Verbose "Creating test package '$TestPackage'"
+    New-ZipArchive $WorkingDirectory $TestPackage
+
+    Write-Output "Created end-to-end test package for toolset '${ToolsetVersion}.0' at '$TestPackage'"
+}
+finally {
+    rm $workingDirectory -r -force -WhatIf:$false
+}

--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -39,3 +39,18 @@ function ReplaceTextInFiles {
             }
     }
 }
+
+Function New-TempDir {
+    $TempDir = Join-Path $env:TEMP "nuget_$([System.Guid]::NewGuid())"
+    New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+    $TempDir
+}
+
+Function New-ZipArchive {
+    param(
+        [string]$SourceDirectory,
+        [string]$ZipFile
+    )
+    Add-Type -Assembly 'System.IO.Compression.FileSystem'
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($SourceDirectory, $ZipFile, 'Optimal', $False)
+}

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -43,14 +43,14 @@ $env:NuGetTestModeEnabled = "True"
 
 $msbuildPath = Join-Path $env:windir Microsoft.NET\Framework\v4.0.30319\msbuild
 $testExtensionNames = ( "GenerateTestPackages.exe", "API.Test.dll" )
-$testExtensionsRoot = Join-Path $nugetRoot "test\TestExtensions"
+$testExtensionsRoot = Join-Path $nugetRoot "artifacts\TestExtensions"
 
 $testExtensions = @()
 
 if ((Test-Path $testExtensionsRoot) -eq $True)
 {
     $testExtensions  = [System.Collections.ArrayList]($testExtensionNames |
-                            %{ Join-Path $testExtensionsRoot ([System.IO.Path]::GetFileNameWithoutExtension($_) + "\bin\Debug\" + $_) })
+                            %{ Join-Path $testExtensionsRoot $_ })
 }
 else
 {
@@ -87,16 +87,16 @@ else
 
 # Add intellisense for the test parameter
 Register-TabExpansion 'Run-Test' @{
-    'Test' = { 
+    'Test' = {
         # Load all of the test scripts
-        Get-ChildItem $testPath -Filter *.ps1 | %{ 
+        Get-ChildItem $testPath -Filter *.ps1 | %{
             . $_.FullName
         }
-    
+
         # Get all of the tests functions
         Get-ChildItem function:\Test* | %{ $_.Name.Substring(5) }
     }
-    'File' = { 
+    'File' = {
         # Get all of the tests files
         Get-ChildItem $testPath -Filter *.ps1 | Select-Object -ExpandProperty Name
     }
@@ -136,13 +136,13 @@ function global:Run-Test {
 
     # Close the solution after every test run
     [API.Test.VSSolutionHelper]::CloseSolution()
-    
+
     # Load the utility script since we need to use guid
     . $utilityPath
-    
+
     # Get a reference to the powershell window so we can set focus after the tests are over
     [API.Test.VSHelper]::StorePSWindow()
-    
+
     if ($RunId)
     {
         $testRunId = $RunId
@@ -155,38 +155,38 @@ function global:Run-Test {
     $testRunOutputPath = Join-Path $testOutputPath $testRunId
     $testLogFile = Join-Path $testRunOutputPath log.txt
     $testRealTimeResultsFile = Join-Path $testRunOutputPath Realtimeresults.txt
-    
+
     # Create the output folder
     mkdir $testRunOutputPath -ErrorAction Ignore | Out-Null
-       
+
     # Load all of the helper scripts from the current location
-    Get-ChildItem $currentPath -Filter *.ps1 | %{ 
+    Get-ChildItem $currentPath -Filter *.ps1 | %{
         . $_.FullName $testRunOutputPath $templatePath
     }
-    
+
     Write-Verbose "Loading scripts from `"$testPath`""
-    
+
     if (!$File) {
         $File = "*.ps1"
     }
 
-    if ($SourceNuGet -eq $null) 
+    if ($SourceNuGet -eq $null)
     {
         $SourceNuGet = "nuget.org"
     }
 
     # Load all of the test scripts
 	if (!$Exclude) {
-        Get-ChildItem $testPath -Filter $File | %{ 
+        Get-ChildItem $testPath -Filter $File | %{
         . $_.FullName
-		} 
+		}
 	}
 	else {
-	    Get-ChildItem $testPath -Exclude $Exclude | %{ 
+	    Get-ChildItem $testPath -Exclude $Exclude | %{
         . $_.FullName
-		} 
+		}
 	}
-        
+
     # If no tests were specified just run all
     if(!$test) {
         # Get all of the the tests functions
@@ -195,14 +195,14 @@ function global:Run-Test {
     }
     else {
         $tests = @(Get-ChildItem "function:\Test-$Test")
-        
+
         if($tests.Count -eq 0) {
             throw "The test `"$Test`" doesn't exist"
-        } 
+        }
     }
-    
+
     $results = @{}
-    
+
     # Add a reference to the msbuild assembly in case it isn't there
     Add-Type -AssemblyName "Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
 
@@ -214,13 +214,13 @@ function global:Run-Test {
     catch
     {
     }
-    
+
 	$startTime = Get-Date
     try {
-        # Run all tests        
+        # Run all tests
         $testIndex = 0
 
-        $tests | %{ 
+        $tests | %{
             $testIndex++
 
 
@@ -261,7 +261,7 @@ function global:Run-Test {
 
                 # set name to test name. If this is a test case, we will add that info to the name
                 $name = $testName
-                
+
                 $testCaseObject = $_
                 if($testCaseObject)
                 {
@@ -275,7 +275,7 @@ function global:Run-Test {
                     # Write to log file as we run tests
                     "$(Get-Date -format o) Running Test case $name... ($testCaseIndex / $($testCases.Count))" >> $testLogFile
                 }
-                
+
                 $repositoryPath = Join-Path $testRepositoryPath $name
 
                 $values = @{
@@ -284,10 +284,10 @@ function global:Run-Test {
                     RepositoryPath = Join-Path $repositoryPath Packages
                     NuGetExe = $nugetExePath
                 }
-                
+
                 $generatePackagesExitCode = 0
-                if (Test-Path $repositoryPath) {            
-                    pushd 
+                if (Test-Path $repositoryPath) {
+                    pushd
                     Set-Location $repositoryPath
                     # Generate any packages that might be in the repository dir
                     Get-ChildItem $repositoryPath\* -Include *.dgml,*.nuspec | %{
@@ -301,10 +301,10 @@ function global:Run-Test {
                         else {
                             Write-Host 'GenerateTestPackages.exe on ' $_.FullName ' succeeded'
                         }
-                    } 
+                    }
                     popd
                 }
-                
+
                 $context = New-Object PSObject -Property $values
 
                 # Some tests are flaky. We give failed tests another chance to succeed.
@@ -321,10 +321,10 @@ function global:Run-Test {
                             throw 'GenerateTestPackages.exe failed. Exit code is ' + $generatePackagesExitCode
                         }
                         $executionTime = measure-command { & $testObject $context $testCaseObject }
-                    
+
                         Write-Host -ForegroundColor DarkGreen "Test $name Passed"
-                    
-                        $results[$name] = New-Object PSObject -Property @{ 
+
+                        $results[$name] = New-Object PSObject -Property @{
                             Test = $name
                             Error = $null
                         }
@@ -334,7 +334,7 @@ function global:Run-Test {
                     catch {
                         if($_.Exception.Message.StartsWith("SKIP")) {
                             $message = $_.Exception.Message.Substring(5).Trim()
-                            $results[$name] = New-Object PSObject -Property @{ 
+                            $results[$name] = New-Object PSObject -Property @{
                                 Test = $name
                                 Error = $message
                                 Skipped = $true
@@ -344,7 +344,7 @@ function global:Run-Test {
                             $testSucceeded = $true
                         }
                         else {
-                            $results[$name] = New-Object PSObject -Property @{ 
+                            $results[$name] = New-Object PSObject -Property @{
                                 Test = $name
                                 Error = $_
                             }
@@ -353,7 +353,7 @@ function global:Run-Test {
                         }
                     }
                     finally {
-                        try {           
+                        try {
                             # Clear the cache after running each test
                             [NuGet.MachineCache]::Default.Clear()
                         }
@@ -386,17 +386,17 @@ function global:Run-Test {
             }
         }
     }
-    finally {        
+    finally {
 		$endTime = Get-Date
 		$totalTimeUsed = ($endTime - $startTime).TotalSeconds
 		"Total time used $totalTimeUsed seconds" >> $testLogFile
 
         # Deleting tests
         rm function:\Test*
-        
+
         # Set focus back to powershell
         [API.Test.VSHelper]::FocusStoredPSWindow()
-               
+
         Write-TestResults $testRunId $results.Values $testRunOutputPath $testLogFile $LaunchResultsOnFailure
 
         try
@@ -430,7 +430,7 @@ function Write-TestResults {
     $fail = 0
     $skipped = 0
 
-    $rows = $Results | % { 
+    $rows = $Results | % {
         if($_.Skipped) {
             $skipped++
         }
@@ -446,7 +446,7 @@ function Write-TestResults {
     Write-Host $resultMessage
     "$(Get-Date -format o) $resultMessage" >> $testLogFile
 
-    if (($fail -gt 0) -and $LaunchResultsOnFailure -and ($Results.Count -gt 1)) 
+    if (($fail -gt 0) -and $LaunchResultsOnFailure -and ($Results.Count -gt 1))
     {
         [System.Diagnostics.Process]::Start($HtmlResultPath)
     }
@@ -491,7 +491,7 @@ function Write-TextResults
         $Path
     )
 
-    $rows = $Results | % { 
+    $rows = $Results | % {
         Get-TextResultRow $_
     }
 
@@ -512,7 +512,7 @@ function Write-HtmlResults
             Test run {0} results
         </title>
         <style>
-            
+
         body
         {{
             font-family: Trebuchet MS;
@@ -547,7 +547,7 @@ function Write-HtmlResults
         h2
         {{
             padding: 0 0 10px 0;
-        }}  
+        }}
         table
         {{
             width: 90%;
@@ -558,18 +558,18 @@ function Write-HtmlResults
             padding: 4px;
             border:1px solid #CCC;
         }}
-        table th 
+        table th
         {{
             text-align:left;
             border:1px solid #CCC;
         }}
-        .Skipped 
+        .Skipped
         {{
             color:black;
             background-color:Yellow;
             font-weight:bold;
         }}
-        .Passed 
+        .Passed
         {{
         }}
         .Failed
@@ -613,12 +613,12 @@ function Write-HtmlResults
     <td class=`"{0}`">{3}</td>
     <td class=`"{0}`">{4}</td>
     </tr>"
-    
+
     $pass = 0
     $fail = 0
     $skipped = 0
 
-    $rows = $Results | % { 
+    $rows = $Results | % {
         $status = 'Passed'
         if($_.Skipped) {
             $status = 'Skipped'
@@ -631,10 +631,10 @@ function Write-HtmlResults
         else {
             $pass++
         }
-        
-        [String]::Format($testTemplate, 
-                         $status, 
-                         [System.Net.WebUtility]::HtmlEncode($_.Test), 
+
+        [String]::Format($testTemplate,
+                         $status,
+                         [System.Net.WebUtility]::HtmlEncode($_.Test),
                          [System.Net.WebUtility]::HtmlEncode($_.Error),
                          $_.Time.TotalSeconds,
                          $_.Retried)

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProjectGuid>{45A5F9FF-2C27-4C62-9B53-C0E8E99A18B1}</ProjectGuid>
@@ -11,8 +11,6 @@
     <AssemblyName>API.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -52,4 +50,19 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuild">
+  <!--
+    Publish test extension artifacts to a well-known location so that
+    Import-Module NuGet.Tests.psm1 is able to locate it.
+  -->
+    <PropertyGroup>
+      <PublishDestination>$(ArtifactRoot)\TestExtensions</PublishDestination>
+    </PropertyGroup>
+    <Message Text="Publishing test extension artifacts..." Importance="high" />
+    <Message Text="$(TargetPath) -> $(PublishDestination)" Importance="high" />
+    <Copy
+      SourceFiles="$(TargetPath)"
+      DestinationFolder="$(PublishDestination)"
+      OverwriteReadOnlyFiles="true" />
+  </Target>
 </Project>

--- a/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
+++ b/test/TestExtensions/GenerateTestPackages/GenerateTestPackages.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\Build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\Build\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProjectGuid>{61EC099A-8AC0-4CCC-AFA8-DF9806CBAFD1}</ProjectGuid>
@@ -49,4 +49,19 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
+  <Target Name="AfterBuild">
+  <!--
+    Publish test extension artifacts to a well-known location so that
+    Import-Module NuGet.Tests.psm1 is able to locate it.
+  -->
+    <PropertyGroup>
+      <PublishDestination>$(ArtifactRoot)\TestExtensions</PublishDestination>
+    </PropertyGroup>
+    <Message Text="Publishing test extension artifacts..." Importance="high" />
+    <Message Text="$(TargetPath) -> $(PublishDestination)" Importance="high" />
+    <Copy
+      SourceFiles="$(TargetPath)"
+      DestinationFolder="$(PublishDestination)"
+      OverwriteReadOnlyFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Summary of changes:
- Moved end-to-end packaging script from TFS.
- Added packaging steps to `build.ps1`.
- Added `AfterBuild` target to test extension project to publish artifact to
  well-known location.
- Fixed `NuGet.Tests.psm1` module script to locate test extension
  artifacts.

//cc @emgarten @joelverhagen @mishra14 @rrelyea 
