### PR TITLE
Better control over execution context in UI ops

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsProjectRestoreInfo.cs
@@ -19,11 +19,6 @@ namespace NuGet.SolutionRestoreManager
         string BaseIntermediatePath { get; }
 
         /// <summary>
-        /// Original raw value of TargetFrameworks property as set in a project file.
-        /// </summary>
-        string OriginalTargetFrameworks { get; }
-
-        /// <summary>
         /// Target frameworks metadata.
         /// </summary>
         IVsTargetFrameworks TargetFrameworks { get; }
@@ -32,5 +27,10 @@ namespace NuGet.SolutionRestoreManager
         /// Collection of tool references.
         /// </summary>
         IVsReferenceItems ToolReferences { get; }
+
+        /// <summary>
+        /// Original raw value of TargetFrameworks property as set in a project file.
+        /// </summary>
+        string OriginalTargetFrameworks { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsTargetFrameworkInfo.cs
@@ -19,12 +19,6 @@ namespace NuGet.SolutionRestoreManager
         string TargetFrameworkMoniker { get; }
 
         /// <summary>
-        /// Collection of project level properties evaluated per each Target Framework,
-        /// e.g. PackageTargetFallback.
-        /// </summary>
-        IVsProjectProperties Properties { get; }
-
-        /// <summary>
         /// Collection of project references.
         /// </summary>
         IVsReferenceItems ProjectReferences { get; }
@@ -33,5 +27,11 @@ namespace NuGet.SolutionRestoreManager
         /// Collection of package references.
         /// </summary>
         IVsReferenceItems PackageReferences { get; }
+
+        /// <summary>
+        /// Collection of project level properties evaluated per each Target Framework,
+        /// e.g. PackageTargetFallback.
+        /// </summary>
+        IVsProjectProperties Properties { get; }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/RestoreOperationProgressUI.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/RestoreOperationProgressUI.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading;
-using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -11,11 +10,21 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         protected static readonly AsyncLocal<RestoreOperationProgressUI> _instance = new AsyncLocal<RestoreOperationProgressUI>();
 
-        public static RestoreOperationProgressUI Current => _instance.Value;
+        public static RestoreOperationProgressUI Current
+        {
+            get
+            {
+                return _instance.Value;
+            }
+            set
+            {
+                _instance.Value = value;
+            }
+        }
 
         public CancellationToken UserCancellationToken { get; protected set; } = CancellationToken.None;
 
-        public abstract Task ReportProgressAsync(
+        public abstract void ReportProgress(
             string progressMessage,
             uint currentStep = 0,
             uint totalSteps = 0);


### PR DESCRIPTION
Resolves NuGet/Home#3734, NuGet/Home#3752.

Every logger operation will run in a task on the UI thread or throw.
Job and logger instances are created via async factory method.
Correct usage pattern of `AsyncLocal`.

//cc @emgarten @joelverhagen @jainaashish @rohit21agrawal @drewgil @rrelyea 
