### PR TITLE
plumbed through passing a list of successful and unsuccessful frameworks for package install

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
@@ -172,7 +172,11 @@ namespace NuGet.PackageManagement.VisualStudio
             return new PackageReference(identity, targetFramework);
         }
 
-        public override async Task<Boolean> InstallPackageAsync(PackageIdentity packageIdentity, DownloadResourceResult downloadResourceResult, INuGetProjectContext nuGetProjectContext, CancellationToken token)
+        public override async Task<Boolean> InstallPackageAsync(PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsuccessfulFrameworks,
+            CancellationToken token)
         {
 
             nuGetProjectContext.Log(MessageLevel.Info, Strings.InstallingPackage, packageIdentity);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -135,7 +135,11 @@ namespace NuGet.PackageManagement.VisualStudio
             return GetPackageReferences(await GetPackageSpecAsync());
         }
 
-        public override async Task<bool> InstallPackageAsync(PackageIdentity packageIdentity, DownloadResourceResult downloadResourceResult, INuGetProjectContext nuGetProjectContext, CancellationToken token)
+        public override async Task<Boolean> InstallPackageAsync(PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsuccessfulFrameworks,
+            CancellationToken token)
         {
             var success = false;
             await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands;
+using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -39,13 +40,28 @@ namespace NuGet.PackageManagement
         /// </summary>
         public IReadOnlyList<NuGetProjectAction> OriginalActions { get; }
 
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was successful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> SuccessfulFrameworksForPreviewRestore { get; }
+
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was unsuccessful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> UnsuccessfulFrameworksForPreviewRestore { get; }
+
+
         public BuildIntegratedProjectAction(NuGetProject project,
             PackageIdentity packageIdentity,
             NuGetProjectActionType nuGetProjectActionType,
             LockFile originalLockFile,
             RestoreResultPair restoreResultPair,
             IReadOnlyList<SourceRepository> sources,
-            IReadOnlyList<NuGetProjectAction> originalActions)
+            IReadOnlyList<NuGetProjectAction> originalActions,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsuccessfulFrameworks )
             : base(packageIdentity, nuGetProjectActionType, project)
         {
             if (packageIdentity == null)
@@ -73,6 +89,8 @@ namespace NuGet.PackageManagement
             RestoreResultPair = restoreResultPair;
             Sources = sources;
             OriginalActions = originalActions;
+            SuccessfulFrameworksForPreviewRestore = successfulFrameworks;
+            UnsuccessfulFrameworksForPreviewRestore = unsuccessfulFrameworks;
         }
 
         public IReadOnlyList<NuGetProjectAction> GetProjectActions()

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -54,6 +54,21 @@ namespace NuGet.ProjectManagement.Projects
             INuGetProjectContext projectContext,
             bool throwOnFailure);
 
+        public abstract Task<bool> InstallPackageAsync(PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsucessfulFrameworks,
+            CancellationToken token);
+
+        public override sealed Task<bool> InstallPackageAsync(
+                    PackageIdentity packageIdentity,
+            DownloadResourceResult downloadResourceResult,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token)
+        {
+            throw  new NotImplementedException("This API should not be called for BuildIntegratedNuGetProject");
+        }
+
         public virtual async Task<bool> IsRestoreRequired(
                     IEnumerable<VersionFolderPathResolver> pathResolvers,
                     ISet<PackageIdentity> packagesChecked,

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -149,7 +149,7 @@ namespace NuGet.ProjectManagement.Projects
         /// Install a package using the global packages folder.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801")]
-        public async Task<bool> AddDependency(PackageDependency dependency,
+        public async Task<bool> AddDependencyAsync(PackageDependency dependency,
             CancellationToken token)
         {
             var json = await GetJsonAsync();
@@ -248,22 +248,22 @@ namespace NuGet.ProjectManagement.Projects
             return new[] { packageSpec };
         }
 
-        public override async Task<bool> InstallPackageAsync(
-                    PackageIdentity packageIdentity,
-            DownloadResourceResult downloadResourceResult,
+        public async override Task<bool> InstallPackageAsync(PackageIdentity packageIdentity,
             INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsucessfulFrameworks,
             CancellationToken token)
         {
             var dependency = new PackageDependency(packageIdentity.Id, new VersionRange(packageIdentity.Version));
 
-            return await AddDependency(dependency, token);
+            return await AddDependencyAsync(dependency, token);
         }
 
         /// <summary>
         /// Uninstall a package from the config file.
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801")]
-        public async Task<bool> RemoveDependency(string packageId,
+        public async Task<bool> RemoveDependencyAsync(string packageId,
             INuGetProjectContext nuGetProjectContext,
             CancellationToken token)
         {
@@ -278,7 +278,7 @@ namespace NuGet.ProjectManagement.Projects
 
         public override async Task<bool> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
-            return await RemoveDependency(packageIdentity.Id, nuGetProjectContext, token);
+            return await RemoveDependencyAsync(packageIdentity.Id, nuGetProjectContext, token);
         }
         private JObject GetJson()
         {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecOperations.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -41,11 +42,11 @@ namespace NuGet.ProjectModel
             }
         }
 
-        public static void RemoveDependency(PackageSpec spec, string packageId)
+        public static void RemoveDependency(PackageSpec spec, string packageId, IEnumerable<NuGetFramework> unsuccessfulFrameworks)
         {
             var depList = new List<IList<LibraryDependency>>();
             depList.Add(spec.Dependencies);
-            depList.AddRange(spec.TargetFrameworks.Select(e => e.Dependencies));
+            depList.AddRange(spec.TargetFrameworks.Where(t => unsuccessfulFrameworks.Contains(t.FrameworkName)).Select(e => e.Dependencies));
 
             foreach (var list in depList)
             {

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1388,8 +1388,8 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonBuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), null, new TestNuGetProjectContext(), token);
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), null, new TestNuGetProjectContext(), token);
+                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), new TestNuGetProjectContext(), null, null, token);
+                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), new TestNuGetProjectContext(), null, null, token);
 
                 // Check that there are no packages returned by PackagesConfigProject
                 var installedPackages = (await buildIntegratedProject.GetInstalledPackagesAsync(token)).ToList();

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -254,7 +254,7 @@ namespace ProjectManagement.Test
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
                     // Act
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
                 }
 
                 // Assert
@@ -294,8 +294,8 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, testNuGetProjectContext, null, null, token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);
@@ -338,8 +338,8 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, testNuGetProjectContext, null, token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);


### PR DESCRIPTION
This is part 1 of the solution for : https://github.com/NuGet/Home/issues/3721

This fix basically modifies the InstallPackageAsync API for BuildIntegratedNuGetProjects to take in a list of successful and unsuccessful target frameworks. The projects can then write their own implementation of the method and do the appropriate action.

Right now, this is only relevant for CpsPacakageReferenceProject as that is the only Multi-TFM project that nuget owns end-to-end. This is what this PR does:

1) Checks if the user operation is a single package install or not.
2) If it is a single package install, do a preview restore by trying to install it to all target frameworks that a project supports.
3) Find out what TFMs were successfully installed to and which one's weren't.
4) Do another preview restore by installing the package to only the TFMs which were successful the first time.
5) If the restore is successful, commit the changes to lock file and pass on the TFM information to the project systems via the install/uninstall API.

**What has not been done** : The work of calling the CPS API which takes in a condition to install a package still needs to be done. That will come as part of another PR, and this bug will be closed only when the second part has been checked in.

CC: @rrelyea @emgarten @alpaix @joelverhagen @jainaashish 
