### PR TITLE
Fix regression of issue NuGet/Home#2785 - push should support timeout

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/PushCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/PackageUpdateResource.cs
@@ -270,7 +270,10 @@ namespace NuGet.Protocol.Core.Types
         {
             var serviceEndpointUrl = GetServiceEndpointUrl(source, string.Empty);
             await _httpSource.ProcessResponseAsync(
-                new HttpSourceRequest(() => CreateRequest(serviceEndpointUrl, pathToPackage, apiKey, logger)),
+                new HttpSourceRequest(() => CreateRequest(serviceEndpointUrl, pathToPackage, apiKey, logger))
+                {
+                    RequestTimeout = requestTimeout
+                },
                 response =>
                 {
                     response.EnsureSuccessStatusCode();

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.CommandLine.Test;
+using NuGet.Test.Utility;
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest.Commands
+{
+    public class PushCommandTest
+    {
+        [Fact]
+        public void PushCommand_AllowsTimeoutToBeSpecifiedHigherThan100Seconds()
+        {
+            // Arrange
+            using (var packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nuget = Util.GetNuGetExePath();
+                var sourcePath = Util.CreateTestPackage("PackageA", "1.1.0", packageDirectory);
+                var outputPath = Path.Combine(packageDirectory, "pushed.nupkg");
+
+                using (var server = new MockServer())
+                {
+                    server.Put.Add("/push", r =>
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(101));
+
+                        byte[] buffer = MockServer.GetPushedPackage(r);
+                        using (var outputStream = new FileStream(outputPath, FileMode.Create))
+                        {
+                            outputStream.Write(buffer, 0, buffer.Length);
+                        }
+
+                        return HttpStatusCode.Created;
+                    });
+
+                    server.Start();
+
+                    // Act
+                    var result = CommandRunner.Run(
+                        nuget,
+                        packageDirectory,
+                        $"push {sourcePath} -Source {server.Uri}push -Timeout 110",
+                        waitForExit: true,
+                        timeOutInMilliseconds: 120 * 1000); // 120 seconds
+
+                    // Assert
+                    server.Stop();
+                    Assert.True(0 == result.Item1, $"{result.Item2} {result.Item3}");
+                    Assert.Contains("Your package was pushed.", result.Item2);
+                    Assert.True(File.Exists(outputPath), "The package should have been pushed");
+                    Assert.Equal(File.ReadAllBytes(sourcePath), File.ReadAllBytes(outputPath));
+                }
+            }
+        }
+
+        [Fact]
+        public void PushCommand_AllowsTimeoutToBeSpecifiedLowerThan100Seconds()
+        {
+            // Arrange
+            using (var packageDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var nuget = Util.GetNuGetExePath();
+                var sourcePath = Util.CreateTestPackage("PackageA", "1.1.0", packageDirectory);
+                var outputPath = Path.Combine(packageDirectory, "pushed.nupkg");
+
+                using (var server = new MockServer())
+                {
+                    server.Put.Add("/push", r =>
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(5));
+
+                        byte[] buffer = MockServer.GetPushedPackage(r);
+                        using (var outputStream = new FileStream(outputPath, FileMode.Create))
+                        {
+                            outputStream.Write(buffer, 0, buffer.Length);
+                        }
+
+                        return HttpStatusCode.Created;
+                    });
+
+                    server.Start();
+
+                    // Act
+                    var result = CommandRunner.Run(
+                        nuget,
+                        packageDirectory,
+                        $"push {sourcePath} -Source {server.Uri}push -Timeout 1",
+                        waitForExit: true,
+                        timeOutInMilliseconds: 20 * 1000); // 20 seconds
+
+                    // Assert
+                    server.Stop();
+                    Assert.True(1 == result.Item1, $"{result.Item2} {result.Item3}");
+                    Assert.DoesNotContain("Your package was pushed.", result.Item2);
+                    Assert.False(File.Exists(outputPath), "The package should not have been pushed");
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Commands/PushCommandTest.cs
@@ -13,6 +13,10 @@ namespace NuGet.CommandLine.FuncTest.Commands
 {
     public class PushCommandTest
     {
+        /// <summary>
+        /// 100 seconds is significant because that is the default timeout on <see cref="HttpClient"/>.
+        /// Related to https://github.com/NuGet/Home/issues/2785.
+        /// </summary>
         [Fact]
         public void PushCommand_AllowsTimeoutToBeSpecifiedHigherThan100Seconds()
         {

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Caching\Tests\PopulatesDestinationFolderTest.cs" />
     <Compile Include="Caching\Tests\UsesGlobalPackagesFolderCopyTest.cs" />
     <Compile Include="Caching\Tests\AllowsMissingPackageOnSourceTest.cs" />
+    <Compile Include="Commands\PushCommandTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;


### PR DESCRIPTION
1. Fix regression of https://github.com/NuGet/Home/issues/2785.
2. Added functional tests to make sure this doesn't regress again.

The tests use actual timeouts (so are slow), so I put them in the `NuGet.CommandLine.FuncTests` project.

/cc @alpaix @jainaashish @emgarten @drewgil @rohit21agrawal @mishra14 
