### PR TITLE
Block xproj resolution for non-xproj projects.

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
@@ -15,5 +15,6 @@ namespace NuGet.LibraryModel
         public static readonly string RuntimeAsset = "NuGet.ProjectModel.RuntimeAsset";
         public static readonly string FrameworkAssemblies = "NuGet.ProjectModel.FrameworkAssemblies";
         public static readonly string ProjectFrameworks = "NuGet.ProjectModel.ProjectFrameworks";
+        public static readonly string ProjectOutputType = "NuGet.ProjectModel.RestoreMetadata.OutputType";
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -111,7 +111,8 @@ namespace NuGet.ProjectModel
             {
                 packageSpec = externalReference.PackageSpec;
             }
-            else if (libraryRange.TypeConstraintAllows(LibraryDependencyTarget.Project))
+            else if (libraryRange.TypeConstraintAllows(LibraryDependencyTarget.Project)
+                && !string.IsNullOrEmpty(rootPath))
             {
                 // Find the package spec resolver for this root path.
                 var specResolver = GetPackageSpecResolver(rootPath);
@@ -171,6 +172,17 @@ namespace NuGet.ProjectModel
             if (packageSpec != null)
             {
                 library[KnownLibraryProperties.PackageSpec] = packageSpec;
+
+                var outputType = packageSpec.RestoreMetadata?.OutputType;
+
+                if (outputType.HasValue)
+                {
+                    library[KnownLibraryProperties.ProjectOutputType] = outputType.Value.ToString();
+                }
+                else
+                {
+                    library[KnownLibraryProperties.ProjectOutputType] = "unknown";
+                }
             }
 
             // Add msbuild path


### PR DESCRIPTION
This is temporary code to stop xproj resolution from leaking to other project types. This will be removed soon when xproj goes away!

Fixes https://github.com/NuGet/Home/issues/3652

//cc @drewgil @jainaashish 
