### PR TITLE
MSBuild project reference support

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
@@ -393,8 +393,10 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 var projectReferences = packageSpec
                     .RestoreMetadata
-                    .ProjectReferences
+                    .TargetFrameworks
+                    .SelectMany(e => e.ProjectReferences)
                     .Select(r => r.ProjectUniqueName)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
                 var reference = new ExternalProjectReference(

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -318,6 +318,21 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>
+    
+    <!-- 
+      Determine project name for the assets file.
+      Highest priority: PackageId
+      If PackageId does not exist use: AssemblyName
+      If AssemblyName does not exist fallback to the project file name without the extension: $(MSBuildProjectName)
+
+      For non-NETCore projects use only: $(MSBuildProjectName)
+    -->
+    <PropertyGroup>
+      <_RestoreProjectName>$(MSBuildProjectName)</_RestoreProjectName>
+      <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(AssemblyName)' != '' ">$(AssemblyName)</_RestoreProjectName>
+      <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
+    </PropertyGroup>
+
 
     <!-- Write properties for the top level entry point -->
     <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
@@ -325,7 +340,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Type>ProjectSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
-        <ProjectName>$(MSBuildProjectName)</ProjectName>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
         <Sources>$(RestoreSources)</Sources>
         <FallbackFolders>$(RestoreFallbackFolders)</FallbackFolders>
         <PackagesPath>$(RestorePackagesPath)</PackagesPath>
@@ -344,7 +359,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Type>ProjectSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
-        <ProjectName>$(MSBuildProjectName)</ProjectName>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
         <Sources>$(RestoreSources)</Sources>
         <FallbackFolders>$(RestoreFallbackFolders)</FallbackFolders>
         <PackagesPath>$(RestorePackagesPath)</PackagesPath>
@@ -360,7 +375,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Type>ProjectSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
-        <ProjectName>$(MSBuildProjectName)</ProjectName>
+        <ProjectName>$(_RestoreProjectName)</ProjectName>
         <OutputType>$(_ProjectRestoreType)</OutputType>
         <TargetFrameworks>$(TargetFrameworkMoniker)</TargetFrameworks>
       </_RestoreGraphEntry>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -96,7 +96,9 @@ namespace NuGet.Commands
 
         private static ExternalProjectReference GetExternalProject(PackageSpec rootProject)
         {
-            var projectReferences = rootProject.RestoreMetadata?.ProjectReferences ?? new List<ProjectRestoreReference>();
+            var projectReferences = rootProject.RestoreMetadata?.TargetFrameworks.SelectMany(e => e.ProjectReferences)
+                ?? new List<ProjectRestoreReference>();
+
             var type = rootProject.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
 
             // Leave the spec null for non-nuget projects.
@@ -112,11 +114,15 @@ namespace NuGet.Commands
                 projectSpec = rootProject;
             }
 
+            var uniqueReferences = projectReferences
+                .Select(p => p.ProjectUniqueName)
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+
             return new ExternalProjectReference(
                 rootProject.RestoreMetadata.ProjectUniqueName,
                 projectSpec,
                 rootProject.RestoreMetadata?.ProjectPath,
-                projectReferences.Select(p => p.ProjectUniqueName));
+                uniqueReferences);
         }
 
         private RestoreSummaryRequest Create(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -103,9 +103,6 @@ namespace NuGet.Commands
                 // Verify project metadata
                 ValidateProjectMSBuildMetadata(spec, files);
 
-                // Verify project references
-                ValidateProjectReferences(spec, files);
-
                 // Verify based on the type.
                 switch (outputType)
                 {
@@ -291,47 +288,6 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.PropertyNotAllowed,
                     nameof(spec.Dependencies));
-
-                throw RestoreSpecException.Create(message, files);
-            }
-        }
-
-        private static void ValidateProjectReferences(PackageSpec spec, IEnumerable<string> files)
-        {
-            var dependencies = new HashSet<string>(GetAllDependencies(spec)
-                .Where(d => d.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.ExternalProject))
-                .Select(d => d.Name),
-                StringComparer.OrdinalIgnoreCase);
-
-            var projectOnly = new HashSet<string>(GetAllDependencies(spec)
-                .Where(d => d.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.ExternalProject)
-                        && !d.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
-                        && !d.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Reference))
-                .Select(d => d.Name),
-                StringComparer.OrdinalIgnoreCase);
-
-            var externalReferences = new HashSet<string>(
-                spec.RestoreMetadata.ProjectReferences.Select(p => p.ProjectUniqueName),
-                StringComparer.OrdinalIgnoreCase);
-
-            foreach (var missing in externalReferences.Except(dependencies))
-            {
-                // Missing dependency in dependencies section
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    Strings.SpecValidationMissingDependency,
-                    missing);
-
-                throw RestoreSpecException.Create(message, files);
-            }
-
-            foreach (var missing in projectOnly.Except(dependencies))
-            {
-                // missing restore section reference containing project path
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    Strings.SpecValidationMissingDependency,
-                    missing);
 
                 throw RestoreSpecException.Create(message, files);
             }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryIncludeFlagUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.LibraryModel
 {
@@ -87,6 +88,29 @@ namespace NuGet.LibraryModel
             }
 
             return string.Join(", ", flagStrings);
+        }
+
+        /// <summary>
+        /// Convert set of flag strings into a LibraryIncludeFlags.
+        /// </summary>
+        public static LibraryIncludeFlags GetFlags(string flags, LibraryIncludeFlags defaultFlags)
+        {
+            LibraryIncludeFlags result = defaultFlags;
+
+            if (!string.IsNullOrEmpty(flags))
+            {
+                var splitFlags = flags.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(s => s.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .ToArray();
+
+                if (splitFlags.Length > 0)
+                {
+                    result = GetFlags(splitFlags);
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryRange.cs
@@ -19,8 +19,13 @@ namespace NuGet.LibraryModel
 
         public LibraryRange(string name, VersionRange versionRange, LibraryDependencyTarget typeConstraint)
         {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             Name = name;
-            VersionRange = versionRange;
+            VersionRange = versionRange ?? VersionRange.All;
             TypeConstraint = typeConstraint;
         }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -307,19 +307,20 @@ namespace NuGet.ProjectManagement.Projects
             {
                 foreach (var reference in references)
                 {
-                    MSBuildRestoreUtility.AddMSBuildProjectReference(
-                        packageSpec,
-                        new ProjectRestoreReference
-                        {
-                            ProjectUniqueName = reference.UniqueName,
-                            ProjectPath = reference.MSBuildProjectPath
-                        },
-                        new LibraryDependency
-                        {
-                            LibraryRange = new LibraryRange(
-                                reference.UniqueName,
-                                LibraryDependencyTarget.ExternalProject)
-                        });
+                    // This reference applies to all frameworks
+                    // Include/exclude flags may be applied later when merged with project.json
+                    var projectReference = new ProjectRestoreReference
+                    {
+                        ProjectUniqueName = reference.UniqueName,
+                        ProjectPath = reference.MSBuildProjectPath
+                    };
+
+                    foreach (var framework in packageSpec.TargetFrameworks.Select(e => e.FrameworkName))
+                    {
+                        var group = new ProjectRestoreMetadataFrameworkInfo(framework);
+                        metadata.TargetFrameworks.Add(group);
+                        group.ProjectReferences.Add(projectReference);
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -573,8 +573,13 @@ namespace NuGet.ProjectManagement
             metadata.ProjectUniqueName = MSBuildNuGetProjectSystem.ProjectFileFullPath;
 
             IReadOnlyList<ExternalProjectReference> references = null;
-            if (referenceContext.DirectReferenceCache.TryGetValue(metadata.ProjectPath, out references))
+            if (referenceContext.DirectReferenceCache.TryGetValue(metadata.ProjectPath, out references)
+                && references.Count > 0)
             {
+                // Add framework group
+                var frameworkGroup = new ProjectRestoreMetadataFrameworkInfo(MSBuildNuGetProjectSystem.TargetFramework);
+                metadata.TargetFrameworks.Add(frameworkGroup);
+
                 foreach (var reference in references)
                 {
                     // This reference applies to all frameworks
@@ -585,9 +590,7 @@ namespace NuGet.ProjectManagement
                         ProjectPath = reference.MSBuildProjectPath
                     };
 
-                    var group = new ProjectRestoreMetadataFrameworkInfo(MSBuildNuGetProjectSystem.TargetFramework);
-                    metadata.TargetFrameworks.Add(group);
-                    group.ProjectReferences.Add(projectReference);
+                    frameworkGroup.ProjectReferences.Add(projectReference);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -577,19 +577,17 @@ namespace NuGet.ProjectManagement
             {
                 foreach (var reference in references)
                 {
-                    MSBuildRestoreUtility.AddMSBuildProjectReference(
-                        packageSpec,
-                        new ProjectRestoreReference
-                        {
-                            ProjectUniqueName = reference.UniqueName,
-                            ProjectPath = reference.MSBuildProjectPath
-                        },
-                        new LibraryDependency
-                        {
-                            LibraryRange = new LibraryRange(
-                                reference.UniqueName,
-                                LibraryDependencyTarget.ExternalProject)
-                        });
+                    // This reference applies to all frameworks
+                    // Include/exclude flags are not possible for this project type
+                    var projectReference = new ProjectRestoreReference
+                    {
+                        ProjectUniqueName = reference.UniqueName,
+                        ProjectPath = reference.MSBuildProjectPath
+                    };
+
+                    var group = new ProjectRestoreMetadataFrameworkInfo(MSBuildNuGetProjectSystem.TargetFramework);
+                    metadata.TargetFrameworks.Add(group);
+                    group.ProjectReferences.Add(projectReference);
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -108,7 +108,11 @@ namespace NuGet.ProjectModel
         private static IEnumerable<string> GetProjectReferenceNames(PackageSpec spec)
         {
             // Handle projects which may not have specs, and which may not have references
-            return spec?.RestoreMetadata?.ProjectReferences?.Select(project => project.ProjectUniqueName)
+            return spec?.RestoreMetadata?
+                .TargetFrameworks
+                .SelectMany(e => e.ProjectReferences)
+                .Select(project => project.ProjectUniqueName)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 ?? Enumerable.Empty<string>();
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -8,6 +8,9 @@ namespace NuGet.ProjectModel
 {
     public static class PackageSpecExtensions
     {
+        /// <summary>
+        /// Get the nearest framework available in the project.
+        /// </summary>
         public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
             var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => f.FrameworkName.Equals(targetFramework));
@@ -19,6 +22,25 @@ namespace NuGet.ProjectModel
             }
 
             return frameworkInfo ?? new TargetFrameworkInformation();
+        }
+
+        /// <summary>
+        /// Get restore metadata framework. This is based on the project's target frameworks, then an 
+        /// exact match is found under restore metadata.
+        /// </summary>
+        public static ProjectRestoreMetadataFrameworkInfo GetRestoreMetadataFramework(this PackageSpec project, NuGetFramework targetFramework)
+        {
+            ProjectRestoreMetadataFrameworkInfo frameworkInfo = null;
+
+            var projectFrameworkInfo = GetTargetFramework(project, targetFramework);
+
+            if (projectFrameworkInfo.FrameworkName != null)
+            {
+                frameworkInfo = project.RestoreMetadata?.TargetFrameworks
+                    .FirstOrDefault(f => f.FrameworkName.Equals(projectFrameworkInfo.FrameworkName));
+            }
+
+            return frameworkInfo ?? new ProjectRestoreMetadataFrameworkInfo();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -287,12 +287,12 @@ namespace NuGet.ProjectModel
 
                     var dependency = new LibraryDependency()
                     {
-                        LibraryRange = new LibraryRange(
-                        dependencyName,
-                        range,
-                        LibraryDependencyTarget.ExternalProject),
                         IncludeType = (reference.IncludeAssets & ~reference.ExcludeAssets),
-                        SuppressParent = reference.PrivateAssets
+                        SuppressParent = reference.PrivateAssets,
+                        LibraryRange = new LibraryRange(
+                            dependencyName,
+                            range,
+                            LibraryDependencyTarget.ExternalProject),
                     };
 
                     // Remove existing reference if one exists, projects override

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -51,10 +51,11 @@ namespace NuGet.ProjectModel
         public IList<string> FallbackFolders { get; set; } = new List<string>();
 
         /// <summary>
-        /// Project reference metadata. This will be added to the non-msbuild dependency reference in the package spec.
+        /// Framework specific metadata, this may be a subset of the project's frameworks.
+        /// Operations to determine the nearest framework should be done against the project's frameworks, 
+        /// and then matched directly to this section.
         /// </summary>
-        public IList<ProjectRestoreReference> ProjectReferences { get; set; } = new List<ProjectRestoreReference>();
-
+        public IList<ProjectRestoreMetadataFrameworkInfo> TargetFrameworks { get; set; } = new List<ProjectRestoreMetadataFrameworkInfo>();
 
         /// <summary>
         /// Original target frameworks strings. These are used to match msbuild conditionals to $(TargetFramework)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.ProjectModel
+{
+    public class ProjectRestoreMetadataFrameworkInfo
+    {
+        /// <summary>
+        /// Framework references apply to
+        /// </summary>
+        public NuGetFramework FrameworkName { get; set; }
+
+        /// <summary>
+        /// Project references
+        /// </summary>
+        public IList<ProjectRestoreReference> ProjectReferences { get; set; } = new List<ProjectRestoreReference>();
+
+        public ProjectRestoreMetadataFrameworkInfo()
+        {
+        }
+
+        public ProjectRestoreMetadataFrameworkInfo(NuGetFramework frameworkName)
+        {
+            FrameworkName = frameworkName;
+        }
+
+        public override string ToString()
+        {
+            return FrameworkName.GetShortFolderName();
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -9,7 +9,7 @@ namespace NuGet.ProjectModel
     public class ProjectRestoreMetadataFrameworkInfo
     {
         /// <summary>
-        /// Framework references apply to
+        /// Target framework
         /// </summary>
         public NuGetFramework FrameworkName { get; set; }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreReference.cs
@@ -1,8 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Shared;
 
 namespace NuGet.ProjectModel
 {
-    public class ProjectRestoreReference
+    public class ProjectRestoreReference : IEquatable<ProjectRestoreReference>
     {
         /// <summary>
         /// Project unique name.
@@ -14,21 +19,52 @@ namespace NuGet.ProjectModel
         /// </summary>
         public string ProjectPath { get; set; }
 
+        public LibraryIncludeFlags IncludeAssets { get; set; } = LibraryIncludeFlags.All;
+
+        public LibraryIncludeFlags ExcludeAssets { get; set; }
+
+        public LibraryIncludeFlags PrivateAssets { get; set; } = LibraryIncludeFlagUtils.DefaultSuppressParent;
+
         public override int GetHashCode()
         {
-            return StringComparer.Ordinal.GetHashCode(ProjectUniqueName);
+            var combiner = new HashCodeCombiner();
+
+            combiner.AddInt32(StringComparer.Ordinal.GetHashCode(ProjectPath));
+            combiner.AddInt32(StringComparer.OrdinalIgnoreCase.GetHashCode(ProjectUniqueName));
+            combiner.AddObject(IncludeAssets);
+            combiner.AddObject(ExcludeAssets);
+            combiner.AddObject(PrivateAssets);
+
+            return combiner.CombinedHash;
         }
 
         public override bool Equals(object obj)
         {
-            var other = obj as ProjectRestoreReference;
-
-            return StringComparer.Ordinal.Equals(ProjectUniqueName, other?.ProjectUniqueName);
+            return Equals(obj as ProjectRestoreReference);
         }
 
         public override string ToString()
         {
-            return ProjectUniqueName;
+            return $"{ProjectUniqueName} : {ProjectPath}";
+        }
+
+        public bool Equals(ProjectRestoreReference other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return StringComparer.Ordinal.Equals(ProjectPath, other.ProjectPath)
+                && StringComparer.OrdinalIgnoreCase.Equals(ProjectUniqueName, other.ProjectUniqueName)
+                && IncludeAssets == other.IncludeAssets
+                && ExcludeAssets == other.ExcludeAssets
+                && PrivateAssets == other.PrivateAssets;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/compiler/resources/project1.csproj
+++ b/src/NuGet.Core/NuGet.Test.Utility/compiler/resources/project1.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestSolution</RootNamespace>
-    <AssemblyName>TestSolution</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
@@ -1,0 +1,315 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class NETCoreProject2ProjectTests
+    {
+        [Fact]
+        public async Task NETCoreProject2Project_ProjectReferenceOnlyUnderRestoreMetadata()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = GetProject(projectName: "projectA", framework: "netstandard1.6");
+                var spec2 = GetProject(projectName: "projectB", framework: "netstandard1.3");
+
+                var specs = new[] { spec1, spec2 };
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, specs);
+
+                // Link projects
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
+                });
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                foreach (var spec in specs)
+                {
+                    dgFile.AddProject(spec);
+                }
+
+                // Restore only the first one
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var targetLib = projects[0].AssetsFile
+                    .Targets
+                    .Single(e => e.TargetFramework.Equals(NuGetFramework.Parse("netstandard1.6")))
+                    .Libraries
+                    .Single(e => e.Name == "projectB");
+
+                var libraryLib = projects[0].AssetsFile
+                    .Libraries
+                    .Single(e => e.Name == "projectB");
+
+                Assert.Equal("projectB", targetLib.Name);
+                Assert.Equal(NuGetFramework.Parse("netstandard1.3"), NuGetFramework.Parse(targetLib.Framework));
+                Assert.Equal("1.0.0", targetLib.Version.ToNormalizedString());
+                Assert.Equal("project", targetLib.Type);
+
+                Assert.Equal("projectB", libraryLib.Name);
+                Assert.Equal("project", libraryLib.Type);
+                Assert.Equal("../projectB/projectB.csproj", libraryLib.MSBuildProject);
+                Assert.Equal("../projectB/projectB.csproj", libraryLib.Path);
+                Assert.Equal("1.0.0", libraryLib.Version.ToNormalizedString());
+            }
+        }
+
+        [Fact]
+        public async Task NETCoreProject2Project_ProjectReference_IgnoredForTFM()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = GetProject(projectName: "projectA", framework: "netstandard1.6");
+                var spec2 = GetProject(projectName: "projectB", framework: "netstandard1.3");
+
+                var specs = new[] { spec1, spec2 };
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, specs);
+
+                // Remove valid link
+                spec1.RestoreMetadata.TargetFrameworks.Clear();
+
+                // Add invalid link, net45 is not a project tfm
+                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName
+                });
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                foreach (var spec in specs)
+                {
+                    dgFile.AddProject(spec);
+                }
+
+                // Restore only the first one
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                Assert.Equal(0, projects[0].AssetsFile.Libraries.Count);
+            }
+        }
+
+        [Fact]
+        public async Task NETCoreProject2Project_ProjectMissing()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = GetProject(projectName: "projectA", framework: "netstandard1.6");
+                var spec2 = GetProject(projectName: "projectB", framework: "netstandard1.3");
+
+                var specs = new[] { spec1, spec2 };
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, specs);
+
+                // Link projects
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
+                });
+                
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+
+                // Only add projectA
+                dgFile.AddProject(spec1);
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.False(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                Assert.Contains("Unable to resolve", string.Join(Environment.NewLine, logger.Messages));
+                Assert.Contains(projects[1].ProjectPath, string.Join(Environment.NewLine, logger.Messages));
+            }
+        }
+
+        [Fact]
+        public async Task NETCoreProject2Project_ProjectFileDependencyGroupsForNETCore()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = GetProject(projectName: "projectA", framework: "netstandard1.6");
+                var spec2 = GetProject(projectName: "projectB", framework: "netstandard1.3");
+                var spec3 = GetProject(projectName: "projectC", framework: "netstandard1.0");
+
+                var specs = new[] { spec1, spec2, spec3 };
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, specs);
+
+                // Link projects
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
+                });
+
+                spec2.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[2].ProjectPath,
+                    ProjectUniqueName = spec3.RestoreMetadata.ProjectUniqueName,
+                });
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                foreach (var spec in specs)
+                {
+                    dgFile.AddProject(spec);
+                }
+
+                // Restore only the first one
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+                var dependencies = projects[0].AssetsFile.ProjectFileDependencyGroups.SelectMany(e => e.Dependencies).ToArray();
+
+                // Ensure ProjectC does not show up
+                Assert.Equal(1, dependencies.Length);
+
+                // Ensure ProjectC is in the libraries
+                Assert.Equal(2, projects[0].AssetsFile.Libraries.Count);
+
+                // Verify the project name is used not the path or unique name
+                Assert.Equal("projectB", dependencies[0]);
+            }
+        }
+
+        private static List<SimpleTestProjectContext> CreateProjectsFromSpecs(SimpleTestPathContext pathContext, params PackageSpec[] specs)
+        {
+            var projects = new List<SimpleTestProjectContext>();
+
+            foreach (var spec in specs)
+            {
+                var project = new SimpleTestProjectContext(spec.Name, RestoreOutputType.NETCore, pathContext.SolutionRoot); 
+
+                // Set proj properties
+                spec.FilePath = project.ProjectPath;
+                spec.RestoreMetadata.OutputPath = project.OutputPath;
+                spec.RestoreMetadata.ProjectPath = project.ProjectPath;
+
+                projects.Add(project);
+            }
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot, projects.ToArray());
+            solution.Create(pathContext.SolutionRoot);
+
+            return projects;
+        }
+
+        private static async Task<IReadOnlyList<RestoreSummary>> RunRestore(
+            SimpleTestPathContext pathContext,
+            TestLogger logger,
+            List<PackageSource> sources,
+            DependencyGraphSpec dgFile,
+            SourceCacheContext cacheContext)
+        {
+            var restoreContext = new RestoreArgs()
+            {
+                CacheContext = cacheContext,
+                DisableParallel = true,
+                GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                Sources = new List<string>() { pathContext.PackageSource },
+                Log = logger,
+                CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
+                {
+                    new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dgFile)
+                }
+            };
+
+            return await RestoreRunner.Run(restoreContext);
+        }
+
+        private static PackageSpec GetProject(string projectName, string framework)
+        {
+            var targetFrameworkInfo = new TargetFrameworkInformation();
+            targetFrameworkInfo.FrameworkName = NuGetFramework.Parse(framework);
+            var frameworks = new[] { targetFrameworkInfo };
+
+            // Create two net45 projects
+            var spec = new PackageSpec(frameworks);
+            spec.RestoreMetadata = new ProjectRestoreMetadata();
+            spec.RestoreMetadata.ProjectUniqueName = $"{projectName}-UNIQUENAME";
+            spec.RestoreMetadata.ProjectName = projectName;
+            spec.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec.RestoreMetadata.OriginalTargetFrameworks.Add(framework);
+            spec.Name = projectName;
+            spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName));
+
+            return spec;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -248,7 +248,11 @@ namespace NuGet.Commands.Test
                     }
                 });
 
-                spec1.RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
+                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+                spec1.RestoreMetadata.TargetFrameworks
+                    .Single()
+                    .ProjectReferences
+                    .Add(new ProjectRestoreReference()
                 {
                     ProjectPath = projPath2,
                     ProjectUniqueName = "project2"
@@ -381,11 +385,15 @@ namespace NuGet.Commands.Test
                     }
                 });
 
-                spec1.RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
-                {
-                    ProjectPath = projPath2,
-                    ProjectUniqueName = "project2"
-                });
+                spec1.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+                spec1.RestoreMetadata.TargetFrameworks
+                    .Single()
+                    .ProjectReferences
+                    .Add(new ProjectRestoreReference()
+                    {
+                        ProjectPath = projPath2,
+                        ProjectUniqueName = "project2"
+                    });
 
                 // Create dg file
                 var dgFile = new DependencyGraphSpec();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -131,46 +131,14 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void SpecValidationUtility_VerifyProjectReferences_MissingFromDependencies()
-        {
-            // Arrange
-            var spec = GetBasicDG();
-            spec.Projects.First().RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
-            {
-                ProjectPath = "b.csproj",
-                ProjectUniqueName = "b"
-            });
-
-            // Act && Assert
-            AssertError(spec, "Missing dependency on 'b'");
-        }
-
-        [Fact]
-        public void SpecValidationUtility_VerifyProjectReferences_MissingFromDependencies_PackageOnly()
-        {
-            // Arrange
-            var spec = GetBasicDG();
-            spec.Projects.First().RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
-            {
-                ProjectPath = "b.csproj",
-                ProjectUniqueName = "b"
-            });
-
-            spec.Projects.First().Dependencies.Add(new LibraryDependency()
-            {
-                LibraryRange = new LibraryRange("b", LibraryDependencyTarget.Package)
-            });
-
-            // Act && Assert
-            AssertError(spec, "Missing dependency on 'b'");
-        }
-
-        [Fact]
         public void SpecValidationUtility_VerifyProjectReferences_TopLevel_Pass()
         {
             // Arrange
             var spec = GetBasicDG();
-            spec.Projects.First().RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
+            spec.Projects.First().RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+
+            spec.Projects.First().RestoreMetadata.TargetFrameworks.Single()
+                .ProjectReferences.Add(new ProjectRestoreReference()
             {
                 ProjectPath = "b.csproj",
                 ProjectUniqueName = "b"
@@ -190,11 +158,14 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var spec = GetBasicDG();
-            spec.Projects.First().RestoreMetadata.ProjectReferences.Add(new ProjectRestoreReference()
-            {
-                ProjectPath = "b.csproj",
-                ProjectUniqueName = "b"
-            });
+            spec.Projects.First().RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45")));
+
+            spec.Projects.First().RestoreMetadata.TargetFrameworks.Single()
+                .ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = "b.csproj",
+                    ProjectUniqueName = "b"
+                });
 
             spec.Projects.First().TargetFrameworks.First().Dependencies.Add(new LibraryDependency()
             {
@@ -258,17 +229,6 @@ namespace NuGet.Commands.Test
 
             // Act && Assert
             AssertError(spec, "Missing required property 'FilePath'");
-        }
-
-        [Fact]
-        public void SpecValidationUtility_UnexpectedError()
-        {
-            // Arrange
-            var spec = GetBasicDG();
-            spec.Projects.First().RestoreMetadata.ProjectReferences = null;
-
-            // Act && Assert
-            AssertError(spec, "Value cannot be null");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -59,7 +59,7 @@ namespace ProjectManagement.Test
 
                 Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
-                Assert.Empty(actual.RestoreMetadata.ProjectReferences);
+                Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }
         }
 
@@ -105,15 +105,13 @@ namespace ProjectManagement.Test
                 Assert.Equal(projectTargetFramework, actual.TargetFrameworks[0].FrameworkName);
                 Assert.Empty(actual.TargetFrameworks[0].Imports);
 
-                Assert.Equal(1, actual.Dependencies.Count);
-                Assert.Equal("uniqueName", actual.Dependencies[0].Name);
-                Assert.Equal(LibraryDependencyTarget.ExternalProject, actual.Dependencies[0].LibraryRange.TypeConstraint);
-
+                Assert.Equal(0, actual.Dependencies.Count);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
 
-                Assert.Equal(1, actual.RestoreMetadata.ProjectReferences.Count);
-                Assert.Equal("uniqueName", actual.RestoreMetadata.ProjectReferences[0].ProjectUniqueName);
-                Assert.Equal("msbuildProjectPath", actual.RestoreMetadata.ProjectReferences[0].ProjectPath);
+                var projectReferences = actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).ToList();
+                Assert.Equal(1, projectReferences.Count);
+                Assert.Equal("uniqueName", projectReferences[0].ProjectUniqueName);
+                Assert.Equal("msbuildProjectPath", projectReferences[0].ProjectPath);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
@@ -64,7 +64,7 @@ namespace ProjectManagement.Test
 
                 Assert.Empty(actual.Dependencies);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
-                Assert.Empty(actual.RestoreMetadata.ProjectReferences);
+                Assert.Empty(actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences));
             }
         }
 
@@ -114,15 +114,13 @@ namespace ProjectManagement.Test
                 Assert.Equal(projectTargetFramework, actual.TargetFrameworks[0].FrameworkName);
                 Assert.Empty(actual.TargetFrameworks[0].Imports);
 
-                Assert.Equal(1, actual.Dependencies.Count);
-                Assert.Equal("uniqueName", actual.Dependencies[0].Name);
-                Assert.Equal(LibraryDependencyTarget.ExternalProject, actual.Dependencies[0].LibraryRange.TypeConstraint);
-
+                Assert.Equal(0, actual.Dependencies.Count);
                 Assert.Empty(actual.TargetFrameworks[0].Dependencies);
 
-                Assert.Equal(1, actual.RestoreMetadata.ProjectReferences.Count);
-                Assert.Equal("uniqueName", actual.RestoreMetadata.ProjectReferences[0].ProjectUniqueName);
-                Assert.Equal("msbuildProjectPath", actual.RestoreMetadata.ProjectReferences[0].ProjectPath);
+                var projectReferences = actual.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).ToList();
+                Assert.Equal(1, projectReferences.Count);
+                Assert.Equal("uniqueName", projectReferences[0].ProjectUniqueName);
+                Assert.Equal("msbuildProjectPath", projectReferences[0].ProjectPath);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecWriterTests.cs
@@ -39,8 +39,7 @@ namespace NuGet.ProjectModel.Test
     ""iconUrl"": ""http://my.url.com"",
     ""summary"": ""Sum"",
     ""releaseNotes"": ""release noted"",
-    ""licenseUrl"": ""http://my.url.com"",
-    ""requireLicenseAcceptance"": ""False""
+    ""licenseUrl"": ""http://my.url.com""
   },
   ""scripts"": {
     ""script1"": [
@@ -67,7 +66,6 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             var json = @"{
   ""packOptions"": {
-    ""requireLicenseAcceptance"": ""False"",
     ""packageType"": ""DotNetTool""
   }
 }";
@@ -82,7 +80,6 @@ namespace NuGet.ProjectModel.Test
             // Arrange
             var json = @"{
   ""packOptions"": {
-    ""requireLicenseAcceptance"": ""False"",
     ""packageType"": [
       ""DotNetTool"",
       ""Dependency""

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project1.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project1.json
@@ -10,15 +10,6 @@
           "type": "platform",
           "version": "1.0.0"
         },
-        "44B29B8D-8413-42D2-8DF4-72225659619B": {
-          "target": "project",
-          "exclude": "build",
-          "include": "runtime,compile",
-          "suppressParent": "analyzers"
-        },
-        "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
-          "target": "project"
-        },
         "nuget.packaging": "3.3.0"
       },
       "imports": "portable-net45+win8"
@@ -39,12 +30,20 @@
       "c:\\fallback1",
       "c:\\fallback2"
     ],
-    "projectReferences": {
-      "44B29B8D-8413-42D2-8DF4-72225659619B": {
-        "projectPath": "c:\\a\\a.csproj"
-      },
-      "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
-        "projectPath": "c:\\b\\b.csproj"
+    "frameworks": {
+      "netcoreapp1.0": {
+        "projectReferences": {
+          "44B29B8D-8413-42D2-8DF4-72225659619B": {
+            "projectPath": "c:\\a\\a.csproj",
+            "target": "project",
+            "exclude": "build",
+            "include": "runtime,compile",
+            "suppressParent": "analyzers"
+          },
+          "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
+            "projectPath": "c:\\b\\b.csproj"
+          }
+        }
       }
     }
   }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
@@ -10,16 +10,10 @@
       "frameworks": {
         "net45": {
           "dependencies": {
-            "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
-              "target": "project"
-            }
           }
         },
         "net461": {
           "dependencies": {
-            "44B29B8D-8413-42D2-8DF4-72225659619B": {
-              "target": "project"
-            }
           }
         }
       },
@@ -38,17 +32,24 @@
           "c:\\fallback1",
           "c:\\fallback2"
         ],
-        "projectReferences": {
-          "44B29B8D-8413-42D2-8DF4-72225659619B": {
-            "projectPath": "c:\\a\\a.csproj"
+        "frameworks": {
+          "net461": {
+            "projectReferences": {
+              "44B29B8D-8413-42D2-8DF4-72225659619B": {
+                "projectPath": "c:\\a\\a.csproj"
+              }
+            }
           },
-          "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
-            "projectPath": "c:\\b\\b.csproj"
+          "net45": {
+            "projectReferences": {
+              "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
+                "projectPath": "c:\\b\\b.csproj"
+              }
+            }
           }
         }
       }
     },
-
     "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
       "version": "1.0.0-*",
       "frameworks": {


### PR DESCRIPTION
This change adds a frameworks section under restore metadata, project references are now placed there instead of in both the restore section and the dependencies section. This allows projects to be referenced with a unique name or path, and later resolved to the correct PackageId or project name. The project name can only be known after reading all projects.

An additional benefit of splitting up the references between what was provided by msbuild and what is in the spec is that UWP can continue to work exactly as it has in the past, while .NET Core projects can take advantage of the restore metadata.

Handling for missing projects is also improved with this change. Resolving a project path to the actual project is now handled in the resolver which allows it to fail in the same way as a missing package.

Fixes https://github.com/NuGet/Home/issues/3611
Related to https://github.com/dotnet/sdk/issues/200

//cc @joelverhagen @rohit21agrawal
