### PR TITLE
Create FallbackFramework for PackageSpecs when reading msbuild output

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -254,9 +254,18 @@ namespace NuGet.Commands
 
                 if (targetFrameworkInfo != null)
                 {
-                    targetFrameworkInfo.Imports = Split(item.GetProperty("PackageTargetFallback"))
+                    var fallbackList = Split(item.GetProperty("PackageTargetFallback"))
                         .Select(NuGetFramework.Parse)
                         .ToList();
+
+                    targetFrameworkInfo.Imports = fallbackList;
+
+                    // Update the PackageSpec framework to include fallback frameworks
+                    if (targetFrameworkInfo.Imports.Count > 0)
+                    {
+                        targetFrameworkInfo.FrameworkName = 
+                            new FallbackFramework(targetFrameworkInfo.FrameworkName, fallbackList);
+                    }
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -245,6 +245,22 @@ namespace NuGet.Commands.Test
 
                 Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.Imports[0]);
                 Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.Imports[1]);
+
+                // Verify fallback framework
+                var fallbackFramework = (FallbackFramework)project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "netstandard1.6")
+                    .FrameworkName;
+
+                // net46 does not have imports
+                var fallbackFrameworkNet45 = project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "net46")
+                    .FrameworkName 
+                    as FallbackFramework;
+
+                Assert.Null(fallbackFrameworkNet45);
+                Assert.Equal(2, fallbackFramework.Fallback.Count);
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), fallbackFramework.Fallback[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), fallbackFramework.Fallback[1]);
             }
         }
 
@@ -296,6 +312,10 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.Equal(0, nsTFM.Imports.Count);
                 Assert.Equal(0, netTFM.Imports.Count);
+
+                // Verify no fallback frameworks
+                var fallbackFrameworks = project1Spec.TargetFrameworks.Select(e => e.FrameworkName as FallbackFramework);
+                Assert.True(fallbackFrameworks.All(e => e == null));
             }
         }
 


### PR DESCRIPTION
This fix add imports to the project target framework for the in memory instance of a PackageSpec. Previously there were no scenarios where the PackageSpec was created and then used in memory, it was always written and read from disk. Loading the file from disk added the imports.

Fixes https://github.com/NuGet/Home/issues/3621

//cc @joelverhagen 
