### PR TITLE
Allow ProjectSystemCache to return projects by unambiguous short names

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -17,6 +17,9 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -32,6 +35,7 @@
   <ItemGroup>
     <Compile Include="FrameworkAssemblyResolverTests.cs" />
     <Compile Include="ProjectKNuGetProjectTests.cs" />
+    <Compile Include="ProjectSystems\ProjectSystemCacheTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Telemetry\NuGetTelemetryServiceTests.cs" />
   </ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class ProjectSystemCacheTests
+    {
+        [Fact]
+        public void TryGetDTEProject_ReturnsProjectByFullName()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = new ProjectNames(
+                fullName: @"C:\src\project\project.csproj",
+                uniqueName: @"folder\project",
+                shortName: "project",
+                customUniqueName: @"folder\project");
+            var dteProject = new Mock<EnvDTE.Project>();
+
+            target.AddProject(projectNames, dteProject.Object, nuGetProject: null);
+            EnvDTE.Project actual;
+
+            // Act
+            var success = target.TryGetDTEProject(projectNames.FullName, out actual);
+
+            // Assert
+            Assert.True(success, "The project should have been fetched from the cache by full name.");
+            Assert.Same(dteProject.Object, actual);
+        }
+
+        [Fact]
+        public void TryGetDTEProject_ReturnsProjectByCustomUniqueName()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = new ProjectNames(
+                fullName: @"C:\src\project\project.csproj",
+                uniqueName: @"folder\project",
+                shortName: "project",
+                customUniqueName: @"custom");
+            var dteProject = new Mock<EnvDTE.Project>();
+
+            target.AddProject(projectNames, dteProject.Object, nuGetProject: null);
+            EnvDTE.Project actual;
+
+            // Act
+            var success = target.TryGetDTEProject(projectNames.CustomUniqueName, out actual);
+
+            // Assert
+            Assert.True(success, "The project should have been fetched from the cache by custom unique name.");
+            Assert.Same(dteProject.Object, actual);
+        }
+
+        [Fact]
+        public void TryGetDTEProject_ReturnsProjectByUniqueName()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = new ProjectNames(
+                fullName: @"C:\src\project\project.csproj",
+                uniqueName: @"folder\project",
+                shortName: "project",
+                customUniqueName: @"folder\project");
+            var dteProject = new Mock<EnvDTE.Project>();
+
+            target.AddProject(projectNames, dteProject.Object, nuGetProject: null);
+            EnvDTE.Project actual;
+
+            // Act
+            var success = target.TryGetDTEProject(projectNames.UniqueName, out actual);
+
+            // Assert
+            Assert.True(success, "The project should have been fetched from the cache by unique name.");
+            Assert.Same(dteProject.Object, actual);
+        }
+
+        [Fact]
+        public void TryGetDTEProject_ReturnsProjectWhenShortNameIsNotAmbiguous()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+            var projectNames = new ProjectNames(
+                fullName: @"C:\src\project\project.csproj",
+                uniqueName: @"folder\project",
+                shortName: "project",
+                customUniqueName: @"folder\project");
+            var dteProject = new Mock<EnvDTE.Project>();
+
+            target.AddProject(projectNames, dteProject.Object, nuGetProject: null);
+            EnvDTE.Project actual;
+
+            // Act
+            var success = target.TryGetDTEProject(projectNames.ShortName, out actual);
+
+            // Assert
+            Assert.True(success, "The project should have been fetched from the cache by short name.");
+            Assert.Same(dteProject.Object, actual);
+        }
+
+        [Fact]
+        public void TryGetDTEProject_ReturnsNullWhenShortNameIsAmbiguous()
+        {
+            // Arrange
+            var target = new ProjectSystemCache();
+
+            var projectNamesA = new ProjectNames(
+                fullName: @"C:\src\projectA\project.csproj",
+                uniqueName: @"folderA\project",
+                shortName: "project",
+                customUniqueName: @"folderA\project");
+
+            var projectNamesB = new ProjectNames(
+                fullName: @"C:\src\projectB\project.csproj",
+                uniqueName: @"folderB\project",
+                shortName: projectNamesA.ShortName,
+                customUniqueName: @"folderB\project");
+            
+            target.AddProject(projectNamesA, dteProject: null, nuGetProject: null);
+            target.AddProject(projectNamesB, dteProject: null, nuGetProject: null);
+
+            EnvDTE.Project actual;
+
+            // Act
+            var success = target.TryGetDTEProject(projectNamesA.ShortName, out actual);
+
+            // Assert
+            Assert.False(success, "The project should not have been fetched from the cache by short name.");
+            Assert.Null(actual);
+        }
+    }
+}


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/3732

/cc @alpaix @emgarten @rrelyea 
