### PR TITLE
Produce release .nupkgs as well as .nupkgs with the build number

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -162,10 +162,9 @@ Invoke-BuildStep 'Building NuGet.Clients projects - VS14 Toolset' {
     -skip:$SkipVS14 `
     -ev +BuildErrors
 
-## ILMerge the VS14 exe only
-Invoke-BuildStep 'Merging NuGet.exe' {
+Invoke-BuildStep 'Creating NuGet.Clients packages - VS14 Toolset' {
         param($Configuration, $MSPFXPath)
-        Invoke-ILMerge $Configuration 14 $MSPFXPath
+        Build-ClientsPackages $Configuration $ReleaseLabel $BuildNumber -ToolsetVersion 14 -KeyFile $MSPFXPath
     } `
     -args $Configuration, $MSPFXPath `
     -skip:($Fast -or $SkipILMerge -or $SkipVS14) `

--- a/build/common.props
+++ b/build/common.props
@@ -78,15 +78,30 @@
     <PreReleaseVersion>0</PreReleaseVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ExcludeBuildNumber)' == ''">
+    <ExcludeBuildNumber>false</ExcludeBuildNumber>
+  </PropertyGroup>
+
   <!--Setting the Pre-release/Build meta-data from CI if Version is set-->
   <PropertyGroup Condition="'$(BuildNumber)' != ''">
     <PreReleaseVersion>$(BuildNumber)</PreReleaseVersion>
   </PropertyGroup>
 
   <!--Setting the product information for Beta builds-->
-  <PropertyGroup Condition="'$(ReleaseLabel)' != 'Release'">
-    <PreReleaseInformationVersion>-$(ReleaseLabel)-$(PreReleaseVersion)</PreReleaseInformationVersion>
-  </PropertyGroup>
+  <Choose>
+    <!-- If we aren't excluding the build number, use the release label and the build number. -->
+    <When Condition="'$(ExcludeBuildNumber)' != 'true'">
+      <PropertyGroup>
+        <PreReleaseInformationVersion>-$(ReleaseLabel)-$(PreReleaseVersion)</PreReleaseInformationVersion>
+      </PropertyGroup>
+    </When>
+    <!-- If we are excluding the build number, show the release label unless we are RTM. -->
+    <When Condition="'$(ReleaseLabel)' != 'rtm'">
+      <PropertyGroup>
+        <PreReleaseInformationVersion>-$(ReleaseLabel)</PreReleaseInformationVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <!-- Generate AssemblyFileVersion and AssemblyVersion attributes. -->
   <PropertyGroup>

--- a/scripts/utils/UpdateNuGetVersion.ps1
+++ b/scripts/utils/UpdateNuGetVersion.ps1
@@ -63,6 +63,7 @@ $miscFiles = @(
     "src\NuGet.Clients\VsExtension\source.extension.dev15.vsixmanifest",
     "src\NuGet.Clients\VsExtension\NuGetPackage.cs",
     "build\common.props",
+    "build\common.ps1",
     ".teamcity.properties",
     "appveyor.yml"
 )

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -59,7 +59,7 @@ namespace NuGet.CommandLine
             if (Self)
             {
                 var selfUpdater = new SelfUpdater(RepositoryFactory) { Console = Console };
-                selfUpdater.UpdateSelf();
+                selfUpdater.UpdateSelf(Prerelease);
                 return;
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Common/SelfUpdaterTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Moq;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class SelfUpdaterTests
+    {
+        [Theory]
+        [InlineData("1.1.1", true, false)]
+        [InlineData("1.1.1", false, false)]
+        [InlineData("1.1.1-beta", true, false)]
+        [InlineData("1.1.1-beta", false, false)]
+        [InlineData("99.99.99", true, true)]
+        [InlineData("99.99.99", false, true)]
+        [InlineData("99.99.99-beta", true, true)]
+        [InlineData("99.99.99-beta", false, false)]
+        public void SelfUpdater_WithArbitraryVersions_UpdateSelf(string version, bool prerelease, bool replaced)
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(testDirectory);
+                tc
+                    .Package
+                    .Setup(x => x.Version)
+                    .Returns(new SemanticVersion(version));
+
+                // Act
+                tc.Target.UpdateSelf(prerelease);
+
+                // Assert
+                tc.VerifyReplacedState(replaced);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SelfUpdater_WithCurrentVersion(bool prerelease)
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var tc = new TestContext(testDirectory);
+                tc.Package.Setup(x => x.Version).Returns(tc.ClientVersion);
+
+                // Act
+                tc.Target.UpdateSelf(prerelease);
+
+                // Assert
+                tc.VerifyReplacedState(replaced: false);
+            }
+        }
+
+        private class TestContext
+        {
+            public TestContext(TestDirectory directory)
+            {
+                Directory = directory;
+                Factory = new Mock<IPackageRepositoryFactory>();
+                Repository = new Mock<IPackageRepository>();
+                Console = new Mock<IConsole>();
+                Package = new Mock<IPackage>();
+                PackageFile = new Mock<IPackageFile>();
+                OriginalContent = new byte[] { 0 };
+                NewContent = new byte[] { 1 };
+
+                var clientVersion = typeof(SelfUpdater)
+                    .Assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    .InformationalVersion;
+                ClientVersion = new SemanticVersion(clientVersion);
+                IsClientPrerelease = NuGetVersion
+                    .Parse(clientVersion)
+                    .IsPrerelease;
+
+                PackageFile.Setup(x => x.Path).Returns("nuget.exe");
+                PackageFile.Setup(x => x.GetStream()).Returns(() => new MemoryStream(NewContent));
+
+                Package.Setup(x => x.Id).Returns("NuGet.CommandLine");
+                Package.Setup(x => x.Version).Returns(new SemanticVersion("99.99.99"));
+                Package.Setup(x => x.Listed).Returns(true);
+                Package
+                    .Setup(x => x.GetFiles())
+                    .Returns(() => PackageFile != null ? new[] { PackageFile.Object }.AsEnumerable() : null);
+
+                var zero = new Mock<IPackage>();
+                zero.Setup(x => x.Id).Returns("NuGet.CommandLine");
+                zero.Setup(x => x.Version).Returns(new SemanticVersion("0.0.0"));
+                zero.Setup(x => x.Listed).Returns(true);
+
+                Target = new SelfUpdater(Factory.Object);
+                Target.Console = Console.Object;
+                Target.AssemblyLocation = Path.Combine(Directory, "nuget.exe");
+
+                Factory
+                    .Setup(x => x.CreateRepository(It.IsAny<string>()))
+                    .Returns(Repository.Object);
+
+                Repository
+                    .Setup(x => x.GetPackages())
+                    .Returns(() => Package != null ? new[] { zero.Object, Package.Object }.AsQueryable() : null);
+
+                File.WriteAllBytes(Target.AssemblyLocation, OriginalContent);
+            }
+
+            public Mock<IPackageRepositoryFactory> Factory { get; }
+            public Mock<IPackageRepository> Repository { get; }
+            public Mock<IConsole> Console { get; }
+            public SelfUpdater Target { get; }
+            public Mock<IPackage> Package { get; set; }
+            public TestDirectory Directory { get; }
+            public Mock<IPackageFile> PackageFile { get; }
+            public byte[] NewContent { get; set; }
+            public byte[] OriginalContent { get; }
+            public SemanticVersion ClientVersion { get; }
+            public bool IsClientPrerelease { get; }
+
+            public void VerifyReplacedState(bool replaced)
+            {
+                Assert.True(File.Exists(Target.AssemblyLocation), "nuget.exe should still exist.");
+                var actualContent = File.ReadAllBytes(Target.AssemblyLocation);
+
+                Assert.Equal(replaced ? NewContent : OriginalContent, actualContent);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
@@ -43,6 +43,7 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\SelfUpdaterTests.cs" />
     <Compile Include="ConsoleCredentialProviderTest.cs" />
     <Compile Include="ConsoleTest.cs" />
     <Compile Include="DefaultConfigurationFilePreserver.cs" />


### PR DESCRIPTION
1. Two sets of .nupkgs are produced. One with the build number and one without. When the release label is `rtm`, the .nupkgs without the build number don't mention `rtm` either. These are for pushing to nuget.org.
2. Produce the `NuGet.CommandLine` .nupkg during this build. Today this is produced by a TFS (private) script.
3. Make `nuget.exe update -self` observe the `-Prerelease`. This means that, by default, nuget.exe no longer updates self to a pre-release nuget.exe. This is fine since we shouldn't be publishing pre-release `NuGet.CommandLine` packages.

/cc @alpaix @jainaashish @emgarten 
