### PR TITLE
add ability to specify output folder for build output in nupkg along with other fixes

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.nuspec
@@ -8,8 +8,8 @@
     <description>NuGet 3 pack for dotnet CLI</description>
   </metadata>
   <files>
-      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\net45\*.dll" target="buildCrossTargeting\Desktop\" />
-      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\netstandard1.3\*.dll" target="buildCrossTargeting\CoreCLR\" />
+      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\net45\*.dll" target="Desktop\" />
+      <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack\bin\$configuration$\netstandard1.3\*.dll" target="CoreCLR\" />
       <file src="Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
       <file src="Pack.targets" target="build\NuGet.Build.Tasks.Pack.targets" />
   </files>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -12,8 +12,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NugetTaskAssemblyFile) -->
   <PropertyGroup Condition="$(NugetTaskAssemblyFile) == ''">
-    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">CoreCLR\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
-    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">Desktop\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
+    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
+    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
   </PropertyGroup>
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NugetTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackNuspecTask" AssemblyFile="$(NugetTaskAssemblyFile)" />
@@ -23,9 +23,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
     <PackageOutputPath Condition=" '$(PackageOutputPath)' == '' ">$(TargetDir)</PackageOutputPath>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
-    <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFilesFromReferencedProjects; _GetSourceFilesForSymbols; _GetTargetPaths</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFiles</GenerateNuspecDependsOn>
     <Description Condition="'$(Description)'==''">Package Description</Description>
     <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
+    <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
+    <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>
+    <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -40,7 +43,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackDependsOn>PackUsingNuspec</PackDependsOn>
   </PropertyGroup>
   <ItemGroup>
-    <_TargetFrameworks Include="$(TargetFrameworks.Split(';'))"></_TargetFrameworks>
+    <_TargetFrameworks Condition="'$(TargetFramework)' == ''" Include="$(TargetFrameworks.Split(';'))"/>
+    <_TargetFrameworks Condition="'$(TargetFramework)' != ''" Include="$(TargetFramework)"/>
   </ItemGroup>
   
   <!--
@@ -63,7 +67,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup Condition="$(ContinuePackingAfterGeneratingNuspec) == '' ">
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
     </PropertyGroup>
-    <Message Text="In target GenerateNuspec with value of the boolean ContinuePackingAfterGeneratingNuspec: $(ContinuePackingAfterGeneratingNuspec)" Importance="High" />
     <!-- Call Pack -->
     <PackTask PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
@@ -80,7 +83,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ReleaseNotes="$(PackageReleaseNotes)"
               Tags="$(PackageTags)"
               Configuration="$(Configuration)"
-              TargetPaths="@(_TargetPaths)"
+              TargetPathsToAssemblies="@(_TargetPathsToAssemblies)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
               AssemblyName="$(AssemblyName)"
               ProjectReferences="@(_ProjectReferences)"
@@ -99,13 +103,9 @@ Copyright (c) .NET Foundation. All rights reserved.
               AssemblyReferences="@(_References)"
               PackageReferences="@(_PackageReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
-              NuspecOutputPath="$(IntermediateOutputPath)"/>
-  </Target>
-
-  <Target Name="_GetTargetPaths">
-    <ItemGroup>
-      <_TargetPaths Include="$(TargetDir)%(_TargetFrameworks.Identity)\$(TargetFileName)"/>
-    </ItemGroup>
+              NuspecOutputPath="$(BaseIntermediateOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"/>
   </Target>
   <!--
     ============================================================
@@ -129,7 +129,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
       Targets="_GetProjectToProjectReferences"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity)
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
               %(_MSBuildProjectReferenceExistent.SetConfiguration);
               %(_MSBuildProjectReferenceExistent.SetPlatform);
               BuildProjectReferences=false;"
@@ -139,11 +139,56 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_ProjectReferences" />
     </MSBuild>
+
+    <MSBuild
+      Condition="'$(IncludeBuildOutput)' == 'true'"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="BuiltProjectOutputGroup"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+              %(_MSBuildProjectReferenceExistent.SetConfiguration);
+              %(_MSBuildProjectReferenceExistent.SetPlatform);
+              BuildProjectReferences=false;"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_TargetPathsToAssemblies" />
+    </MSBuild>
+
+    <MSBuild
+      Condition="'$(IncludeSymbols)' == 'true' OR '$(IncludeSource)' == 'true'"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="DebugSymbolsProjectOutputGroup"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+              %(_MSBuildProjectReferenceExistent.SetConfiguration);
+              %(_MSBuildProjectReferenceExistent.SetPlatform);
+              BuildProjectReferences=false;"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_TargetPathsToSymbols" />
+    </MSBuild>
+    
+    <MSBuild
+      Condition="'$(IncludeSource)' == 'true'"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="SourceFilesProjectOutputGroup"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+              %(_MSBuildProjectReferenceExistent.SetConfiguration);
+              %(_MSBuildProjectReferenceExistent.SetPlatform);
+              BuildProjectReferences=false;"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_SourceFiles" />
+    </MSBuild>
     
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
       Targets="_GetPackageReferences"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity)
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
               %(_MSBuildProjectReferenceExistent.SetConfiguration);
               %(_MSBuildProjectReferenceExistent.SetPlatform);
               BuildProjectReferences=false;"
@@ -206,15 +251,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
   </Target>
 
-  
-
   <!--
     ============================================================
-    _GetPackageFilesFromReferencedProjects
+    _GetPackageFiles
     Entry point for generating the project to project references.
     ============================================================
   -->
-  <Target Name="_GetPackageFilesFromReferencedProjects" Condition="$(IncludeContentInPack) == 'true'">
+  <Target Name="_GetPackageFiles" Condition="$(IncludeContentInPack) == 'true'">
     <ItemGroup>
       <_PackageFilesToExclude Include="@(Content)" Condition="'%(Content.Pack)' == 'false'"/>
     </ItemGroup>
@@ -223,19 +266,6 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_PackageFiles Include="@(Content)" Condition=" %(Content.Pack) != 'false' " />
       <_PackageFiles Include="@(Compile)" Condition=" %(Compile.Pack) == 'true' " />
       <_PackageFiles Include="@(None)" Condition=" %(None.Pack) == 'true' " />
-    </ItemGroup>
-  </Target>
-
-  
-  <!--
-    ============================================================
-    _GetSourceFilesForSymbols
-    Entry point for getting the source files for the project & it's references.
-    ============================================================
-  -->
-  <Target Name="_GetSourceFilesForSymbols" Condition="$(IncludeSource) == 'true'">
-    <ItemGroup>
-      <_SourceFiles Include="@(Compile)" />
     </ItemGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -1,15 +1,15 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
-using NuGet.Build.Tasks;
 using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Packaging;
-using NuGet.ProjectModel;
 using NuGet.Versioning;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -37,7 +37,8 @@ namespace NuGet.Build.Tasks.Pack
         public string[] Tags { get; set; }
         public string ReleaseNotes { get; set; }
         public string Configuration { get; set; }
-        public string[] TargetPaths { get; set; }
+        public string[] TargetPathsToAssemblies { get; set; }
+        public string[] TargetPathsToSymbols { get; set; }
         public string AssemblyName { get; set; }
         public string PackageOutputPath { get; set; }
         public bool IsTool { get; set; }
@@ -55,6 +56,8 @@ namespace NuGet.Build.Tasks.Pack
         public ITaskItem[] ProjectReferences { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string NuspecOutputPath { get; set; }
+        public bool IncludeBuildOutput { get; set; }
+        public string BuildOutputFolder { get; set; }
 
         public override bool Execute()
         {
@@ -80,9 +83,12 @@ namespace NuGet.Build.Tasks.Pack
             packArgs.NoPackageAnalysis = NoPackageAnalysis;
             packArgs.PackTargetArgs = new MSBuildPackTargetArgs()
             {
-                TargetPaths = TargetPaths,
+                TargetPathsToAssemblies = TargetPathsToAssemblies,
+                TargetPathsToSymbols = TargetPathsToSymbols,
                 Configuration = Configuration,
-                AssemblyName = AssemblyName
+                AssemblyName = AssemblyName,
+                IncludeBuildOutput = IncludeBuildOutput,
+                BuildOutputFolder = BuildOutputFolder
             };
             packArgs.PackTargetArgs.TargetFrameworks = ParseFrameworks();
             if (MinClientVersion != null)

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -8,7 +8,8 @@ namespace NuGet.Commands
 {
     public class MSBuildPackTargetArgs
     {
-        public string[] TargetPaths { get; set; }
+        public string[] TargetPathsToSymbols { get; set; }
+        public string[] TargetPathsToAssemblies { get; set; }
         public string AssemblyName { get; set; }
         public string Configuration { get; set; }
         public string NuspecOutputPath { get; set; }
@@ -16,6 +17,8 @@ namespace NuGet.Commands
         public Dictionary<string, HashSet<string>> ContentFiles { get; set; }
         public ISet<NuGetFramework> TargetFrameworks { get; set; }
         public IDictionary<string, string> SourceFiles { get; set; }
+        public bool IncludeBuildOutput { get; set; }
+        public string BuildOutputFolder { get; set; }
 
 
         public MSBuildPackTargetArgs()


### PR DESCRIPTION
This PR does the following:

1) Adds a msbuild bool  property $(PackBuildOutput) which determines whether output assemblies should be packed into the resulting nupkg or not.
2) Adds a msbuild property $(BuildOutputTargetFolder) which helps user control the name of the target folder in which the output assemblies (*.dll, *.exe, *.winmd, *.pdb, *.xml) will go in the nupkg.
3) Leverages MSBuild targets like BuildProjectGroupOutput, DebugSymbolsGroupOutput, SourceFilesGroupOutput etc instead of relying on file lookup to pack these files.
4) Moves the DLLs from buildCrossTargeting\Desktop and CoreCLR to the root of nupkg in the Desktop and CoreCLR folders. This was done so that the targets under build and buildCrossTargeting could be exactly the same and provide the same relative path to the Task assemblies and its dependencies.

CC: @emgarten @joelverhagen @alpaix @dtivel @rrelyea @jainaashish @zhili1208 @mishra14 @drewgil 
