### PR TITLE
Fix VS hang issue on restore

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -431,7 +431,12 @@ namespace NuGet.PackageManagement.UI
             // only when package is missing last time and is not missing this time, we need to refresh
             if (!e.PackagesMissing && _missingPackageStatus)
             {
-                UpdateAfterPackagesMissingStatusChanged();
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    UpdateAfterPackagesMissingStatusChanged();
+                });
             }
             _missingPackageStatus = e.PackagesMissing;
         }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -100,7 +100,11 @@ namespace NuGet.PackageManagement.UI
 
         private void OnPackagesMissingStatusChanged(object sender, PackagesMissingStatusEventArgs e)
         {
-            UpdateRestoreBar(e.PackagesMissing);
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                UpdateRestoreBar(e.PackagesMissing);
+            });
         }
 
         private void UpdateRestoreBar(bool packagesMissing)
@@ -177,7 +181,7 @@ namespace NuGet.PackageManagement.UI
             {
                 message = string.Format(CultureInfo.CurrentCulture, message, args);
             }
-            
+
             ShowMessage(message);
         }
 
@@ -194,7 +198,7 @@ namespace NuGet.PackageManagement.UI
         private void PackageRestoreFailedEvent(object sender, PackageRestoreFailedEventArgs e)
         {
             // We just store any one of the package restore failures and show it on the yellow bar
-            if(RestoreException == null)
+            if (RestoreException == null)
             {
                 RestoreException = e.Exception;
             }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageRestoreBar.xaml.cs
@@ -100,6 +100,7 @@ namespace NuGet.PackageManagement.UI
 
         private void OnPackagesMissingStatusChanged(object sender, PackagesMissingStatusEventArgs e)
         {
+            // make sure update happens on the UI thread.
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -109,13 +110,7 @@ namespace NuGet.PackageManagement.UI
 
         private void UpdateRestoreBar(bool packagesMissing)
         {
-            if (!UIDispatcher.CheckAccess())
-            {
-                UIDispatcher.Invoke(
-                    (Action<bool>)UpdateRestoreBar,
-                    packagesMissing);
-                return;
-            }
+            ThreadHelper.ThrowIfNotOnUIThread();
 
             if (packagesMissing)
             {


### PR DESCRIPTION
This code change will make sure that PackagesMissingStatusChanged event handler is always executed on UI thread since this will update the ui either through PackageRestoreBar or Manager UI. Earlier restore was always trigger on UI thread so this wasn't an issue but now since restore is executed on bg thread so this becomes as issue. 

Also this PackagesMissingStatusChanged event is being raised from nuget core in PackageRestoreManager and event handlers are in nuget client so we should make sure to consume it in UI thread.

Fixes https://github.com/NuGet/Home/issues/3777

@rrelyea @alpaix @joelverhagen @emgarten 
