### PR TITLE
Adding explicit dependency on newtonsoft.json v6.0.4

### DIFF
--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
@@ -15,7 +15,8 @@
     "Microsoft.VisualStudio.Text.UI.Wpf": "15.0.25123-Dev15Preview",
     "Microsoft.VisualStudio.Threading": "15.0.20-pre",
     "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4",
-    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920"
+    "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+    "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/3795 and @drewgil 's test failure on CI.

//cc: @emgarten @drewgil 
