### PR TITLE
Fix VS14 build failure

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -956,7 +956,7 @@ Function Build-ClientsProjectHelper {
     }
 
     if ($IsSolution -And $ToolsetVersion -eq 14) {
-        $opts += "/p:Configuration=$Configuration VS14"
+        $opts += "/p:Configuration=`"$Configuration VS14`""
     }
     else {
         $opts += "/p:Configuration=$Configuration"


### PR DESCRIPTION
The VS14 build executes:

```
C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe D:\git\NuGet.Client\NuGet.Clients.sln /p:Configuration=Debug VS14 /p:ReleaseLabel=zlocal;BuildNumber=25883 /p:VisualStudioVersion=14.0 /tv:14.0
```

...and fails with:

```
MSBUILD : error MSB1008: Only one project can be specified.
Switch: VS14
```

Reference #862.

@rrelyea @emgarten @joelverhagen @drewgil @alpaix @mishra14 @jainaashish @zhili1208 @rohit21agrawal
