### PR TITLE
Build script changes for SxS willow instances

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -18,10 +18,6 @@
     <ArtifactRoot>$(EnlistmentRoot)\artifacts</ArtifactRoot>
     <ArtifactRoot>$([System.IO.Path]::GetFullPath( $(ArtifactRoot) ))</ArtifactRoot>
 
-    <VisualStudioRegistryKey>HKEY_CURRENT_USER\Software\Microsoft\VisualStudio\$(VisualStudioVersion)_Config\InstallDir</VisualStudioRegistryKey>
-    <VisualStudioDefaultInstallDir>$(ProgramFiles)\Microsoft Visual Studio $(VisualStudioVersion)\Common7\IDE\</VisualStudioDefaultInstallDir>
-    <VisualStudioInstallDir>$([MSBuild]::GetRegistryValue($(VisualStudioRegistryKey), $(VisualStudioDefaultInstallDir))</VisualStudioInstallDir>
-
     <OutDirFx>$(VisualStudioVersion)\$(Configuration)\</OutDirFx>
     <OutputPath>$(ArtifactRoot)\$(MSBuildProjectName)\$(OutDirFx)</OutputPath>
     <OutputPath>$([System.IO.Path]::GetFullPath( $(OutputPath) ))\</OutputPath>

--- a/build/common.targets
+++ b/build/common.targets
@@ -1,13 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NuGet.MsBuild.Integration\build\Microsoft.NuGet.targets" 
-	Condition="!Exists('$(MSBuildBinPath)\..\Imports\Microsoft.Common.Props\ImportBefore\Microsoft.NuGet.ImportBefore.props')"  />
-	<Target Name="MakeNuGetReferencesPrivate" 
-		AfterTargets="ResolveNuGetPackageAssets"
-		Condition="Exists('$(MSBuildBinPath)\..\Imports\Microsoft.Common.Props\ImportBefore\Microsoft.NuGet.ImportBefore.props')">
-	  <ItemGroup>
-		<Reference Include="@(_ReferencesFromNuGetPackages)">
-		  <Private>True</Private>
-		</Reference>
-	  </ItemGroup>
-	</Target>
+  <Import Project="$(EnlistmentRoot)\packages\NuGet.MsBuild.Integration.3.1.0-beta-001\build\Microsoft.NuGet.targets"
+  Condition="!Exists('$(MSBuildBinPath)\..\Imports\Microsoft.Common.Props\ImportBefore\Microsoft.NuGet.ImportBefore.props')"  />
+  <Target Name="MakeNuGetReferencesPrivate"
+    AfterTargets="ResolveNuGetPackageAssets"
+    Condition="Exists('$(MSBuildBinPath)\..\Imports\Microsoft.Common.Props\ImportBefore\Microsoft.NuGet.ImportBefore.props')">
+    <ItemGroup>
+    <Reference Include="@(_ReferencesFromNuGetPackages)">
+      <Private>True</Private>
+    </Reference>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/configure.ps1
+++ b/configure.ps1
@@ -1,9 +1,7 @@
 <#
 .SYNOPSIS
-Configures NuGet.Client build environment.
-
-.PARAMETER ToolsetVersion
-Sets environment variables relevant to the desired VS toolset.
+Configures NuGet.Client build environment. Detects and initializes
+VS build toolsets. Configuration settings are stored at configure.json file.
 
 .PARAMETER CleanCache
 Cleans NuGet packages cache before build
@@ -15,16 +13,15 @@ Switch to force installation of required tools.
 Indicates the build script is invoked from CI
 
 .EXAMPLE
-Clean install using VS14 (default) toolset
 .\configure.ps1 -cc -v
+Clean repo build environment configuration
 
-Incremental install for VS15 toolset
-.\configure.ps1 -tv 15 -v
+.EXAMPLE
+.\configure.ps1 -v
+Incremental install of build tools
 #>
 [CmdletBinding(SupportsShouldProcess=$True)]
 Param (
-    [Alias('tv')]
-    [int]$ToolsetVersion = 14,
     [Alias('cc')]
     [switch]$CleanCache,
     [Alias('f')]
@@ -34,50 +31,139 @@ Param (
 
 . "$PSScriptRoot\build\common.ps1"
 
-Trace-Log "Configuring NuGet.Client build environment for VS${ToolsetVersion} Toolset"
+Trace-Log "Configuring NuGet.Client build environment"
 
-Update-SubModules -Force:$Force
+$BuildErrors = @()
 
-Install-NuGet -Force:$Force
+Invoke-BuildStep 'Configuring git repo' {
+    Update-SubModules -Force:$Force
+} -ev +BuildErrors
 
-Install-DotnetCLI -Force:$Force
+Invoke-BuildStep 'Installing NuGet.exe' {
+    Install-NuGet -Force:$Force
+} -ev +BuildErrors
 
-if ($CleanCache) {
+Invoke-BuildStep 'Installing .NET CLI' {
+    Install-DotnetCLI -Force:$Force
+} -ev +BuildErrors
+
+# Restoring tools required for build
+Invoke-BuildStep 'Restoring solution packages' {
+    Restore-SolutionPackages
+} -ev +BuildErrors
+
+Invoke-BuildStep 'Cleaning package cache' {
     Clear-PackageCache
+} -skip:(-not $CleanCache) -ev +BuildErrors
+
+$ConfigureObject = @{
+    BuildTools = @{}
+    Toolsets = @{}
 }
 
-Trace-Log "Validating VS${ToolsetVersion} toolset installation"
-
-$CommonToolsVar = "Env:VS${ToolsetVersion}0COMNTOOLS"
-if (Test-Path $CommonToolsVar) {
-    $CommonToolsValue = gci $CommonToolsVar | select -expand value -ea Ignore
-    Verbose-Log "Using environment variable `"$CommonToolsVar`" = `"$CommonToolsValue`""
-    $VisualStudioInstallDir = [System.IO.Path]::GetFullPath((Join-Path $CommonToolsValue '..\IDE'))
-}
-else {
-    $VisualStudioRegistryKey = "HKCU:\SOFTWARE\Microsoft\VisualStudio\${ToolsetVersion}.0_Config"
-    Verbose-Log "Retrieving Visual Studio installation path from registry '$VisualStudioRegistryKey'"
-
-    $VisualStudioInstallDir = gp $VisualStudioRegistryKey | select -expand InstallDir -ea Ignore
-    if (-not $VisualStudioInstallDir) {
-        Verbose-Log "Using default location of Visual Studio installation path"
-        $VisualStudioInstallDir = "${env:ProgramFiles}\Microsoft Visual Studio ${ToolsetVersion}.0\Common7\IDE\"
+Function New-BuildToolset {
+    param(
+        [int]$ToolsetVersion
+    )
+    $CommonToolsVar = "Env:VS${ToolsetVersion}0COMNTOOLS"
+    if (Test-Path $CommonToolsVar) {
+        $CommonToolsValue = gci $CommonToolsVar | select -expand value -ea Ignore
+        Verbose-Log "Using environment variable `"$CommonToolsVar`" = `"$CommonToolsValue`""
+        $ToolsetObject = @{
+            VisualStudioInstallDir = [System.IO.Path]::GetFullPath((Join-Path $CommonToolsValue '..\IDE'))
+        }
     }
+
+    if (-not $ToolsetObject) {
+        $VisualStudioRegistryKey = "HKCU:\SOFTWARE\Microsoft\VisualStudio\${ToolsetVersion}.0_Config"
+        if (Test-Path $VisualStudioRegistryKey) {
+            Verbose-Log "Retrieving Visual Studio installation path from registry '$VisualStudioRegistryKey'"
+            $ToolsetObject = @{
+                VisualStudioInstallDir = gp $VisualStudioRegistryKey | select -expand InstallDir -ea Ignore
+            }
+        }
+    }
+
+    if (-not $ToolsetObject -and $ToolsetVersion -gt 14) {
+        $WillowInstance = Get-ChildItem $env:ProgramData\Microsoft\VisualStudio\Packages\_Instances -filter state.json -recurse |
+            sort LastWriteTime |
+            select -last 1 |
+            Get-Content -raw |
+            ConvertFrom-Json
+
+        if ($WillowInstance) {
+            Verbose-Log "Using willow instance '$($WillowInstance.installationName)' installation path"
+            $ToolsetObject = @{
+                VisualStudioInstallDir = [System.IO.Path]::GetFullPath((Join-Path $WillowInstance.installationPath Common7\IDE\))
+            }
+        }
+    }
+
+    if (-not $ToolsetObject) {
+        $DefaultInstallDir = Join-Path $env:ProgramFiles "Microsoft Visual Studio ${ToolsetVersion}.0\Common7\IDE\"
+        if (Test-Path $DefaultInstallDir) {
+            Verbose-Log "Using default location of Visual Studio installation path"
+            $ToolsetObject = @{
+                $VisualStudioInstallDir = $DefaultInstallDir
+            }
+        }
+    }
+
+    if (-not $ToolsetObject) {
+        Warning-Log "Toolset VS${ToolsetVersion} is not found."
+    }
+
+    # return toolset build configuration object
+    $ToolsetObject
 }
 
-Resolve-Path $VisualStudioInstallDir | Out-Null
+$MSBuildDefaultRoot = Join-Path ${env:ProgramFiles(x86)} MSBuild
+$MSBuildRelativePath = 'bin\msbuild.exe'
 
-Verbose-Log "VisualInstallDir = '$VisualStudioInstallDir'"
-
-if ($ToolsetVersion -eq 15) {
-    $MSBuildDefaultRoot = Get-MSBuildRoot 15 -Default
-    $VSToolsPath = Join-Path $MSBuildDefaultRoot 'Microsoft\VisualStudio\v15.0'
-    $Targets = Join-Path $VSToolsPath 'VSSDK\Microsoft.VsSDK.targets'
-    if (-not (Test-Path $Targets)) {
-        Warning-Log "VSSDK is not found at default location '$VSToolsPath'. Attempting to override."
-        # Attempting to fix VS SDK path for VS15 willow install builds
-        # as MSBUILD failes to resolve it correctly
-        $env:VSToolsPath = Join-Path $VisualStudioInstallDir '..\..\MSBuild\Microsoft\VisualStudio\v15.0' -Resolve
-        Trace-Log "VSToolsPath now is '${env:VSToolsPath}'"
+Invoke-BuildStep 'Validating VS14 toolset installation' {
+    $vs14 = New-BuildToolset 14
+    if ($vs14) {
+        $ConfigureObject.Toolsets.Add('vs14', $vs14)
+        $script:MSBuildExe = Join-Path $MSBuildDefaultRoot "14.0\${MSBuildRelativePath}"
     }
+} -ev +BuildErrors
+
+Invoke-BuildStep 'Validating VS15 toolset installation' {
+    $vs15 = New-BuildToolset 15
+    if ($vs15) {
+        $ConfigureObject.Toolsets.Add('vs15', $vs15)
+        $WillowMSBuild = Join-Path $vs15.VisualStudioInstallDir ..\..\MSBuild
+        $script:MSBuildExe = switch (Test-Path $WillowMSBuild) {
+            $True { Join-Path $WillowMSBuild "15.0\${MSBuildRelativePath}" }
+            $False { Join-Path $MSBuildDefaultRoot "15.0\${MSBuildRelativePath}" }
+        }
+
+        # Hack VSSDK path
+        $VSToolsPath = Join-Path $MSBuildDefaultRoot 'Microsoft\VisualStudio\v15.0'
+        $Targets = Join-Path $VSToolsPath 'VSSDK\Microsoft.VsSDK.targets'
+        if (-not (Test-Path $Targets)) {
+            Warning-Log "VSSDK is not found at default location '$VSToolsPath'. Attempting to override."
+            # Attempting to fix VS SDK path for VS15 willow install builds
+            # as MSBUILD failes to resolve it correctly
+            $VSToolsPath = Join-Path $vs15.VisualStudioInstallDir '..\..\MSBuild\Microsoft\VisualStudio\v15.0' -Resolve
+            $ConfigureObject.Add('EnvVars', @{ VSToolsPath = $VSToolsPath })
+        }
+    }
+} -ev +BuildErrors
+
+if ($MSBuildExe) {
+    $MSBuildExe = [System.IO.Path]::GetFullPath($MSBuildExe)
+    $MSBuildVersion = & $MSBuildExe '/version' '/nologo'
+    Trace-Log "Using MSBUILD version $MSBuildVersion found at '$MSBuildExe'"
+    $ConfigureObject.BuildTools.Add('MSBuildExe', $MSBuildExe)
+}
+
+New-Item $Artifacts -ItemType Directory -ea Ignore | Out-Null
+$ConfigureObject | ConvertTo-Json | Set-Content $ConfigureJson
+
+Trace-Log "Configuration data has been written to '$ConfigureJson'"
+
+if ($BuildErrors) {
+    $ErrorLines = $BuildErrors | %{ ">>> $($_.Exception.Message)" }
+    Write-Error "Build's completed with $($BuildErrors.Count) error(s):`r`n$($ErrorLines -join "`r`n")" -ErrorAction Stop
 }

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -85,74 +85,53 @@ if (-not $SkipVS15 -and -not $VS15Installed) {
 
 $BuildErrors = @()
 
-# Restoring tools required for build
-Invoke-BuildStep 'Restoring solution packages' { Restore-SolutionPackages } `
-    -skip:$SkipRestore `
-    -ev +BuildErrors
-
 Invoke-BuildStep 'Running NuGet.Core unit-tests' {
-        param($Configuration)
         Test-CoreProjects $Configuration
     } `
-    -args $Configuration `
     -skip:($SkipXProj -or $SkipUnitTests) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Running NuGet.Core functional tests' {
-        param($Configuration)
         Test-FuncCoreProjects $Configuration
     } `
-    -args $Configuration `
     -skip:($SkipXProj -or $SkipFuncTests) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Building NuGet.Clients projects - VS14 Toolset' {
-        param($Configuration, $ReleaseLabel, $BuildNumber)
-        Build-ClientsProjects $Configuration $ReleaseLabel $BuildNumber -ToolsetVersion 14
+        Build-ClientsProjects $Configuration $DefaultReleaseLabel $BuildNumber -ToolsetVersion 14
     } `
-    -args $Configuration, $DefaultReleaseLabel, $BuildNumber `
     -skip:$SkipVS14 `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Running NuGet.Clients unit-tests - VS14 Toolset' {
-        param($Configuration)
         Test-ClientsProjects $Configuration -ToolsetVersion 14
     } `
-    -args $Configuration `
     -skip:($SkipVS14 -or $SkipUnitTests) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Running NuGet.Clients functional tests - VS14 Toolset' {
-        param($Configuration)
         Test-FuncClientsProjects $Configuration -ToolsetVersion 14
     } `
-    -args $Configuration `
     -skip:($SkipVS14 -or $SkipFuncTests) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Building NuGet.Clients projects - VS15 Toolset' {
-        param($Configuration, $ReleaseLabel, $BuildNumber)
-        Build-ClientsProjects $Configuration $ReleaseLabel $BuildNumber -ToolsetVersion 15
+        Build-ClientsProjects $Configuration $DefaultReleaseLabel $BuildNumber -ToolsetVersion 15
     } `
-    -args $Configuration, $DefaultReleaseLabel, $BuildNumber `
     -skip:$SkipVS15 `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Running NuGet.Clients tests - VS15 Toolset' {
-        param($Configuration)
         # We don't run command line tests on VS15 as we don't build a nuget.exe for this version
         Test-ClientsProjects $Configuration -ToolsetVersion 15 -SkipProjects 'NuGet.CommandLine.Test'
     } `
-    -args $Configuration `
     -skip:($SkipVS15 -or $SkipUnitTests) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Running NuGet.Clients functional tests - VS15 Toolset' {
-        param($Configuration)
         # We don't run command line tests on VS15 as we don't build a nuget.exe for this version
         Test-FuncClientsProjects $Configuration -ToolsetVersion 15 -SkipProjects 'NuGet.CommandLine.FuncTest'
     } `
-    -args $Configuration `
     -skip:($SkipVS15 -or $SkipFuncTests) `
     -ev +BuildErrors
 

--- a/scripts/cibuild/CreateEndToEndTestPackage.ps1
+++ b/scripts/cibuild/CreateEndToEndTestPackage.ps1
@@ -48,6 +48,9 @@ $opts = '/s', '/z', '/r:3', '/w:30', '/np', '/nfl'
 if ($VerbosePreference) {
     $opts += '/v'
 }
+else {
+    $opts += '/ndl', '/njs'
+}
 
 try {
     $TestSource = Join-Path $NuGetRoot test\EndToEnd -Resolve
@@ -71,10 +74,11 @@ try {
 
     $TestPackage = Join-Path $OutputDirectory EndToEnd.zip
     Write-Verbose "Creating test package '$TestPackage'"
+    Remove-Item $TestPackage -Force -ea Ignore | Out-Null
     New-ZipArchive $WorkingDirectory $TestPackage
 
     Write-Output "Created end-to-end test package for toolset '${ToolsetVersion}.0' at '$TestPackage'"
 }
 finally {
-    rm $workingDirectory -r -force -WhatIf:$false
+    rm $workingDirectory -r -Force -WhatIf:$false
 }

--- a/scripts/utils/UpdateNuGetVersion.ps1
+++ b/scripts/utils/UpdateNuGetVersion.ps1
@@ -58,9 +58,6 @@ Write-Output "Updating NuGet version [$OldVersion => $NewVersion]"
 gci -r project.json | %{ $_.FullName } | ReplaceTextInFiles -old $OldVersion -new $NewVersion
 
 $miscFiles = @(
-    "src\NuGet.Clients\NuGet.CommandLine\NuGet.CommandLine.nuspec"
-    "src\NuGet.Clients\VsExtension\source.extension.dev14.vsixmanifest",
-    "src\NuGet.Clients\VsExtension\source.extension.dev15.vsixmanifest",
     "src\NuGet.Clients\VsExtension\NuGetPackage.cs",
     "build\common.props",
     "build\common.ps1",

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\Build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\Build\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProjectGuid>{306CDDFA-FF0B-4299-930C-9EC6C9308160}</ProjectGuid>
@@ -18,13 +18,27 @@
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '14.0'">
-	  <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"/>
-	  </ItemGroup>
-	</When>
-	<When Condition="'$(VisualStudioVersion)' == '15.0'">
-	  <ItemGroup>
-		<Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"/>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.14.1.127-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="'$(VisualStudioVersion)' == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+        <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.183-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <EmbedInteropTypes>True</EmbedInteropTypes>
+        </Reference>
       </ItemGroup>
     </When>
   </Choose>
@@ -36,34 +50,12 @@
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-  <Choose>
-    <When Condition="$(VisualStudioVersion)=='14.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.14.1.127-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
-          <EmbedInteropTypes>True</EmbedInteropTypes>
-        </Reference>
-      </ItemGroup>
-    </When>
-    <When Condition="$(VisualStudioVersion)=='15.0'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.183-pre\lib\net451\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
-          <EmbedInteropTypes>True</EmbedInteropTypes>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <ItemGroup>
     <Reference Include="Microsoft.Build">
       <HintPath>$(MSBuildToolsPath)\Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Microsoft.VisualStudio.VCProjectEngine">
-      <HintPath>$(VisualStudioInstallDir)PublicAssemblies\Microsoft.VisualStudio.VCProjectEngine.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/NuGet.Clients/VsExtension/VsExtension.csproj
+++ b/src/NuGet.Clients/VsExtension/VsExtension.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug'">
     <StartAction>Program</StartAction>
-    <StartProgram>$(VisualStudioInstallDir)\Common7\IDE\devenv.exe</StartProgram>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp /log</StartArguments>
     <CreateVsixContainer>True</CreateVsixContainer>
     <DeployExtension>True</DeployExtension>
@@ -230,13 +230,13 @@
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '14.0'">
-	  <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"/>
-	  </ItemGroup>
-	</When>
-	<When Condition="'$(VisualStudioVersion)' == '15.0'">
-	  <ItemGroup>
-		<Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"/>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(VisualStudioVersion)' == '15.0'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
       </ItemGroup>
     </When>
   </Choose>

--- a/src/NuGet.Clients/VsExtension/source.extension.vs14.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vs14.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="3.6.0" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.0d421874-a3b2-4f67-b53a-ecfce878063b" Version="99.99.99" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 2015</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Icon>Resources/nuget_96.png</Icon>

--- a/src/NuGet.Clients/VsExtension/source.extension.vs15.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vs15.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="3.6.0" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="99.99.99" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 15</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <Icon>Resources/nuget_96.png</Icon>


### PR DESCRIPTION
Sharing build script changes to support development in SxS willow environment.

`configure.ps1` script is now able to identify the latest willow instance and deduce VS install dir and msbuild path. Configuration parameters are store in `artifacts\configure.json` file so that build or test script don't need to run in the same PS session.

Fixed VC++ project system interop assembly dependency.

Optional. Set VSIX version in manifest to 3.6.99.99 to be able to publish locally built extension to experimental instance. Otherwise this fails due to version conflict. This change is safe as CI overwrites the version string in the manifest on S&P build step.

//cc @rohit21agrawal @emgarten @joelverhagen @drewgil @rrelyea @jainaashish 
