### PR TITLE
Observe the RuntimeIdentifier(s) and RuntimeSupports in legacy .csproj

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
 using NuGet.RuntimeModel;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using VSLangProj;
 using VSLangProj150;
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -1,18 +1,17 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
-using NuGet.ProjectManagement;
+using NuGet.RuntimeModel;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using VSLangProj;
 using VSLangProj150;
-using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -34,7 +33,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         // Property caches
         private string _projectFullPath;
-        private string _baseIntermediatePath;
         private bool? _isLegacyCSProjPackageReferenceProject;
 
         public EnvDTEProjectAdapter(Project project)
@@ -97,27 +95,18 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                if (string.IsNullOrEmpty(_baseIntermediatePath))
+                var intermediateDirectory = GetMSBuildProperty(AsIVsBuildPropertyStorage, "BaseIntermediateOutputPath");
+
+                if (string.IsNullOrEmpty(intermediateDirectory))
                 {
-                    if (AsIVsBuildPropertyStorage != null)
-                    {
-                        var intermediateDirectory = GetMSBuildProperty(AsIVsBuildPropertyStorage, "BaseIntermediateOutputPath");
-                        var projectDirectory = Path.GetDirectoryName(ProjectFullPath);
-                        if (string.IsNullOrEmpty(intermediateDirectory))
-                        {
-                            _baseIntermediatePath = Path.GetDirectoryName(projectDirectory);
-                        }
-                        else
-                        {
-                            if (!Path.IsPathRooted(intermediateDirectory))
-                            {
-                                _baseIntermediatePath = Path.Combine(projectDirectory, intermediateDirectory);
-                            }
-                        }
-                    }
+                    throw new InvalidOperationException(string.Format(
+                        Strings.BaseIntermediateOutputPathNotFound,
+                        ProjectFullPath));
                 }
 
-                return _baseIntermediatePath;
+                var projectDirectory = Path.GetDirectoryName(ProjectFullPath);
+
+                return Path.Combine(projectDirectory, intermediateDirectory);
             }
         }
 
@@ -165,6 +154,62 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        public IEnumerable<RuntimeDescription> Runtimes
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                var unparsedRuntimeIdentifer = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeIdentifier");
+                var unparsedRuntimeIdentifers = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeIdentifiers");
+
+                var runtimes = Enumerable.Empty<string>();
+
+                if (unparsedRuntimeIdentifer != null)
+                {
+                    runtimes = runtimes.Concat(new[] { unparsedRuntimeIdentifer });
+                }
+
+                if (unparsedRuntimeIdentifers != null)
+                {
+                    runtimes = runtimes.Concat(unparsedRuntimeIdentifers.Split(';'));
+                }
+
+                runtimes = runtimes
+                    .Select(x => x.Trim())
+                    .Where(x => !string.IsNullOrEmpty(x));
+
+                return runtimes
+                    .Select(runtime => new RuntimeDescription(runtime));
+            }
+        }
+
+        public IEnumerable<CompatibilityProfile> Supports
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                if (AsIVsBuildPropertyStorage == null)
+                {
+                    return Enumerable.Empty<CompatibilityProfile>();
+                }
+
+                var unparsedRuntimeSupports = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeSupports");
+                
+                if (unparsedRuntimeSupports == null)
+                {
+                    return Enumerable.Empty<CompatibilityProfile>();
+                }
+
+                return unparsedRuntimeSupports
+                    .Split(';')
+                    .Select(x => x.Trim())
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .Select(support => new CompatibilityProfile(support));
+            }
+        }
+
         private IVsHierarchy AsIVsHierarchy
         {
             get
@@ -181,7 +226,18 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                return _asIVsBuildPropertyStorage ?? (_asIVsBuildPropertyStorage = AsIVsHierarchy as IVsBuildPropertyStorage);
+                var output =
+                    _asIVsBuildPropertyStorage ??
+                    (_asIVsBuildPropertyStorage = AsIVsHierarchy as IVsBuildPropertyStorage);
+
+                if (output == null)
+                {
+                    throw new InvalidOperationException(string.Format(
+                        Strings.ProjectCouldNotBeCastedToBuildPropertyStorage,
+                        ProjectFullPath));
+                }
+
+                return output;
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IEnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IEnvDTEProjectAdapter.cs
@@ -8,6 +8,7 @@ using EnvDTE;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
 using Task = System.Threading.Tasks.Task;
+using NuGet.RuntimeModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -50,6 +51,16 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Project's target framework
         /// </summary>
         NuGetFramework TargetNuGetFramework { get; }
+
+        /// <summary>
+        /// Project's runtime identifiers. Should never be null but can be an empty sequence.
+        /// </summary>
+        IEnumerable<RuntimeDescription> Runtimes { get; }
+
+        /// <summary>
+        /// Project's supports (a.k.a guardrails). Should never be null but can be an empty sequence.
+        /// </summary>
+        IEnumerable<CompatibilityProfile> Supports { get; }
 
         /// <summary>
         /// Project references for legacy CSProj project

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
@@ -6,19 +6,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.ProjectSystem;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using Task = System.Threading.Tasks.Task;
 using EnvDTEProject = EnvDTE.Project;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
 {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -16,6 +16,7 @@ using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 using Task = System.Threading.Tasks.Task;
+using NuGet.RuntimeModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -267,12 +268,18 @@ namespace NuGet.PackageManagement.VisualStudio
                 Dependencies = packageReferences.ToList()
             };
 
+            // Build up runtime information.
+            var runtimes = _project.Runtimes;
+            var supports = _project.Supports;
+            var runtimeGraph = new RuntimeGraph(runtimes, supports);
+
             // In legacy CSProj, we only have one target framework per project
             var tfis = new TargetFrameworkInformation[] { projectTfi };
             return new PackageSpec(tfis)
             {
                 Name = _projectName ?? _projectUniqueName,
                 FilePath = _projectFullPath,
+                RuntimeGraph = runtimeGraph,
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
                     OutputType = RestoreOutputType.NETCore,

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,16 +17,15 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
-using Task = System.Threading.Tasks.Task;
 using NuGet.RuntimeModel;
+using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
-/// <summary>
-/// An implementation of <see cref="NuGetProject"/> that interfaces with VS project APIs to coordinate
-/// packages in a legacy CSProj with package references.
-/// </summary>
+    /// <summary>
+    /// An implementation of <see cref="NuGetProject"/> that interfaces with VS project APIs to coordinate
+    /// packages in a legacy CSProj with package references.
+    /// </summary>
     public class LegacyCSProjPackageReferenceProject : BuildIntegratedNuGetProject
     {
         private const string _includeAssets = "IncludeAssets";

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -38,6 +38,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private string _projectName;
         private string _projectUniqueName;
         private string _projectFullPath;
+        private readonly String _projectId;
 
         static LegacyCSProjPackageReferenceProject()
         {
@@ -48,7 +49,8 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         public LegacyCSProjPackageReferenceProject(
-            IEnvDTEProjectAdapter project)
+            IEnvDTEProjectAdapter project,
+            string projectId)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -61,11 +63,12 @@ namespace NuGet.PackageManagement.VisualStudio
             _projectName = _project.Name;
             _projectUniqueName = _project.UniqueName;
             _projectFullPath = _project.ProjectFullPath;
-
+            _projectId = projectId;
 
             InternalMetadata.Add(NuGetProjectMetadataKeys.Name, _projectName);
             InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, _projectUniqueName);
             InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, _projectFullPath);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.ProjectId, _projectId);
         }
 
         public override string ProjectName => _projectName;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
@@ -52,7 +52,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return false;
             }
 
-            result = new LegacyCSProjPackageReferenceProject(project);
+            result = new LegacyCSProjPackageReferenceProject(
+                project,
+                VsHierarchyUtility.GetProjectId(dteProject));
 
             return true;
         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -70,6 +70,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The BaseIntermediateOutputPath could not be found for project &apos;{0}&apos;..
+        /// </summary>
+        public static string BaseIntermediateOutputPathNotFound {
+            get {
+                return ResourceManager.GetString("BaseIntermediateOutputPathNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet operation failed.
         /// </summary>
         public static string ConfigErrorDialogBoxTitle {
@@ -312,6 +321,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         public static string PathToExistingFileNotPresent {
             get {
                 return ResourceManager.GetString("PathToExistingFileNotPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The .csproj &apos;{0}&apos; could not be casted to a build property storage interace..
+        /// </summary>
+        public static string ProjectCouldNotBeCastedToBuildPropertyStorage {
+            get {
+                return ResourceManager.GetString("ProjectCouldNotBeCastedToBuildPropertyStorage", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -245,4 +245,12 @@ Missing packages: {0}</value>
   <data name="ProjectNotLoaded_RestoreFailed" xml:space="preserve">
     <value>The operation failed as details for project {0} could not be loaded.</value>
   </data>
+  <data name="BaseIntermediateOutputPathNotFound" xml:space="preserve">
+    <value>The BaseIntermediateOutputPath MSBuild property could not be found for project '{0}'.</value>
+    <comment>{0} is the full path to the project.</comment>
+  </data>
+  <data name="ProjectCouldNotBeCastedToBuildPropertyStorage" xml:space="preserve">
+    <value>The project '{0}' could not be casted to a build property storage interace, which is required to get MSBuild properties inside Visual Studio.</value>
+    <comment>{0} is the full path to the project.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
@@ -67,7 +67,17 @@ namespace NuGet.PackageManagement.Telemetry
                 {
                     projectType = NuGetProjectType.PackagesConfig;
                 }
-                else if (nuGetProject is BuildIntegratedNuGetProject)
+#if VS15
+                else if (nuGetProject is CpsPackageReferenceProject)
+                {
+                    projectType = NuGetProjectType.CPSBasedPackageRefs;
+                }
+                else if (nuGetProject is LegacyCSProjPackageReferenceProject)
+                {
+                    projectType = NuGetProjectType.LegacyProjectSystemWithPackageRefs;
+                }
+#endif
+                else if (nuGetProject is ProjectJsonBuildIntegratedProjectSystem)
                 {
                     projectType = NuGetProjectType.UwpProjectJson;
                 }
@@ -75,12 +85,7 @@ namespace NuGet.PackageManagement.Telemetry
                 {
                     projectType = NuGetProjectType.XProjProjectJson;
                 }
-#if VS15
-                else if(nuGetProject is CpsPackageReferenceProject)
-                {
-                    projectType = NuGetProjectType.CPSBasedPackageRefs;
-                }
-#endif
+
                 var projectInformation = new ProjectInformation(
                     NuGetVersion.Value,
                     projectId,

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
@@ -12,7 +12,6 @@ using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.VisualStudio.Facade.Telemetry;
-using EnvDTEProject = EnvDTE.Project;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.Telemetry


### PR DESCRIPTION
Observe the RuntimeIdentifier(s) and RuntimeSupports in legacy .csproj
Fix up project telemetry mappings

Fix https://github.com/NuGet/Home/issues/3740

/cc @drewgil @alpaix @rohit21agrawal @emgarten 
