### PR TITLE
Add -Recursive switch to nuget.exe restore

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -43,6 +43,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandMSBuildPath")]
         public string MSBuildPath { get; set; }
 
+        [Option(typeof(NuGetCommand), "Recursive")]
+        public bool Recursive { get; set; }
+
         [ImportingConstructor]
         public RestoreCommand()
             : base(MachineCache.Default)
@@ -594,7 +597,8 @@ namespace NuGet.CommandLine
                 _msbuildDirectory.Value,
                 projectsWithPotentialP2PReferences,
                 scaleTimeout,
-                Console);
+                Console,
+                Recursive);
         }
 
         /// <summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -66,7 +66,8 @@ namespace NuGet.CommandLine
             string msbuildDirectory,
             string[] projectPaths,
             int timeOut,
-            IConsole console)
+            IConsole console,
+            bool recursive)
         {
             string msbuildPath = Path.Combine(msbuildDirectory, "msbuild.exe");
 
@@ -135,6 +136,12 @@ namespace NuGet.CommandLine
 
                 // Disallow the import of targets/props from packages
                 argumentBuilder.Append(" /p:ExcludeRestorePackageImports=true ");
+
+                // Add all depenencies as top level restore projects if recursive is set
+                if (recursive)
+                {
+                    argumentBuilder.Append($" /p:RestoreRecursive=true ");
+                }
 
                 // Projects to restore
                 argumentBuilder.Append(" /p:RestoreGraphProjectInput=\"");

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -10144,6 +10144,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore all referenced projects for UWP and NETCore projects. This does not include packages.config projects..
+        /// </summary>
+        internal static string RestoreCommandRecursive {
+            get {
+                return ResourceManager.GetString("RestoreCommandRecursive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Checks if package restore consent is granted before installing a package..
         /// </summary>
         internal static string RestoreCommandRequireConsent {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5333,4 +5333,7 @@ nuget locals global-packages -list</value>
   <data name="CommandMSBuildPath" xml:space="preserve">
     <value>Specifies the path of MSBuild to be used with this command. This command will takes precedence over MSbuildVersion, nuget will always pick MSbuild from this specified path.</value>
   </data>
+  <data name="RestoreCommandRecursive" xml:space="preserve">
+    <value>Restore all referenced projects for UWP and NETCore projects. This does not include packages.config projects.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -1,10 +1,26 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Build.Framework;
+using NuGet.ProjectModel;
 
 namespace NuGet.Build.Tasks
 {
     public static class BuildTasksUtility
     {
+        /// <summary>
+        /// Add all restorable projects to the restore list.
+        /// This is the behavior for --recursive
+        /// </summary>
+        public static void AddAllProjectsForRestore(DependencyGraphSpec spec)
+        {
+            // Add everything from projects except for packages.config and unknown project types
+            foreach (var project in spec.Projects
+                .Where(project => RestorableTypes.Contains(project.RestoreMetadata.OutputType)))
+            {
+                spec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
+            }
+        }
+
         public static void CopyPropertyIfExists(ITaskItem item, IDictionary<string, string> properties, string key)
         {
             CopyPropertyIfExists(item, properties, key, key);
@@ -31,5 +47,13 @@ namespace NuGet.Build.Tasks
                 properties.Add(key, value);
             }
         }
+
+        private static HashSet<RestoreOutputType> RestorableTypes = new HashSet<RestoreOutputType>()
+        {
+            RestoreOutputType.DotnetCliTool,
+            RestoreOutputType.NETCore,
+            RestoreOutputType.Standalone,
+            RestoreOutputType.UAP
+        };
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -38,6 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IsRestoreTargetsFileLoaded>true</IsRestoreTargetsFileLoaded>
     <!-- Load NuGet.Build.Tasks.dll, this can be overridden to use a different version with $(RestoreTaskAssemblyFile) -->
     <RestoreTaskAssemblyFile Condition=" '$(RestoreTaskAssemblyFile)' == '' ">NuGet.Build.Tasks.dll</RestoreTaskAssemblyFile>
+    <!-- Recurse by default -->
+    <RestoreRecursive Condition=" '$(RestoreRecursive)' == '' ">true</RestoreRecursive>
   </PropertyGroup>
 
   <!-- Tasks -->
@@ -72,7 +74,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreDisableParallel="$(RestoreDisableParallel)"
       RestoreConfigFile="$(RestoreConfigFile)"
       RestoreNoCache="$(RestoreNoCache)"
-      RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)" />
+      RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
+      RestoreRecursive="$(RestoreRecursive)" />
   </Target>
 
   <!--
@@ -96,7 +99,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Write file -->
     <WriteRestoreGraphTask
       RestoreGraphItems="@(_RestoreGraphEntryFiltered)"
-      RestoreGraphOutputPath="$(RestoreGraphOutputPath)" />
+      RestoreGraphOutputPath="$(RestoreGraphOutputPath)"
+      RestoreRecursive="$(RestoreRecursive)" />
   </Target>
 
   <!--
@@ -122,7 +126,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
   </Target>
 
-    <!--
+  <!--
     ============================================================
     _GenerateRestoreGraph
     Entry point for creating the project to project restore graph.
@@ -307,7 +311,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>
-    
+
     <!-- 
       Determine project name for the assets file.
       Highest priority: PackageId
@@ -321,7 +325,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(AssemblyName)' != '' ">$(AssemblyName)</_RestoreProjectName>
       <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
     </PropertyGroup>
-    
+
     <!-- Determine if this will use cross targeting -->
     <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' != '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
@@ -511,7 +515,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="RestoreGraphItems"
         ItemName="_RestoreGraphEntry" />
     </GetRestorePackageReferencesTask>
-    
+
     <!-- Write out target framework information -->
     <ItemGroup Condition="  '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageTargetFallback)' != '' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -58,6 +58,11 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestoreIgnoreFailedSources { get; set; }
 
+        /// <summary>
+        /// Restore all projects.
+        /// </summary>
+        public bool RestoreRecursive { get; set; }
+
         public override bool Execute()
         {
             if (RestoreGraphItems.Length < 1)
@@ -69,6 +74,7 @@ namespace NuGet.Build.Tasks
             var log = new MSBuildLogger(Log);
 
             // Log inputs
+            log.LogDebug($"(in) RestoreGraphItems Count '{RestoreGraphItems?.Count() ?? 0}'");
             log.LogDebug($"(in) RestoreSources '{RestoreSources}'");
             log.LogDebug($"(in) RestorePackagesPath '{RestorePackagesPath}'");
             log.LogDebug($"(in) RestoreFallbackFolders '{RestoreFallbackFolders}'");
@@ -76,6 +82,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreConfigFile '{RestoreConfigFile}'");
             log.LogDebug($"(in) RestoreNoCache '{RestoreNoCache}'");
             log.LogDebug($"(in) RestoreIgnoreFailedSources '{RestoreIgnoreFailedSources}'");
+            log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
 
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(GetMSBuildItem);
@@ -98,6 +105,12 @@ namespace NuGet.Build.Tasks
                     // Restore will fail if given no inputs, but here we should skip it and provide a friendly message.
                     log.LogMinimal("Nothing to do. None of the projects specified contain packages to restore.");
                     return true;
+                }
+
+                // Add all child projects
+                if (RestoreRecursive)
+                {
+                    BuildTasksUtility.AddAllProjectsForRestore(dgFile);
                 }
 
                 providers.Add(new DependencyGraphSpecRequestProvider(providerCache, dgFile));

--- a/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WriteRestoreGraphTask.cs
@@ -21,6 +21,11 @@ namespace NuGet.Build.Tasks
         [Required]
         public string RestoreGraphOutputPath { get; set; }
 
+        /// <summary>
+        /// Restore all projects.
+        /// </summary>
+        public bool RestoreRecursive { get; set; }
+
         public override bool Execute()
         {
             if (RestoreGraphItems.Length < 1)
@@ -31,11 +36,21 @@ namespace NuGet.Build.Tasks
 
             var log = new MSBuildLogger(Log);
 
+            log.LogDebug($"(in) RestoreGraphItems Count '{RestoreGraphItems?.Count() ?? 0}'");
+            log.LogDebug($"(in) RestoreGraphOutputPath '{RestoreGraphOutputPath}'");
+            log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
+
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(GetMSBuildItem);
 
             // Create file
             var dgFile = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+
+            // Add all child projects
+            if (RestoreRecursive)
+            {
+                BuildTasksUtility.AddAllProjectsForRestore(dgFile);
+            }
 
             var fileInfo = new FileInfo(RestoreGraphOutputPath);
             fileInfo.Directory.Create();

--- a/src/NuGet.Core/NuGet.Build.Tasks/project.json
+++ b/src/NuGet.Core/NuGet.Build.Tasks/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "3.6.0-*",
   "description": "NuGet 3 restore for dotnet CLI",
   "packOptions": {


### PR DESCRIPTION
The Recursive switch will add all projects in the dg file to the restore list, this will ensure that all projects have been restored, which is needed for build to run.

Fixes https://github.com/NuGet/Home/issues/3577

//cc @rohit21agrawal @joelverhagen @jainaashish @drewgil @alpaix 
