### PR TITLE
Publish NuGet.VisualStudio nuget packages to build artifacts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -163,11 +163,11 @@ Invoke-BuildStep 'Building NuGet.Clients projects - VS14 Toolset' {
     -ev +BuildErrors
 
 Invoke-BuildStep 'Creating NuGet.Clients packages - VS14 Toolset' {
-        param($Configuration, $MSPFXPath)
-        Build-ClientsPackages $Configuration $ReleaseLabel $BuildNumber -ToolsetVersion 14 -KeyFile $MSPFXPath
+        param($Configuration, $MSPFXPath, $SkipILMerge)
+        Build-ClientsPackages $Configuration $ReleaseLabel $BuildNumber -ToolsetVersion 14 -KeyFile $MSPFXPath -SkipILMerge:$SkipILMerge
     } `
-    -args $Configuration, $MSPFXPath `
-    -skip:($Fast -or $SkipILMerge -or $SkipVS14) `
+    -args $Configuration, $MSPFXPath, $SkipILMerge `
+    -skip:($Fast -or $SkipVS14) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Creating the VS14 EndToEnd test package' {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -765,7 +765,7 @@ Function Build-ClientsPackages {
         [switch]$SkipILMerge
     )
 
-	$prereleaseNupkgVersion = "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
+    $prereleaseNupkgVersion = "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
     if ($ReleaseLabel -Ne 'rtm') {
         $releaseNupkgVersion = "$PackageReleaseVersion-$ReleaseLabel"
     } else {
@@ -845,10 +845,10 @@ Function Build-ClientsPackages {
 
 Function Build-NuGetPackage {
     param(
-		[string]$NuspecPath,
-		[string]$BasePath,
-		[string]$OutputDir,
-		[string]$Version
+        [string]$NuspecPath,
+        [string]$BasePath,
+        [string]$OutputDir,
+        [string]$Version
 	)
 
     $opts = 'pack', $NuspecPath

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -819,22 +819,19 @@ Function Build-ClientsPackages {
 		}
 		& $NuGetExe $opts
 	}
-	
+
 	# Pack the NuGet.VisualStudio project with the build number and release label.
 	$projectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.VisualStudio")
 	$projectNuspec = Join-Path $projectDir "NuGet.VisualStudio.nuspec"
 	$projectInputDir = [io.path]::combine($Artifacts, "NuGet.VisualStudio", "${ToolsetVersion}.0", "${Configuration}")
-	$projectInstallPs1 = Join-Path $projectDir "install.ps1"
-	
-	Copy-Item -Path "${projectInstallPs1}" -Destination "${projectInputDir}"
-	
+
 	$opts = 'pack', $projectNuspec
     $opts += '-BasePath', $projectInputDir
     $opts += '-OutputDirectory', $Nupkgs
-    $opts += '-Symbols'	
+    $opts += '-Symbols'
     $opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
-    & $NuGetExe $opts	
-	
+    & $NuGetExe $opts
+
 	# Pack the NuGet.VisualStudio project with just the release label.
 	$opts = 'pack', $projectNuspec
     $opts += '-BasePath', $projectInputDir

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -829,18 +829,18 @@ Function Build-ClientsPackages {
 
     Copy-Item -Path "${projectInstallPs1}" -Destination "${projectInputDir}"
 
-	Build-NuGetPackage `
-            -NuspecPath $projectNuspec `
-            -BasePath $projectInputDir `
-            -OutputDir $Nupkgs `
-            -Version $prereleaseNupkgVersion
+    Build-NuGetPackage `
+        -NuspecPath $projectNuspec `
+        -BasePath $projectInputDir `
+        -OutputDir $Nupkgs `
+        -Version $prereleaseNupkgVersion
 
     # Pack the NuGet.VisualStudio project with just the release label.
-	Build-NuGetPackage `
-            -NuspecPath $projectNuspec `
-            -BasePath $projectInputDir `
-            -OutputDir $ReleaseNupkgs `
-            -Version $releaseNupkgVersion
+    Build-NuGetPackage `
+        -NuspecPath $projectNuspec `
+        -BasePath $projectInputDir `
+        -OutputDir $ReleaseNupkgs `
+        -Version $releaseNupkgVersion
 }
 
 Function Build-NuGetPackage {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -824,6 +824,9 @@ Function Build-ClientsPackages {
     $projectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.VisualStudio")
     $projectNuspec = Join-Path $projectDir "NuGet.VisualStudio.nuspec"
     $projectInputDir = [io.path]::combine($Artifacts, "NuGet.VisualStudio", "${ToolsetVersion}.0", "${Configuration}")
+    $projectInstallPs1 = Join-Path $projectDir "install.ps1"
+
+    Copy-Item -Path "${projectInstallPs1}" -Destination "${projectInputDir}"
 
     $opts = 'pack', $projectNuspec
     $opts += '-BasePath', $projectInputDir

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -761,53 +761,83 @@ Function Build-ClientsPackages {
         [int]$BuildNumber = (Get-BuildNumber),
         [ValidateSet(14,15)]
         [int]$ToolsetVersion = $DefaultMSBuildVersion,
-        [string]$KeyFile
+        [string]$KeyFile,
+		[switch]$SkipILMerge
     )
 
-    $exeProjectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.CommandLine")
-    $exeProject = Join-Path $exeProjectDir "NuGet.CommandLine.csproj"
-    $exeNuspec = Join-Path $exeProjectDir "NuGet.CommandLine.nuspec"
-    $exeInputDir = [io.path]::combine($Artifacts, "NuGet.CommandLine", "${ToolsetVersion}.0", $Configuration)
-    $exeOutputDir = Join-Path $Artifacts "VS${ToolsetVersion}"
+	if (-not $SkipILMerge){
+		$exeProjectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.CommandLine")
+		$exeProject = Join-Path $exeProjectDir "NuGet.CommandLine.csproj"
+		$exeNuspec = Join-Path $exeProjectDir "NuGet.CommandLine.nuspec"
+		$exeInputDir = [io.path]::combine($Artifacts, "NuGet.CommandLine", "${ToolsetVersion}.0", $Configuration)
+		$exeOutputDir = Join-Path $Artifacts "VS${ToolsetVersion}"
 
-    # Build and pack the NuGet.CommandLine project with the build number and release label.
-    Build-ClientsProjectHelper `
-        -SolutionOrProject $exeProject `
-        -Configuration $Configuration `
-        -ReleaseLabel $ReleaseLabel `
-        -BuildNumber $BuildNumber `
-        -ToolsetVersion $ToolsetVersion `
-        -Rebuild
+		# Build and pack the NuGet.CommandLine project with the build number and release label.
+		Build-ClientsProjectHelper `
+			-SolutionOrProject $exeProject `
+			-Configuration $Configuration `
+			-ReleaseLabel $ReleaseLabel `
+			-BuildNumber $BuildNumber `
+			-ToolsetVersion $ToolsetVersion `
+			-Rebuild
 
-    Invoke-ILMerge `
-        -InputDir $exeInputDir `
-        -OutputDir $exeOutputDir `
-        -KeyFile $KeyFile
+		Invoke-ILMerge `
+			-InputDir $exeInputDir `
+			-OutputDir $exeOutputDir `
+			-KeyFile $KeyFile
 
-    $opts = 'pack', $exeNuspec
-    $opts += '-BasePath', $exeOutputDir
+		$opts = 'pack', $exeNuspec
+		$opts += '-BasePath', $exeOutputDir
+		$opts += '-OutputDirectory', $Nupkgs
+		$opts += '-Symbols'
+		$opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
+		& $NuGetExe $opts
+
+		# Build and pack the NuGet.CommandLine project with just the release label.
+		Build-ClientsProjectHelper `
+			-SolutionOrProject $exeProject `
+			-Configuration $Configuration `
+			-ReleaseLabel $ReleaseLabel `
+			-BuildNumber $BuildNumber `
+			-ToolsetVersion $ToolsetVersion `
+			-ExcludeBuildNumber `
+			-Rebuild
+
+		Invoke-ILMerge `
+			-InputDir $exeInputDir `
+			-OutputDir $exeOutputDir `
+			-KeyFile $KeyFile
+
+		$opts = 'pack', $exeNuspec
+		$opts += '-BasePath', $exeOutputDir
+		$opts += '-OutputDirectory', $ReleaseNupkgs
+		$opts += '-Symbols'
+		if ($ReleaseLabel -Ne 'rtm') {
+			$opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel"
+		} else {
+			$opts += '-Version', $PackageReleaseVersion
+		}
+		& $NuGetExe $opts
+	}
+	
+	# Pack the NuGet.VisualStudio project with the build number and release label.
+	$projectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.VisualStudio")
+	$projectNuspec = Join-Path $projectDir "NuGet.VisualStudio.nuspec"
+	$projectInputDir = [io.path]::combine($Artifacts, "NuGet.VisualStudio", "${ToolsetVersion}.0", "${Configuration}")
+	$projectInstallPs1 = Join-Path $projectDir "install.ps1"
+	
+	Copy-Item -Path "${projectInstallPs1}" -Destination "${projectInputDir}"
+	
+	$opts = 'pack', $projectNuspec
+    $opts += '-BasePath', $projectInputDir
     $opts += '-OutputDirectory', $Nupkgs
-    $opts += '-Symbols'
+    $opts += '-Symbols'	
     $opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
-    & $NuGetExe $opts
-
-    # Build and pack the NuGet.CommandLine project with just the release label.
-    Build-ClientsProjectHelper `
-        -SolutionOrProject $exeProject `
-        -Configuration $Configuration `
-        -ReleaseLabel $ReleaseLabel `
-        -BuildNumber $BuildNumber `
-        -ToolsetVersion $ToolsetVersion `
-        -ExcludeBuildNumber `
-        -Rebuild
-
-    Invoke-ILMerge `
-        -InputDir $exeInputDir `
-        -OutputDir $exeOutputDir `
-        -KeyFile $KeyFile
-
-    $opts = 'pack', $exeNuspec
-    $opts += '-BasePath', $exeOutputDir
+    & $NuGetExe $opts	
+	
+	# Pack the NuGet.VisualStudio project with just the release label.
+	$opts = 'pack', $projectNuspec
+    $opts += '-BasePath', $projectInputDir
     $opts += '-OutputDirectory', $ReleaseNupkgs
     $opts += '-Symbols'
     if ($ReleaseLabel -Ne 'rtm') {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -762,78 +762,78 @@ Function Build-ClientsPackages {
         [ValidateSet(14,15)]
         [int]$ToolsetVersion = $DefaultMSBuildVersion,
         [string]$KeyFile,
-		[switch]$SkipILMerge
+        [switch]$SkipILMerge
     )
 
-	if (-not $SkipILMerge){
-		$exeProjectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.CommandLine")
-		$exeProject = Join-Path $exeProjectDir "NuGet.CommandLine.csproj"
-		$exeNuspec = Join-Path $exeProjectDir "NuGet.CommandLine.nuspec"
-		$exeInputDir = [io.path]::combine($Artifacts, "NuGet.CommandLine", "${ToolsetVersion}.0", $Configuration)
-		$exeOutputDir = Join-Path $Artifacts "VS${ToolsetVersion}"
+    if (-not $SkipILMerge){
+        $exeProjectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.CommandLine")
+        $exeProject = Join-Path $exeProjectDir "NuGet.CommandLine.csproj"
+        $exeNuspec = Join-Path $exeProjectDir "NuGet.CommandLine.nuspec"
+        $exeInputDir = [io.path]::combine($Artifacts, "NuGet.CommandLine", "${ToolsetVersion}.0", $Configuration)
+        $exeOutputDir = Join-Path $Artifacts "VS${ToolsetVersion}"
 
-		# Build and pack the NuGet.CommandLine project with the build number and release label.
-		Build-ClientsProjectHelper `
-			-SolutionOrProject $exeProject `
-			-Configuration $Configuration `
-			-ReleaseLabel $ReleaseLabel `
-			-BuildNumber $BuildNumber `
-			-ToolsetVersion $ToolsetVersion `
-			-Rebuild
+        # Build and pack the NuGet.CommandLine project with the build number and release label.
+        Build-ClientsProjectHelper `
+            -SolutionOrProject $exeProject `
+            -Configuration $Configuration `
+            -ReleaseLabel $ReleaseLabel `
+            -BuildNumber $BuildNumber `
+            -ToolsetVersion $ToolsetVersion `
+            -Rebuild
 
-		Invoke-ILMerge `
-			-InputDir $exeInputDir `
-			-OutputDir $exeOutputDir `
-			-KeyFile $KeyFile
+        Invoke-ILMerge `
+            -InputDir $exeInputDir `
+            -OutputDir $exeOutputDir `
+            -KeyFile $KeyFile
 
-		$opts = 'pack', $exeNuspec
-		$opts += '-BasePath', $exeOutputDir
-		$opts += '-OutputDirectory', $Nupkgs
-		$opts += '-Symbols'
-		$opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
-		& $NuGetExe $opts
+        $opts = 'pack', $exeNuspec
+        $opts += '-BasePath', $exeOutputDir
+        $opts += '-OutputDirectory', $Nupkgs
+        $opts += '-Symbols'
+        $opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
+        & $NuGetExe $opts
 
-		# Build and pack the NuGet.CommandLine project with just the release label.
-		Build-ClientsProjectHelper `
-			-SolutionOrProject $exeProject `
-			-Configuration $Configuration `
-			-ReleaseLabel $ReleaseLabel `
-			-BuildNumber $BuildNumber `
-			-ToolsetVersion $ToolsetVersion `
-			-ExcludeBuildNumber `
-			-Rebuild
+        # Build and pack the NuGet.CommandLine project with just the release label.
+        Build-ClientsProjectHelper `
+            -SolutionOrProject $exeProject `
+            -Configuration $Configuration `
+            -ReleaseLabel $ReleaseLabel `
+            -BuildNumber $BuildNumber `
+            -ToolsetVersion $ToolsetVersion `
+            -ExcludeBuildNumber `
+            -Rebuild
 
-		Invoke-ILMerge `
-			-InputDir $exeInputDir `
-			-OutputDir $exeOutputDir `
-			-KeyFile $KeyFile
+        Invoke-ILMerge `
+            -InputDir $exeInputDir `
+            -OutputDir $exeOutputDir `
+            -KeyFile $KeyFile
 
-		$opts = 'pack', $exeNuspec
-		$opts += '-BasePath', $exeOutputDir
-		$opts += '-OutputDirectory', $ReleaseNupkgs
-		$opts += '-Symbols'
-		if ($ReleaseLabel -Ne 'rtm') {
-			$opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel"
-		} else {
-			$opts += '-Version', $PackageReleaseVersion
-		}
-		& $NuGetExe $opts
-	}
+        $opts = 'pack', $exeNuspec
+        $opts += '-BasePath', $exeOutputDir
+        $opts += '-OutputDirectory', $ReleaseNupkgs
+        $opts += '-Symbols'
+        if ($ReleaseLabel -Ne 'rtm') {
+            $opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel"
+        } else {
+            $opts += '-Version', $PackageReleaseVersion
+        }
+        & $NuGetExe $opts
+    }
 
-	# Pack the NuGet.VisualStudio project with the build number and release label.
-	$projectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.VisualStudio")
-	$projectNuspec = Join-Path $projectDir "NuGet.VisualStudio.nuspec"
-	$projectInputDir = [io.path]::combine($Artifacts, "NuGet.VisualStudio", "${ToolsetVersion}.0", "${Configuration}")
+    # Pack the NuGet.VisualStudio project with the build number and release label.
+    $projectDir = [io.path]::combine($NuGetClientRoot, "src", "NuGet.Clients", "NuGet.VisualStudio")
+    $projectNuspec = Join-Path $projectDir "NuGet.VisualStudio.nuspec"
+    $projectInputDir = [io.path]::combine($Artifacts, "NuGet.VisualStudio", "${ToolsetVersion}.0", "${Configuration}")
 
-	$opts = 'pack', $projectNuspec
+    $opts = 'pack', $projectNuspec
     $opts += '-BasePath', $projectInputDir
     $opts += '-OutputDirectory', $Nupkgs
     $opts += '-Symbols'
     $opts += '-Version', "$PackageReleaseVersion-$ReleaseLabel-$BuildNumber"
     & $NuGetExe $opts
 
-	# Pack the NuGet.VisualStudio project with just the release label.
-	$opts = 'pack', $projectNuspec
+    # Pack the NuGet.VisualStudio project with just the release label.
+    $opts = 'pack', $projectNuspec
     $opts += '-BasePath', $projectInputDir
     $opts += '-OutputDirectory', $ReleaseNupkgs
     $opts += '-Symbols'

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -14,8 +14,6 @@
     <CodeAnalysisRuleSet>..\..\..\NuGet.ruleset</CodeAnalysisRuleSet>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.xml</DocumentationFile>
   </PropertyGroup>
   <Choose>

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -98,9 +98,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="install.ps1">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="install.ps1" />
     <None Include="NuGet.VisualStudio.nuspec" />
     <None Include="project.json" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -18,6 +18,12 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Mono Release'">
+    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
+  </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '14.0'">
 	  <ItemGroup>
@@ -92,7 +98,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="install.ps1" />
+    <None Include="install.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="NuGet.VisualStudio.nuspec" />
     <None Include="project.json" />
   </ItemGroup>

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -15,14 +15,8 @@
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Mono Release'">
-    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.XML</DocumentationFile>
+  <PropertyGroup>
+    <DocumentationFile>$(OutputPath)\NuGet.VisualStudio.xml</DocumentationFile>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '14.0'">

--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.nuspec
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.nuspec
@@ -13,7 +13,7 @@
   </metadata>
   <files>
      <file src="NuGet.VisualStudio.dll" target="lib\net45\NuGet.VisualStudio.dll" />
-     <file src="NuGet.VisualStudio.XML" target="lib\net45\NuGet.VisualStudio.XML" />
+     <file src="NuGet.VisualStudio.xml" target="lib\net45\NuGet.VisualStudio.xml" />
      <file src="install.ps1" target="tools\install.ps1" />
   </files>
 </package>


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/3166

Is `dev` the correct target branch for this change?
- Ensured we copy the install.ps1 to the output path for NuGet.VisualStudio for packaging
- Ensured we create the NuGet.VisualStudio.XML doc on Release and MonoRelease build configurations for packaging
- Passing the -SkipILMerge switch as an argument to the Build-ClientsPackages function in `common.ps1` so we still create the NuGet.VisualStudio nupkg when skipping the ILMerge of NuGet.Commandline

Please review @joelverhagen
