### PR TITLE
DPL minbar implementation to support with Nuget

### DIFF
--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
@@ -15,7 +15,8 @@
     "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Threading": "15.0.20-pre",
     "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4",
-    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920"
+    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+    "Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime":  "15.0.0"
   },
   "frameworks": {
     "net46": {}

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -354,6 +354,10 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                     return;
                 }
 
+                // make sure all projects are loaded before start to execute init scripts. Since
+                // projects might not be loaded when DPL is enabled.
+                _solutionManager.EnsureSolutionIsLoaded();
+
                 // invoke init.ps1 files in the order of package dependency.
                 // if A -> B, we invoke B's init.ps1 before A's.
 

--- a/src/NuGet.Clients/VsExtension/.vsixignore.vs15
+++ b/src/NuGet.Clients/VsExtension/.vsixignore.vs15
@@ -49,6 +49,7 @@ Microsoft.VisualStudio.RemoteControl.dll
 Microsoft.VisualStudio.Services.Client.dll
 Microsoft.VisualStudio.Services.Common.dll
 Microsoft.VisualStudio.Services.WebApi.dll
+Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime.dll
 Microsoft.VisualStudio.Telemetry.dll
 Microsoft.VisualStudio.Utilities.Internal.dll
 Microsoft.WindowsAzure.Configuration.dll

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -900,6 +900,9 @@ namespace NuGetVSExtension
                 throw new InvalidOperationException(Strings.SolutionIsNotSaved);
             }
 
+            // make sure all projects are loaded before showing manager ui even with DPL enabled.
+            solutionManager.EnsureSolutionIsLoaded();
+
             var projects = solutionManager.GetNuGetProjects();
             if (!projects.Any())
             {

--- a/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
+++ b/src/NuGet.Clients/VsExtension/VsEvents/OnBuildPackageRestorer.cs
@@ -166,6 +166,12 @@ namespace NuGetVSExtension
                     return;
                 }
 
+                // Check if solution is DPL enabled, then don't restore
+                if (SolutionManager.IsSolutionDPLEnabled)
+                {
+                    return;
+                }
+
                 if (!IsAutomatic(Settings))
                 {
                     return;
@@ -211,6 +217,10 @@ namespace NuGetVSExtension
                 {
                     // Get MSBuildOutputVerbosity from _dte
                     _msBuildOutputVerbosity = GetMSBuildOutputVerbositySetting(_dte);
+
+                    // make sure all projects are loaded before start to restore. Since
+                    // projects might not be loaded when DPL is enabled.
+                    SolutionManager.EnsureSolutionIsLoaded();
 
                     // Get the projects from the SolutionManager
                     // Note that projects that are not supported by NuGet, will not show up in this list

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -59,6 +59,14 @@ namespace NuGet.PackageManagement
         /// </summary>
         bool IsSolutionAvailable { get; }
 
+        /// <summary>
+        /// Returns true if the solution is loaded with DPL enabled.
+        /// That is, when no project is loaded by default.
+        /// This is only applicable for VS15, for VS14 it will always return false.
+        /// </summary>
+        bool IsSolutionDPLEnabled { get; }
+
+
         INuGetProjectContext NuGetProjectContext { get; set; }
 
         IEnumerable<NuGetProject> GetNuGetProjects();
@@ -96,6 +104,13 @@ namespace NuGet.PackageManagement
         /// </summary>
         /// <param name="nuGetProject"></param>
         void SaveProject(NuGetProject nuGetProject);
+		
+        /// <summary>
+        /// It ensure to completely load the solution before continue if it was loaded with DPL.
+        /// That is, not all the projects were loaded when solution was open.
+        /// This will only be applicable for VS15 and will do nothing for VS14.
+        /// </summary>
+        void EnsureSolutionIsLoaded();
     }
 
     public class NuGetProjectEventArgs : EventArgs

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -154,6 +154,16 @@ namespace Test.Utility
             get { return IsSolutionOpen; }
         }
 
+        public bool IsSolutionDPLEnabled
+        {
+            get { return false; }
+        }
+
+        public void EnsureSolutionIsLoaded()
+        {
+            // do nothing
+        }
+
 #pragma warning disable 0067
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectAdded;
 


### PR DESCRIPTION
This is the DPL minbar implementation to support DPL mode with NuGet in VS15. IT covers below scenarios:
- Load solution when manager ui is opened at solution level and show all packages across solution.
- Load solution when PMC is opened after solution load with DPL or solution is already loaded under DPL and then opened PMC.
- Load solution when restore is performed at solution level.
- Ignore onbuild restore when solution is loaded with DPL enabled.

DPL settling - Tools -> Options -> Projects and Solutions -> Lightweight Solution load (experimental)

Fixes https://github.com/NuGet/Home/issues/3614

@rrelyea @emgarten @joelverhagen @alpaix @dtivel @rohit21agrawal @drewgil 
