### PR TITLE
Move the SearchTask onto the main thread

### DIFF
--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -275,8 +275,8 @@ namespace NuGetVSExtension
             //    ServiceLocator.GetInstance<IDebugConsoleController>());
 
             // Add our command handlers for menu (commands must exist in the .vsct file)
-            AddMenuCommandHandlers();
-            RestorePackagesCommand.Initialize(this);
+            await AddMenuCommandHandlersAsync();
+            await RestorePackagesCommand.InitializeAsync(this);
 
             // IMPORTANT: Do NOT do anything that can lead to a call to ServiceLocator.GetGlobalService().
             // Doing so is illegal and may cause VS to hang.
@@ -431,9 +431,9 @@ namespace NuGetVSExtension
                 exception);
         }
 
-        private void AddMenuCommandHandlers()
+        private async Task AddMenuCommandHandlersAsync()
         {
-            _mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            _mcs = await GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (null != _mcs)
             {
                 // menu command for opening Package Manager Console
@@ -609,7 +609,7 @@ namespace NuGetVSExtension
 
             // Find existing hierarchy and item id of the document window if it's
             // already registered.
-            var rdt = (IVsRunningDocumentTable)GetService(typeof(IVsRunningDocumentTable));
+            var rdt = await GetServiceAsync(typeof(IVsRunningDocumentTable)) as IVsRunningDocumentTable;
             IVsHierarchy hier;
             uint itemId;
             IntPtr docData = IntPtr.Zero;
@@ -696,7 +696,7 @@ namespace NuGetVSExtension
                 project.Name);
 
             IVsWindowFrame windowFrame;
-            IVsUIShell uiShell = (IVsUIShell)GetService(typeof(SVsUIShell));
+            var uiShell = await GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
 
             IntPtr ppunkDocView = IntPtr.Zero;
             IntPtr ppunkDocData = IntPtr.Zero;
@@ -788,9 +788,9 @@ namespace NuGetVSExtension
             });
         }
 
-        private IVsWindowFrame FindExistingSolutionWindowFrame()
+        private async Task<IVsWindowFrame> FindExistingSolutionWindowFrameAsync()
         {
-            IVsUIShell uiShell = (IVsUIShell)GetService(typeof(SVsUIShell));
+            var uiShell = await GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
             foreach (var windowFrame in VsUtility.GetDocumentWindows(uiShell))
             {
                 object property;
@@ -864,7 +864,7 @@ namespace NuGetVSExtension
         {
             IVsWindowFrame windowFrame = null;
             IVsSolution solution = ServiceLocator.GetInstance<IVsSolution>();
-            IVsUIShell uiShell = (IVsUIShell)GetService(typeof(SVsUIShell));
+            var uiShell = await GetServiceAsync(typeof(SVsUIShell)) as IVsUIShell;
             uint windowFlags =
                 (uint)_VSRDTFLAGS.RDT_DontAddToMRU |
                 (uint)_VSRDTFLAGS.RDT_DontSaveAs;
@@ -962,7 +962,7 @@ namespace NuGetVSExtension
 
             ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                var windowFrame = FindExistingSolutionWindowFrame();
+                var windowFrame = await FindExistingSolutionWindowFrameAsync();
                 if (windowFrame == null)
                 {
                     // Create the window frame

--- a/src/NuGet.Clients/VsExtension/NuGetSearchTask.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetSearchTask.cs
@@ -61,22 +61,27 @@ namespace NuGetVSExtension
 
         public void Start()
         {
-            SetStatus(VsSearchTaskStatus.Started);
-
-            SetStatus(VsSearchTaskStatus.Completed);
-            OleMenuCommand supportedManagePackageCommand = GetSupportedManagePackageCommand();
-
-            if (!String.IsNullOrEmpty(SearchQuery.SearchString)
-                && null != supportedManagePackageCommand)
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                var result = new NuGetStaticSearchResult(SearchQuery.SearchString, _provider, supportedManagePackageCommand);
-                _searchCallback.ReportResult(this, result);
-                _searchCallback.ReportComplete(this, 1);
-            }
-            else
-            {
-                _searchCallback.ReportComplete(this, 0);
-            }
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                SetStatus(VsSearchTaskStatus.Started);
+
+                SetStatus(VsSearchTaskStatus.Completed);
+                var supportedManagePackageCommand = GetSupportedManagePackageCommand();
+
+                if (!string.IsNullOrEmpty(SearchQuery.SearchString)
+                    && null != supportedManagePackageCommand)
+                {
+                    var result = new NuGetStaticSearchResult(SearchQuery.SearchString, _provider, supportedManagePackageCommand);
+                    _searchCallback.ReportResult(this, result);
+                    _searchCallback.ReportComplete(this, 1);
+                }
+                else
+                {
+                    _searchCallback.ReportComplete(this, 0);
+                }
+            });
         }
 
         public void Stop()


### PR DESCRIPTION
Resolves NuGet/Home#3775.

Root cause of the issue was calling `IOleCommandTarget.QueryStatus` from
the background thread in VS15. This change moves the entire
`NuGetSearchTask.Start` method execution to the main UI thread.

Also replaced `GetService` with `GetServiceAsync` in the `NuGetPackage` as
recommended by VSSDK.

//cc @jainaashish @mishra14 @emgarten @joelverhagen @rrelyea 
