### PR TITLE
Added missing restore properties to CPS project

### DIFF
--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -119,6 +119,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestableVSCredentialProvide
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManager", "src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj", "{06662133-1292-4918-90F3-36C930C0B16F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManager.Test", "test\NuGet.Clients.Tests\NuGet.SolutionRestoreManager.Test\NuGet.SolutionRestoreManager.Test.csproj", "{F7837EEB-1B49-482F-8722-EB35BA0937CC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug VS14|Any CPU = Debug VS14|Any CPU
@@ -524,6 +526,18 @@ Global
 		{06662133-1292-4918-90F3-36C930C0B16F}.Release VS14|Any CPU.Build.0 = Release|Any CPU
 		{06662133-1292-4918-90F3-36C930C0B16F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06662133-1292-4918-90F3-36C930C0B16F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Debug VS14|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Debug VS14|Any CPU.Build.0 = Debug|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Mono Debug|Any CPU.ActiveCfg = Mono Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Mono Debug|Any CPU.Build.0 = Mono Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Mono Release|Any CPU.ActiveCfg = Mono Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Mono Release|Any CPU.Build.0 = Mono Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Release VS14|Any CPU.ActiveCfg = Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Release VS14|Any CPU.Build.0 = Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -548,5 +562,6 @@ Global
 		{6043EF0C-9C45-4EE1-AB2D-A3F4936AB2BB} = {3EF356B5-E2D3-45E3-B515-99F4611ACBDA}
 		{DBFE233D-074A-4977-A9A0-37F6FF900475} = {6043EF0C-9C45-4EE1-AB2D-A3F4936AB2BB}
 		{7D0DDCB8-E362-4283-8AC8-3FF1E9B0263E} = {6F6D0E69-329D-4D0E-9795-A253FB2CA0CD}
+		{F7837EEB-1B49-482F-8722-EB35BA0937CC} = {25E91311-400E-47A6-A844-733D604E662A}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -32,24 +32,19 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ProjectRestoreInfoBuilder.cs" />
     <Compile Include="RestoreManagerPackage.cs" />
-    <Compile Include="VsItemList.cs" />
-    <Compile Include="VsProjectRestoreInfo.cs" />
-    <Compile Include="VsReferenceItem.cs" />
-    <Compile Include="VsReferenceItems.cs" />
-    <Compile Include="VsReferenceProperties.cs" />
-    <Compile Include="VsReferenceProperty.cs" />
     <Compile Include="VsSolutionRestoreService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="VsTargetFrameworkInfo.cs" />
-    <Compile Include="VsTargetFrameworks.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj">
       <Project>{4003E1AB-70DE-4B9C-8999-96160EE91D84}</Project>
       <Name>NuGet.SolutionRestoreManager.Interop</Name>
       <EmbedInteropTypes>True</EmbedInteropTypes>
+    </ProjectReference>
+    <ProjectReference Include="..\PackageManagement.UI\NuGet.PackageManagement.UI.csproj">
+      <Project>{538ADEFD-2170-40A9-A2C5-EC8369CFE490}</Project>
+      <Name>NuGet.PackageManagement.UI</Name>
     </ProjectReference>
     <ProjectReference Include="..\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj">
       <Project>{306CDDFA-FF0B-4299-930C-9EC6C9308160}</Project>

--- a/src/NuGet.Clients/PackageManagement.UI/Common/VisualStudioActivityLogger.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Common/VisualStudioActivityLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 
 namespace NuGet.PackageManagement.UI
@@ -6,7 +9,9 @@ namespace NuGet.PackageManagement.UI
     /// <summary>
     /// Logger routing messages into VS ActivityLog
     /// </summary>
-    internal class VisualStudioActivityLogger : Common.ILogger
+    /// 
+    [Export(typeof(VisualStudioActivityLogger))]
+    public sealed class VisualStudioActivityLogger : NuGet.Common.ILogger
     {
         private const string LogEntrySource = "NuGet Package Manager";
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
   </PropertyGroup>
@@ -13,6 +13,8 @@
     <RootNamespace>NuGet.CommandLine.Test</RootNamespace>
     <AssemblyName>NuGet.CommandLine.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -105,7 +107,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy /diy $(ArtifactRoot)\TestableCredentialProvider\$(OutDirFx). $(TargetDir)TestableCredentialProvider</PostBuildEvent>
   </PropertyGroup>

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/NuGet.Credentials.Test.csproj
@@ -45,5 +45,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
   <Import Project="$(EnlistmentRoot)\build\sign.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
   </PropertyGroup>
@@ -13,6 +13,8 @@
     <RootNamespace>NuGet.PackageManagement.UI.Test</RootNamespace>
     <AssemblyName>NuGet.PackageManagement.UI.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -72,5 +74,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
   <Import Project="$(EnlistmentRoot)\build\sign.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\Build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\Build\Common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <ProjectGuid>{9EA84487-C70C-420C-9674-75CF19F43757}</ProjectGuid>
@@ -14,6 +14,8 @@
     <PackagesDirectory>$(UserProfile)\.nuget\packages</PackagesDirectory>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -76,5 +78,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
   <Import Project="$(EnlistmentRoot)\build\sign.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F7837EEB-1B49-482F-8722-EB35BA0937CC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NuGet.SolutionRestoreManager.Test</RootNamespace>
+    <AssemblyName>NuGet.SolutionRestoreManager.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ProjectRestoreInfoBuilder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VsItemList.cs" />
+    <Compile Include="VsProjectRestoreInfo.cs" />
+    <Compile Include="VsReferenceItem.cs" />
+    <Compile Include="VsReferenceItems.cs" />
+    <Compile Include="VsReferenceProperties.cs" />
+    <Compile Include="VsReferenceProperty.cs" />
+    <Compile Include="VsSolutionRestoreServiceTests.cs" />
+    <Compile Include="VsTargetFrameworkInfo.cs" />
+    <Compile Include="VsTargetFrameworks.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj">
+      <Project>{4003e1ab-70de-4b9c-8999-96160ee91d84}</Project>
+      <Name>NuGet.SolutionRestoreManager.Interop</Name>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj">
+      <Project>{06662133-1292-4918-90f3-36c930c0b16f}</Project>
+      <Name>NuGet.SolutionRestoreManager</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\PackageManagement.UI\NuGet.PackageManagement.UI.csproj">
+      <Project>{538ADEFD-2170-40A9-A2C5-EC8369CFE490}</Project>
+      <Name>NuGet.PackageManagement.UI</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj">
+      <Project>{306CDDFA-FF0B-4299-930C-9EC6C9308160}</Project>
+      <Name>NuGet.PackageManagement.VisualStudio</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(EnlistmentRoot)\build\common.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
+</Project>

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -6,7 +6,7 @@ using NuGet.ProjectModel;
 using System;
 using System.Linq;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     /// <summary>
     /// Helper class providing a method of building <see cref="IVsProjectRestoreInfo"/>
@@ -19,7 +19,7 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         /// <param name="packageSpec">Source project restore object</param>
         /// <returns>Desired project restore object</returns>
-        public static IVsProjectRestoreInfo Build(PackageSpec packageSpec)
+        public static IVsProjectRestoreInfo Build(PackageSpec packageSpec, string baseIntermediatePath)
         {
             if (packageSpec == null)
             {
@@ -37,7 +37,7 @@ namespace NuGet.SolutionRestoreManager
                     .Select(ToTargetFrameworkInfo));
 
             return new VsProjectRestoreInfo(
-                packageSpec.RestoreMetadata.OutputPath,
+                baseIntermediatePath,
                 targetFrameworks);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NuGet.SolutionRestoreManager.Test")]
+[assembly: AssemblyDescription("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f7837eeb-1b49-482f-8722-eb35ba0937cc")]

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsItemList.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsItemList.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     /// <summary>
     /// Abstract list with Item method for getting members by index or name

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     /// <summary>
     /// Root object containing project restore info.

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItem.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItem.cs
@@ -3,23 +3,28 @@
 
 using System;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
-    internal class VsReferenceProperty : IVsReferenceProperty
+    internal class VsReferenceItem : IVsReferenceItem
     {
         public String Name { get; }
 
-        public String Value { get; }
+        public IVsReferenceProperties Properties { get; }
 
-        public VsReferenceProperty(string name, string value)
+        public VsReferenceItem(string name, IVsReferenceProperties properties)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException(ProjectManagement.Strings.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
+            if (properties == null)
+            {
+                throw new ArgumentNullException(nameof(properties));
+            }
+
             Name = name;
-            Value = value;
+            Properties = properties;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItems.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceItems.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     internal class VsReferenceItems : VsItemList<IVsReferenceItem>, IVsReferenceItems
     {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperties.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperties.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     internal class VsReferenceProperties : VsItemList<IVsReferenceProperty>, IVsReferenceProperties
     {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperty.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperty.cs
@@ -3,28 +3,23 @@
 
 using System;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
-    internal class VsReferenceItem : IVsReferenceItem
+    internal class VsReferenceProperty : IVsReferenceProperty
     {
         public String Name { get; }
 
-        public IVsReferenceProperties Properties { get; }
+        public String Value { get; }
 
-        public VsReferenceItem(string name, IVsReferenceProperties properties)
+        public VsReferenceProperty(string name, string value)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException(ProjectManagement.Strings.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
-
             Name = name;
-            Properties = properties;
+            Value = value;
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.PackageManagement.UI;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    public class VsSolutionRestoreServiceTests:IDisposable
+    {
+        private readonly TestDirectory _testDirectory;
+
+        static VsSolutionRestoreServiceTests()
+        {
+            var mainThread = Thread.CurrentThread;
+            var synchronizationContext = SynchronizationContext.Current;
+            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(mainThread, synchronizationContext);
+        }
+
+        public VsSolutionRestoreServiceTests()
+        {
+            _testDirectory = TestDirectory.Create();
+        }
+
+        public void Dispose()
+        {
+            _testDirectory.Dispose();
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_ConsoleAppTemplate_Succeeds()
+        {
+            var projectLocation = _testDirectory.Path;
+            var projectName = "ConsoleApp1";
+            var projectFullPath = Path.Combine(projectLocation, $"{projectName}.csproj");
+
+            var baseIntermediatePath = Path.Combine(projectLocation, "obj");
+            Directory.CreateDirectory(baseIntermediatePath);
+
+            var consoleAppProjectJson = $@"{{
+    ""frameworks"": {{
+        ""netcoreapp1.0"": {{
+            ""dependencies"": {{
+                ""Microsoft.NET.Sdk"": {{
+                    ""target"": ""Package"",
+                    ""version"": ""1.0.0-alpha-20161019-1""
+                }},
+                ""Microsoft.NETCore.App"": {{
+                    ""target"": ""Package"",
+                    ""version"": ""1.0.1""
+                }}
+            }}
+        }}
+    }}
+}}";
+
+            var spec = JsonPackageSpecReader.GetPackageSpec(consoleAppProjectJson, projectName, projectFullPath);
+
+            var pri = ProjectRestoreInfoBuilder.Build(spec, baseIntermediatePath);
+
+            var dte = Mock.Of<EnvDTE.DTE>();
+
+            var serviceProvider = Mock.Of<IServiceProvider>();
+            Mock.Get(serviceProvider)
+                .Setup(x => x.GetService(typeof(EnvDTE.DTE)))
+                .Returns(dte);
+
+            var cache = Mock.Of<IProjectSystemCache>();
+
+            var dteProject = Mock.Of<EnvDTE.Project>();
+            Mock.Get(dteProject)
+                .SetupGet(x => x.UniqueName)
+                .Returns(projectFullPath);
+            Mock.Get(dteProject)
+                .SetupGet(x => x.Name)
+                .Returns(projectName);
+
+            Mock.Get(cache)
+                .Setup(x => x.TryGetDTEProject(projectFullPath, out dteProject))
+                .Returns(true);
+
+            PackageSpec actualRestoreSpec = null;
+
+            Mock.Get(cache)
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(), It.IsAny<PackageSpec>()))
+                .Callback<ProjectNames, PackageSpec>(
+                    (_, ps) => { actualRestoreSpec = ps; }
+                )
+                .Returns(true);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(
+                    It.IsAny<SolutionRestoreRequest>(), CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var service = new VsSolutionRestoreService(
+                serviceProvider, cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+
+            // Act
+            var result = await service.NominateProjectAsync(projectFullPath, pri, CancellationToken.None);
+
+            Assert.True(result, "Project restore nomination should succeed.");
+            Assert.NotNull(actualRestoreSpec?.RestoreMetadata);
+
+            var actualMetadata = actualRestoreSpec.RestoreMetadata;
+            Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
+            Assert.Equal(projectName, actualMetadata.ProjectName);
+            Assert.Equal(RestoreOutputType.NETCore, actualMetadata.OutputType);
+            Assert.Equal(baseIntermediatePath, actualMetadata.OutputPath);
+
+            Assert.Single(actualRestoreSpec.TargetFrameworks);
+            var actualTfi = actualRestoreSpec.TargetFrameworks.Single();
+
+            var expectedFramework = NuGetFramework.Parse("netcoreapp1.0");
+            Assert.Equal(expectedFramework, actualTfi.FrameworkName);
+
+            var expectedPackages = new[]
+            {
+                "Microsoft.NET.Sdk:1.0.0-alpha-20161019-1",
+                "Microsoft.NETCore.App:1.0.1"
+            };
+            var actualPackages = actualTfi.Dependencies
+                .Where(ld => ld.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package)
+                .Select(ld => $"{ld.Name}:{ld.LibraryRange.VersionRange.OriginalString}");
+            Assert.Equal(expectedPackages, actualPackages);
+
+            Mock.Get(restoreWorker)
+                .Verify(
+                    x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), CancellationToken.None), 
+                    Times.Once());
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     internal class VsTargetFrameworkInfo : IVsTargetFrameworkInfo
     {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworks.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworks.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace NuGet.SolutionRestoreManager
+namespace NuGet.SolutionRestoreManager.Test
 {
     internal class VsTargetFrameworks : VsItemList<IVsTargetFrameworkInfo>, IVsTargetFrameworks
     {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/project.json
@@ -1,0 +1,15 @@
+﻿{
+  "dependencies": {
+    "Moq": "4.2.1507.118",
+    "Test.Utility": "4.0.0-*",
+    "xunit": "2.1.0",
+    "xunit.runner.visualstudio": "2.1.0"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {}
+  }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
   </PropertyGroup>
@@ -13,6 +13,8 @@
     <RootNamespace>NuGet.VisualStudio.Implementation.Test</RootNamespace>
     <AssemblyName>NuGet.VisualStudio.Implementation.Test</AssemblyName>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -57,5 +59,5 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
 </Project>

--- a/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/NuGet.VsExtension.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VsExtension.Test/NuGet.VsExtension.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\build\Common.props" Condition="Exists('..\..\..\Build\Common.props')" />
+  <Import Project="..\..\..\build\Common.props" />
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
   </PropertyGroup>
@@ -59,5 +59,5 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(EnlistmentRoot)\build\common.targets" />
   <Import Project="$(EnlistmentRoot)\build\sign.targets" />
-  <Import Project="..\..\..\build\test.targets" />
+  <Import Project="$(EnlistmentRoot)\build\test.targets" />
 </Project>


### PR DESCRIPTION
Restore for .NETCore project requires the following fields which are not present in `CpsPackageReferenceProject`.
- `PackageTargetFallback`  - imports equivalent, this needs to be per TFM
- `CrossTargeting` - true when `$(TargetFrameworks)` is used, false otherwise. This enables writing `buildCrossTargeting` imports to the generated targets/props.
- `OriginalTargetFrameworks` - Generated imports needs the exact framework strings used in the project. (its unclear if this is being passed already or if the strings are modified)
- `RuntimeIdentifier`/`RuntimeIdentifiers` - Allows RID specific restore
- `RuntimeSupports` - Equivalent to the supports section in project.json

Fixes NuGet/Home#3739.

//cc @emgarten @jainaashish @drewgil @joelverhagen @mishra14 @rrelyea 
