### PR TITLE
Unload AppDomain on a thread pool thread

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RuntimeHelpers.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RuntimeHelpers.cs
@@ -45,7 +45,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             finally
             {
-                AppDomain.Unload(domain);
+                QueueUnloadAndForget(domain);
             }
         }
 
@@ -200,6 +200,20 @@ namespace NuGet.PackageManagement.VisualStudio
         private static string ConvertToHexString(byte[] data)
         {
             return new SoapHexBinary(data).ToString();
+        }
+
+        private static void QueueUnloadAndForget(AppDomain domain)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    AppDomain.Unload(domain);
+                }
+                catch (Exception)
+                {
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Fix NuGet/Home#3491.

Move `AppDomain.Unload(...)` off of the main thread to a thread pool thread.

@rrelyea @emgarten @joelverhagen @drewgil @alpaix @mishra14 @jainaashish @zhili1208 @rohit21agrawal
