### PR TITLE
Dev zhi monopackfix

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -452,7 +452,7 @@ namespace NuGet.CommandLine
             {
                 List<MsbuildToolSet> installedToolsets = new List<MsbuildToolSet>();
                 var assembly = Assembly.Load(
-                        "Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+                        "Microsoft.Build, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
                 Type projectCollectionType = assembly.GetType(
                    "Microsoft.Build.Evaluation.ProjectCollection",
                    throwOnError: true);
@@ -729,18 +729,5 @@ namespace NuGet.CommandLine
 
             return escaped;
         }
-    }
-
-    public class MsbuildToolSet
-    {
-        public MsbuildToolSet(string toolsVersion, string toolsPath)
-        {
-            ToolsPath = toolsPath;
-            ToolsVersion = toolsVersion;
-        }
-
-        public string ToolsPath { get; }
-
-        public string ToolsVersion { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -344,53 +344,53 @@ namespace NuGet.CommandLine
         /// <returns>The matching toolset.</returns>
         /// <remarks>This method is not intended to be called directly. It's marked public so that it
         /// can be called by unit tests.</remarks>
-        public static Toolset SelectMsbuildToolset(
-            Version msbuildVersion,
-            IEnumerable<Toolset> installedToolsets)
-        {
-            Toolset selectedToolset;
-            if (msbuildVersion == null)
-            {
-                // MSBuild does not exist in PATH. In this case, the highest installed version is used
-                selectedToolset = installedToolsets.FirstOrDefault();
-            }
-            else
-            {
-                // Search by major & minor version
-                selectedToolset = installedToolsets.FirstOrDefault(
-                    toolset =>
-                    {
-                        var v = SafeParseVersion(toolset.ToolsVersion);
-                        return v.Major == msbuildVersion.Major && v.Minor == v.Minor;
-                    });
+        //public static Toolset SelectMsbuildToolset(
+        //    Version msbuildVersion,
+        //    IEnumerable<Toolset> installedToolsets)
+        //{
+        //    Toolset selectedToolset;
+        //    if (msbuildVersion == null)
+        //    {
+        //        // MSBuild does not exist in PATH. In this case, the highest installed version is used
+        //        selectedToolset = installedToolsets.FirstOrDefault();
+        //    }
+        //    else
+        //    {
+        //        // Search by major & minor version
+        //        selectedToolset = installedToolsets.FirstOrDefault(
+        //            toolset =>
+        //            {
+        //                var v = SafeParseVersion(toolset.ToolsVersion);
+        //                return v.Major == msbuildVersion.Major && v.Minor == v.Minor;
+        //            });
 
-                if (selectedToolset == null)
-                {
-                    // no match found. Now search by major only
-                    selectedToolset = installedToolsets.FirstOrDefault(
-                        toolset =>
-                        {
-                            var v = SafeParseVersion(toolset.ToolsVersion);
-                            return v.Major == msbuildVersion.Major;
-                        });
-                }
+        //        if (selectedToolset == null)
+        //        {
+        //            // no match found. Now search by major only
+        //            selectedToolset = installedToolsets.FirstOrDefault(
+        //                toolset =>
+        //                {
+        //                    var v = SafeParseVersion(toolset.ToolsVersion);
+        //                    return v.Major == msbuildVersion.Major;
+        //                });
+        //        }
 
-                if (selectedToolset == null)
-                {
-                    // still no match. Use the highest installed version in this case
-                    selectedToolset = installedToolsets.FirstOrDefault();
-                }
-            }
+        //        if (selectedToolset == null)
+        //        {
+        //            // still no match. Use the highest installed version in this case
+        //            selectedToolset = installedToolsets.FirstOrDefault();
+        //        }
+        //    }
 
-            if (selectedToolset == null)
-            {
-                throw new CommandLineException(
-                    LocalizedResourceManager.GetString(
-                            nameof(NuGetResources.Error_MSBuildNotInstalled)));
-            }
+        //    if (selectedToolset == null)
+        //    {
+        //        throw new CommandLineException(
+        //            LocalizedResourceManager.GetString(
+        //                    nameof(NuGetResources.Error_MSBuildNotInstalled)));
+        //    }
 
-            return selectedToolset;
-        }
+        //    return selectedToolset;
+        //}
 
         /// <summary>
         /// Returns the msbuild directory. If <paramref name="userVersion"/> is null, then the directory containing
@@ -403,98 +403,99 @@ namespace NuGet.CommandLine
         /// <returns>The msbuild directory.</returns>
         public static string GetMsbuildDirectory(string userVersion, IConsole console)
         {
-            List<Toolset> installedToolsets;
-            using (var projectCollection = new ProjectCollection())
-            {
-                installedToolsets = projectCollection.Toolsets.OrderByDescending(
-                    toolset => SafeParseVersion(toolset.ToolsVersion)).ToList();
-            }
+            //List<Toolset> installedToolsets;
+            //using (var projectCollection = new ProjectCollection())
+            //{
+            //    installedToolsets = projectCollection.Toolsets.OrderByDescending(
+            //        toolset => SafeParseVersion(toolset.ToolsVersion)).ToList();
+            //}
 
-            return GetMsbuildDirectoryInternal(userVersion, console, installedToolsets);
+            //return GetMsbuildDirectoryInternal(userVersion, console, installedToolsets);
+            return CommandLineConstants.MsbuildPathOnMac14;
         }
 
         // This method is called by GetMsbuildDirectory(). This method is not intended to be called directly.
         // It's marked public so that it can be called by unit tests.
-        public static string GetMsbuildDirectoryInternal(
-            string userVersion,
-            IConsole console,
-            IEnumerable<Toolset> installedToolsets)
-        {
-            if (string.IsNullOrEmpty(userVersion))
-            {
-                var msbuildVersion = GetMSBuildVersionInPath();
-                var toolset = SelectMsbuildToolset(msbuildVersion, installedToolsets);
+        //public static string GetMsbuildDirectoryInternal(
+        //    string userVersion,
+        //    IConsole console,
+        //    IEnumerable<Toolset> installedToolsets)
+        //{
+        //    if (string.IsNullOrEmpty(userVersion))
+        //    {
+        //        var msbuildVersion = GetMSBuildVersionInPath();
+        //        var toolset = SelectMsbuildToolset(msbuildVersion, installedToolsets);
 
-                if (console != null)
-                {
-                    if (console.Verbosity == Verbosity.Detailed)
-                    {
-                        console.WriteLine(
-                            LocalizedResourceManager.GetString(
-                                nameof(NuGetResources.MSBuildAutoDetection_Verbose)),
-                            toolset.ToolsVersion,
-                            toolset.ToolsPath);
-                    }
-                    else
-                    {
-                        console.WriteLine(
-                            LocalizedResourceManager.GetString(
-                                nameof(NuGetResources.MSBuildAutoDetection)),
-                            toolset.ToolsVersion,
-                            toolset.ToolsPath);
-                    }
-                }
+        //        if (console != null)
+        //        {
+        //            if (console.Verbosity == Verbosity.Detailed)
+        //            {
+        //                console.WriteLine(
+        //                    LocalizedResourceManager.GetString(
+        //                        nameof(NuGetResources.MSBuildAutoDetection_Verbose)),
+        //                    toolset.ToolsVersion,
+        //                    toolset.ToolsPath);
+        //            }
+        //            else
+        //            {
+        //                console.WriteLine(
+        //                    LocalizedResourceManager.GetString(
+        //                        nameof(NuGetResources.MSBuildAutoDetection)),
+        //                    toolset.ToolsVersion,
+        //                    toolset.ToolsPath);
+        //            }
+        //        }
 
-                return toolset.ToolsPath;
-            }
-            else
-            {
-                // append ".0" if the userVersion is a number
-                string userVersionString = userVersion;
-                int unused;
+        //        return toolset.ToolsPath;
+        //    }
+        //    else
+        //    {
+        //        // append ".0" if the userVersion is a number
+        //        string userVersionString = userVersion;
+        //        int unused;
 
-                if (int.TryParse(userVersion, out unused))
-                {
-                    userVersionString = userVersion + ".0";
-                }
+        //        if (int.TryParse(userVersion, out unused))
+        //        {
+        //            userVersionString = userVersion + ".0";
+        //        }
 
-                Version ver;
-                bool hasNumericVersion = Version.TryParse(userVersionString, out ver);
+        //        Version ver;
+        //        bool hasNumericVersion = Version.TryParse(userVersionString, out ver);
 
-                var selectedToolset = installedToolsets.FirstOrDefault(
-                toolset =>
-                {
-                    // first match by string comparison
-                    if (string.Equals(userVersionString, toolset.ToolsVersion, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
+        //        var selectedToolset = installedToolsets.FirstOrDefault(
+        //        toolset =>
+        //        {
+        //            // first match by string comparison
+        //            if (string.Equals(userVersionString, toolset.ToolsVersion, StringComparison.OrdinalIgnoreCase))
+        //            {
+        //                return true;
+        //            }
 
-                    // then match by Major & Minor version numbers.
-                    Version toolsVersion;
-                    if (hasNumericVersion && Version.TryParse(toolset.ToolsVersion, out toolsVersion))
-                    {
-                        return (toolsVersion.Major == ver.Major &&
-                            toolsVersion.Minor == ver.Minor);
-                    }
+        //            // then match by Major & Minor version numbers.
+        //            Version toolsVersion;
+        //            if (hasNumericVersion && Version.TryParse(toolset.ToolsVersion, out toolsVersion))
+        //            {
+        //                return (toolsVersion.Major == ver.Major &&
+        //                    toolsVersion.Minor == ver.Minor);
+        //            }
 
-                    return false;
-                });
+        //            return false;
+        //        });
 
-                if (selectedToolset == null)
-                {
-                    var message = string.Format(
-                        CultureInfo.CurrentCulture,
-                        LocalizedResourceManager.GetString(
-                            nameof(NuGetResources.Error_CannotFindMsbuild)),
-                        userVersion);
+        //        if (selectedToolset == null)
+        //        {
+        //            var message = string.Format(
+        //                CultureInfo.CurrentCulture,
+        //                LocalizedResourceManager.GetString(
+        //                    nameof(NuGetResources.Error_CannotFindMsbuild)),
+        //                userVersion);
 
-                    throw new CommandLineException(message);
-                }
+        //            throw new CommandLineException(message);
+        //        }
 
-                return selectedToolset.ToolsPath;
-            }
-        }
+        //        return selectedToolset.ToolsPath;
+        //    }
+        //}
 
         private static void AppendQuoted(StringBuilder builder, string targetPath)
         {

--- a/src/NuGet.Clients/NuGet.CommandLine/MsbuildToolSet.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsbuildToolSet.cs
@@ -1,0 +1,16 @@
+﻿
+namespace NuGet.CommandLine
+{
+    public class MsbuildToolSet
+    {
+        public MsbuildToolSet(string toolsVersion, string toolsPath)
+        {
+            ToolsPath = toolsPath;
+            ToolsVersion = toolsVersion;
+        }
+
+        public string ToolsPath { get; }
+
+        public string ToolsVersion { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
@@ -81,6 +81,7 @@
     <Compile Include="ICommandManager.cs" />
     <Compile Include="MSBuildCachedRequestProvider.cs" />
     <Compile Include="MSBuildTasks\ProjectReferencesTask.cs" />
+    <Compile Include="MsbuildToolSet.cs" />
     <Compile Include="MsBuildUtility.cs" />
     <Compile Include="NuGetCommand.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -5686,15 +5686,6 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t load Msbuild ToolSet..
-        /// </summary>
-        public static string LoadMsbuildToolSetError {
-            get {
-                return ResourceManager.GetString("LoadMsbuildToolSetError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Local resources cleared..
         /// </summary>
         public static string LocalsCommand_ClearedSuccessful {
@@ -6051,6 +6042,15 @@ namespace NuGet.CommandLine {
         public static string MsBuildDoesNotExistAtPath {
             get {
                 return ResourceManager.GetString("MsBuildDoesNotExistAtPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load msbuild Toolset.
+        /// </summary>
+        public static string MsbuildLoadToolSetError {
+            get {
+                return ResourceManager.GetString("MsbuildLoadToolSetError", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -5686,6 +5686,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t load Msbuild ToolSet..
+        /// </summary>
+        public static string LoadMsbuildToolSetError {
+            get {
+                return ResourceManager.GetString("LoadMsbuildToolSetError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Local resources cleared..
         /// </summary>
         public static string LocalsCommand_ClearedSuccessful {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6102,4 +6102,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_MultipleTargetFrameworks" xml:space="preserve">
     <value>project.json cannot contain multiple Target Frameworks.</value>
   </data>
+  <data name="LoadMsbuildToolSetError" xml:space="preserve">
+    <value>Can't load Msbuild ToolSet.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6102,7 +6102,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_MultipleTargetFrameworks" xml:space="preserve">
     <value>project.json cannot contain multiple Target Frameworks.</value>
   </data>
-  <data name="LoadMsbuildToolSetError" xml:space="preserve">
-    <value>Can't load Msbuild ToolSet.</value>
+  <data name="MsbuildLoadToolSetError" xml:space="preserve">
+    <value>Failed to load msbuild Toolset</value>
   </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Microsoft.Build.Evaluation;
+using System;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -7,297 +7,197 @@ namespace NuGet.CommandLine.Test
     public class MSBuildUtilityTest
     {
         // test that when msbuildVersion is null, SelectMsbuildToolset returns the highest installed version.
-        //[Fact]
-        //public void HighestVersionSelectedIfMSBuildVersionIsNull()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+        [Fact]
+        public void HighestVersionSelectedIfMSBuildVersionIsNull()
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetV4
-        //        };
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
 
-        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-        //            msbuildVersion: null,
-        //            installedToolsets: installedToolsets);
+            var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                msbuildVersion: null,
+                installedToolsets: installedToolsets);
 
-        //        Assert.Equal(selectedToolset, toolsetV14);
-        //    }
-        //}
+            Assert.Equal(selectedToolset, toolsetV14);
+        }
 
-        //// test that SelectMsbuildToolset returns the toolset that matches the msbuild version (major + minor)
-        //[Fact]
-        //public void VersionSelectedThatMatchesMSBuildVersion()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12_5 = new Toolset(
-        //            "12.5", "v12_5path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+        // test that SelectMsbuildToolset returns the toolset that matches the msbuild version (major + minor)
+        [Fact]
+        public void VersionSelectedThatMatchesMSBuildVersion()
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12_5 = new Tuple<string, string>("12.5", "v12_5path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
-        //        };
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
+                };
 
-        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-        //            msbuildVersion: new System.Version("12.5.4.12"),
-        //            installedToolsets: installedToolsets);
+            var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                msbuildVersion: new Version("12.5.4.12"),
+                installedToolsets: installedToolsets);
 
-        //        Assert.Equal(selectedToolset, toolsetV12_5);
-        //    }
-        //}
+            Assert.Equal(selectedToolset, toolsetV12_5);
 
-        //// test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if
-        //// (major + minor) do not match
-        //[Fact]
-        //public void VersionSelectedThatMatchesMSBuildVersionMajor()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+        }
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetV4
-        //        };
+        // test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if
+        // (major + minor) do not match
+        [Fact]
+        public void VersionSelectedThatMatchesMSBuildVersionMajor()
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-        //            msbuildVersion: new System.Version("4.6"),
-        //            installedToolsets: installedToolsets);
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
 
-        //        Assert.Equal(selectedToolset, toolsetV4);
-        //    }
-        //}
+            var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                msbuildVersion: new Version("4.6"),
+                installedToolsets: installedToolsets);
 
-        //// test that SelectMsbuildToolset returns the highest version toolset if
-        //// there are no matches using major nor (major + minor)
-        //[Fact]
-        //public void HighestVersionSelectedIfNoVersionMatch()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+            Assert.Equal(selectedToolset, toolsetV4);
+        }
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetV4
-        //        };
+        // test that SelectMsbuildToolset returns the highest version toolset if
+        // there are no matches using major nor (major + minor)
+        [Fact]
+        public void HighestVersionSelectedIfNoVersionMatch()
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-        //            msbuildVersion: new System.Version("5.6"),
-        //            installedToolsets: installedToolsets);
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
 
-        //        Assert.Equal(selectedToolset, toolsetV14);
-        //    }
-        //}
+            var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                msbuildVersion: new System.Version("5.6"),
+                installedToolsets: installedToolsets);
 
-        //// Tests that GetMsbuildDirectoryInternal() returns path of the toolset whose toolset version matches
-        //// the userVersion.
-        //[Fact]
-        //public void TestVersionMatch()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        // Arrange
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+            Assert.Equal(selectedToolset, toolsetV14);
+        }
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetV4
-        //        };
+        // Tests that GetMsbuildDirectoryInternal() returns path of the toolset whose toolset version matches
+        // the userVersion.
+        [Fact]
+        public void TestVersionMatch()
+        {
+            // Arrange
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        // Act
-        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-        //            userVersion: "12.0",
-        //            console: null,
-        //            installedToolsets: installedToolsets);
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
 
-        //        // Assert
-        //        Assert.Equal(directory, toolsetV12.ToolsPath);
-        //    }
-        //}
+            // Act
+            var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+                userVersion: "12.0",
+                console: null,
+                installedToolsets: installedToolsets);
 
-        //// Tests that, when userVersion is just a number, it can be matched with version userVersion + ".0".
-        //[Fact]
-        //public void TestVersionMatchByNumber()
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        // Arrange
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV4 = new Toolset(
-        //            "4.0", "v4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+            // Assert
+            Assert.Equal(directory, toolsetV12.Item2);
+        }
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetV4
-        //        };
+        // Tests that, when userVersion is just a number, it can be matched with version userVersion + ".0".
+        [Fact]
+        public void TestVersionMatchByNumber()
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
 
-        //        // Act
-        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-        //            userVersion: "12",
-        //            console: null,
-        //            installedToolsets: installedToolsets);
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
 
-        //        // Assert
-        //        Assert.Equal(directory, toolsetV12.ToolsPath);
-        //    }
-        //}
+            // Act
+            var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+                    userVersion: "12",
+                    console: null,
+                    installedToolsets: installedToolsets);
+
+            // Assert
+            Assert.Equal(directory, toolsetV12.Item2);
+        }
 
 
-        //[Theory]
+        [Theory]
 
-        //// Tests that, when userVersion cannot be parsed into Version, string comparison is used
-        //// to match toolset.
-        //[InlineData("Foo4.0", "foo4path")]
+        // Tests that, when userVersion cannot be parsed into Version, string comparison is used
+        // to match toolset.
+        [InlineData("Foo4.0", "foo4path")]
 
-        //// Tests that case insensitive string comparison is used
-        //[InlineData("foo4.0", "foo4path")]
-        //public void TestVersionMatchByString(string userVersion, string expectedDirectory)
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        // Arrange
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetFoo4 = new Toolset(
-        //            "Foo4.0", "foo4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+        // Tests that case insensitive string comparison is used
+        [InlineData("foo4.0", "foo4path")]
+        public void TestVersionMatchByString(string userVersion, string expectedDirectory)
+        {
+            // Arrange
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetFoo4 = new Tuple<string, string>("Foo4.0", "foo4path");
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetFoo4
-        //        };
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetFoo4
+                };
 
-        //        // Act
-        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-        //            userVersion: userVersion,
-        //            console: null,
-        //            installedToolsets: installedToolsets);
+            // Act
+            var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+                userVersion: userVersion,
+                console: null,
+                installedToolsets: installedToolsets);
 
-        //        // Assert
-        //        Assert.Equal(directory, expectedDirectory);
-        //    }
-        //}
+            // Assert
+            Assert.Equal(directory, expectedDirectory);
+        }
 
-        //[Theory]
+        [Theory]
 
-        //// Tests that, when userVersion cannot be parsed into Version, string comparison is used
-        //// to match toolset and ".0" is not appended during matching.
-        //[InlineData("Foo4")]
+        // Tests that, when userVersion cannot be parsed into Version, string comparison is used
+        // to match toolset and ".0" is not appended during matching.
+        [InlineData("Foo4")]
 
-        //// Tests that leading/trailing spaces are significant during string comparison.
-        //[InlineData(" Foo4.0")]
-        //[InlineData("Foo4.0 ")]
-        //[InlineData(" Foo4.0 ")]
+        // Tests that leading/trailing spaces are significant during string comparison.
+        [InlineData(" Foo4.0")]
+        [InlineData("Foo4.0 ")]
+        [InlineData(" Foo4.0 ")]
 
-        //// Tests that 0 can't be matched to version "Foo4.0"
-        //[InlineData("0")]
-        //public void TestVersionMatchByStringFailure(string userVersion)
-        //{
-        //    using (var projectCollection = new ProjectCollection())
-        //    {
-        //        // Arrange
-        //        var toolsetV14 = new Toolset(
-        //            "14.0", "v14path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetV12 = new Toolset(
-        //            "12.0", "v12path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
-        //        var toolsetFoo4 = new Toolset(
-        //            "Foo4.0", "foo4path",
-        //            projectCollection: projectCollection,
-        //            msbuildOverrideTasksPath: null);
+        // Tests that 0 can't be matched to version "Foo4.0"
+        [InlineData("0")]
+        public void TestVersionMatchByStringFailure(string userVersion)
+        {
+            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
+            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
+            var toolsetFoo4 = new Tuple<string, string>("Foo4.0", "foo4path");
 
-        //        var installedToolsets = new List<Toolset> {
-        //            toolsetV14, toolsetV12, toolsetFoo4
-        //        };
+            var installedToolsets = new List<Tuple<string, string>> {
+                    toolsetV14, toolsetV12, toolsetFoo4
+                };
 
-        //        // Act
-        //        var ex = Assert.Throws<CommandLineException>(() =>
-        //        {
-        //            var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-        //                userVersion: userVersion,
-        //                console: null,
-        //                installedToolsets: installedToolsets);
-        //        });
+            // Act
+            var ex = Assert.Throws<CommandLineException>(() =>
+                {
+                    var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+                        userVersion: userVersion,
+                        console: null,
+                        installedToolsets: installedToolsets);
+                });
 
-        //        // Assert
-        //        Assert.Equal(
-        //            $"Cannot find the specified version of msbuild: '{userVersion}'",
-        //            ex.Message);
-        //    }
-        //}
+            // Assert
+            Assert.Equal(
+                $"Cannot find the specified version of msbuild: '{userVersion}'",
+                ex.Message);
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System;
 using Xunit;
+using NuGet.Common;
 
 namespace NuGet.CommandLine.Test
 {
@@ -10,11 +11,11 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void HighestVersionSelectedIfMSBuildVersionIsNull()
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetV4
                 };
 
@@ -29,12 +30,12 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void VersionSelectedThatMatchesMSBuildVersion()
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12_5 = new Tuple<string, string>("12.5", "v12_5path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12_5 = new MsbuildToolSet("12.5", "v12_5path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
                 };
 
@@ -51,11 +52,11 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void VersionSelectedThatMatchesMSBuildVersionMajor()
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetV4
                 };
 
@@ -71,11 +72,11 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void HighestVersionSelectedIfNoVersionMatch()
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetV4
                 };
 
@@ -92,11 +93,11 @@ namespace NuGet.CommandLine.Test
         public void TestVersionMatch()
         {
             // Arrange
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetV4
                 };
 
@@ -107,18 +108,18 @@ namespace NuGet.CommandLine.Test
                 installedToolsets: installedToolsets);
 
             // Assert
-            Assert.Equal(directory, toolsetV12.Item2);
+            Assert.Equal(directory, toolsetV12.ToolsPath);
         }
 
         // Tests that, when userVersion is just a number, it can be matched with version userVersion + ".0".
         [Fact]
         public void TestVersionMatchByNumber()
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetV4 = new Tuple<string, string>("4.0", "v4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetV4 = new MsbuildToolSet("4.0", "v4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetV4
                 };
 
@@ -129,7 +130,7 @@ namespace NuGet.CommandLine.Test
                     installedToolsets: installedToolsets);
 
             // Assert
-            Assert.Equal(directory, toolsetV12.Item2);
+            Assert.Equal(directory, toolsetV12.ToolsPath);
         }
 
 
@@ -144,11 +145,11 @@ namespace NuGet.CommandLine.Test
         public void TestVersionMatchByString(string userVersion, string expectedDirectory)
         {
             // Arrange
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetFoo4 = new Tuple<string, string>("Foo4.0", "foo4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetFoo4 = new MsbuildToolSet("Foo4.0", "foo4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetFoo4
                 };
 
@@ -177,11 +178,11 @@ namespace NuGet.CommandLine.Test
         [InlineData("0")]
         public void TestVersionMatchByStringFailure(string userVersion)
         {
-            var toolsetV14 = new Tuple<string, string>("14.0", "v14path");
-            var toolsetV12 = new Tuple<string, string>("12.0", "v12path");
-            var toolsetFoo4 = new Tuple<string, string>("Foo4.0", "foo4path");
+            var toolsetV14 = new MsbuildToolSet("14.0", "v14path");
+            var toolsetV12 = new MsbuildToolSet("12.0", "v12path");
+            var toolsetFoo4 = new MsbuildToolSet("Foo4.0", "foo4path");
 
-            var installedToolsets = new List<Tuple<string, string>> {
+            var installedToolsets = new List<MsbuildToolSet> {
                     toolsetV14, toolsetV12, toolsetFoo4
                 };
 
@@ -198,6 +199,29 @@ namespace NuGet.CommandLine.Test
             Assert.Equal(
                 $"Cannot find the specified version of msbuild: '{userVersion}'",
                 ex.Message);
+        }
+
+        [Fact]
+        public void TestGetMsbuildDirectoryForMonoOnMac()
+        {
+            var os = Environment.GetEnvironmentVariable("OSTYPE");
+            if (RuntimeEnvironmentHelper.IsMono && os != null && os.StartsWith("darwin"))
+            {
+                // Act
+                var directory15version = MsBuildUtility.GetMsbuildDirectory("15.0", null);
+                var directory15 = MsBuildUtility.GetMsbuildDirectory("15", null);
+                var directory14 = MsBuildUtility.GetMsbuildDirectory("14.1", null);
+                var directory = MsBuildUtility.GetMsbuildDirectory(null, null);
+
+                var msbuild14 = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin/";
+                var msbuild15 = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
+                
+                // Assert
+                Assert.Equal(directory15version, msbuild15);
+                Assert.Equal(directory15, msbuild15);
+                Assert.Equal(directory14, msbuild14);
+                Assert.True(new List<string> { msbuild14, msbuild15 }.Contains(directory));
+            }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -7,297 +7,297 @@ namespace NuGet.CommandLine.Test
     public class MSBuildUtilityTest
     {
         // test that when msbuildVersion is null, SelectMsbuildToolset returns the highest installed version.
-        [Fact]
-        public void HighestVersionSelectedIfMSBuildVersionIsNull()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //[Fact]
+        //public void HighestVersionSelectedIfMSBuildVersionIsNull()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetV4
+        //        };
 
-                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-                    msbuildVersion: null,
-                    installedToolsets: installedToolsets);
+        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+        //            msbuildVersion: null,
+        //            installedToolsets: installedToolsets);
 
-                Assert.Equal(selectedToolset, toolsetV14);
-            }
-        }
+        //        Assert.Equal(selectedToolset, toolsetV14);
+        //    }
+        //}
 
-        // test that SelectMsbuildToolset returns the toolset that matches the msbuild version (major + minor)
-        [Fact]
-        public void VersionSelectedThatMatchesMSBuildVersion()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12_5 = new Toolset(
-                    "12.5", "v12_5path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// test that SelectMsbuildToolset returns the toolset that matches the msbuild version (major + minor)
+        //[Fact]
+        //public void VersionSelectedThatMatchesMSBuildVersion()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12_5 = new Toolset(
+        //            "12.5", "v12_5path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
+        //        };
 
-                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-                    msbuildVersion: new System.Version("12.5.4.12"),
-                    installedToolsets: installedToolsets);
+        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+        //            msbuildVersion: new System.Version("12.5.4.12"),
+        //            installedToolsets: installedToolsets);
 
-                Assert.Equal(selectedToolset, toolsetV12_5);
-            }
-        }
+        //        Assert.Equal(selectedToolset, toolsetV12_5);
+        //    }
+        //}
 
-        // test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if
-        // (major + minor) do not match
-        [Fact]
-        public void VersionSelectedThatMatchesMSBuildVersionMajor()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if
+        //// (major + minor) do not match
+        //[Fact]
+        //public void VersionSelectedThatMatchesMSBuildVersionMajor()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetV4
+        //        };
 
-                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-                    msbuildVersion: new System.Version("4.6"),
-                    installedToolsets: installedToolsets);
+        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+        //            msbuildVersion: new System.Version("4.6"),
+        //            installedToolsets: installedToolsets);
 
-                Assert.Equal(selectedToolset, toolsetV4);
-            }
-        }
+        //        Assert.Equal(selectedToolset, toolsetV4);
+        //    }
+        //}
 
-        // test that SelectMsbuildToolset returns the highest version toolset if
-        // there are no matches using major nor (major + minor)
-        [Fact]
-        public void HighestVersionSelectedIfNoVersionMatch()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// test that SelectMsbuildToolset returns the highest version toolset if
+        //// there are no matches using major nor (major + minor)
+        //[Fact]
+        //public void HighestVersionSelectedIfNoVersionMatch()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetV4
+        //        };
 
-                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
-                    msbuildVersion: new System.Version("5.6"),
-                    installedToolsets: installedToolsets);
+        //        var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+        //            msbuildVersion: new System.Version("5.6"),
+        //            installedToolsets: installedToolsets);
 
-                Assert.Equal(selectedToolset, toolsetV14);
-            }
-        }
+        //        Assert.Equal(selectedToolset, toolsetV14);
+        //    }
+        //}
 
-        // Tests that GetMsbuildDirectoryInternal() returns path of the toolset whose toolset version matches
-        // the userVersion.
-        [Fact]
-        public void TestVersionMatch()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                // Arrange
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// Tests that GetMsbuildDirectoryInternal() returns path of the toolset whose toolset version matches
+        //// the userVersion.
+        //[Fact]
+        //public void TestVersionMatch()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        // Arrange
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetV4
+        //        };
 
-                // Act
-                var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-                    userVersion: "12.0",
-                    console: null,
-                    installedToolsets: installedToolsets);
+        //        // Act
+        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+        //            userVersion: "12.0",
+        //            console: null,
+        //            installedToolsets: installedToolsets);
 
-                // Assert
-                Assert.Equal(directory, toolsetV12.ToolsPath);
-            }
-        }
+        //        // Assert
+        //        Assert.Equal(directory, toolsetV12.ToolsPath);
+        //    }
+        //}
 
-        // Tests that, when userVersion is just a number, it can be matched with version userVersion + ".0".
-        [Fact]
-        public void TestVersionMatchByNumber()
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                // Arrange
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset(
-                    "4.0", "v4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// Tests that, when userVersion is just a number, it can be matched with version userVersion + ".0".
+        //[Fact]
+        //public void TestVersionMatchByNumber()
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        // Arrange
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV4 = new Toolset(
+        //            "4.0", "v4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetV4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetV4
+        //        };
 
-                // Act
-                var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-                    userVersion: "12",
-                    console: null,
-                    installedToolsets: installedToolsets);
+        //        // Act
+        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+        //            userVersion: "12",
+        //            console: null,
+        //            installedToolsets: installedToolsets);
 
-                // Assert
-                Assert.Equal(directory, toolsetV12.ToolsPath);
-            }
-        }
+        //        // Assert
+        //        Assert.Equal(directory, toolsetV12.ToolsPath);
+        //    }
+        //}
 
 
-        [Theory]
+        //[Theory]
 
-        // Tests that, when userVersion cannot be parsed into Version, string comparison is used
-        // to match toolset.
-        [InlineData("Foo4.0", "foo4path")]
+        //// Tests that, when userVersion cannot be parsed into Version, string comparison is used
+        //// to match toolset.
+        //[InlineData("Foo4.0", "foo4path")]
 
-        // Tests that case insensitive string comparison is used
-        [InlineData("foo4.0", "foo4path")]
-        public void TestVersionMatchByString(string userVersion, string expectedDirectory)
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                // Arrange
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetFoo4 = new Toolset(
-                    "Foo4.0", "foo4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// Tests that case insensitive string comparison is used
+        //[InlineData("foo4.0", "foo4path")]
+        //public void TestVersionMatchByString(string userVersion, string expectedDirectory)
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        // Arrange
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetFoo4 = new Toolset(
+        //            "Foo4.0", "foo4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetFoo4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetFoo4
+        //        };
 
-                // Act
-                var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-                    userVersion: userVersion,
-                    console: null,
-                    installedToolsets: installedToolsets);
+        //        // Act
+        //        var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+        //            userVersion: userVersion,
+        //            console: null,
+        //            installedToolsets: installedToolsets);
 
-                // Assert
-                Assert.Equal(directory, expectedDirectory);
-            }
-        }
+        //        // Assert
+        //        Assert.Equal(directory, expectedDirectory);
+        //    }
+        //}
 
-        [Theory]
+        //[Theory]
 
-        // Tests that, when userVersion cannot be parsed into Version, string comparison is used
-        // to match toolset and ".0" is not appended during matching.
-        [InlineData("Foo4")]
+        //// Tests that, when userVersion cannot be parsed into Version, string comparison is used
+        //// to match toolset and ".0" is not appended during matching.
+        //[InlineData("Foo4")]
 
-        // Tests that leading/trailing spaces are significant during string comparison.
-        [InlineData(" Foo4.0")]
-        [InlineData("Foo4.0 ")]
-        [InlineData(" Foo4.0 ")]
+        //// Tests that leading/trailing spaces are significant during string comparison.
+        //[InlineData(" Foo4.0")]
+        //[InlineData("Foo4.0 ")]
+        //[InlineData(" Foo4.0 ")]
 
-        // Tests that 0 can't be matched to version "Foo4.0"
-        [InlineData("0")]
-        public void TestVersionMatchByStringFailure(string userVersion)
-        {
-            using (var projectCollection = new ProjectCollection())
-            {
-                // Arrange
-                var toolsetV14 = new Toolset(
-                    "14.0", "v14path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset(
-                    "12.0", "v12path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
-                var toolsetFoo4 = new Toolset(
-                    "Foo4.0", "foo4path",
-                    projectCollection: projectCollection,
-                    msbuildOverrideTasksPath: null);
+        //// Tests that 0 can't be matched to version "Foo4.0"
+        //[InlineData("0")]
+        //public void TestVersionMatchByStringFailure(string userVersion)
+        //{
+        //    using (var projectCollection = new ProjectCollection())
+        //    {
+        //        // Arrange
+        //        var toolsetV14 = new Toolset(
+        //            "14.0", "v14path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetV12 = new Toolset(
+        //            "12.0", "v12path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
+        //        var toolsetFoo4 = new Toolset(
+        //            "Foo4.0", "foo4path",
+        //            projectCollection: projectCollection,
+        //            msbuildOverrideTasksPath: null);
 
-                var installedToolsets = new List<Toolset> {
-                    toolsetV14, toolsetV12, toolsetFoo4
-                };
+        //        var installedToolsets = new List<Toolset> {
+        //            toolsetV14, toolsetV12, toolsetFoo4
+        //        };
 
-                // Act
-                var ex = Assert.Throws<CommandLineException>(() =>
-                {
-                    var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
-                        userVersion: userVersion,
-                        console: null,
-                        installedToolsets: installedToolsets);
-                });
+        //        // Act
+        //        var ex = Assert.Throws<CommandLineException>(() =>
+        //        {
+        //            var directory = MsBuildUtility.GetMsbuildDirectoryInternal(
+        //                userVersion: userVersion,
+        //                console: null,
+        //                installedToolsets: installedToolsets);
+        //        });
 
-                // Assert
-                Assert.Equal(
-                    $"Cannot find the specified version of msbuild: '{userVersion}'",
-                    ex.Message);
-            }
-        }
+        //        // Assert
+        //        Assert.Equal(
+        //            $"Cannot find the specified version of msbuild: '{userVersion}'",
+        //            ex.Message);
+        //    }
+        //}
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
-using System;
-using Xunit;
+﻿using System;
+using System.Collections.Generic;
 using NuGet.Common;
+using Xunit;
 
 namespace NuGet.CommandLine.Test
 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -201,26 +201,35 @@ namespace NuGet.CommandLine.Test
                 ex.Message);
         }
 
-        [Fact]
-        public void TestGetMsbuildDirectoryForMonoOnMac()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("15")]
+        [InlineData("15.0")]
+        [InlineData("14")]
+        public void TestGetMsbuildDirectoryForMonoOnMac(string version)
         {
             var os = Environment.GetEnvironmentVariable("OSTYPE");
             if (RuntimeEnvironmentHelper.IsMono && os != null && os.StartsWith("darwin"))
             {
-                // Act
-                var directory15version = MsBuildUtility.GetMsbuildDirectory("15.0", null);
-                var directory15 = MsBuildUtility.GetMsbuildDirectory("15", null);
-                var directory14 = MsBuildUtility.GetMsbuildDirectory("14.1", null);
-                var directory = MsBuildUtility.GetMsbuildDirectory(null, null);
+                // Act;
+                var directory = MsBuildUtility.GetMsbuildDirectory(version, null);
 
                 var msbuild14 = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/14.1/bin/";
                 var msbuild15 = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
-                
+
                 // Assert
-                Assert.Equal(directory15version, msbuild15);
-                Assert.Equal(directory15, msbuild15);
-                Assert.Equal(directory14, msbuild14);
-                Assert.True(new List<string> { msbuild14, msbuild15 }.Contains(directory));
+                if (version == "15.0" || version == "15")
+                {
+                    Assert.Equal(directory, msbuild15);
+                }
+                else if (version == "14.1")
+                {
+                    Assert.Equal(directory, msbuild14);
+                }
+                else if (version == null)
+                {
+                    Assert.True(new List<string> { msbuild14, msbuild15 }.Contains(directory));
+                }
             }
         }
     }


### PR DESCRIPTION
fixed https://github.com/NuGet/Home/issues/3550
1. removed Microsoft.build.dll reference from GetMsbuildDirectory(). Because it will reference the dll from gac(14.0), that cause conflict with 14.1 on mono.
2. if user specify msbuildVersion 14.1 and 15.0, it will return hard code path on mono. if user specify 14.0/12.0/4.0... nuget will load Microsoft.build.dll and figure out the right path.
3. if user doesn't specify any version, nuget will try to find msbuild on mono, then fall back to xbuild if it can't find msbuild.
