### PR TITLE
Adding PackageTargetFallback support for NETCore projects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -456,7 +456,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreGraphWalk"
-      DependsOnTargets="_GetProjectRestoreType;_GetRestoreTargetFrameworksOutput;_GenerateRestoreProjectSpec;_GenerateRestoreDependencies;_GetChildRestoreProjects"
+      DependsOnTargets="
+      _GetProjectRestoreType;
+      _GetRestoreTargetFrameworksOutput;
+      _GenerateRestoreProjectSpec;
+      _GenerateRestoreDependencies;
+      _GetChildRestoreProjects"
       Returns="@(_RestoreGraphEntry)">
 
     <!-- Output from dependency targets -->
@@ -494,6 +499,16 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="RestoreGraphItems"
         ItemName="_RestoreGraphEntry" />
     </GetRestorePackageReferencesTask>
+    
+    <!-- Write out target framework information -->
+    <ItemGroup Condition="  '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageTargetFallback)' != '' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
+        <Type>TargetFrameworkInformation</Type>
+        <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
+        <PackageTargetFallback>$(PackageTargetFallback)</PackageTargetFallback>
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </_RestoreGraphEntry>
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
@@ -275,7 +275,7 @@ namespace NuGet.ProjectModel
             }
         }
 
-        private static void SetImports(JObject json, IReadOnlyList<NuGetFramework> frameworks)
+        private static void SetImports(JObject json, IList<NuGetFramework> frameworks)
         {
             if (frameworks?.Any() == true)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -11,23 +11,18 @@ namespace NuGet.ProjectModel
     {
         public NuGetFramework FrameworkName { get; set; }
 
-        public IList<LibraryDependency> Dependencies { get; set; }
+        public IList<LibraryDependency> Dependencies { get; set; } = new List<LibraryDependency>();
 
         /// <summary>
         /// A fallback PCL framework to use when no compatible items
         /// were found for <see cref="FrameworkName"/>.
         /// </summary>
-        public IReadOnlyList<NuGetFramework> Imports { get; set; }
+        public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
         /// Display warnings when the Imports framework is used.
         /// </summary>
         public bool Warn { get; set; }
-
-        public TargetFrameworkInformation()
-        {
-            Dependencies = new List<LibraryDependency>();
-        }
 
         public override string ToString()
         {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1341,6 +1341,50 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task RestoreNetCore_SingleProjectWithPackageTargetFallback()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("lib/dnxcore50/a.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                // Add imports property
+                projectA.Properties.Add("PackageTargetFallback", "portable-net45+win8;dnxcore50");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+                var xTarget = projectA.AssetsFile.Targets.Single().Libraries.Single();
+
+                // Assert
+                Assert.Equal("lib/dnxcore50/a.dll", xTarget.CompileTimeAssemblies.Single());
+            }
+        }
+
+        [Fact]
         public async Task RestoreNetCore_SingleProject_SingleTFM()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -192,6 +192,111 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyImports()
+        {
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "OutputType", "netcore" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "PackageTargetFallback", "portable-net45+win8;dnxcore50;;" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(2, nsTFM.Imports.Count);
+                Assert.Equal(0, netTFM.Imports.Count);
+
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.Imports[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.Imports[1]);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyImportsEmpty()
+        {
+            using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "OutputType", "netcore" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(0, nsTFM.Imports.Count);
+                Assert.Equal(0, netTFM.Imports.Count);
+            }
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyRuntimes()
         {
             using (var workingDir = TestFileSystemUtility.CreateRandomTestFolder())


### PR DESCRIPTION
This change adds support for the PackageTargetFallback property in MSBuild projects, this will be used as a replacement for imports that project.json had.

Spec: https://github.com/NuGet/Home/wiki/PackageTargetFallback-(new-design-for-Imports)

Imports for tools will be done separately once it has been decided if they are needed.

I've made some minor changes to TargetFrameworkInformation to make the class more coherent.

Fixes https://github.com/NuGet/Home/issues/3494

//cc @joelverhagen @rrelyea @alpaix @dtivel @rohit21agrawal 
