### PR TITLE
make projects unique name to be same as full path

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -213,7 +213,7 @@ namespace NuGet.SolutionRestoreManager
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
                     ProjectName = projectNames.ShortName,
-                    ProjectUniqueName = projectNames.UniqueName,
+                    ProjectUniqueName = projectFullPath,
                     ProjectPath = projectFullPath,
                     OutputPath = Path.GetFullPath(
                         Path.Combine(


### PR DESCRIPTION
Fixes issue : https://github.com/NuGet/Home/issues/3778

This only fixes the RestoreSpec exception part of the issue. The NuGet package is installed successfully and the package reference is written out to to the csproj file.

@rrelyea @emgarten @alpaix @joelverhagen @jainaashish 
