### PR TITLE
Log summary information as High for msbuild restore task output

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/MSBuildLogger.cs
@@ -37,7 +37,7 @@ namespace NuGet.Build.Tasks
 
         public void LogInformationSummary(string data)
         {
-            LogInformation(data);
+            _taskLogging.LogMessage(MessageImportance.High, data);
         }
 
         public void LogMinimal(string data)


### PR DESCRIPTION
Feeds used during restore are logged as part of the summary. For MSBuild this is now logged as `high` importance.

Fixes https://github.com/NuGet/Home/issues/3719

//cc @joelverhagen @livarcocc
