### PR TITLE
Adding support for project level properties in NRM

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectProperties.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectProperties.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a collection of project properties.
+    /// </summary>
+    [ComImport]
+    [Guid("8ba829f1-0271-40a7-a098-21c518b8148b")]
+    public interface IVsProjectProperties : IEnumerable
+    {
+        /// <summary>
+        /// Total count of properties in container.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Retrieves a property by name or index.
+        /// </summary>
+        /// <param name="index">Property name or index.</param>
+        /// <returns>Property matching index.</returns>
+        IVsProjectProperty Item(object index);
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectProperty.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectProperty.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Represents a property as a key-value pair
+    /// </summary>
+    [ComImport]
+    [Guid("28954114-b5b5-40c4-8ca3-c983e1429960")]
+    public interface IVsProjectProperty
+    {
+        /// <summary>
+        /// Property name.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Property value.
+        /// </summary>
+        string Value { get; }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
@@ -19,6 +19,11 @@ namespace NuGet.SolutionRestoreManager
         string BaseIntermediatePath { get; }
 
         /// <summary>
+        /// Original raw value of TargetFrameworks property as set in a project file.
+        /// </summary>
+        string OriginalTargetFrameworks { get; }
+
+        /// <summary>
         /// Target frameworks metadata.
         /// </summary>
         IVsTargetFrameworks TargetFrameworks { get; }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo.cs
@@ -19,6 +19,12 @@ namespace NuGet.SolutionRestoreManager
         string TargetFrameworkMoniker { get; }
 
         /// <summary>
+        /// Collection of project level properties evaluated per each Target Framework,
+        /// e.g. PackageTargetFallback.
+        /// </summary>
+        IVsProjectProperties Properties { get; }
+
+        /// <summary>
         /// Collection of project references.
         /// </summary>
         IVsReferenceItems ProjectReferences { get; }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/NuGet.SolutionRestoreManager.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/NuGet.SolutionRestoreManager.Interop.csproj
@@ -23,6 +23,8 @@
     <None Include="NuGet.SolutionRestoreManager.Interop.nuspec" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IVsProjectProperties.cs" />
+    <Compile Include="IVsProjectProperty.cs" />
     <Compile Include="IVsProjectRestoreInfo.cs" />
     <Compile Include="IVsReferenceItem.cs" />
     <Compile Include="IVsReferenceProperties.cs" />
@@ -49,10 +51,7 @@
       <Nuspec Include="*.nuspec" />
       <PackageInclude Include="install.ps1" />
     </ItemGroup>
-    <Copy
-      SourceFiles="%(PackageInclude.Identity)"
-      DestinationFolder="$(TargetDir)" />
-    <Exec
-      Command="$(NuGetExe) pack %(Nuspec.Identity) -Version $(PackageVersion) -BasePath $(TargetDir) -OutputDirectory $(PublishDestination) -Verbosity detailed" />
+    <Copy SourceFiles="%(PackageInclude.Identity)" DestinationFolder="$(TargetDir)" />
+    <Exec Command="$(NuGetExe) pack %(Nuspec.Identity) -Version $(PackageVersion) -BasePath $(TargetDir) -OutputDirectory $(PublishDestination) -Verbosity detailed" />
   </Target>
 </Project>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsProjectRestoreInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsProjectRestoreInfo.cs
@@ -14,6 +14,8 @@ namespace NuGet.SolutionRestoreManager
     {
         public String BaseIntermediatePath { get; }
 
+        public string OriginalTargetFrameworks { get; }
+
         public IVsTargetFrameworks TargetFrameworks { get; }
 
         public IVsReferenceItems ToolReferences { get; }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsTargetFrameworkInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsTargetFrameworkInfo.cs
@@ -11,6 +11,8 @@ namespace NuGet.SolutionRestoreManager
 
         public IVsReferenceItems ProjectReferences { get; }
 
+        public IVsProjectProperties Properties { get; }
+
         public String TargetFrameworkMoniker { get; }
 
         public VsTargetFrameworkInfo(


### PR DESCRIPTION
Added an attribute to `IVsTargetFrameworkInfo` to support project level restore properties collection as evaluated per each TFI.

Prerequisite for NuGet/Home#3746.

//cc @natidea @srivatsn @emgarten @drewgil @joelverhagen @rohit21agrawal @rrelyea 
