### PR TITLE
Skip restore when the dg file is empty

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -90,31 +90,35 @@ namespace NuGet.PackageManagement
                 }
             }
 
-            using (var cacheContext = new SourceCacheContext())
+            // Check if there are actual projects to restore before running.
+            if (dgSpec.Restore.Count > 0)
             {
-                var providers = new List<IPreLoadedRestoreRequestProvider>();
-                var providerCache = new RestoreCommandProvidersCache();
-                providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgSpec));
-
-                var sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
-
-                var restoreContext = new RestoreArgs
+                using (var cacheContext = new SourceCacheContext())
                 {
-                    CacheContext = cacheContext,
-                    LockFileVersion = LockFileFormat.Version,
-                    ConfigFile = null,
-                    DisableParallel = false,
-                    GlobalPackagesFolder = pathContext.UserPackageFolder,
-                    Log = referenceContext.Logger,
-                    MachineWideSettings = new XPlatMachineWideSetting(),
-                    PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider,
-                    Sources = sources.ToList()
-                };
+                    var providers = new List<IPreLoadedRestoreRequestProvider>();
+                    var providerCache = new RestoreCommandProvidersCache();
+                    providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgSpec));
 
-                var restoreSummaries = await RestoreRunner.Run(restoreContext);
-                
-                RestoreSummary.Log(referenceContext.Logger, restoreSummaries);
+                    var sourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings));
+
+                    var restoreContext = new RestoreArgs
+                    {
+                        CacheContext = cacheContext,
+                        LockFileVersion = LockFileFormat.Version,
+                        ConfigFile = null,
+                        DisableParallel = false,
+                        GlobalPackagesFolder = pathContext.UserPackageFolder,
+                        Log = referenceContext.Logger,
+                        MachineWideSettings = new XPlatMachineWideSetting(),
+                        PreLoadedRequestProviders = providers,
+                        CachingSourceProvider = sourceProvider,
+                        Sources = sources.ToList()
+                    };
+
+                    var restoreSummaries = await RestoreRunner.Run(restoreContext);
+
+                    RestoreSummary.Log(referenceContext.Logger, restoreSummaries);
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/DependencyGraphRestoreUtilityTests.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.ProjectManagement;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.Test
+{
+    public class DependencyGraphRestoreUtilityTests
+    {
+        [Fact]
+        public async Task DependencyGraphRestoreUtility_NoopIsRestoreRequiredAsyncTest()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+
+            using (var rootFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                projectFolder.Create();
+                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+
+                var sources = new List<string>
+                {
+                    "https://www.nuget.org/api/v2/"
+                };
+
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext());
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                var effectiveGlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(NullSettings.Instance);
+
+                var externalReferenceContext = new ExternalProjectReferenceContext(logger);
+
+                var projects = new List<IDependencyGraphProject>() { project };
+
+                var cache = await DependencyGraphProjectCacheUtility.CreateDependencyGraphProjectCache(
+                    projects,
+                    externalReferenceContext);
+
+                externalReferenceContext.ProjectCache = cache;
+
+                var pathContext = NuGetPathContext.Create(NullSettings.Instance);
+
+                // Act
+                var result = await DependencyGraphRestoreUtility.IsRestoreRequiredAsync(
+                    projects,
+                    forceRestore: false,
+                    pathContext: pathContext,
+                    referenceContext: externalReferenceContext);
+
+                // Assert
+                Assert.Equal(false, result);
+                Assert.Equal(0, logger.Errors);
+                Assert.Equal(0, logger.Warnings);
+                Assert.Equal(0, logger.MinimalMessages.Count);
+            }
+        }
+
+        [Fact]
+        public async Task DependencyGraphRestoreUtility_NoopRestoreTest()
+        {
+            // Arrange
+            var projectName = "testproj";
+            var logger = new TestLogger();
+
+            using (var rootFolder = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                projectFolder.Create();
+                var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+                var msbuildProjectPath = new FileInfo(Path.Combine(projectFolder.FullName, $"{projectName}.csproj"));
+
+                var sources = new List<string>
+                {
+                    "https://www.nuget.org/api/v2/"
+                };
+
+                var targetFramework = NuGetFramework.Parse("net46");
+
+                var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(targetFramework, new TestNuGetProjectContext());
+                var project = new TestMSBuildNuGetProject(msBuildNuGetProjectSystem, rootFolder, projectFolder.FullName);
+
+                var effectiveGlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(NullSettings.Instance);
+
+                var externalReferenceContext = new ExternalProjectReferenceContext(logger);
+
+                var projects = new List<IDependencyGraphProject>() { project };
+
+                // Act
+                await DependencyGraphRestoreUtility.RestoreAsync(
+                    projects,
+                    sources,
+                    NullSettings.Instance,
+                    externalReferenceContext);
+
+                // Assert
+                Assert.Equal(0, logger.Errors);
+                Assert.Equal(0, logger.Warnings);
+            }
+        }
+    }
+}


### PR DESCRIPTION
DependencyGraphRestoreUtility.RestoreAsync will now verify that there is restore work to do before calling into restore runner.

The only real change here is `if (dgSpec.Restore.Count > 0)` in RestoreAsync, this will skip passing the dg file to RestoreRunner if there is nothing to restore.

Ideally this would be checked up front but it looks like with the msbuild shell out project we don't have enough info to rule out a restore until the dg file is created. This can be improved once the CPS APIs are available.

Adding tests for DependencyGraphRestoreUtility scenarios where packages.config projects are passed in.

Fixes https://github.com/NuGet/Home/issues/3585

//cc @joelverhagen @alpaix @rohit21agrawal @drewgil @jainaashish 
