### PR TITLE
Adding logs to locals -clear temp

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/LocalsCommandRunner.cs
@@ -195,9 +195,16 @@ namespace NuGet.Commands
         /// <returns><code>True</code> if the operation was successful; otherwise <code>false</code>.</returns>
         private bool ClearNuGetTempFolder(LocalsArgs localsArgs)
         {
+            var success = true;
             var tempFolderPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp);
+            if (!string.IsNullOrEmpty(tempFolderPath))
+            {
+                localsArgs.LogInformation(string.Format(CultureInfo.CurrentCulture, Strings.LocalsCommand_ClearingNuGetTempCache,
+                    tempFolderPath));
 
-            return ClearCacheDirectory(tempFolderPath, localsArgs);
+                success &= ClearCacheDirectory(tempFolderPath, localsArgs);
+            }
+            return success;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -321,6 +321,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Clearing NuGet Temp cache: {0}.
+        /// </summary>
+        public static string LocalsCommand_ClearingNuGetTempCache {
+            get {
+                return ResourceManager.GetString("LocalsCommand_ClearingNuGetTempCache", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Failed to delete &apos;{0}&apos;..
         /// </summary>
         public static string LocalsCommand_FailedToDeletePath {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -426,15 +426,19 @@
   </data>
   <data name="LocalsCommand_ClearingNuGetCache" xml:space="preserve">
     <value>Clearing NuGet cache: {0}</value>
+    <comment>{0} : Cache path</comment>
   </data>
   <data name="LocalsCommand_ClearingNuGetGlobalPackagesCache" xml:space="preserve">
     <value>Clearing NuGet global packages cache: {0}</value>
+    <comment>{0} : Global packages cache path</comment>
   </data>
   <data name="LocalsCommand_ClearingNuGetHttpCache" xml:space="preserve">
     <value>Clearing NuGet HTTP cache: {0}</value>
+    <comment>{0} : Http cache path</comment>
   </data>
   <data name="LocalsCommand_FailedToDeletePath" xml:space="preserve">
     <value>Failed to delete '{0}'.</value>
+    <comment>{0} : Path to be deleted</comment>
   </data>
   <data name="LocalsCommand_InvalidLocalResourceName" xml:space="preserve">
     <value>An invalid local resource name was provided. Please provide one of the following values: http-cache, temp, global-packages, all.</value>
@@ -502,5 +506,9 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   </data>
   <data name="Error_XPROJNotAllowed" xml:space="preserve">
     <value>Invalid input '{0}'. XProj support has been removed. Support for XProj and standalone project.json files has been removed, to continue working with legacy projects use NuGet 3.5.x from https://nuget.org/downloads</value>
+  </data>
+  <data name="LocalsCommand_ClearingNuGetTempCache" xml:space="preserve">
+    <value>Clearing NuGet Temp cache: {0}</value>
+    <comment>{0} : Temp cache path</comment>
   </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatLocalsTests.cs
@@ -121,6 +121,12 @@ namespace NuGet.XPlat.FuncTest
                     DotnetCliUtil.VerifyClearSuccess(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyClearSuccess(mockHttpCacheDirectory.FullName);
                     DotnetCliUtil.VerifyClearSuccess(mockTmpCacheDirectory.FullName);
+
+                    // Assert clear message
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet HTTP cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet Temp cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
                 else if (cacheType == "global-packages")
                 {
@@ -130,6 +136,10 @@ namespace NuGet.XPlat.FuncTest
                     // Http cache and Temp cahce should be untouched
                     DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
+
+                    // Assert clear message
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet global packages cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
                 else if (cacheType == "http-cache")
                 {
@@ -139,6 +149,10 @@ namespace NuGet.XPlat.FuncTest
                     // Global packages cache and temp cache should be untouched
                     DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockTmpCacheDirectory.FullName);
+
+                    // Assert clear message
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet HTTP cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
                 else if (cacheType == "temp")
                 {
@@ -148,8 +162,11 @@ namespace NuGet.XPlat.FuncTest
                     // Global packages cache and Http cache should be un touched
                     DotnetCliUtil.VerifyNoClear(mockGlobalPackagesDirectory.FullName);
                     DotnetCliUtil.VerifyNoClear(mockHttpCacheDirectory.FullName);
+
+                    // Assert clear message
+                    DotnetCliUtil.VerifyResultSuccess(result, "Clearing NuGet Temp cache:");
+                    DotnetCliUtil.VerifyResultSuccess(result, "Local resources cleared.");
                 }
-                DotnetCliUtil.VerifyResultSuccess(result, string.Empty);
             }
         }
 


### PR DESCRIPTION
Adding log to clearTempCache method to indicate that the temp cache is also cleared.
Also adding some comments to other log strings.

```
> .\NuGet.exe locals -clear all
Clearing NuGet HTTP cache: C:\Users\anmishr\AppData\Local\NuGet\v3-cache
Clearing NuGet global packages cache: C:\Users\anmishr\.nuget\packages\
Clearing NuGet Temp cache: C:\Users\anmishr\AppData\Local\Temp\NuGetScratch
Local resources cleared.
```

Fixes: https://github.com/NuGet/Home/issues/3607

//cc: @joelverhagen @rohit21agrawal @rrelyea @emgarten @alpaix @jainaashish @dtivel @zhili1208 @drewgil 
