### PR TITLE
ToolReferences in Restore Nomination API

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
@@ -22,5 +22,10 @@ namespace NuGet.SolutionRestoreManager
         /// Target frameworks metadata.
         /// </summary>
         IVsTargetFrameworks TargetFrameworks { get; }
+
+        /// <summary>
+        /// Collection of tool references.
+        /// </summary>
+        IVsReferenceItems ToolReferences { get; }
     }
 }


### PR DESCRIPTION
Added collection of tool references matching `DotNetCliToolReference` items in csproj.

Resolves NuGet/Home#3702.

//cc @rrelyea @emgarten @srivatsn @natidea
