### PR TITLE
Fix several glob/path bugs

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -61,7 +61,7 @@ namespace NuGet.Common
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*/", @"(.+/)*") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", "(.+/)*") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -58,7 +61,7 @@ namespace NuGet.Common
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*/", ".*") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", @"(.+/)*") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character
@@ -69,7 +72,7 @@ namespace NuGet.Common
                 pattern = pattern
                     .Replace("/", @"\\") // On Windows, / is treated the same as \.
                     .Replace(@"\.\*\*", @"\.[^\\.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*\\", ".*") //For recursive wildcards \**\, include the current directory.
+                    .Replace(@"\*\*\\", @"(.+\\)*") //For recursive wildcards \**\, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character
@@ -88,7 +91,7 @@ namespace NuGet.Common
         public static IEnumerable<SearchPathResult> PerformWildcardSearch(string basePath, string searchPath, bool includeEmptyDirectories, out string normalizedBasePath)
         {
             bool searchDirectory = false;
-            
+
             // If the searchPath ends with \ or /, we treat searchPath as a directory,
             // and will include everything under it, recursively
             if (IsDirectoryPath(searchPath))
@@ -173,17 +176,18 @@ namespace NuGet.Common
 
         internal static string NormalizeBasePath(string basePath, ref string searchPath)
         {
-            const string relativePath = @"..\";
+            string parentDirectoryPath = $"..{Path.DirectorySeparatorChar}";
+            string currentDirectoryPath = $".{Path.DirectorySeparatorChar}";
 
             // If no base path is provided, use the current directory.
-            basePath = String.IsNullOrEmpty(basePath) ? @".\" : basePath;
+            basePath = String.IsNullOrEmpty(basePath) ? currentDirectoryPath : basePath;
 
-            // If the search path is relative, transfer the ..\ portion to the base path. 
+            // If the search path is relative, transfer the parent directory portion to the base path.
             // This needs to be done because the base path determines the root for our enumeration.
-            while (searchPath.StartsWith(relativePath, StringComparison.OrdinalIgnoreCase))
+            while (searchPath.StartsWith(parentDirectoryPath, StringComparison.OrdinalIgnoreCase))
             {
-                basePath = Path.Combine(basePath, relativePath);
-                searchPath = searchPath.Substring(relativePath.Length);
+                basePath = Path.Combine(basePath, parentDirectoryPath);
+                searchPath = searchPath.Substring(parentDirectoryPath.Length);
             }
 
             return Path.GetFullPath(basePath);

--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/PackageBuilder.cs
@@ -605,7 +605,10 @@ namespace NuGet.Packaging
 
         public void AddFiles(string basePath, string source, string destination, string exclude = null)
         {
+            exclude = exclude?.Replace('\\', Path.DirectorySeparatorChar);
+
             List<PhysicalPackageFile> searchFiles = ResolveSearchPattern(basePath, source.Replace('\\', Path.DirectorySeparatorChar), destination, _includeEmptyDirectories).ToList();
+
             if (_includeEmptyDirectories)
             {
                 // we only allow empty directories which are under known root folders.
@@ -616,13 +619,12 @@ namespace NuGet.Packaging
             ExcludeFiles(searchFiles, basePath, exclude);
 
             // Don't throw if the exclude is what made this find no files. Adding files from
-            // project.json ends up calling this one file at a time where some may be filtered out.  
+            // project.json ends up calling this one file at a time where some may be filtered out.
             if (!PathResolver.IsWildcardSearch(source) && !PathResolver.IsDirectoryPath(source) && !searchFiles.Any() && string.IsNullOrEmpty(exclude))
             {
                 throw new FileNotFoundException(
                     String.Format(CultureInfo.CurrentCulture, NuGetResources.PackageAuthoring_FileNotFound, source));
             }
-
 
             Files.AddRange(searchFiles);
         }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ConcurrencyUtilitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CultureUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CultureUtilityTests.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Globalization;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.Common.Test

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ExceptionUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ExceptionUtilitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -1,4 +1,7 @@
-﻿using NuGet.Test.Utility;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Test.Utility;
 using System.IO;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NetworkProtocolUtilityTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
@@ -1,0 +1,701 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Common.Test
+{
+    public class PathResolverTests : IClassFixture<TestDirectoryFixture>
+    {
+        private TestDirectoryFixture _fixture;
+
+        public PathResolverTests(TestDirectoryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData("", false)]
+        [InlineData("*", true)]
+        [InlineData("a.*", true)]
+        [InlineData("*.b", true)]
+        [InlineData("*.*", true)]
+        [InlineData("a/b", false)]
+        [InlineData("a/b.*", true)]
+        [InlineData(@"a\b", false)]
+        [InlineData(@"a\b.*", true)]
+        [InlineData("**", true)]
+        [InlineData("**/a", true)]
+        [InlineData("**/*.a", true)]
+        [InlineData(@"**\a", true)]
+        [InlineData(@"**\*.a", true)]
+        [InlineData("?", false)]
+        [InlineData("[", false)]
+        public void PathResolver_IsWildcardSearch(string filter, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, PathResolver.IsWildcardSearch(filter));
+        }
+
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("/", false)]
+        [InlineData(@"\", false)]
+        [InlineData("a", false)]
+        [InlineData("a/", true)]
+        [InlineData("/a", false)]
+        [InlineData("/a/", true)]
+        public void PathResolver_IsDirectoryPath(string path, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, PathResolver.IsDirectoryPath(path));
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData(@"a\", true)]
+        [InlineData(@"\\a", false)]
+        [InlineData(@"\\a\", true)]
+        [InlineData(@"\\a\b", false)]
+        [InlineData(@"\\a\c\", true)]
+        [InlineData("C:", false)]
+        [InlineData(@"C:\a", false)]
+        [InlineData(@"C:\a\", true)]
+        [InlineData(@".\", true)]
+        [InlineData(@"..\", true)]
+        public void PathResolver_IsDirectoryPath_OnWindows(string path, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, PathResolver.IsDirectoryPath(path));
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData(@"a\", false)]
+        [InlineData(@"\\a", false)]
+        [InlineData(@"\\a\", false)]
+        [InlineData(@"\\a\b", false)]
+        [InlineData(@"\\a\c\", false)]
+        [InlineData("C:", false)]
+        [InlineData(@"C:\a", false)]
+        [InlineData(@"C:\a\", false)]
+        [InlineData(@".\", false)]
+        [InlineData(@"..\", false)]
+        public void PathResolver_IsDirectoryPath_OnMacOS(string path, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, PathResolver.IsDirectoryPath(path));
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData(@"a\", false)]
+        [InlineData(@"\\a", false)]
+        [InlineData(@"\\a\", false)]
+        [InlineData(@"\\a\b", false)]
+        [InlineData(@"\\a\c\", false)]
+        [InlineData("C:", false)]
+        [InlineData(@"C:\a", false)]
+        [InlineData(@"C:\a\", false)]
+        [InlineData(@".\", false)]
+        [InlineData(@"..\", false)]
+        public void PathResolver_IsDirectoryPath_OnLinux(string path, bool expectedResult)
+        {
+            Assert.Equal(expectedResult, PathResolver.IsDirectoryPath(path));
+        }
+
+        [Theory]
+        [InlineData("**")]
+        [InlineData("**/")]
+        [InlineData(@"**\")]
+        [InlineData("**/a/*.b")]
+        [InlineData(@"**\a\*.b")]
+        public void PathResolver_NormalizeWildcardForExcludedFiles_WithLeadingGlobstarReturnsWildcardAsIs(string wildcard)
+        {
+            var actualResult = PathResolver.NormalizeWildcardForExcludedFiles(_fixture.TestDirectoryPath, wildcard);
+
+            Assert.Equal(wildcard, actualResult);
+        }
+
+        [Fact]
+        public void PathResolver_NormalizeWildcardForExcludedFiles_HandlesLeadingOsSpecificParentPathReference()
+        {
+            var basePath = Path.Combine(_fixture.TestDirectoryPath, "dir1", "dir2");
+            var wildcard = string.Format("..{0}..{0}*", Path.DirectorySeparatorChar);
+            var expectedResult = string.Format("{0}{1}*", new DirectoryInfo(_fixture.TestDirectoryPath).FullName, Path.DirectorySeparatorChar);
+            var actualResult = PathResolver.NormalizeWildcardForExcludedFiles(basePath, wildcard);
+
+            Assert.Equal(expectedResult, actualResult);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatches_HandlesDotGlobstar()
+        {
+            var sources = GetPlatformSpecificPaths(new[] { ".{0}a{0}.c", ".{0}a{0}c", ".{0}.c", ".{0}c", "bc", "b.c", "c", ".c" });
+            var wildcards = new[] { ".**" };
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = GetPlatformSpecificPaths(new[] { ".c" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatches_HandlesGlobstarSlash()
+        {
+            var sources = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}de", "a{0}b{0}d", "a{0}b{0}de", "a{0}b{0}c{0}d", "a{0}b{0}c{0}de" });
+            var wildcards = GetPlatformSpecificPaths(new[] { "a{0}**{0}d" });
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}b{0}d", "a{0}b{0}c{0}d" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatches_WithGlobstarSlashFileNameMatchesFileName()
+        {
+            var sources = GetPlatformSpecificPaths(new[] { ".{0}c", "a{0}c", "a{0}bc", "bc" });
+            var wildcards = GetPlatformSpecificPaths(new[] { "**{0}c" });
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = GetPlatformSpecificPaths(new[] { ".{0}c", "a{0}c" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatches_HandlesGlobstar()
+        {
+            var sources = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}de", "a{0}b{0}d", "a{0}b{0}de", "a{0}b{0}c{0}d", "a{0}b{0}c{0}de" });
+            var wildcards = GetPlatformSpecificPaths(new[] { "a{0}**d" });
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}b{0}d", "a{0}b{0}c{0}d" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatchesHandlesStar()
+        {
+            var sources = GetPlatformSpecificPaths(new[] { "a{0}d", "a{0}de", "a{0}b{0}d", "a{0}b{0}de", "a{0}b{0}c{0}d", "a{0}b{0}c{0}de" });
+            var wildcards = GetPlatformSpecificPaths(new[] { "a{0}*{0}*{0}d" });
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = GetPlatformSpecificPaths(new[] { "a{0}b{0}c{0}d" });
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_GetMatches_HandlesQuestionMark()
+        {
+            var sources = new[] { "a", "ab", "abc", "ac", "adc" };
+            var wildcards = new[] { "a?c" };
+            var actualResults = PathResolver.GetMatches(sources, source => source, wildcards);
+            var expectedResults = new[] { "abc", "adc" };
+
+            Assert.Equal(expectedResults, actualResults);
+        }
+
+        [Fact]
+        public void PathResolver_FilterPackageFiles_HandlesWildcard()
+        {
+            var sources = new List<string>(GetPlatformSpecificPaths(new[] { "c", "a{0}c", "a{0}b{0}c", "a{0}d" }));
+            var wildcards = GetPlatformSpecificPaths(new[] { "**{0}c" });
+
+            PathResolver.FilterPackageFiles(sources, path => path, wildcards);
+
+            var expectedResults = GetPlatformSpecificPaths(new[] { "a{0}d" });
+            Assert.Equal(expectedResults, sources);
+        }
+
+        [Theory]
+        [InlineData("dir1/dir2")]
+        [InlineData(@"dir1\dir2")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryFindsNoMatchingFiles(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new string[] { }, actualFullPaths);
+        }
+
+        [Fact]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryFindsMatchingEmptyDirectory()
+        {
+            string normalizedBasePath;
+            var actualResults = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, "dir*", includeEmptyDirectories: true, normalizedBasePath: out normalizedBasePath);
+
+            Assert.Collection(actualResults, result =>
+            {
+                Assert.False(result.IsFile);
+
+                var expectedRelativePath = string.Format("{0}dir5", Path.DirectorySeparatorChar);
+                var actualRelativePath = result.Path.Substring(_fixture.TestDirectoryPath.Length);
+
+                Assert.Equal(expectedRelativePath, actualRelativePath);
+            });
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("dir1/dir2/")]
+        [InlineData(@"dir1\dir2\")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndTrailingSlashRecursivelyFindsAllMatchingFiles_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[]
+                {
+                    @"\dir1\dir2\file1.txt",
+                    @"\dir1\dir2\file2.txt",
+                    @"\dir1\dir2\dir3\file1.txt",
+                    @"\dir1\dir2\dir3\file2.txt"
+                }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("dir1/dir2/", new[]
+            {
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir2/dir3/file2.txt"
+            })]
+        [InlineData(@"dir1\dir2\", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndTrailingSlashRecursivelyFindsAllMatchingFiles_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("dir1/dir2/", new[]
+            {
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir2/dir3/file2.txt"
+            })]
+        [InlineData(@"dir1\dir2\", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndTrailingSlashRecursivelyFindsAllMatchingFiles_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Fact]
+        public void PathResolver_PerformWildcardSearch_WithFileNameFindsNoMatchingFile()
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, "file3.txt");
+
+            Verify(new string[] { }, actualFullPaths);
+        }
+
+        [Fact]
+        public void PathResolver_PerformWildcardSearch_WithFileNameFindsMatchingFile()
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, "file1.txt");
+
+            Verify(new[]
+                {
+                    $"{Path.DirectorySeparatorChar}file1.txt"
+                }, actualFullPaths);
+        }
+
+        [Fact]
+        public void PathResolver_PerformWildcardSearch_WithFileNamePatternFindsMatchingFiles()
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, "*.txt");
+
+            Verify(new[]
+                {
+                    $"{Path.DirectorySeparatorChar}file1.txt",
+                    $"{Path.DirectorySeparatorChar}file2.txt"
+                }, actualFullPaths);
+        }
+
+        [Fact]
+        public void PathResolver_PerformWildcardSearch_WithFileNamePatternFindsNoMatchingFile()
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, "*.dll");
+
+            Verify(new string[] { }, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("dir1/file2.txt")]
+        [InlineData(@"dir1\file2.txt")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndFileNameFindsMatchingFile_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[] { @"\dir1\file2.txt" }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("dir1/file2.txt", new[] { "/dir1/file2.txt" })]
+        [InlineData(@"dir1\file2.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndFileNameFindsMatchingFile_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("dir1/file2.txt", new[] { "/dir1/file2.txt" })]
+        [InlineData(@"dir1\file2.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryAndFileNameFindsMatchingFile_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("dir1/../file1.txt")]
+        [InlineData(@"dir1\..\file1.txt")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryRelativePathAndFileNameFindsMatchingFile_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[] { @"\dir1\..\file1.txt" }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("dir1/../file1.txt", new[] { "/dir1/../file1.txt" })]
+        [InlineData(@"dir1\..\file1.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryRelativePathAndFileNameFindsMatchingFile_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("dir1/../file1.txt", new[] { "/dir1/../file1.txt" })]
+        [InlineData(@"dir1\..\file1.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryRelativePathAndFileNameFindsMatchingFile_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("**/file1.txt")]
+        [InlineData(@"**\file1.txt")]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNameRecursivelyFindsAllMatchingFiles(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[]
+                {
+                    @"\file1.txt",
+                    @"\dir1\file1.txt",
+                    @"\dir1\dir2\file1.txt",
+                    @"\dir1\dir2\dir3\file1.txt",
+                    @"\dir1\dir4\file1.txt"
+                }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("**/file1.txt", new[]
+            {
+                "/file1.txt",
+                "/dir1/file1.txt",
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir4/file1.txt"
+            })]
+        [InlineData(@"**\file1.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNameRecursivelyFindsAllMatchingFiles_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("**/file1.txt", new[]
+            {
+                "/file1.txt",
+                "/dir1/file1.txt",
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir4/file1.txt"
+            })]
+        [InlineData(@"**\file1.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNameRecursivelyFindsAllMatchingFiles_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("**/*.txt")]
+        [InlineData(@"**\*.txt")]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[]
+                {
+                    @"\file1.txt",
+                    @"\file2.txt",
+                    @"\dir1\file1.txt",
+                    @"\dir1\file2.txt",
+                    @"\dir1\dir2\file1.txt",
+                    @"\dir1\dir2\file2.txt",
+                    @"\dir1\dir2\dir3\file1.txt",
+                    @"\dir1\dir2\dir3\file2.txt",
+                    @"\dir1\dir4\file1.txt",
+                    @"\dir1\dir4\file2.txt"
+                }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("**/*.txt", new[]
+            {
+                "/file1.txt",
+                "/file2.txt",
+                "/dir1/file1.txt",
+                "/dir1/file2.txt",
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir2/dir3/file2.txt",
+                "/dir1/dir4/file1.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"**\*.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("**/*.txt", new[]
+            {
+                "/file1.txt",
+                "/file2.txt",
+                "/dir1/file1.txt",
+                "/dir1/file2.txt",
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file1.txt",
+                "/dir1/dir2/dir3/file2.txt",
+                "/dir1/dir4/file1.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"**\*.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithGlobstarAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("dir1/**/file2.txt")]
+        [InlineData(@"dir1\**\file2.txt")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryGlobstarAndFileNameAtNonRootDirectoryRecursivelyFindsAllMatchingFiles_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[]
+                {
+                    @"\dir1\file2.txt",
+                    @"\dir1\dir2\file2.txt",
+                    @"\dir1\dir2\dir3\file2.txt",
+                    @"\dir1\dir4\file2.txt"
+                }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("dir1/**/file2.txt", new[]
+            {
+                "/dir1/file2.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file2.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"dir1\**\file2.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryGlobstarAndFileNameAtNonRootDirectoryRecursivelyFindsAllMatchingFiles_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("dir1/**/file2.txt", new[]
+            {
+                "/dir1/file2.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir2/dir3/file2.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"dir1\**\file2.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryGlobstarAndFileNameAtNonRootDirectoryRecursivelyFindsAllMatchingFiles_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("dir1/dir*/*.txt")]
+        [InlineData(@"dir1\dir*\*.txt")]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryPatternAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnWindows(string searchPath)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(new[]
+                {
+                    @"\dir1\dir2\file1.txt",
+                    @"\dir1\dir2\file2.txt",
+                    @"\dir1\dir4\file1.txt",
+                    @"\dir1\dir4\file2.txt"
+                }, actualFullPaths);
+        }
+
+        [Platform(Platform.Darwin)]
+        [Theory]
+        [InlineData("dir1/dir*/*.txt", new[]
+            {
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir4/file1.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"dir1\dir*\*.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryPatternAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnMacOs(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        [Platform(Platform.Linux)]
+        [Theory]
+        [InlineData("dir1/dir*/*.txt", new[]
+            {
+                "/dir1/dir2/file1.txt",
+                "/dir1/dir2/file2.txt",
+                "/dir1/dir4/file1.txt",
+                "/dir1/dir4/file2.txt"
+            })]
+        [InlineData(@"dir1\dir*\*.txt", new string[] { })]
+        public void PathResolver_PerformWildcardSearch_WithDirectoryPatternAndFileNamePatternRecursivelyFindsAllMatchingFiles_OnLinux(string searchPath, string[] expectedResults)
+        {
+            var actualFullPaths = PathResolver.PerformWildcardSearch(_fixture.TestDirectoryPath, searchPath);
+
+            Verify(expectedResults, actualFullPaths);
+        }
+
+        private void Verify(IEnumerable<string> expectedRelativePaths, IEnumerable<string> actualFullPaths)
+        {
+            var actualRelativePaths = actualFullPaths.Select(fullPath => fullPath.Substring(_fixture.TestDirectoryPath.Length));
+
+            Assert.Equal(expectedRelativePaths, actualRelativePaths);
+        }
+
+        private static IEnumerable<string> GetPlatformSpecificPaths(IEnumerable<string> platformUnspecificPaths)
+        {
+            return platformUnspecificPaths.Select(path => string.Format(path, Path.DirectorySeparatorChar));
+        }
+    }
+
+    /*
+    Test directory contents:
+
+        dir1
+            dir2
+                dir3
+                    file1.txt
+                    file2.txt
+                file1.txt
+                file2.txt
+            dir4
+                file1.txt
+                file2.txt
+            file1.txt
+            file2.txt
+        dir5
+        file1.txt
+        file2.txt
+    */
+    public sealed class TestDirectoryFixture : IDisposable
+    {
+        private DirectoryInfo _directory;
+
+        public string TestDirectoryPath
+        {
+            get { return _directory.FullName; }
+        }
+
+        public TestDirectoryFixture()
+        {
+            _directory = CreateTestDirectory();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _directory.Delete(recursive: true);
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+        }
+
+        private static DirectoryInfo CreateTestDirectory()
+        {
+            var rootDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var rootDirectory = Directory.CreateDirectory(rootDirectoryPath);
+            var directory1 = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, "dir1"));
+            var directory2 = Directory.CreateDirectory(Path.Combine(directory1.FullName, "dir2"));
+            var directory3 = Directory.CreateDirectory(Path.Combine(directory2.FullName, "dir3"));
+            var directory4 = Directory.CreateDirectory(Path.Combine(directory1.FullName, "dir4"));
+            var directory5 = Directory.CreateDirectory(Path.Combine(rootDirectory.FullName, "dir5"));
+
+            CreateTestFiles(rootDirectory);
+            CreateTestFiles(directory1);
+            CreateTestFiles(directory2);
+            CreateTestFiles(directory3);
+            CreateTestFiles(directory4);
+
+            return rootDirectory;
+        }
+
+        private static void CreateTestFiles(DirectoryInfo directory)
+        {
+            File.WriteAllText(Path.Combine(directory.FullName, "file1.txt"), string.Empty);
+            File.WriteAllText(Path.Combine(directory.FullName, "file2.txt"), string.Empty);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathResolverTests.cs
@@ -619,8 +619,10 @@ namespace NuGet.Common.Test
         private void Verify(IEnumerable<string> expectedRelativePaths, IEnumerable<string> actualFullPaths)
         {
             var actualRelativePaths = actualFullPaths.Select(fullPath => fullPath.Substring(_fixture.TestDirectoryPath.Length));
+            var expectedResults = expectedRelativePaths.OrderBy(path => path);
+            var actualResults = actualRelativePaths.OrderBy(path => path);
 
-            Assert.Equal(expectedRelativePaths, actualRelativePaths);
+            Assert.Equal(expectedResults, actualResults);
         }
 
         private static IEnumerable<string> GetPlatformSpecificPaths(IEnumerable<string> platformUnspecificPaths)

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PathValidatorTest.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using Xunit;
 
 namespace NuGet.Common

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ProjectJsonPathUtilitiesTests.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using NuGet.Test.Utility;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/UriUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/UriUtilityTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace NuGet.Common.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ExceptionAssert.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ExceptionAssert.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/FallbackPackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/FallbackPackagePathResolverTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Packaging.Core;
 using NuGet.Test.Utility;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestFileTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestFileTest.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
 using System.Linq;
 
 using Xunit;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestSchemaUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestSchemaUtilityTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using Xunit;
 
 namespace NuGet.Packaging.Test

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestTest.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/ManifestVersionUtilityTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Xml.Linq;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Xml.Linq;
 using NuGet.Versioning;
 using Xunit;
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageHelperTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageHelperTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace NuGet.Packaging.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackageIdValidatorTest.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
 
 namespace NuGet.Packaging.Test
 {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/StreamExtensions.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/StreamExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.IO;
 using System.Text;
 


### PR DESCRIPTION
Fix NuGet/Home#3526.
Fix NuGet/Home#3405.
Fix a bug with `PathResolver.NormalizeBasePath(...)` where `../` was unsupported on Unix-flavored operating systems.
Add >150 unit tests.
Add copyright headers to files.

@rrelyea @emgarten @joelverhagen @drewgil @alpaix @mishra14 @jainaashish @zhili1208 
