### PR TITLE
Fix VS Install path for d15prerel based dev15 for our E2E tests

### DIFF
--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -12,7 +12,14 @@
         $ProgramFilesPath = ${env:ProgramFiles(x86)}
     }
 
-    $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)
+    if ($VSVersion -Eq "15.0")
+    {
+        $VSFolderPath = Join-Path $ProgramFilesPath "Microsoft Visual Studio\2017\Enterprise"
+    }
+    else
+    {
+        $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)    
+    }
 
     return $VSFolderPath
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/3709

Part of the dev15 E2E test fix was checked in by @emgarten in https://github.com/NuGet/NuGet.Client/commit/64570ba3e6c786d1334442104bbf729075ffb5ba.

This should allow dev to run the dev15 E2E test on the new d15prerel based machine.

@joelverhagen @emgarten @drewgil @rohit21agrawal @jainaashish @dtivel @zhili1208 @rrelyea @alpaix 
