### PR TITLE
Set the SystemComponent attribute in the dev15 VSIX manifest

### DIFF
--- a/src/NuGet.Clients/VsExtension/source.extension.vs15.vsixmanifest
+++ b/src/NuGet.Clients/VsExtension/source.extension.vs15.vsixmanifest
@@ -8,7 +8,7 @@
     <PreviewImage>Resources/nuget_256.png</PreviewImage>
     <ShortcutPath>..\CommonExtensions\Microsoft\NuGet</ShortcutPath>
   </Metadata>
-  <Installation InstalledByMsi="false" AllUsers="true">
+  <Installation SystemComponent="true" InstalledByMsi="false" AllUsers="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,16.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.VWDExpress" Version="[15.0,16.0)" />


### PR DESCRIPTION
Addresses https://github.com/NuGet/Home/issues/3700.

This makes it so NuGet does not appear in the dev15 Extensions and Updates window.

/cc @drewgil @alpaix 
