### PR TITLE
Fix pack -symbol on Mono

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -486,9 +486,10 @@ namespace NuGet.CommandLine
             }
         }
 
-        private static IEnumerable<string> GetFiles(string path, string fileNameWithoutExtension, HashSet<string> allowedExtensions, SearchOption searchOption)
+        private static IEnumerable<string> GetFiles(string path, ISet<string> fileNames, SearchOption searchOption)
         {
-            return allowedExtensions.Select(extension => Directory.GetFiles(path, fileNameWithoutExtension + extension, searchOption)).SelectMany(a => a);
+            return Directory.EnumerateFiles(path, "*", searchOption)
+                .Where(filePath => fileNames.Contains(Path.GetFileName(filePath)));
         }
 
         private void ApplyAction(Action<ProjectFactory> action)
@@ -756,27 +757,10 @@ namespace NuGet.CommandLine
                 nugetFramework = TargetFramework != null ? NuGetFramework.Parse(TargetFramework.FullName) : null;
             }
 
-            // Get the target file path
-            string targetPath = TargetPath;
-
-            // List of extensions to allow in the output path
-            var allowedOutputExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
-                ".dll",
-                ".exe",
-                ".xml",
-                ".winmd"
-            };
-
-            if (IncludeSymbols)
-            {
-                // Include pdbs for symbol packages
-                allowedOutputExtensions.Add(".pdb");
-            }
-
-            string projectOutputDirectory = Path.GetDirectoryName(targetPath);
-
+            string projectOutputDirectory = Path.GetDirectoryName(TargetPath);
             string targetFileName;
-            if (Directory.Exists(targetPath))
+
+            if (Directory.Exists(TargetPath))
             {
                 targetFileName = builder.Id;
             }
@@ -785,17 +769,23 @@ namespace NuGet.CommandLine
                 targetFileName = Path.GetFileNameWithoutExtension(TargetPath);
             }
 
-            // By default we add all files in the project's output directory
-            foreach (var file in GetFiles(projectOutputDirectory, targetFileName, allowedOutputExtensions, SearchOption.AllDirectories))
+            var outputFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
-                string extension = Path.GetExtension(file);
+                $"{targetFileName}.dll",
+                $"{targetFileName}.exe",
+                $"{targetFileName}.xml",
+                $"{targetFileName}.winmd"
+            };
 
-                // Only look at files we care about
-                if (!allowedOutputExtensions.Contains(extension))
-                {
-                    continue;
-                }
+            if (IncludeSymbols)
+            {
+                outputFileNames.Add($"{targetFileName}.pdb");
+                outputFileNames.Add($"{targetFileName}.dll.mdb");
+                outputFileNames.Add($"{targetFileName}.exe.mdb");
+            }
 
+            foreach (var file in GetFiles(projectOutputDirectory, outputFileNames, SearchOption.AllDirectories))
+            {
                 string targetFolder;
 
                 if (IsTool)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -77,7 +77,7 @@ namespace NuGet.CommandLine
         {
             LoadAssemblies(msbuildDirectory);
 
-            // create project            
+            // create project
             var project = Activator.CreateInstance(
                 _projectType,
                 path,
@@ -136,7 +136,7 @@ namespace NuGet.CommandLine
                     console.Verbosity = Verbosity.Quiet;
                     break;
                 }
-            }                
+            }
         }
 
         private string TargetPath
@@ -757,7 +757,7 @@ namespace NuGet.CommandLine
                 nugetFramework = TargetFramework != null ? NuGetFramework.Parse(TargetFramework.FullName) : null;
             }
 
-            string projectOutputDirectory = Path.GetDirectoryName(TargetPath);
+            var projectOutputDirectory = Path.GetDirectoryName(TargetPath);
             string targetFileName;
 
             if (Directory.Exists(TargetPath))

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -219,7 +219,7 @@ namespace NuGet.Commands
 
             if (!Directory.Exists(projectOutputDirectory))
             {
-                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnableToLocateBuildOutput, projectOutputDirectory));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnableToLocateBuildOutput, projectOutputDirectory));
             }
 
             var targetFramework = NuGetFramework.AnyFramework;

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -217,15 +217,13 @@ namespace NuGet.Commands
                 projectOutputDirectory = targetPath.Substring(0, targetPath.IndexOf(configFolderPath) + configFolderPath.Length);
             }
 
-            NuGetFramework targetFramework = NuGetFramework.AnyFramework;
-
-            var targetFileName = Path.GetFileNameWithoutExtension(targetPath);
-
             if (!Directory.Exists(projectOutputDirectory))
             {
                 throw new Exception("No build found in " + projectOutputDirectory + ". Use the -Build option or build the project.");
             }
 
+            NuGetFramework targetFramework = NuGetFramework.AnyFramework;
+            var targetFileName = Path.GetFileNameWithoutExtension(targetPath);
             var outputFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 $"{targetFileName}.dll",

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -219,10 +219,10 @@ namespace NuGet.Commands
 
             if (!Directory.Exists(projectOutputDirectory))
             {
-                throw new Exception("No build found in " + projectOutputDirectory + ". Use the -Build option or build the project.");
+                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_UnableToLocateBuildOutput, projectOutputDirectory));
             }
 
-            NuGetFramework targetFramework = NuGetFramework.AnyFramework;
+            var targetFramework = NuGetFramework.AnyFramework;
             var targetFileName = Path.GetFileNameWithoutExtension(targetPath);
             var outputFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/PackCommandRunner.cs
@@ -233,14 +233,14 @@ namespace NuGet.Commands
                 $"{targetFileName}.runtimeconfig.json"
             };
 
-            if (IncludeSymbols)
+            if (includeSymbols)
             {
                 outputFileNames.Add($"{targetFileName}.pdb");
                 outputFileNames.Add($"{targetFileName}.dll.mdb");
                 outputFileNames.Add($"{targetFileName}.exe.mdb");
             }
 
-            foreach (var file in GetFiles(projectOutputDirectory, targetFileName, outputFileNames))
+            foreach (var file in GetFiles(projectOutputDirectory, outputFileNames))
             {
                 var targetFolder = Path.GetDirectoryName(file).Replace(projectOutputDirectory + Path.DirectorySeparatorChar, "");
                 var packageFile = new PhysicalPackageFile
@@ -261,9 +261,9 @@ namespace NuGet.Commands
             }
         }
 
-        private static IEnumerable<string> GetFiles(string path, ISet<string> fileNames, SearchOption searchOption)
+        private static IEnumerable<string> GetFiles(string path, ISet<string> fileNames)
         {
-            return Directory.EnumerateFiles(path, "*", searchOption)
+            return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
                 .Where(filePath => fileNames.Contains(Path.GetFileName(filePath)));
         }
 

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -177,6 +177,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to No build found in {0}. Use the -Build option or build the project..
+        /// </summary>
+        public static string Error_UnableToLocateBuildOutput {
+            get {
+                return ResourceManager.GetString("Error_UnableToLocateBuildOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to The folder &apos;{0}&apos; does not contain a project to restore..
         /// </summary>
         public static string Error_UnableToLocateRestoreTarget {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -454,5 +454,6 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   </data>
   <data name="Error_UnableToLocateBuildOutput" xml:space="preserve">
     <value>No build found in {0}. Use the -Build option or build the project.</value>
+    <comment>{0} is the project output directory</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -452,4 +452,7 @@
     <value>usage: NuGet locals &lt;all | http-cache | global-packages | temp&gt; [--clear | -c | --list | -l]
 For more information, visit http://docs.nuget.org/docs/reference/command-line-reference</value>
   </data>
+  <data name="Error_UnableToLocateBuildOutput" xml:space="preserve">
+    <value>No build found in {0}. Use the -Build option or build the project.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1080,7 +1080,7 @@ namespace Proj2
         }
 
         [Fact]
-        public void PackCommand_IncludeDllSymbols()
+        public void PackCommand_IncludesDllSymbols()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -1138,7 +1138,7 @@ namespace Proj2
         }
 
         [Fact]
-        public void PackCommand_IncludeExeSymbols()
+        public void PackCommand_IncludesExeSymbols()
         {
             var nugetexe = Util.GetNuGetExePath();
 
@@ -1198,7 +1198,7 @@ public class B
         }
 
         [Fact]
-        public void PackCommand_IncludeDocCommentsXmlFile()
+        public void PackCommand_IncludesDocCommentsXmlFile()
         {
             var nugetexe = Util.GetNuGetExePath();
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1049,15 +1049,30 @@ namespace Proj2
                 var package = new OptimizedZipPackage(Path.Combine(proj2Directory, "proj2.0.0.0.symbols.nupkg"));
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
+
+                string proj1SymbolsFileName;
+                string proj2SymbolsFileName;
+
+                if (RuntimeEnvironmentHelper.IsMono)
+                {
+                    proj1SymbolsFileName = "proj1.dll.mdb";
+                    proj2SymbolsFileName = "proj2.dll.mdb";
+                }
+                else
+                {
+                    proj1SymbolsFileName = "proj1.pdb";
+                    proj2SymbolsFileName = "proj2.pdb";
+                }
+
                 Assert.Equal(
                     files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
-                        Path.Combine("lib", "net40", "proj1.pdb"),
+                        Path.Combine("lib", "net40", proj1SymbolsFileName),
                         Path.Combine("lib", "net40", "proj2.dll"),
-                        Path.Combine("lib", "net40", "proj2.pdb"),
+                        Path.Combine("lib", "net40", proj2SymbolsFileName),
                         Path.Combine("src", "proj1", "proj1_file1.cs"),
                         Path.Combine("src", "proj2", "proj2_file1.cs"),
                     });

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1124,7 +1124,7 @@ namespace Proj2
                 var files = package.GetFiles().Select(file => file.Path).ToArray();
                 Array.Sort(files);
 
-                string symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.dll.mdb" : "A.pdb";
+                var symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.dll.mdb" : "A.pdb";
 
                 Assert.Equal(
                     new string[]
@@ -1184,7 +1184,7 @@ public class B
                 var files = package.GetFiles().Select(file => file.Path).ToArray();
                 Array.Sort(files);
 
-                string symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.exe.mdb" : "A.pdb";
+                var symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.exe.mdb" : "A.pdb";
 
                 Assert.Equal(
                     new string[]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -415,14 +415,14 @@ namespace NuGet.CommandLine.Test
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                             Path.Combine("lib", "uap10.0", "a.dll"),
                             Path.Combine("native", "a.dll"),
                             Path.Combine("ref", "uap10.0", "a.dll"),
                             Path.Combine("runtimes", "win-x86", "lib", "uap10.0", "a.dll"),
-                    });
+                    },
+                    files);
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
             }
@@ -484,12 +484,12 @@ namespace NuGet.CommandLine.Test
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                             Path.Combine("lib", "native", id + ".dll"),
                             Path.Combine("lib", "uap10.0" , id + ".dll"),
-                    });
+                    },
+                    files);
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
             }
@@ -594,11 +594,11 @@ namespace NuGet.CommandLine.Test
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                             Path.Combine("lib", "native" ,id + ".dll")
-                    });
+                    },
+                    files);
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
             }
@@ -665,12 +665,12 @@ namespace NuGet.CommandLine.Test
                     Array.Sort(files);
 
                     Assert.Equal(
-                        files,
                         new string[]
                         {
-                        Path.Combine("contentFiles", "any", "any", "image.jpg"),
-                        Path.Combine("contentFiles", "cs", "net45", "code.cs"),
-                        });
+                            Path.Combine("contentFiles", "any", "any", "image.jpg"),
+                            Path.Combine("contentFiles", "cs", "net45", "code.cs"),
+                        },
+                        files);
 
                     Assert.Equal(
                         @"<contentFiles xmlns=""http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"">
@@ -775,13 +775,13 @@ namespace Proj2
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -867,11 +867,11 @@ namespace Proj1
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "netstandard1.3", "proj1.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -1065,7 +1065,6 @@ namespace Proj2
                 }
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
@@ -1075,7 +1074,188 @@ namespace Proj2
                         Path.Combine("lib", "net40", proj2SymbolsFileName),
                         Path.Combine("src", "proj1", "proj1_file1.cs"),
                         Path.Combine("src", "proj2", "proj2_file1.cs"),
-                    });
+                    },
+                    files);
+            }
+        }
+
+        [Fact]
+        public void PackCommand_IncludeDllSymbols()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var projDirectory = Path.Combine(workingDirectory, "A");
+
+                Util.CreateFile(
+                    projDirectory,
+                    "A.csproj",
+@"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='B.cs' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+                Util.CreateFile(
+                    projDirectory,
+                    "B.cs",
+@"public class B
+{
+    public int C { get; set; }
+}");
+
+                // Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    projDirectory,
+                    "pack A.csproj -build -symbols",
+                    waitForExit: true);
+                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+
+                // Assert
+                var package = new OptimizedZipPackage(Path.Combine(projDirectory, "A.0.0.0.symbols.nupkg"));
+                var files = package.GetFiles().Select(file => file.Path).ToArray();
+                Array.Sort(files);
+
+                string symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.dll.mdb" : "A.pdb";
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        Path.Combine("lib", "net40", "A.dll"),
+                        Path.Combine("lib", "net40", symbolsFileName),
+                        Path.Combine("src", "B.cs")
+                    },
+                    files);
+            }
+        }
+
+        [Fact]
+        public void PackCommand_IncludeExeSymbols()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var projDirectory = Path.Combine(workingDirectory, "A");
+
+                Util.CreateFile(
+                    projDirectory,
+                    "A.csproj",
+@"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>exe</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='B.cs' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+                Util.CreateFile(
+                    projDirectory,
+                    "B.cs",
+@"using System;
+
+public class B
+{
+    public static void Main() { }
+}");
+
+                // Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    projDirectory,
+                    "pack A.csproj -build -symbols",
+                    waitForExit: true);
+                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+
+                // Assert
+                var package = new OptimizedZipPackage(Path.Combine(projDirectory, "A.0.0.0.symbols.nupkg"));
+                var files = package.GetFiles().Select(file => file.Path).ToArray();
+                Array.Sort(files);
+
+                string symbolsFileName = RuntimeEnvironmentHelper.IsMono ? "A.exe.mdb" : "A.pdb";
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        Path.Combine("lib", "net40", "A.exe"),
+                        Path.Combine("lib", "net40", symbolsFileName),
+                        Path.Combine("src", "B.cs")
+                    },
+                    files);
+            }
+        }
+
+        [Fact]
+        public void PackCommand_IncludeDocCommentsXmlFile()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            using (var workingDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var projDirectory = Path.Combine(workingDirectory, "A");
+
+                Util.CreateFile(
+                    projDirectory,
+                    "A.csproj",
+@"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <DocumentationFile>out\A.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='B.cs' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+                Util.CreateFile(
+                    projDirectory,
+                    "B.cs",
+@"/// <summary>
+/// B
+/// </summary>
+public class B
+{
+    /// <summary>
+    /// C
+    /// </summary>
+    public int C { get; set; }
+}");
+
+                // Act
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    projDirectory,
+                    "pack A.csproj -build",
+                    waitForExit: true);
+                Assert.True(result.Item1 == 0, result.Item2 + " " + result.Item3);
+
+                // Assert
+                var package = new OptimizedZipPackage(Path.Combine(projDirectory, "A.0.0.0.nupkg"));
+                var files = package.GetFiles().Select(file => file.Path).ToArray();
+                Array.Sort(files);
+
+                Assert.Equal(
+                    new string[]
+                    {
+                        Path.Combine("lib", "net40", "A.dll"),
+                        Path.Combine("lib", "net40", "A.xml"),
+                    },
+                    files);
             }
         }
 
@@ -1170,23 +1350,23 @@ namespace Proj2
 
                 // proj3 and proj7 are included in the package.
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj3.dll"),
                         Path.Combine("lib", "net40", "proj7.dll")
-                    });
+                    },
+                    files);
 
                 // proj2 and proj6 are added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
                 Assert.Equal(
-                    dependencies,
                     new PackageDependency[]
                     {
                         new PackageDependency("proj2", VersionUtility.ParseVersionSpec("1.0.0")),
                         new PackageDependency("proj6", VersionUtility.ParseVersionSpec("2.0.0"))
                     },
+                    dependencies,
                     new PackageDepencyComparer());
             }
         }
@@ -1284,13 +1464,13 @@ namespace Proj2
 
                 // proj3 and proj7 are included in the package.
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj3.dll"),
                         Path.Combine("lib", "net40", "proj7.dll")
-                    });
+                    },
+                    files);
 
                 // proj2 and proj6 are added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
@@ -1394,23 +1574,23 @@ namespace Proj2
 
                 // proj3 and proj7 are included in the package.
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj3.dll"),
                         Path.Combine("lib", "net40", "proj7.dll")
-                    });
+                    },
+                    files);
 
                 // proj2 and proj6 are added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
                 Assert.Equal(
-                    dependencies,
                     new PackageDependency[]
                     {
                         new PackageDependency("proj2", VersionUtility.ParseVersionSpec("1.0.0")),
                         new PackageDependency("proj6", VersionUtility.ParseVersionSpec("2.0.0"))
                     },
+                    dependencies,
                     new PackageDepencyComparer());
             }
         }
@@ -1506,23 +1686,23 @@ namespace Proj2
 
                 // proj3 and proj7 are included in the package.
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj3.dll"),
                         Path.Combine("lib", "net40", "proj7.dll")
-                    });
+                    },
+                    files);
 
                 // proj2 and proj6 are added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
                 Assert.Equal(
-                    dependencies,
                     new PackageDependency[]
                     {
                         new PackageDependency("proj2", VersionUtility.ParseVersionSpec("1.0.0")),
                         new PackageDependency("proj6", VersionUtility.ParseVersionSpec("2.0.0"))
                     },
+                    dependencies,
                     new PackageDepencyComparer());
             }
         }
@@ -1619,12 +1799,12 @@ namespace Proj2
                 // proj2 and proj6 are added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
                 Assert.Equal(
-                    dependencies.OrderBy(d => d.ToString()),
                     new PackageDependency[]
                     {
                         new PackageDependency("proj2", VersionUtility.ParseVersionSpec("1.0.0")),
                         new PackageDependency(prefixTokenValue + "proj6", VersionUtility.ParseVersionSpec("2.0.0"))
                     }.OrderBy(d => d.ToString()),
+                    dependencies.OrderBy(d => d.ToString()),
                     new PackageDepencyComparer());
             }
         }
@@ -1679,20 +1859,20 @@ namespace Proj2
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll")
-                    });
+                    },
+                    files);
 
                 // proj2 is added as dependencies.
                 var dependencies = package.DependencySets.First().Dependencies.OrderBy(d => d.Id);
                 Assert.Equal(
-                    dependencies,
                     new PackageDependency[]
                     {
                         new PackageDependency("proj2", VersionUtility.ParseVersionSpec("1.2.0"))
                     },
+                    dependencies,
                     new PackageDepencyComparer());
             }
         }
@@ -1733,11 +1913,11 @@ namespace Proj2
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -1782,13 +1962,13 @@ namespace Proj2
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                        Path.Combine("lib", "net40", "proj1.dll"),
                        Path.Combine("lib", "net40", "proj2.dll"),
                        Path.Combine("lib", "net40", "proj3.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -1825,12 +2005,12 @@ namespace Proj2
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -1954,11 +2134,11 @@ namespace Proj2
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -2072,13 +2252,13 @@ namespace Proj2
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -2130,11 +2310,11 @@ namespace Proj2
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("Content", "package", "include.me")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -2869,13 +3049,13 @@ namespace Proj2
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -2993,13 +3173,13 @@ namespace Proj2
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll"),
                         Path.Combine("lib", "net40", "proj2.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -3394,7 +3574,7 @@ namespace Proj2
 
                 // Assert
                 var package = new OptimizedZipPackage(Path.Combine(proj1Directory, "proj1.0.0.0-alpha.nupkg"));
-                Assert.Equal(package.Version.ToString(), "0.0.0-alpha");
+                Assert.Equal("0.0.0-alpha", package.Version.ToString());
             }
         }
 
@@ -3998,12 +4178,12 @@ stuff \n <<".Replace("\r\n", "\n");
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                             Path.Combine("lib", "netcoreapp1.0", id + ".dll"),
                             Path.Combine("lib", "netcoreapp1.0", "win7-x64", id + ".dll"),
-                    });
+                    },
+                    files);
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
             }
@@ -4130,12 +4310,12 @@ stuff \n <<".Replace("\r\n", "\n");
                 var files = package.GetFiles().Select(f => f.Path).OrderBy(s => s).ToArray();
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                             Path.Combine("lib", "netcoreapp1.0" , dllName + extension),
                             Path.Combine("lib", "netcoreapp1.0", "win7-x64", dllName + extension),
-                    });
+                    },
+                    files);
 
                 Assert.False(r.Item2.Contains("Assembly outside lib folder"));
             }
@@ -4244,11 +4424,11 @@ stuff \n <<".Replace("\r\n", "\n");
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net46", "proj1.dll"),
-                    });
+                    },
+                    files);
             }
         }
 
@@ -4311,11 +4491,11 @@ stuff \n <<".Replace("\r\n", "\n");
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net46", "proj1.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -4377,11 +4557,11 @@ stuff \n <<".Replace("\r\n", "\n");
                 Array.Sort(files);
 
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("lib", "net46", "proj1.dll")
-                    });
+                    },
+                    files);
             }
         }
 
@@ -4510,12 +4690,12 @@ namespace Proj1
                 var files = package.GetFiles().Select(f => f.Path).ToArray();
                 Array.Sort(files);
                 Assert.Equal(
-                    files,
                     new string[]
                     {
                         Path.Combine("content", "proj1_file2.txt"),
                         Path.Combine("lib", "net40", "proj1.dll")
-                    });
+                    },
+                    files);
             }
         }
 


### PR DESCRIPTION
Fix NuGet/Home#3527.

In Mono symbols files are MDB's not PDB's.  Additionally, instead of using a PDB file naming convention of _fileNameWithoutExtension.pdb_ (e.g.:  a.pdb), MDB's use the convention _fileNameWithExtension.mdb_ (e.g.:  a.dll.mdb).

Also improve performance of `GetFiles(...)`.  Instead of traversing the file system `n` times where `n` is the number of allowed file extensions, traverse the file system once.
