### PR TITLE
Conditions for targets/props imports

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -133,6 +133,9 @@ namespace NuGet.CommandLine
                 argumentBuilder.Append(" /p:RestoreGraphOutputPath=");
                 AppendQuoted(argumentBuilder, resultsPath);
 
+                // Disallow the import of targets/props from packages
+                argumentBuilder.Append(" /p:ExcludeRestorePackageImports=true ");
+
                 // Projects to restore
                 argumentBuilder.Append(" /p:RestoreGraphProjectInput=\"");
                 for (var i = 0; i < projectPaths.Length; i++)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
@@ -50,6 +50,11 @@ namespace NuGet.PackageManagement.VisualStudio
         private const string TargetFrameworksName = "TargetFrameworks";
 
         /// <summary>
+        /// Single Framework
+        /// </summary>
+        private const string TargetFrameworkName = "TargetFramework";
+
+        /// <summary>
         /// The MSBuild property for the path to MSBuild.
         /// </summary>
         private const string MSBuildToolsPathName = "MSBuildToolsPath";
@@ -103,8 +108,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            // The project must have the "TargetFrameworks" property.
-            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null)
+            // The project must have the "TargetFrameworks" or "TargetFramework" property.
+            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null
+                && GetMSBuildProperty(buildPropertyStorage, TargetFrameworkName) == null)
             {
                 return null;
             }
@@ -479,6 +485,9 @@ namespace NuGet.PackageManagement.VisualStudio
                     {
                         argumentBuilder.Append($" {msbuildAdditionalArgs} ");
                     }
+
+                    // Disallow the import of targets/props from packages
+                    argumentBuilder.Append(" /p:ExcludeRestorePackageImports=true ");
 
                     argumentBuilder.Append(" /p:RestoreTaskAssemblyFile=");
                     AppendQuoted(argumentBuilder, buildTasksPath);

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -133,47 +133,36 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Message Text="%(RestoreGraphProjectInputItems.Identity)" Importance="low" />
 
     <!-- Generate a restore graph for each entry point project -->
+    <PropertyGroup>
+      <_GenerateRestoreGraphProjectEntryInputProperties>
+        %(_MSBuildProjectReferenceExistent.SetConfiguration);
+        %(_MSBuildProjectReferenceExistent.SetPlatform);
+        RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
+        NuGetRestoreTargets=$(MSBuildThisFileFullPath);
+        BuildProjectReferences=false;
+        ExcludeRestorePackageImports=true;
+      </_GenerateRestoreGraphProjectEntryInputProperties>
+
+      <!-- Standalone mode
+        This is used by NuGet.exe or to directly override NuGet.targets with the current file.
+        Override the ImportAfter targets with NuGetRestoreTargets if they exist.
+        Set CustomAfterMicrosoftCommonCrossTargetingTargets and CustomAfterMicrosoftCommonTargets
+        for both the inner and outer builds.
+      -->
+      <_GenerateRestoreGraphProjectEntryInputProperties Condition=" '$(RestoreUseCustomAfterTargets)' == 'true' ">
+        $(_GenerateRestoreGraphProjectEntryInputProperties);
+        CustomAfterMicrosoftCommonCrossTargetingTargets=$(MSBuildThisFileFullPath);
+        CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileFullPath);
+      </_GenerateRestoreGraphProjectEntryInputProperties>
+    </PropertyGroup>
 
     <!-- Using targets imported with ImportsAfter -->
     <MsBuild
-        Condition=" '$(RestoreUseCustomAfterTargets)' != 'true' "
         Projects="@(RestoreGraphProjectInputItems)"
         Targets="_GenerateRestoreGraphProjectEntry"
         BuildInParallel="false"
-        Properties="
-                %(_MSBuildProjectReferenceExistent.SetConfiguration);
-                %(_MSBuildProjectReferenceExistent.SetPlatform);
-                RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
-                NuGetRestoreTargets=$(MSBuildThisFileFullPath);
-                BuildProjectReferences=false;"
+        Properties="$(_GenerateRestoreGraphProjectEntryInputProperties)"
         RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-
-      <Output
-          TaskParameter="TargetOutputs"
-          ItemName="_RestoreGraphEntry" />
-    </MsBuild>
-
-    <!-- Standalone mode
-      This is used by NuGet.exe or to directly override NuGet.targets with the current file.
-      Override the ImportAfter targets with NuGetRestoreTargets if they exist.
-      Set CustomAfterMicrosoftCommonCrossTargetingTargets and CustomAfterMicrosoftCommonTargets
-      for both the inner and outer builds.
-    -->
-    <MsBuild
-        Condition=" '$(RestoreUseCustomAfterTargets)' == 'true' "
-        Projects="@(RestoreGraphProjectInputItems)"
-        Targets="_GenerateRestoreGraphProjectEntry"
-        BuildInParallel="false"
-        Properties="
-                %(_MSBuildProjectReferenceExistent.SetConfiguration);
-                %(_MSBuildProjectReferenceExistent.SetPlatform);
-                CustomAfterMicrosoftCommonCrossTargetingTargets=$(MSBuildThisFileFullPath);
-                CustomAfterMicrosoftCommonTargets=$(MSBuildThisFileFullPath);
-                RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
-                NuGetRestoreTargets=$(MSBuildThisFileFullPath);
-                BuildProjectReferences=false;"
-        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-
       <Output
           TaskParameter="TargetOutputs"
           ItemName="_RestoreGraphEntry" />
@@ -332,7 +321,11 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(AssemblyName)' != '' ">$(AssemblyName)</_RestoreProjectName>
       <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
     </PropertyGroup>
-
+    
+    <!-- Determine if this will use cross targeting -->
+    <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' != '' ">
+      <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
+    </PropertyGroup>
 
     <!-- Write properties for the top level entry point -->
     <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
@@ -348,8 +341,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <OutputType>$(_ProjectRestoreType)</OutputType>
         <OutputPath>$(RestoreOutputAbsolutePath)</OutputPath>
         <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
-        <RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
+        <RuntimeIdentifiers>$(RuntimeIdentifiers);$(RuntimeIdentifier)</RuntimeIdentifiers>
         <RuntimeSupports>$(RuntimeSupports)</RuntimeSupports>
+        <CrossTargeting>$(_RestoreCrossTargeting)</CrossTargeting>
       </_RestoreGraphEntry>
     </ItemGroup>
 
@@ -400,7 +394,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       Properties="TargetFramework=%(_RestoreTargetFrameworksOutputFiltered.Identity);
               %(_MSBuildProjectReferenceExistent.SetConfiguration);
               %(_MSBuildProjectReferenceExistent.SetPlatform);
-              BuildProjectReferences=false;"
+              BuildProjectReferences=false;
+              ExcludeRestorePackageImports=true;"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
       <Output
@@ -428,7 +423,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               %(_MSBuildProjectReferenceExistent.SetPlatform);
               RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
               NuGetRestoreTargets=$(MSBuildThisFileFullPath);
-              BuildProjectReferences=false;"
+              BuildProjectReferences=false;
+              ExcludeRestorePackageImports=true;"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
       <Output
@@ -455,7 +451,8 @@ Copyright (c) .NET Foundation. All rights reserved.
             %(_MSBuildProjectReferenceExistent.SetPlatform);
             RestoreUseCustomAfterTargets=$(RestoreUseCustomAfterTargets);
             NuGetRestoreTargets=$(MSBuildThisFileFullPath);
-            BuildProjectReferences=false"
+            BuildProjectReferences=false;
+            ExcludeRestorePackageImports=true;"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
 
       <Output

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreImportGroup.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/MSBuildRestoreImportGroup.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.Commands
+{
+    public class MSBuildRestoreImportGroup
+    {
+        /// <summary>
+        /// Optional position arguement used when ordering groups in the output file.
+        /// </summary>
+        public int Position { get; set; } = 1;
+
+        /// <summary>
+        /// Conditions applied to the item group. These will be AND'd together.
+        /// </summary>
+        public List<string> Conditions { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Project paths to import.
+        /// </summary>
+        public List<string> Imports { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Combined conditions
+        /// </summary>
+        public string Condition
+        {
+            get
+            {
+                if (Conditions.Count > 0)
+                {
+                    return " " + string.Join(" AND ", Conditions.Select(s => s.Trim())) + " ";
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -169,6 +169,9 @@ namespace NuGet.Commands
 
                     // Add PackageTargetFallback
                     AddPackageTargetFallbacks(result, items);
+
+                    // Add CrossTargeting flag
+                    result.RestoreMetadata.CrossTargeting = IsPropertyTrue(specItem, "CrossTargeting");
                 }
             }
 
@@ -535,6 +538,11 @@ namespace NuGet.Commands
 
                 spec.Save(path);
             }
+        }
+
+        private static bool IsPropertyTrue(IMSBuildItem item, string propertyName)
+        {
+            return StringComparer.OrdinalIgnoreCase.Equals(item.GetProperty(propertyName), Boolean.TrueString);
         }
 
         private static readonly Lazy<bool> _isPersistDGSet = new Lazy<bool>(() => IsPersistDGSet());

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -235,6 +235,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.ProjectJsonPath = rawMSBuildMetadata.GetValue<string>("projectJsonPath");
             msbuildMetadata.ProjectName = rawMSBuildMetadata.GetValue<string>("projectName");
             msbuildMetadata.ProjectPath = rawMSBuildMetadata.GetValue<string>("projectPath");
+            msbuildMetadata.CrossTargeting = rawMSBuildMetadata.GetValue<bool>("crossTargeting");
 
             msbuildMetadata.Sources = new List<PackageSource>();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
@@ -105,11 +105,17 @@ namespace NuGet.ProjectModel
             SetValue(rawMSBuildMetadata, "projectName", msbuildMetadata.ProjectName);
             SetValue(rawMSBuildMetadata, "projectPath", msbuildMetadata.ProjectPath);
             SetValue(rawMSBuildMetadata, "projectJsonPath", msbuildMetadata.ProjectJsonPath);
+            SetValue(rawMSBuildMetadata, "packagesPath", msbuildMetadata.PackagesPath);
             SetValue(rawMSBuildMetadata, "outputPath", msbuildMetadata.OutputPath);
 
             if (msbuildMetadata.OutputType != RestoreOutputType.Unknown)
             {
                 SetValue(rawMSBuildMetadata, "outputType", msbuildMetadata.OutputType.ToString());
+            }
+
+            if (msbuildMetadata.CrossTargeting)
+            {
+                SetValue(rawMSBuildMetadata, "crossTargeting", msbuildMetadata.CrossTargeting.ToString());
             }
 
             SetValue(rawMSBuildMetadata, "packagesPath", msbuildMetadata.PackagesPath);

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -61,5 +61,10 @@ namespace NuGet.ProjectModel
         /// Original target frameworks strings. These are used to match msbuild conditionals to $(TargetFramework)
         /// </summary>
         public IList<string> OriginalTargetFrameworks { get; set; } = new List<string>();
+
+        /// <summary>
+        /// True if $(TargetFrameworks) is used and the build is using Cross Targeting.
+        /// </summary>
+        public bool CrossTargeting { get; set; }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreImportGroupTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreImportGroupTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class MSBuildRestoreImportGroupTests
+    {
+        [Fact]
+        public void MSBuildRestoreImportGroupTest_VerifyEmptyCondition()
+        {
+            // Arrange
+            var group = new MSBuildRestoreImportGroup();
+
+            // Act
+            var condition = group.Condition;
+
+            // Assert
+            Assert.Equal(string.Empty, condition);
+        }
+
+        [Fact]
+        public void MSBuildRestoreImportGroupTest_SingleCondition()
+        {
+            // Arrange
+            var group = new MSBuildRestoreImportGroup();
+            group.Conditions.Add("'$(a)' == 'a'  ");
+
+            // Act
+            var condition = group.Condition;
+
+            // Assert
+            Assert.Equal(" '$(a)' == 'a' ", condition);
+        }
+
+        [Fact]
+        public void MSBuildRestoreImportGroupTest_MultipleConditions()
+        {
+            // Arrange
+            var group = new MSBuildRestoreImportGroup();
+            group.Conditions.Add("'$(b)' != 'b'  ");
+            group.Conditions.Add("    '$(a)' == 'a'  ");
+
+            // Act
+            var condition = group.Condition;
+
+            // Assert
+            Assert.Equal(" '$(b)' != 'b' AND '$(a)' == 'a' ", condition);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreResultTests.cs
@@ -35,14 +35,17 @@ namespace NuGet.Commands.Test
                     var propsName = $"{projectName}.nuget.props";
                     var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                    var targets = new Dictionary<string, IList<string>>();
-                    targets.Add(string.Empty, new List<string>() { "blah" });
+                    var targets = new List<MSBuildRestoreImportGroup>();
+                    targets.Add(new MSBuildRestoreImportGroup()
+                    {
+                        Imports = new List<string>() { "blah" }
+                    });
 
-                      var msBuildRestoreResult = new MSBuildRestoreResult(
+                    var msBuildRestoreResult = new MSBuildRestoreResult(
                         targetsPath,
                         propsPath,
                         globalPackagesFolder,
-                        new Dictionary<string, IList<string>>(),
+                        new List<MSBuildRestoreImportGroup>(),
                         targets);
 
                     // Assert
@@ -88,25 +91,113 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                targets.Add("net45", new List<string>() { "a.targets", "b.targets" });
-                targets.Add("netstandard16", new List<string>() { "c.targets" });
-                targets.Add("netStandard1.7", new List<string>() { });
-                targets.Add(" '$(IsCrossTargetingBuild)' == 'true' ", new List<string>() { "x.targets", "y.targets" });
+                var propGroups = new List<MSBuildRestoreImportGroup>();
+                var targetGroups = new List<MSBuildRestoreImportGroup>();
 
-                var props = new Dictionary<string, IList<string>>();
-                props.Add("net45", new List<string>() { "a.props", "b.props" });
-                props.Add("netstandard16", new List<string>() { "c.props" });
-                props.Add("netStandard1.7", new List<string>() { });
-                props.Add("netStandard1.8", new List<string>() { });
-                props.Add(" '$(IsCrossTargetingBuild)' == 'true' ", new List<string>() { "z.props" });
+                targetGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "a.targets", "b.targets"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    }
+                });
+
+                targetGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "c.targets"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netstandard16'"
+                    }
+                });
+
+                targetGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                targetGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                         "x.targets", "y.targets"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(IsCrossTargetingBuild)' == 'true'"
+                    },
+                    Position = 0,
+                });
+
+                propGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "a.props", "b.props"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    }
+                });
+
+                propGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "c.props"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netstandard16'"
+                    }
+                });
+
+                propGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                propGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.8'"
+                    }
+                });
+
+                propGroups.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                         "z.props"
+                    },
+                    Conditions = new List<string>()
+                    {
+                        "'$(IsCrossTargetingBuild)' == 'true'"
+                    },
+                    Position = 0,
+                });
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
                   propsPath,
                   globalPackagesFolder,
-                  props,
-                  targets);
+                  propGroups,
+                  targetGroups);
 
                 // Act
                 msBuildRestoreResult.Commit(Common.NullLogger.Instance);
@@ -160,15 +251,56 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                targets.Add("net45", new List<string>() { });
-                targets.Add("netStandard1.7", new List<string>() { });
-                targets.Add(" '$(IsCrossTargetingBuild)' == 'true' ", new List<string>() { });
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
 
-                var props = new Dictionary<string, IList<string>>();
-                props.Add("net45", new List<string>() { });
-                props.Add("netStandard1.7", new List<string>() { });
-                props.Add(" '$(IsCrossTargetingBuild)' == 'true' ", new List<string>() { });
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(IsCrossTargetingBuild)' == 'true'"
+                    }
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    }
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(IsCrossTargetingBuild)' == 'true'"
+                    }
+                });
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
@@ -204,16 +336,80 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                targets.Add("net45", new List<string>() { "a.targets", "b.targets" });
-                targets.Add("netstandard16", new List<string>() { "c.targets" });
-                targets.Add("netStandard1.7", new List<string>() { });
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
 
-                var props = new Dictionary<string, IList<string>>();
-                props.Add("net45", new List<string>() { "a.props", "b.props" });
-                props.Add("netstandard16", new List<string>() { "c.props" });
-                props.Add("netStandard1.7", new List<string>() { });
-                props.Add("netStandard1.8", new List<string>() { });
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets", "b.targets"
+                    }
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netstandard16'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "c.targets"
+                    }
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.props", "b.props"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netstandard16'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "c.props"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.7'"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'netStandard1.8'"
+                    }
+                });
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
@@ -262,8 +458,8 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                var props = new Dictionary<string, IList<string>>();
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
@@ -299,11 +495,32 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                targets.Add("net45", new List<string>() { "a.targets", "b.targets" });
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
 
-                var props = new Dictionary<string, IList<string>>();
-                props.Add("net45", new List<string>() { "a.props", "b.props" });
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets", "b.targets"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "'$(TargetFramework)' == 'net45'"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.props", "b.props"
+                    }
+                });
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
@@ -350,11 +567,24 @@ namespace NuGet.Commands.Test
                 var propsName = $"{projectName}.nuget.g.props";
                 var propsPath = Path.Combine(randomProjectDirectory, propsName);
 
-                var targets = new Dictionary<string, IList<string>>();
-                targets.Add("", new List<string>() { "a.targets", "b.targets" });
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
 
-                var props = new Dictionary<string, IList<string>>();
-                props.Add("", new List<string>() { "a.props", "b.props" });
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "a.targets", "b.targets"
+                    }
+                });
+
+                props.Add(new MSBuildRestoreImportGroup()
+                {
+                    Imports = new List<string>()
+                    {
+                        "a.props", "b.props"
+                    }
+                });
 
                 var msBuildRestoreResult = new MSBuildRestoreResult(
                   targetsPath,
@@ -380,6 +610,98 @@ namespace NuGet.Commands.Test
                 Assert.Equal(2, targetItemGroups[0].Elements().Count());
                 Assert.Equal("a.targets", targetItemGroups[0].Elements().ToList()[0].Attribute(XName.Get("Project")).Value);
                 Assert.Equal("b.targets", targetItemGroups[0].Elements().ToList()[1].Attribute(XName.Get("Project")).Value);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreResult_VerifyPositionAndSortOrder()
+        {
+            // Arrange
+            using (var globalPackagesFolder = TestDirectory.Create())
+            using (var randomProjectDirectory = TestDirectory.Create())
+            {
+                var projectName = "testproject";
+                var targetsName = $"{projectName}.nuget.g.targets";
+                var targetsPath = Path.Combine(randomProjectDirectory, targetsName);
+
+                var propsName = $"{projectName}.nuget.g.props";
+                var propsPath = Path.Combine(randomProjectDirectory, propsName);
+
+                var props = new List<MSBuildRestoreImportGroup>();
+                var targets = new List<MSBuildRestoreImportGroup>();
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "b"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets"
+                    },
+                    Position = 0
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "a"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets"
+                    },
+                    Position = 0
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "z"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets"
+                    },
+                    Position = -1
+                });
+
+                targets.Add(new MSBuildRestoreImportGroup()
+                {
+                    Conditions = new List<string>()
+                    {
+                        "x"
+                    },
+                    Imports = new List<string>()
+                    {
+                        "a.targets"
+                    },
+                    Position = 100
+                });
+
+                var msBuildRestoreResult = new MSBuildRestoreResult(
+                  targetsPath,
+                  propsPath,
+                  globalPackagesFolder,
+                  props,
+                  targets);
+
+                // Act
+                msBuildRestoreResult.Commit(Common.NullLogger.Instance);
+
+                // Assert
+                Assert.True(File.Exists(targetsPath));
+                var targetsXML = XDocument.Load(targetsPath);
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal(4, targetItemGroups.Count);
+                Assert.Equal("z", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("a", targetItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("b", targetItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("x", targetItemGroups[3].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -36,6 +36,7 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "netcoreapp1.0" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // Package reference
@@ -46,6 +47,7 @@ namespace NuGet.Commands.Test
                     { "Id", "x" },
                     { "VersionRange", "1.0.0-beta.*" },
                     { "TargetFrameworks", "netcoreapp1.0" },
+                    { "CrossTargeting", "true" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -81,6 +83,7 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "net46" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // Package references
@@ -93,6 +96,7 @@ namespace NuGet.Commands.Test
                     { "VersionRange", "1.0.0" },
                     { "TargetFrameworks", "net46" },
                     { "IncludeAssets", "build;compile" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // A net46 -> Y
@@ -167,6 +171,7 @@ namespace NuGet.Commands.Test
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" }
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -191,6 +196,51 @@ namespace NuGet.Commands.Test
                 Assert.Equal(packagesFolder, string.Join("|", project1Spec.RestoreMetadata.PackagesPath));
                 Assert.Equal(0, project1Spec.RuntimeGraph.Runtimes.Count);
                 Assert.Equal(0, project1Spec.RuntimeGraph.Supports.Count);
+                Assert.True(project1Spec.RestoreMetadata.CrossTargeting);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreNonCrossTargeting()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "OutputType", "netcore" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                // Assert
+                Assert.Equal(project1Path, project1Spec.FilePath);
+                Assert.Equal("a", project1Spec.Name);
+                Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
+                Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
+                Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
+                Assert.False(project1Spec.RestoreMetadata.CrossTargeting);
             }
         }
 
@@ -220,6 +270,7 @@ namespace NuGet.Commands.Test
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
                 });
 
                 items.Add(new Dictionary<string, string>()
@@ -290,6 +341,7 @@ namespace NuGet.Commands.Test
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
                 });
 
                 items.Add(new Dictionary<string, string>()
@@ -344,6 +396,7 @@ namespace NuGet.Commands.Test
                     { "TargetFrameworks", "net46;netstandard16" },
                     { "RuntimeIdentifiers", "win7-x86;linux-x64" },
                     { "RuntimeSupports", "net46.app;win8.app" },
+                    { "CrossTargeting", "true" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -387,6 +440,7 @@ namespace NuGet.Commands.Test
                     { "TargetFrameworks", "net46;netstandard16" },
                     { "RuntimeIdentifiers", "win7-x86;linux-x64;win7-x86;linux-x64" },
                     { "RuntimeSupports", "net46.app;win8.app;net46.app;win8.app" },
+                    { "CrossTargeting", "true" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -431,6 +485,7 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "net46;netstandard1.6" },
+                    { "CrossTargeting", "true" },
                 });
 
                 items.Add(new Dictionary<string, string>()
@@ -442,6 +497,7 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project2Path },
                     { "TargetFrameworks", "net45;netstandard1.0" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // A -> B
@@ -452,6 +508,7 @@ namespace NuGet.Commands.Test
                     { "ProjectReferenceUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project2Path },
                     { "TargetFrameworks", "netstandard1.6" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // Package references
@@ -463,6 +520,7 @@ namespace NuGet.Commands.Test
                     { "Id", "x" },
                     { "VersionRange", "1.0.0-beta.*" },
                     { "TargetFrameworks", "net46" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // A netstandard1.6 -> Z
@@ -473,6 +531,7 @@ namespace NuGet.Commands.Test
                     { "Id", "z" },
                     { "VersionRange", "2.0.0" },
                     { "TargetFrameworks", "netstandard1.6" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // B ALL -> Y
@@ -483,6 +542,7 @@ namespace NuGet.Commands.Test
                     { "Id", "y" },
                     { "VersionRange", "[1.0.0]" },
                     { "TargetFrameworks", "netstandard1.0;net45" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // Framework assembly
@@ -492,6 +552,7 @@ namespace NuGet.Commands.Test
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "Id", "System.IO" },
                     { "TargetFrameworks", "net46" },
+                    { "CrossTargeting", "true" },
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -736,6 +797,7 @@ namespace NuGet.Commands.Test
                     { "ProjectPath", projectPath },
                     { "TargetFrameworks", "net462" },
                     { "ProjectName", "a" },
+                    { "CrossTargeting", "true" },
                 });
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -1,0 +1,474 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class RestoreBuildTargetsAndPropsTests
+    {
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyPropsAndTargetsGenerated()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462", "netstandard1.6");
+
+                spec.RestoreMetadata.CrossTargeting = true;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/x.targets");
+                packageX.AddFile("build/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX);
+
+                var project = projects[0];
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
+                var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == 'netstandard1.6' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+
+                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == 'netstandard1.6' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyPropsAndTargetsGeneratedWithNoTFMConditions()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462");
+
+                spec.RestoreMetadata.CrossTargeting = false;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/x.targets");
+                packageX.AddFile("build/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX);
+
+                var project = projects[0];
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
+                var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyPropsAndTargetsGenerated_SingleTFMWithConditions()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462");
+
+                spec.RestoreMetadata.CrossTargeting = true;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/x.targets");
+                packageX.AddFile("build/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX);
+
+                var project = projects[0];
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
+                var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == 'net462' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyPropsAndTargetsCrossTargeting()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462", "netstandard1.6");
+
+                spec.RestoreMetadata.CrossTargeting = true;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("buildCrossTargeting/x.targets");
+                packageX.AddFile("buildCrossTargeting/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX);
+
+                var project = projects[0];
+
+                // Act
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var targetsXML = XDocument.Parse(File.ReadAllText(project.TargetsOutput));
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
+                var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyRestoreNoop()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462", "netstandard1.6");
+
+                spec.RestoreMetadata.CrossTargeting = true;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/x.targets");
+                packageX.AddFile("build/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX);
+
+                var project = projects[0];
+
+                // First restore
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                // Act
+                var secondLogger = new TestLogger();
+                summaries = await RunRestore(pathContext, secondLogger, sources, dgFile, cacheContext);
+                success = summaries.All(s => s.Success);
+                var messages = string.Join(Environment.NewLine, secondLogger.Messages);
+                Assert.True(success, "Failed: " + messages);
+
+                // Verify the file was not rewritten
+                Assert.Contains("No changes found. Skipping write of imports file to disk", messages);
+                Assert.DoesNotContain("Writing imports file to disk", messages);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreBuildTargetsAndProps_VerifyRestoreChange()
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec = GetProject("projectA", "net462", "netstandard1.6");
+
+                spec.RestoreMetadata.CrossTargeting = true;
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("x", LibraryDependencyTarget.Package)
+                });
+
+                // Create fake projects, the real data is in the specs
+                var projects = CreateProjectsFromSpecs(pathContext, spec);
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec);
+                dgFile.AddRestore(spec.RestoreMetadata.ProjectUniqueName);
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/x.targets");
+                packageX.AddFile("build/x.props");
+                packageX.AddFile("contentFiles/any/any/_._");
+
+                packageY.AddFile("build/y.targets");
+                packageY.AddFile("build/y.props");
+                packageY.AddFile("contentFiles/any/any/_._");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX, packageY);
+
+                var project = projects[0];
+
+                // First restore
+                var summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                // Modify spec
+                spec.Dependencies.Add(new LibraryDependency()
+                {
+                    LibraryRange = new LibraryRange("y", LibraryDependencyTarget.Package)
+                });
+
+                // Act
+                summaries = await RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                success = summaries.All(s => s.Success);
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                // Verify the file was rewritten
+                Assert.Contains("y.targets", File.ReadAllText(project.TargetsOutput));
+                Assert.Contains("y.props", File.ReadAllText(project.PropsOutput));
+            }
+        }
+
+        private static List<SimpleTestProjectContext> CreateProjectsFromSpecs(SimpleTestPathContext pathContext, params PackageSpec[] specs)
+        {
+            var projects = new List<SimpleTestProjectContext>();
+
+            foreach (var spec in specs)
+            {
+                var project = new SimpleTestProjectContext(spec.Name, RestoreOutputType.NETCore, pathContext.SolutionRoot);
+
+                // Set proj properties
+                spec.FilePath = project.ProjectPath;
+                spec.RestoreMetadata.OutputPath = project.OutputPath;
+                spec.RestoreMetadata.ProjectPath = project.ProjectPath;
+
+                projects.Add(project);
+            }
+
+            var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot, projects.ToArray());
+            solution.Create(pathContext.SolutionRoot);
+
+            return projects;
+        }
+
+        private static async Task<IReadOnlyList<RestoreSummary>> RunRestore(
+            SimpleTestPathContext pathContext,
+            TestLogger logger,
+            List<PackageSource> sources,
+            DependencyGraphSpec dgFile,
+            SourceCacheContext cacheContext)
+        {
+            var restoreContext = new RestoreArgs()
+            {
+                CacheContext = cacheContext,
+                DisableParallel = true,
+                GlobalPackagesFolder = pathContext.UserPackagesFolder,
+                Sources = new List<string>() { pathContext.PackageSource },
+                Log = logger,
+                CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
+                PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
+                {
+                    new DependencyGraphSpecRequestProvider(new RestoreCommandProvidersCache(), dgFile)
+                }
+            };
+
+            return await RestoreRunner.Run(restoreContext);
+        }
+
+        private static PackageSpec GetProject(string projectName, params string[] frameworks)
+        {
+            var frameworkGroups = frameworks.Select(s =>
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse(s)
+                })
+                .ToList();
+
+            // Create two net45 projects
+            var spec = new PackageSpec(frameworkGroups);
+            spec.RestoreMetadata = new ProjectRestoreMetadata();
+            spec.RestoreMetadata.ProjectUniqueName = $"{projectName}-UNIQUENAME";
+            spec.RestoreMetadata.ProjectName = projectName;
+            spec.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec.Name = projectName;
+
+            foreach (var framework in frameworks)
+            {
+                spec.RestoreMetadata.OriginalTargetFrameworks.Add(framework);
+            }
+
+            foreach (var frameworkInfo in frameworkGroups)
+            {
+                spec.RestoreMetadata.TargetFrameworks.Add(
+                    new ProjectRestoreMetadataFrameworkInfo(frameworkInfo.FrameworkName));
+            }
+
+            return spec;
+        }
+    }
+}


### PR DESCRIPTION
Framework conditions for targets/props are added only when a project uses cross targeting. For scenarios with a single framework under $(TargetFramework) buildCrossTargeting will be left out and there will be no framework conditions to block the imports.

In addition to this a new property has been added to allow control over package imports: ExcludeRestorePackageImports. This flag is used at restore time to avoid imports from packages changing the inputs to restore, without this it is possible to get different results between the first and second restore.

This change also contains support for nooping when writing out targets/props files. Currently the check is a simple string compare on the files since these files are small. Nooping is now a major benefit since all NETCore projects reference the SDK package, without nooping on the targets/props files MSBuild will always end up rebuilding everything for NETCore solutions.

Fixes https://github.com/NuGet/Home/issues/3588
Fixes https://github.com/NuGet/Home/issues/3637
Fixes https://github.com/NuGet/Home/issues/3604
Fixes https://github.com/NuGet/Home/issues/3641
Fixes https://github.com/NuGet/Home/issues/3199

//cc @rohit21agrawal @joelverhagen @rrelyea @dtivel @alpaix @drewgil @jainaashish 
