### PR TITLE
Select a subset of TFMs when installing a single package to .NET Core

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -3,8 +3,9 @@
   <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
   <package id="NuGet.MsBuild.Integration" version="3.1.0-beta-001" targetFramework="net45" />
   <package id="Microsoft.Build" version="15.1.262-preview5" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Composition" version="15.0.30-pre" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.ProjectSystem" version="14.1.127-pre" targetFramework="net45" />
-  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.0.530-pre-g355f3866ef" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.ProjectSystem" version="15.0.582-pre-g76aab6d79c" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" version="15.0.0" targetFramework="net45" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
   <package id="xunit.runner.msbuild" version="2.1.0" targetFramework="net45" />

--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25806.3
+VisualStudioVersion = 15.0.25806.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -35,11 +35,14 @@
         <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
           <EmbedInteropTypes>True</EmbedInteropTypes>
         </Reference>
+        <Reference Include="Microsoft.VisualStudio.Composition">
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.Composition.15.0.30-pre\lib\net45\Microsoft.VisualStudio.Composition.dll</HintPath>
+        </Reference>
         <Reference Include="Microsoft.VisualStudio.ProjectSystem">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.530-pre-g355f3866ef\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.582-pre-g76aab6d79c\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
         </Reference>
         <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.530-pre-g355f3866ef\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.582-pre-g76aab6d79c\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
           <EmbedInteropTypes>True</EmbedInteropTypes>
         </Reference>
         <Reference Include="VSLangProj140, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -135,7 +135,8 @@ namespace NuGet.PackageManagement.VisualStudio
         }
 
         public override async Task<Boolean> InstallPackageAsync(
-            PackageIdentity packageIdentity,
+            string packageId,
+            VersionRange range,
             INuGetProjectContext nuGetProjectContext,
             IEnumerable<NuGetFramework> successfulFrameworks,
             IEnumerable<NuGetFramework> unsuccessfulFrameworks,
@@ -149,10 +150,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 // We don't adjust package reference metadata from UI
                 _project.AddOrUpdateLegacyCSProjPackage(
-                    packageIdentity.Id,
-                    packageIdentity.Version.ToNormalizedString(),
-                    metadataElements: new string[] { },
-                    metadataValues: new string[] { });
+                    packageId,
+                    range.MinVersion.ToNormalizedString(),
+                    metadataElements: new string[0],
+                    metadataValues: new string[0]);
 
                 success = true;
             });

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -89,7 +89,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override async Task<string> GetAssetsFilePathAsync()
         {
-            return Path.Combine(await GetBaseIntermediatePathAsync(), LockFileFormat.AssetsFileName); ;
+            return Path.Combine(await GetBaseIntermediatePathAsync(), LockFileFormat.AssetsFileName);
         }
 
         public override async Task<bool> ExecuteInitScriptAsync(
@@ -134,9 +134,15 @@ namespace NuGet.PackageManagement.VisualStudio
             return GetPackageReferences(await GetPackageSpecAsync());
         }
 
-        public override async Task<bool> InstallPackageAsync(PackageIdentity packageIdentity, DownloadResourceResult downloadResourceResult, INuGetProjectContext nuGetProjectContext, CancellationToken token)
+        public override async Task<Boolean> InstallPackageAsync(
+            PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsuccessfulFrameworks,
+            CancellationToken token)
         {
             var success = false;
+
             await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -138,8 +138,7 @@ namespace NuGet.PackageManagement.VisualStudio
             string packageId,
             VersionRange range,
             INuGetProjectContext nuGetProjectContext,
-            IEnumerable<NuGetFramework> successfulFrameworks,
-            IEnumerable<NuGetFramework> unsuccessfulFrameworks,
+            BuildIntegratedInstallationContext installationContext,
             CancellationToken token)
         {
             var success = false;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The BaseIntermediateOutputPath could not be found for project &apos;{0}&apos;..
+        ///   Looks up a localized string similar to The BaseIntermediateOutputPath MSBuild property could not be found for project &apos;{0}&apos;..
         /// </summary>
         public static string BaseIntermediateOutputPathNotFound {
             get {
@@ -325,7 +325,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The .csproj &apos;{0}&apos; could not be casted to a build property storage interace..
+        ///   Looks up a localized string similar to The project &apos;{0}&apos; could not be casted to a build property storage interace, which is required to get MSBuild properties inside Visual Studio..
         /// </summary>
         public static string ProjectCouldNotBeCastedToBuildPropertyStorage {
             get {
@@ -375,6 +375,15 @@ namespace NuGet.PackageManagement.VisualStudio {
         public static string SolutionIsNotSaved {
             get {
                 return ResourceManager.GetString("SolutionIsNotSaved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to get the project&apos;s package installation service for project &apos;{0}&apos;..
+        /// </summary>
+        public static string UnableToGetCPSPackageInstallationService {
+            get {
+                return ResourceManager.GetString("UnableToGetCPSPackageInstallationService", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -253,4 +253,8 @@ Missing packages: {0}</value>
     <value>The project '{0}' could not be casted to a build property storage interace, which is required to get MSBuild properties inside Visual Studio.</value>
     <comment>{0} is the full path to the project.</comment>
   </data>
+  <data name="UnableToGetCPSPackageInstallationService" xml:space="preserve">
+    <value>Unable to get the project's package installation service for project '{0}'.</value>
+    <comment>{0} is the full path to the project.</comment>
+  </data>
 </root>

--- a/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
+++ b/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
@@ -55,7 +55,7 @@
           <Name>NuGet.VisualStudio15.Packages</Name>
         </ProjectReference>
         <Reference Include="Microsoft.VisualStudio.ProjectSystem">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.530-pre-g355f3866ef\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.582-pre-g76aab6d79c\lib\net46\Microsoft.VisualStudio.ProjectSystem.dll</HintPath>
         </Reference>
         <Reference Include="Microsoft.Build">
           <HintPath>$(EnlistmentRoot)\packages\Microsoft.Build.15.1.262-preview5\lib\net46\Microsoft.Build.dll</HintPath>

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using NuGet.Commands;
+using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -39,13 +40,27 @@ namespace NuGet.PackageManagement
         /// </summary>
         public IReadOnlyList<NuGetProjectAction> OriginalActions { get; }
 
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was successful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> SuccessfulFrameworksForPreviewRestore { get; }
+
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was unsuccessful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> UnsuccessfulFrameworksForPreviewRestore { get; }
+
         public BuildIntegratedProjectAction(NuGetProject project,
             PackageIdentity packageIdentity,
             NuGetProjectActionType nuGetProjectActionType,
             LockFile originalLockFile,
             RestoreResultPair restoreResultPair,
             IReadOnlyList<SourceRepository> sources,
-            IReadOnlyList<NuGetProjectAction> originalActions)
+            IReadOnlyList<NuGetProjectAction> originalActions,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsuccessfulFrameworks)
             : base(packageIdentity, nuGetProjectActionType, project)
         {
             if (packageIdentity == null)
@@ -68,11 +83,28 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(sources));
             }
 
+            if (originalActions == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            if (successfulFrameworks == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
+            if (unsuccessfulFrameworks == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
             OriginalLockFile = originalLockFile;
             RestoreResult = restoreResultPair.Result;
             RestoreResultPair = restoreResultPair;
             Sources = sources;
             OriginalActions = originalActions;
+            SuccessfulFrameworksForPreviewRestore = successfulFrameworks;
+            UnsuccessfulFrameworksForPreviewRestore = unsuccessfulFrameworks;
         }
 
         public IReadOnlyList<NuGetProjectAction> GetProjectActions()

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
 using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
@@ -41,16 +40,9 @@ namespace NuGet.PackageManagement
         public IReadOnlyList<NuGetProjectAction> OriginalActions { get; }
 
         /// <summary>
-        /// Shows the frameworks for which a preview restore operation was successful. Only use it
-        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// The context necessary for installing a package.
         /// </summary>
-        public IEnumerable<NuGetFramework> SuccessfulFrameworksForPreviewRestore { get; }
-
-        /// <summary>
-        /// Shows the frameworks for which a preview restore operation was unsuccessful. Only use it
-        /// in case of single package install case, and only for CpsPackageReference projects.
-        /// </summary>
-        public IEnumerable<NuGetFramework> UnsuccessfulFrameworksForPreviewRestore { get; }
+        public BuildIntegratedInstallationContext InstallationContext { get; }
 
         public BuildIntegratedProjectAction(NuGetProject project,
             PackageIdentity packageIdentity,
@@ -59,8 +51,7 @@ namespace NuGet.PackageManagement
             RestoreResultPair restoreResultPair,
             IReadOnlyList<SourceRepository> sources,
             IReadOnlyList<NuGetProjectAction> originalActions,
-            IEnumerable<NuGetFramework> successfulFrameworks,
-            IEnumerable<NuGetFramework> unsuccessfulFrameworks)
+            BuildIntegratedInstallationContext installationContext)
             : base(packageIdentity, nuGetProjectActionType, project)
         {
             if (packageIdentity == null)
@@ -88,12 +79,7 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(sources));
             }
 
-            if (successfulFrameworks == null)
-            {
-                throw new ArgumentNullException(nameof(sources));
-            }
-
-            if (unsuccessfulFrameworks == null)
+            if (installationContext == null)
             {
                 throw new ArgumentNullException(nameof(sources));
             }
@@ -103,8 +89,7 @@ namespace NuGet.PackageManagement
             RestoreResultPair = restoreResultPair;
             Sources = sources;
             OriginalActions = originalActions;
-            SuccessfulFrameworksForPreviewRestore = successfulFrameworks;
-            UnsuccessfulFrameworksForPreviewRestore = unsuccessfulFrameworks;
+            InstallationContext = installationContext;
         }
 
         public IReadOnlyList<NuGetProjectAction> GetProjectActions()

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2345,17 +2345,17 @@ namespace NuGet.PackageManagement
 
                 originalLockFile = originalRestoreResult.Result.LockFile;
             }
-
-            // Modify the package spec
+            
             foreach (var action in nuGetProjectActions)
             {
                 if (action.NuGetProjectActionType == NuGetProjectActionType.Uninstall)
                 {
+                    // Remove the package from all frameworks and dependencies section.
                     PackageSpecOperations.RemoveDependency(updatedPackageSpec, action.PackageIdentity.Id);
                 }
                 else if (action.NuGetProjectActionType == NuGetProjectActionType.Install)
                 {
-                    PackageSpecOperations.AddDependency(updatedPackageSpec, action.PackageIdentity);
+                    PackageSpecOperations.AddOrUpdateDependency(updatedPackageSpec, action.PackageIdentity);
                 }
             }
 
@@ -2371,6 +2371,55 @@ namespace NuGet.PackageManagement
                 Settings,
                 logger,
                 token);
+
+            var nugetProjectActionsList = nuGetProjectActions.ToList();
+
+            var allFrameworks = updatedPackageSpec
+                .TargetFrameworks
+                .Select(t => t.FrameworkName)
+                .ToList();
+
+            var unsuccessfulFrameworks = restoreResult
+                .Result
+                .CompatibilityCheckResults
+                .Where(t => !t.Success)
+                .Select(t => t.Graph.Framework)
+                .ToList();
+
+            var successfulFrameworks = allFrameworks
+                .Except(unsuccessfulFrameworks)
+                .ToList();
+
+            var firstAction = nugetProjectActionsList[0];
+
+            // If the restore failed and this was a single package install, try to install the package to a subset of
+            // the target frameworks.
+            if (nugetProjectActionsList.Count == 1 &&
+                firstAction.NuGetProjectActionType == NuGetProjectActionType.Install &&
+                successfulFrameworks.Any() &&
+                unsuccessfulFrameworks.Any() &&
+                !restoreResult.Result.Success &&
+                !PackageSpecOperations.HasPackage(originalPackageSpec, firstAction.PackageIdentity.Id))
+            {
+                updatedPackageSpec = originalPackageSpec.Clone();
+
+                PackageSpecOperations.AddDependency(
+                    updatedPackageSpec,
+                    firstAction.PackageIdentity,
+                    successfulFrameworks);
+
+                restoreResult = await DependencyGraphRestoreUtility.PreviewRestoreAsync(
+                    SolutionManager,
+                    buildIntegratedProject,
+                    updatedPackageSpec,
+                    dependencyGraphContext,
+                    providerCache,
+                    cacheModifier,
+                    sources,
+                    Settings,
+                    logger,
+                    token);
+            }
 
             InstallationCompatibility.EnsurePackageCompatibility(
                 buildIntegratedProject,
@@ -2392,13 +2441,16 @@ namespace NuGet.PackageManagement
                 string.Format(TelemetryConstants.PreviewBuildIntegratedStepName, projectId),
                 stopWatch.Elapsed.TotalSeconds);
 
-            return new BuildIntegratedProjectAction(buildIntegratedProject,
+            return new BuildIntegratedProjectAction(
+                buildIntegratedProject,
                 nuGetProjectActions.First().PackageIdentity,
                 actionType,
                 originalLockFile,
                 restoreResult,
                 sources.ToList(),
-                nuGetProjectActions.ToList());
+                nugetProjectActionsList,
+                successfulFrameworks,
+                unsuccessfulFrameworks);
         }
 
         /// <summary>
@@ -2466,8 +2518,9 @@ namespace NuGet.PackageManagement
                         // Install the package to the project
                         await buildIntegratedProject.InstallPackageAsync(
                             originalAction.PackageIdentity,
-                            downloadResourceResult: null,
-                            nuGetProjectContext: nuGetProjectContext,
+                            nuGetProjectContext,
+                            projectAction.SuccessfulFrameworksForPreviewRestore,
+                            projectAction.UnsuccessfulFrameworksForPreviewRestore,
                             token: token);
                     }
                     else if (originalAction.NuGetProjectActionType == NuGetProjectActionType.Uninstall)

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2377,6 +2377,7 @@ namespace NuGet.PackageManagement
             var allFrameworks = updatedPackageSpec
                 .TargetFrameworks
                 .Select(t => t.FrameworkName)
+                .Distinct()
                 .ToList();
 
             var unsuccessfulFrameworks = restoreResult
@@ -2384,6 +2385,7 @@ namespace NuGet.PackageManagement
                 .CompatibilityCheckResults
                 .Where(t => !t.Success)
                 .Select(t => t.Graph.Framework)
+                .Distinct()
                 .ToList();
 
             var successfulFrameworks = allFrameworks
@@ -2399,6 +2401,7 @@ namespace NuGet.PackageManagement
                 successfulFrameworks.Any() &&
                 unsuccessfulFrameworks.Any() &&
                 !restoreResult.Result.Success &&
+                // Exclude upgrades, for now we take the simplest case.
                 !PackageSpecOperations.HasPackage(originalPackageSpec, firstAction.PackageIdentity.Id))
             {
                 updatedPackageSpec = originalPackageSpec.Clone();
@@ -2517,7 +2520,8 @@ namespace NuGet.PackageManagement
                     {
                         // Install the package to the project
                         await buildIntegratedProject.InstallPackageAsync(
-                            originalAction.PackageIdentity,
+                            originalAction.PackageIdentity.Id,
+                            new VersionRange(originalAction.PackageIdentity.Version),
                             nuGetProjectContext,
                             projectAction.SuccessfulFrameworksForPreviewRestore,
                             projectAction.UnsuccessfulFrameworksForPreviewRestore,

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2424,6 +2424,17 @@ namespace NuGet.PackageManagement
                     token);
             }
 
+            // Build the installation context
+            var originalFrameworks = updatedPackageSpec
+                .RestoreMetadata
+                .OriginalTargetFrameworks
+                .GroupBy(x => NuGetFramework.Parse(x))
+                .ToDictionary(x => x.Key, x => x.First());
+            var installationContext = new BuildIntegratedInstallationContext(
+                successfulFrameworks,
+                unsuccessfulFrameworks,
+                originalFrameworks);
+
             InstallationCompatibility.EnsurePackageCompatibility(
                 buildIntegratedProject,
                 pathContext,
@@ -2452,8 +2463,7 @@ namespace NuGet.PackageManagement
                 restoreResult,
                 sources.ToList(),
                 nugetProjectActionsList,
-                successfulFrameworks,
-                unsuccessfulFrameworks);
+                installationContext);
         }
 
         /// <summary>
@@ -2523,8 +2533,7 @@ namespace NuGet.PackageManagement
                             originalAction.PackageIdentity.Id,
                             new VersionRange(originalAction.PackageIdentity.Version),
                             nuGetProjectContext,
-                            projectAction.SuccessfulFrameworksForPreviewRestore,
-                            projectAction.UnsuccessfulFrameworksForPreviewRestore,
+                            projectAction.InstallationContext,
                             token: token);
                     }
                     else if (originalAction.NuGetProjectActionType == NuGetProjectActionType.Uninstall)

--- a/src/NuGet.Core/NuGet.ProjectManagement/BuildIntegratedInstallationContext.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/BuildIntegratedInstallationContext.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Frameworks;
+using NuGet.ProjectManagement.Projects;
+
+namespace NuGet.ProjectManagement
+{
+    /// <summary>
+    /// Information used by <see cref="BuildIntegratedNuGetProject"/> when installing a package.
+    /// </summary>
+    public class BuildIntegratedInstallationContext
+    {
+        public BuildIntegratedInstallationContext(
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsucessfulFrameworks,
+            IDictionary<NuGetFramework, string> originalFrameworks)
+        {
+            SuccessfulFrameworks = successfulFrameworks;
+            UnsuccessfulFrameworks = unsucessfulFrameworks;
+            OriginalFrameworks = originalFrameworks;
+        }
+
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was successful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> SuccessfulFrameworks { get; }
+
+        /// <summary>
+        /// Shows the frameworks for which a preview restore operation was unsuccessful. Only use it
+        /// in case of single package install case, and only for CpsPackageReference projects.
+        /// </summary>
+        public IEnumerable<NuGetFramework> UnsuccessfulFrameworks { get; }
+
+        /// <summary>
+        /// A mapping to allow the original framework string to fetched. This is important because MSBuild target
+        /// framework evaluation depends on the target framework string matching exactly.
+        /// </summary>
+        public IDictionary<NuGetFramework, string> OriginalFrameworks { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -13,6 +13,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace NuGet.ProjectManagement.Projects
 {
@@ -50,7 +51,8 @@ namespace NuGet.ProjectManagement.Projects
             bool throwOnFailure);
 
         public abstract Task<bool> InstallPackageAsync(
-            PackageIdentity packageIdentity,
+            string packageId,
+            VersionRange range,
             INuGetProjectContext nuGetProjectContext,
             IEnumerable<NuGetFramework> successfulFrameworks,
             IEnumerable<NuGetFramework> unsucessfulFrameworks,
@@ -62,7 +64,7 @@ namespace NuGet.ProjectManagement.Projects
             INuGetProjectContext nuGetProjectContext,
             CancellationToken token)
         {
-            throw new NotImplementedException("This API should not be called for BuildIntegratedNuGetProject");
+            throw new NotImplementedException("This API should not be called for BuildIntegratedNuGetProject.");
         }
 
         public virtual async Task<bool> IsRestoreRequired(

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -3,23 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.Versioning;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
-using NuGet.Commands;
-using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 
 namespace NuGet.ProjectManagement.Projects
 {
@@ -29,7 +22,9 @@ namespace NuGet.ProjectManagement.Projects
     /// </summary>
     public abstract class BuildIntegratedNuGetProject : NuGetProject, INuGetIntegratedProject, IDependencyGraphProject
     {
-        protected BuildIntegratedNuGetProject() { }
+        protected BuildIntegratedNuGetProject()
+        {
+        }
 
         /// <summary>
         /// Project name
@@ -53,6 +48,22 @@ namespace NuGet.ProjectManagement.Projects
             string packageInstallPath,
             INuGetProjectContext projectContext,
             bool throwOnFailure);
+
+        public abstract Task<bool> InstallPackageAsync(
+            PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            IEnumerable<NuGetFramework> successfulFrameworks,
+            IEnumerable<NuGetFramework> unsucessfulFrameworks,
+            CancellationToken token);
+
+        public override sealed Task<bool> InstallPackageAsync(
+            PackageIdentity packageIdentity,
+            DownloadResourceResult downloadResourceResult,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token)
+        {
+            throw new NotImplementedException("This API should not be called for BuildIntegratedNuGetProject");
+        }
 
         public virtual async Task<bool> IsRestoreRequired(
                     IEnumerable<VersionFolderPathResolver> pathResolvers,

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -54,8 +54,7 @@ namespace NuGet.ProjectManagement.Projects
             string packageId,
             VersionRange range,
             INuGetProjectContext nuGetProjectContext,
-            IEnumerable<NuGetFramework> successfulFrameworks,
-            IEnumerable<NuGetFramework> unsucessfulFrameworks,
+            BuildIntegratedInstallationContext installationContext,
             CancellationToken token);
 
         public override sealed Task<bool> InstallPackageAsync(

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -236,8 +236,7 @@ namespace NuGet.ProjectManagement.Projects
             string packageId,
             VersionRange range,
             INuGetProjectContext nuGetProjectContext,
-            IEnumerable<NuGetFramework> successfulFrameworks,
-            IEnumerable<NuGetFramework> unsucessfulFrameworks,
+            BuildIntegratedInstallationContext installationContext,
             CancellationToken token)
         {
             var dependency = new PackageDependency(packageId, range);

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -233,13 +233,14 @@ namespace NuGet.ProjectManagement.Projects
         }
 
         public async override Task<bool> InstallPackageAsync(
-            PackageIdentity packageIdentity,
+            string packageId,
+            VersionRange range,
             INuGetProjectContext nuGetProjectContext,
             IEnumerable<NuGetFramework> successfulFrameworks,
             IEnumerable<NuGetFramework> unsucessfulFrameworks,
             CancellationToken token)
         {
-            var dependency = new PackageDependency(packageIdentity.Id, new VersionRange(packageIdentity.Version));
+            var dependency = new PackageDependency(packageId, range);
 
             var json = await GetJsonAsync();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFrameworkInfo.cs
@@ -14,6 +14,12 @@ namespace NuGet.ProjectModel
         public NuGetFramework FrameworkName { get; set; }
 
         /// <summary>
+        /// The original string before parsing the framework name. In some cases, it is important to keep this around
+        /// because MSBuild framework conditions require the framework name to be the original string (non-normalized).
+        /// </summary>
+        public string OriginalFrameworkName { get; set; }
+
+        /// <summary>
         /// Project references
         /// </summary>
         public IList<ProjectRestoreReference> ProjectReferences { get; set; } = new List<ProjectRestoreReference>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -67,7 +67,7 @@
     <When Condition="$(VisualStudioVersion)=='15.0'">
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.ProjectSystem.Interop">
-          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.530-pre-g355f3866ef\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
+          <HintPath>$(EnlistmentRoot)\packages\Microsoft.VisualStudio.ProjectSystem.15.0.582-pre-g76aab6d79c\lib\net46\Microsoft.VisualStudio.ProjectSystem.Interop.dll</HintPath>
           <EmbedInteropTypes>True</EmbedInteropTypes>
         </Reference>
       </ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1388,8 +1388,20 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonBuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), new TestNuGetProjectContext(), null, null, token);
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), new TestNuGetProjectContext(), null, null, token);
+                await buildIntegratedProject.InstallPackageAsync(
+                    "dotnetrdf",
+                    VersionRange.Parse("1.0.8.3533"),
+                    new TestNuGetProjectContext(),
+                    null,
+                    null,
+                    token);
+                await buildIntegratedProject.InstallPackageAsync(
+                    "newtonsoft.json",
+                    VersionRange.Parse("6.0.8"),
+                    new TestNuGetProjectContext(),
+                    null,
+                    null,
+                    token);
 
                 // Check that there are no packages returned by PackagesConfigProject
                 var installedPackages = (await buildIntegratedProject.GetInstalledPackagesAsync(token)).ToList();

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1393,13 +1393,11 @@ namespace NuGet.Test
                     VersionRange.Parse("1.0.8.3533"),
                     new TestNuGetProjectContext(),
                     null,
-                    null,
                     token);
                 await buildIntegratedProject.InstallPackageAsync(
                     "newtonsoft.json",
                     VersionRange.Parse("6.0.8"),
                     new TestNuGetProjectContext(),
-                    null,
                     null,
                     token);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1388,8 +1388,8 @@ namespace NuGet.Test
                 var projectFilePath = Path.Combine(randomProjectFolderPath, $"{msBuildNuGetProjectSystem.ProjectName}.csproj");
                 var buildIntegratedProject = new ProjectJsonBuildIntegratedNuGetProject(randomConfig, projectFilePath, msBuildNuGetProjectSystem);
 
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), null, new TestNuGetProjectContext(), token);
-                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), null, new TestNuGetProjectContext(), token);
+                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("dotnetrdf", NuGetVersion.Parse("1.0.8.3533")), new TestNuGetProjectContext(), null, null, token);
+                await buildIntegratedProject.InstallPackageAsync(new PackageIdentity("newtonsoft.json", NuGetVersion.Parse("6.0.8")), new TestNuGetProjectContext(), null, null, token);
 
                 // Check that there are no packages returned by PackagesConfigProject
                 var installedPackages = (await buildIntegratedProject.GetInstalledPackagesAsync(token)).ToList();

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -254,7 +254,7 @@ namespace ProjectManagement.Test
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
                     // Act
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
                 }
 
                 // Assert
@@ -294,8 +294,8 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
+                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, testNuGetProjectContext, null, null, token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);
@@ -338,8 +338,18 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, packageStream, testNuGetProjectContext, token);
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, packageStream, testNuGetProjectContext, token);
+                    await buildIntegratedProject.InstallPackageAsync(
+                        packageIdentity,
+                        testNuGetProjectContext,
+                        Enumerable.Empty<NuGetFramework>(),
+                        Enumerable.Empty<NuGetFramework>(),
+                        token);
+                    await buildIntegratedProject.InstallPackageAsync(
+                        packageIdentity2,
+                        testNuGetProjectContext,
+                        Enumerable.Empty<NuGetFramework>(),
+                        Enumerable.Empty<NuGetFramework>(),
+                        token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -258,9 +258,8 @@ namespace ProjectManagement.Test
                         packageIdentity.Id,
                         new VersionRange(packageIdentity.Version),
                         testNuGetProjectContext,
-                        null,
-                        null,
-                        token);
+                        installationContext: null,
+                        token: token);
                 }
 
                 // Assert
@@ -304,16 +303,14 @@ namespace ProjectManagement.Test
                         packageIdentity.Id,
                         new VersionRange(packageIdentity.Version),
                         testNuGetProjectContext,
-                        null,
-                        null,
-                        token);
+                        installationContext: null,
+                        token: token);
                     await buildIntegratedProject.InstallPackageAsync(
                         packageIdentity2.Id,
                         new VersionRange(packageIdentity2.Version),
                         testNuGetProjectContext,
-                        null,
-                        null,
-                        token);
+                        installationContext: null,
+                        token: token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);
@@ -360,16 +357,14 @@ namespace ProjectManagement.Test
                         packageIdentity.Id,
                         new VersionRange(packageIdentity.Version),
                         testNuGetProjectContext,
-                        Enumerable.Empty<NuGetFramework>(),
-                        Enumerable.Empty<NuGetFramework>(),
-                        token);
+                        installationContext: null,
+                        token: token);
                     await buildIntegratedProject.InstallPackageAsync(
                         packageIdentity2.Id,
                         new VersionRange(packageIdentity2.Version),
                         testNuGetProjectContext,
-                        Enumerable.Empty<NuGetFramework>(),
-                        Enumerable.Empty<NuGetFramework>(),
-                        token);
+                        installationContext: null,
+                        token: token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -254,7 +254,13 @@ namespace ProjectManagement.Test
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
                     // Act
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
+                    await buildIntegratedProject.InstallPackageAsync(
+                        packageIdentity.Id,
+                        new VersionRange(packageIdentity.Version),
+                        testNuGetProjectContext,
+                        null,
+                        null,
+                        token);
                 }
 
                 // Assert
@@ -294,8 +300,20 @@ namespace ProjectManagement.Test
                     packageIdentity.Id, packageIdentity.Version.ToNormalizedString());
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity, testNuGetProjectContext, null, null, token);
-                    await buildIntegratedProject.InstallPackageAsync(packageIdentity2, testNuGetProjectContext, null, null, token);
+                    await buildIntegratedProject.InstallPackageAsync(
+                        packageIdentity.Id,
+                        new VersionRange(packageIdentity.Version),
+                        testNuGetProjectContext,
+                        null,
+                        null,
+                        token);
+                    await buildIntegratedProject.InstallPackageAsync(
+                        packageIdentity2.Id,
+                        new VersionRange(packageIdentity2.Version),
+                        testNuGetProjectContext,
+                        null,
+                        null,
+                        token);
 
                     // Act
                     await buildIntegratedProject.UninstallPackageAsync(packageIdentity2, new TestNuGetProjectContext(), CancellationToken.None);
@@ -339,13 +357,15 @@ namespace ProjectManagement.Test
                 using (var packageStream = GetDownloadResourceResult(packageFileInfo))
                 {
                     await buildIntegratedProject.InstallPackageAsync(
-                        packageIdentity,
+                        packageIdentity.Id,
+                        new VersionRange(packageIdentity.Version),
                         testNuGetProjectContext,
                         Enumerable.Empty<NuGetFramework>(),
                         Enumerable.Empty<NuGetFramework>(),
                         token);
                     await buildIntegratedProject.InstallPackageAsync(
-                        packageIdentity2,
+                        packageIdentity2.Id,
+                        new VersionRange(packageIdentity2.Version),
                         testNuGetProjectContext,
                         Enumerable.Empty<NuGetFramework>(),
                         Enumerable.Empty<NuGetFramework>(),

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecOperationsTests.cs
@@ -1,0 +1,238 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackageSpecOperationsTests
+    {
+        [Fact]
+        public void AddOrUpdateDependency_AddsNewDependencyToAllFrameworks()
+        {
+            // Arrange
+            var spec = new PackageSpec(new[]
+            {
+                new TargetFrameworkInformation
+                {
+                    FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+                }
+            });
+            var identity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
+
+            // Act
+            PackageSpecOperations.AddOrUpdateDependency(spec, identity);
+
+            // Assert
+            Assert.Equal(1, spec.Dependencies.Count);
+            Assert.Empty(spec.TargetFrameworks[0].Dependencies);
+            Assert.Equal(identity.Id, spec.Dependencies[0].LibraryRange.Name);
+            Assert.Equal(identity.Version, spec.Dependencies[0].LibraryRange.VersionRange.MinVersion);
+        }
+
+        [Fact]
+        public void AddOrUpdateDependency_UpdatesExistingDependencies()
+        {
+            // Arrange
+            var frameworkA = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            frameworkA.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "nuget.versioning",
+                    VersionRange = new VersionRange(new NuGetVersion("0.9.0"))
+                }
+            });
+            var frameworkB = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard16
+            };
+            frameworkB.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "NUGET.VERSIONING",
+                    VersionRange = new VersionRange(new NuGetVersion("0.8.0"))
+                }
+            });
+            var spec = new PackageSpec(new[] { frameworkA, frameworkB });
+            var identity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
+
+            // Act
+            PackageSpecOperations.AddOrUpdateDependency(spec, identity);
+
+            // Assert
+            Assert.Empty(spec.Dependencies);
+
+            Assert.Equal(1, spec.TargetFrameworks[0].Dependencies.Count);
+            Assert.Equal("nuget.versioning", spec.TargetFrameworks[0].Dependencies[0].LibraryRange.Name);
+            Assert.Equal(
+                identity.Version,
+                spec.TargetFrameworks[0].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+
+            Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Count);
+            Assert.Equal("NUGET.VERSIONING", spec.TargetFrameworks[1].Dependencies[0].LibraryRange.Name);
+            Assert.Equal(
+                identity.Version,
+                spec.TargetFrameworks[1].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+        }
+
+        [Fact]
+        public void AddDependency_ToSpecificFrameworks_RejectsExistingDependencies()
+        {
+            // Arrange
+            var frameworkA = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            var frameworkB = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard16
+            };
+            var spec = new PackageSpec(new[] { frameworkA, frameworkB });
+            var identity = new PackageIdentity("NuGet.Versioning", new NuGetVersion("1.0.0"));
+
+            // Act
+            PackageSpecOperations.AddDependency(
+                spec,
+                identity,
+                new[] { frameworkB.FrameworkName });
+
+            // Assert
+            Assert.Empty(spec.Dependencies);
+
+            Assert.Empty(spec.TargetFrameworks[0].Dependencies);
+
+            Assert.Equal(1, spec.TargetFrameworks[1].Dependencies.Count);
+            Assert.Equal(identity.Id, spec.TargetFrameworks[1].Dependencies[0].LibraryRange.Name);
+            Assert.Equal(
+                identity.Version,
+                spec.TargetFrameworks[1].Dependencies[0].LibraryRange.VersionRange.MinVersion);
+        }
+
+        [Fact]
+        public void RemoveDependency_RemovesFromAllFrameworkLists()
+        {
+            // Arrange
+            var frameworkA = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            frameworkA.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "nuget.versioning",
+                    VersionRange = new VersionRange(new NuGetVersion("0.9.0"))
+                }
+            });
+            var frameworkB = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.NetStandard16
+            };
+            frameworkB.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "NUGET.VERSIONING",
+                    VersionRange = new VersionRange(new NuGetVersion("0.8.0"))
+                }
+            });
+            var spec = new PackageSpec(new[] { frameworkA, frameworkB });
+            spec.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "NuGet.VERSIONING",
+                    VersionRange = new VersionRange(new NuGetVersion("0.7.0"))
+                }
+            });
+            var id = "NuGet.Versioning";
+
+            // Act
+            PackageSpecOperations.RemoveDependency(spec, id);
+
+            // Assert
+            Assert.Empty(spec.Dependencies);
+            Assert.Empty(spec.TargetFrameworks[0].Dependencies);
+            Assert.Empty(spec.TargetFrameworks[1].Dependencies);
+        }
+
+        [Fact]
+        public void HasPackage_ReturnsTrueWhenIdIsInFramework()
+        {
+            // Arrange
+            var framework = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            framework.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "nuget.versioning",
+                    VersionRange = new VersionRange(new NuGetVersion("0.9.0"))
+                }
+            });
+            var spec = new PackageSpec(new[] { framework });
+            var id = "NuGet.Versioning";
+
+            // Act
+            var actual = PackageSpecOperations.HasPackage(spec, id);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void HasPackage_ReturnsTrueWhenIdIsForAllFrameworks()
+        {
+            // Arrange
+            var framework = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            var spec = new PackageSpec(new[] { framework });
+            spec.Dependencies.Add(new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "nuget.versioning",
+                    VersionRange = new VersionRange(new NuGetVersion("0.9.0"))
+                }
+            });
+            var id = "NuGet.Versioning";
+
+            // Act
+            var actual = PackageSpecOperations.HasPackage(spec, id);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void HasPackage_ReturnsFalseWhenIdIsNotInSpec()
+        {
+            // Arrange
+            var framework = new TargetFrameworkInformation
+            {
+                FrameworkName = FrameworkConstants.CommonFrameworks.Net45
+            };
+            var spec = new PackageSpec(new[] { framework });
+            var id = "NuGet.Versioning";
+
+            // Act
+            var actual = PackageSpecOperations.HasPackage(spec, id);
+
+            // Assert
+            Assert.False(actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/3721.
Supersedes https://github.com/NuGet/NuGet.Client/pull/962.

The initial preview restore is executed. If the following conditions are all true about the result, the package is installed to the subset of the project's target frameworks that are compatible:
1. Only a single package is being installed.
2. There are one or more compatible frameworks.
3. There are one or more incompatible frameworks.
4. The preview restore failed.
5. The package is not already installed (it's not an upgrade).

This uses the new `IConditionalPackageReferencesService` API from CPS.

/cc @alpaix @drewgil @emgarten @natidea
