### PR TITLE
Re-enable project information emits, now with JTF.RunAsync (instead of JTF.Run)

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -578,8 +578,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // Finally, try to add the project to the cache.
             var added = _nuGetAndEnvDTEProjectCache.AddProject(newEnvDTEProjectName, envDTEProject, nuGetProject);
-
-            /* TODO: Enable this in such a way that it does not effect project load time.
+            
             if (added)
             {
                 // Emit project specific telemetry as we are adding the project to the cache.
@@ -587,7 +586,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 // open.
                 NuGetProjectTelemetryService.Instance.EmitNuGetProject(envDTEProject, nuGetProject);
             }
-            */
 
             if (string.IsNullOrEmpty(DefaultNuGetProjectName) ||
                 newEnvDTEProjectName.ShortName.Equals(DefaultNuGetProjectName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
1. Re-enable project information emits, now with `JTF.RunAsync` (instead of `JTF.Run`) ([already existing in `dev`](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs#L66-L79))
2. (unrelated clean-up) Remove unused or useless parameters in common.ps1 (build script)

Fixes https://github.com/NuGet/Home/issues/3546.

/cc @jainaashish @emgarten 
