### PR TITLE
Fix regression in IsHigherAssemblyVersionInFramework

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/FrameworkAssemblyResolver.cs
@@ -87,7 +87,8 @@ namespace NuGet.PackageManagement.VisualStudio
             // Find a frameworkAssembly with the same name as assemblyName.
             // If one exists, see if its version is greater than that of the available version.
             return frameworkAssembliesDictionary[dotNetFrameworkVersion].Any(p =>
-                string.Equals(p.AssemblyName.Name, simpleAssemblyName, StringComparison.OrdinalIgnoreCase)
+                !p.IsFacade
+                    && string.Equals(p.AssemblyName.Name, simpleAssemblyName, StringComparison.OrdinalIgnoreCase)
                     && p.AssemblyName.Version > availableVersion);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/FrameworkAssemblyResolverTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/FrameworkAssemblyResolverTests.cs
@@ -255,6 +255,22 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.False(actualResult);
             Assert.Equal(0, _dictionary.Count);
         }
+
+        [Theory]
+        [InlineData("System.Collections")]
+        [InlineData("System.Runtime")]
+        public void FrameworkAssemblyResolver_IsHigherAssemblyVersionInFramework_DoesNotSupportFacadeAssemblies(string simpleAssemblyName)
+        {
+            var actualResult = FrameworkAssemblyResolver.IsHigherAssemblyVersionInFramework(
+                simpleAssemblyName,
+                new Version("3.0.0"),
+                _frameworkName,
+                frameworkName => new List<string>() { _fixture.Path },
+                _dictionary);
+
+            Assert.False(actualResult);
+            Assert.Equal(1, _dictionary.Count);
+        }
     }
 
     /*


### PR DESCRIPTION
Continuation of fix NuGet/Home#2193.

`FrameworkAssemblyResolver.IsHigherAssemblyVersionInFramework(...)` did not support facade assemblies before my previous fix.  To maintain that behavior, facades must be explicitly excluded.

Add a unit test.

@rrelyea @emgarten @joelverhagen @drewgil @alpaix @mishra14 @jainaashish @zhili1208 @rohit21agrawal
