### PR TITLE
fix nuget.build.tasks.pack nupkg to not have lib folder

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>NuGet.Build.Tasks.Pack</id>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>NuGet 3 pack for dotnet CLI</description>
+  </metadata>
+  <files>
+      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\net45\*.dll" target="buildCrossTargeting\Desktop\" />
+      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\netstandard1.3\*.dll" target="buildCrossTargeting\CoreCLR\" />
+      <file src="Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
+      <file src="Pack.targets" target="build\NuGet.Build.Tasks.Pack.targets" />
+  </files>
+</package>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/3557

We actually don't need an output folder at all (tools or lib), so this fixes the script and adds a nuspec file to do just that.

Note that we are not generating symbols nupkg right now, we'll fix this when eventually pack3 replaces the dotnet pack we use currently in our projects.

CC: @alpaix @emgarten 
