### PR TITLE
move evaluation of packageversion and output path to when the target is actually run

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -20,8 +20,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
-    <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
-    <PackageOutputPath Condition=" '$(PackageOutputPath)' == '' ">$(TargetDir)</PackageOutputPath>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
     <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFiles</GenerateNuspecDependsOn>
     <Description Condition="'$(Description)'==''">Package Description</Description>
@@ -66,6 +64,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="GenerateNuspec" DependsOnTargets="$(GenerateNuspecDependsOn)" Condition="$(IsPackable) == 'true'">
     <PropertyGroup Condition="$(ContinuePackingAfterGeneratingNuspec) == '' ">
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+    </PropertyGroup>
+    <PropertyGroup>      
+      <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
+      <PackageOutputPath Condition=" '$(PackageOutputPath)' == '' ">$(OutputPath)</PackageOutputPath>
     </PropertyGroup>
     <!-- Call Pack -->
     <PackTask PackItem="$(PackProjectInputFile)"


### PR DESCRIPTION
This is based on the nuget side of fix for  :
https://github.com/dotnet/sdk/issues/217
https://github.com/dotnet/sdk/issues/224

CC: @emgarten @joelverhagen @alpaix @jainaashish @drewgil @rrelyea @zhili1208 @mishra14 @dtivel 
