### PR TITLE
Change IsCrossTargetingBuild condition to TargetFramework

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -22,7 +22,7 @@ namespace NuGet.Commands
 {
     public static class BuildAssetsUtils
     {
-        internal static readonly string CrossTargetingCondition = "'$(IsCrossTargetingBuild)' == 'true'";
+        internal static readonly string CrossTargetingCondition = "'$(TargetFramework)' == ''";
         internal static readonly string TargetFrameworkCondition = "'$(TargetFramework)' == '{0}'";
         internal static readonly string ExcludeAllCondition = "'$(ExcludeRestorePackageImports)' != 'true'";
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -663,7 +663,7 @@ namespace NuGet.CommandLine.Test
 
                 // CrossTargeting should be first
                 Assert.Equal(2, targetItemGroups.Count);
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("'$(TargetFramework)' == 'net45' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
 
                 Assert.Equal(3, targetItemGroups[0].Elements().Count());
@@ -677,7 +677,7 @@ namespace NuGet.CommandLine.Test
                 Assert.EndsWith("x.targets", targetItemGroups[1].Elements().ToList()[2].Attribute(XName.Get("Project")).Value);
 
                 Assert.Equal(2, propsItemGroups.Count);
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("'$(TargetFramework)' == 'net45' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
 
                 Assert.Equal(3, propsItemGroups[0].Elements().Count());
@@ -735,7 +735,7 @@ namespace NuGet.CommandLine.Test
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
 
                 Assert.Equal(1, targetItemGroups.Count);
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal(1, targetItemGroups[0].Elements().Count());
                 Assert.EndsWith("x.targets", targetItemGroups[0].Elements().ToList()[0].Attribute(XName.Get("Project")).Value);
             }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreResultTests.cs
@@ -134,7 +134,7 @@ namespace NuGet.Commands.Test
                     },
                     Conditions = new List<string>()
                     {
-                        "'$(IsCrossTargetingBuild)' == 'true'"
+                        "'$(TargetFramework)' == ''"
                     },
                     Position = 0,
                 });
@@ -187,7 +187,7 @@ namespace NuGet.Commands.Test
                     },
                     Conditions = new List<string>()
                     {
-                        "'$(IsCrossTargetingBuild)' == 'true'"
+                        "'$(TargetFramework)' == ''"
                     },
                     Position = 0,
                 });
@@ -213,7 +213,7 @@ namespace NuGet.Commands.Test
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
 
                 Assert.Equal(3, targetItemGroups.Count);
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == ''", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("'$(TargetFramework)' == 'net45'", targetItemGroups[1].Attribute(XName.Get("Condition")).Value.Trim());
                 Assert.Equal("'$(TargetFramework)' == 'netstandard16'", targetItemGroups[2].Attribute(XName.Get("Condition")).Value.Trim());
 
@@ -229,7 +229,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("c.targets", targetItemGroups[2].Elements().ToList()[0].Attribute(XName.Get("Project")).Value);
 
                 Assert.Equal(3, propsItemGroups.Count);
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == ''", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
 
                 Assert.Equal(1, propsItemGroups[0].Elements().Count());
                 Assert.Equal("z.props", propsItemGroups[0].Elements().ToList()[0].Attribute(XName.Get("Project")).Value);
@@ -274,7 +274,7 @@ namespace NuGet.Commands.Test
                 {
                     Conditions = new List<string>()
                     {
-                        "'$(IsCrossTargetingBuild)' == 'true'"
+                        "'$(TargetFramework)' == ''"
                     }
                 });
 
@@ -298,7 +298,7 @@ namespace NuGet.Commands.Test
                 {
                     Conditions = new List<string>()
                     {
-                        "'$(IsCrossTargetingBuild)' == 'true'"
+                        "'$(TargetFramework)' == ''"
                     }
                 });
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -256,8 +256,8 @@ namespace NuGet.Commands.Test
                 var propsXML = XDocument.Parse(File.ReadAllText(project.PropsOutput));
                 var propsItemGroups = propsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
 
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
-                Assert.Equal("'$(IsCrossTargetingBuild)' == 'true' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", propsItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
             }
         }
 


### PR DESCRIPTION
Previous condition '$(IsCrossTargetingBuild)' == 'true'
New condition '$(TargetFramework)' == ''

Fixes https://github.com/NuGet/Home/issues/3532

//cc @rohit21agrawal @nguerrera @joelverhagen @jainaashish @dtivel @alpaix 
