### PR TITLE
Use the StreamReader properties on Process instead of events since you can miss output

### DIFF
--- a/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace NuGet.Test.Utility
 {
@@ -58,32 +59,13 @@ namespace NuGet.Test.Utility
             {
                 p = new Process();
 
-                p.OutputDataReceived += (o, e) =>
-                {
-                    if (e.Data != null)
-                    {
-                        output.AppendLine(e.Data);
-                    }
-                };
-
-                p.ErrorDataReceived += (o, e) =>
-                {
-                    if (e.Data != null)
-                    {
-                        errors.AppendLine(e.Data);
-                    }
-                };
-
                 p.StartInfo = psi;
                 p.Start();
 
-                p.BeginErrorReadLine();
-                p.BeginOutputReadLine();
+                var outputTask = ConsumeStreamReaderAsync(p.StandardOutput, output);
+                var errorTask = ConsumeStreamReaderAsync(p.StandardError, errors);
 
-                if (inputAction != null)
-                {
-                    inputAction(p.StandardInput);
-                }
+                inputAction?.Invoke(p.StandardInput);
 
                 if (waitForExit)
                 {
@@ -91,8 +73,9 @@ namespace NuGet.Test.Utility
                     var processExited = true;
                     p.WaitForExit();
 #else
-                    bool processExited = p.WaitForExit(timeOutInMilliseconds);
+                    var processExited = p.WaitForExit(timeOutInMilliseconds);
 #endif
+                    Task.WaitAll(outputTask, errorTask);
                     if (!processExited)
                     {
                         p.Kill();
@@ -117,6 +100,17 @@ namespace NuGet.Test.Utility
             }
 
             return new CommandRunnerResult(p, exitCode, output, errors);
+        }
+
+        private static async Task ConsumeStreamReaderAsync(StreamReader reader, LockedStringBuilder lines)
+        {
+            await Task.Yield();
+
+            string line;
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                lines.AppendLine(line);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/CommandRunner.cs
@@ -75,7 +75,6 @@ namespace NuGet.Test.Utility
 #else
                     var processExited = p.WaitForExit(timeOutInMilliseconds);
 #endif
-                    Task.WaitAll(outputTask, errorTask);
                     if (!processExited)
                     {
                         p.Kill();
@@ -87,6 +86,7 @@ namespace NuGet.Test.Utility
 
                     if (processExited)
                     {
+                        Task.WaitAll(outputTask, errorTask);
                         exitCode = p.ExitCode;
                     }
                 }

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.FuncTest
+{
+    public class CommandRunnerTest
+    {
+        [Fact]
+        public async Task Run_AlwaysCaptureStdout()
+        {
+            // Arrange
+            var tasks = Enumerable
+                .Range(0, 8)
+                .Select(taskIndex =>
+                {
+                    return Task.Run(() =>
+                    {
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            VerifyWithCommandRunner();
+                        }
+
+                        return true;
+                    });
+                })
+                .ToList();
+
+            // Act
+            var successes = await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.All(successes, Assert.True);
+        }
+
+        private static void VerifyWithCommandRunner()
+        {
+            // Arrange
+            var expected = Guid.NewGuid().ToString();
+
+            string fileName;
+            string args;
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                fileName = @"C:\Windows\System32\cmd.exe";
+                args = $"/c echo {expected}";
+            }
+            else
+            {
+                fileName = "/bin/echo";
+                args = expected;
+
+            }
+
+            // Act
+            var result = CommandRunner.Run(
+                fileName,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.Equal(0, result.Item1);
+            Assert.Contains(expected, result.Item2);
+        }
+    }
+}

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/CommandRunnerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Test.Utility;
@@ -38,6 +39,72 @@ namespace NuGet.CommandLine.FuncTest
 
             // Assert
             Assert.All(successes, Assert.True);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(4)]
+        [InlineData(8)]
+        [InlineData(16)]
+        [InlineData(32)]
+        [InlineData(64)]
+        public void Run_DoesNotHangWhenReadingLargeStdout(int outputSizeInKilobytes)
+        {
+            // Arrange
+            using (var testDirectory = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Write the line of the desired size.
+                var filePath = Path.Combine(testDirectory, "file.txt");
+                var expectedLineContent = new string('a', 14);
+                var expectedLine = expectedLineContent + "\r\n"; // a line that is 16 bytes long
+                var expectedLineCount = (1024 * outputSizeInKilobytes) / 16;
+                using (var fileStream = File.OpenWrite(filePath))
+                using (var fileWriter = new StreamWriter(fileStream, Encoding.ASCII))
+                {
+                    for (var i = 0; i < expectedLineCount; i++)
+                    {
+                        fileWriter.Write(expectedLine);
+                    }
+                }
+                
+                // Run a program that just reads a file to stdout.
+                string fileName;
+                string args;
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    fileName = @"C:\Windows\System32\cmd.exe";
+                    args = $"/c type {filePath}";
+                }
+                else
+                {
+                    fileName = "/bin/cat";
+                    args = filePath;
+                }
+
+                // Act
+                var result = CommandRunner.Run(
+                    fileName,
+                    Directory.GetCurrentDirectory(),
+                    args,
+                    waitForExit: true);
+
+                // Assert
+                Assert.Equal(0, result.Item1);
+
+                var actualLineCount = 0;
+                using (var stringReader = new StringReader(result.Item2))
+                {
+                    string actualLineContent;
+                    while ((actualLineContent = stringReader.ReadLine()) != null)
+                    {
+                        actualLineCount++;
+                        Assert.Equal(expectedLineContent, actualLineContent);
+                    }
+                }
+
+                Assert.Equal(expectedLineCount, actualLineCount);
+            }
         }
 
         private static void VerifyWithCommandRunner()

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/NuGet.CommandLine.FuncTest.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Caching\Tests\PopulatesDestinationFolderTest.cs" />
     <Compile Include="Caching\Tests\UsesGlobalPackagesFolderCopyTest.cs" />
     <Compile Include="Caching\Tests\AllowsMissingPackageOnSourceTest.cs" />
+    <Compile Include="CommandRunnerTest.cs" />
     <Compile Include="Commands\PushCommandTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
corefx issue: https://github.com/dotnet/corefx/issues/12219

This has been the cause of some test flakiness.

/cc @alpaix @emgarten @rohit21agrawal @drewgil @jainaashish @dtivel 
