### PR TITLE
Add a registry key to opt into the MSBuildShellOutNuGetProject

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
@@ -89,6 +89,12 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
+            // The project must have the CPS capability.
+            if (!hierarchy.IsCapabilityMatch("CPS"))
+            {
+                return null;
+            }
+
             // The project must be an IVsBuildPropertyStorage.
             var buildPropertyStorage = hierarchy as IVsBuildPropertyStorage;
             if (buildPropertyStorage == null)
@@ -96,15 +102,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            // MSBuild must be found.
-            var msbuildPath = GetMSBuildPath(buildPropertyStorage, project.DTE);
-            if (msbuildPath == null)
+            // The project must have the "TargetFrameworks" property.
+            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null)
             {
                 return null;
             }
 
-            // The project must have the "TargetFrameworks" property.
-            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null)
+            // MSBuild must be found.
+            var msbuildPath = GetMSBuildPath(buildPropertyStorage, project.DTE);
+            if (msbuildPath == null)
             {
                 return null;
             }
@@ -351,19 +357,6 @@ namespace NuGet.PackageManagement.VisualStudio
             if (File.Exists(msbuildPath))
             {
                 return msbuildPath;
-            }
-
-            // Try to get MSBuild from the PATH.
-            var pathVariable = Environment.GetEnvironmentVariable("PATH");
-            var pathDirectories = pathVariable.Split(Path.PathSeparator);
-            foreach (var pathDirectory in pathDirectories)
-            {
-                msbuildPath = Path.Combine(pathDirectory, MSBuildExe);
-
-                if (File.Exists(msbuildPath))
-                {
-                    return msbuildPath;
-                }
             }
 
             return null;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
@@ -99,12 +99,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            // The project must have the CPS capability.
-            if (!hierarchy.IsCapabilityMatch("CPS"))
-            {
-                return null;
-            }
-
             // The project must be an IVsBuildPropertyStorage.
             var buildPropertyStorage = hierarchy as IVsBuildPropertyStorage;
             if (buildPropertyStorage == null)
@@ -112,15 +106,15 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            // The project must have the "TargetFrameworks" property.
-            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null)
+            // MSBuild must be found.
+            var msbuildPath = GetMSBuildPath(buildPropertyStorage, project.DTE);
+            if (msbuildPath == null)
             {
                 return null;
             }
 
-            // MSBuild must be found.
-            var msbuildPath = GetMSBuildPath(buildPropertyStorage, project.DTE);
-            if (msbuildPath == null)
+            // The project must have the "TargetFrameworks" property.
+            if (GetMSBuildProperty(buildPropertyStorage, TargetFrameworksName) == null)
             {
                 return null;
             }
@@ -383,6 +377,19 @@ namespace NuGet.PackageManagement.VisualStudio
             if (File.Exists(msbuildPath))
             {
                 return msbuildPath;
+            }
+
+            // Try to get MSBuild from the PATH.
+            var pathVariable = Environment.GetEnvironmentVariable("PATH");
+            var pathDirectories = pathVariable.Split(Path.PathSeparator);
+            foreach (var pathDirectory in pathDirectories)
+            {
+                msbuildPath = Path.Combine(pathDirectory, MSBuildExe);
+
+                if (File.Exists(msbuildPath))
+                {
+                    return msbuildPath;
+                }
             }
 
             return null;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/MSBuildShellOutNuGetProject.cs
@@ -57,6 +57,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private const string MSBuildExe = "msbuild.exe";
 
+        private const string NuGetSubKey = @"Software\NuGet";
         private const string EnableRegistryKey = "EnableMSBuildShellOutNuGetProject";
 
         private static readonly string MSBuild14Path = Path.Combine(
@@ -143,7 +144,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             try
             {
-                using (var subKey = Registry.CurrentUser.OpenSubKey(@"Software\NuGet"))
+                using (var subKey = Registry.CurrentUser.OpenSubKey(NuGetSubKey))
                 {
                     var keyValue = subKey == null ? null : subKey.GetValue(key) as string;
                     return keyValue != null && keyValue != "0";


### PR DESCRIPTION
If this is key is present, use the `MSBuildShellOutNuGetProject`. This is to unblock VS WPT branch RI.

```
[HKEY_CURRENT_USER\SOFTWARE\NuGet]
"EnableMSBuildShellOutNuGetProject"="1"
```

Otherwise, we fall back to the original factory logic.

/cc @rrelyea @emgarten @rohit21agrawal @alpaix 
