### PR TITLE
Write restore outputs to temp files and then move them

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -169,22 +169,18 @@ namespace NuGet.Commands
                     {
                         log.LogDebug($"Writing tool lock file to disk. Path: {result.LockFilePath}");
 
-                        await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
-                            result.LockFilePath,
-                            lockedToken =>
-                            {
-                                lockFileFormat.Write(result.LockFilePath, result.LockFile);
-
-                                return Task.FromResult(0);
-                            },
-                            token);
+                        await FileUtility.ReplaceWithLock(
+                            (outputPath) => lockFileFormat.Write(outputPath, result.LockFile),
+                            result.LockFilePath);
                     }
                 }
                 else
                 {
                     log.LogMinimal($"Writing lock file to disk. Path: {result.LockFilePath}");
 
-                    lockFileFormat.Write(result.LockFilePath, result.LockFile);
+                    FileUtility.Replace(
+                        (outputPath) => lockFileFormat.Write(outputPath, result.LockFile),
+                        result.LockFilePath);
                 }
             }
             else
@@ -198,18 +194,6 @@ namespace NuGet.Commands
                     log.LogMinimal($"Lock file has not changed. Skipping lock file write. Path: {result.LockFilePath}");
                 }
             }
-        }
-
-        private static void WriteLockFile(
-            LockFileFormat lockFileFormat,
-            IRestoreResult result,
-            bool createDirectory)
-        {
-            if (createDirectory)
-            {
-            }
-            
-            lockFileFormat.Write(result.LockFilePath, result.LockFile);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -4,11 +4,131 @@
 using NuGet.Test.Utility;
 using System.IO;
 using Xunit;
+using System;
+using System.Threading.Tasks;
 
 namespace NuGet.Common.Test
 {
     public class FileUtilityTests
     {
+        [Fact]
+        public void FileUtility_Replace_BasicSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+
+                Action<string> action = (path) =>
+                {
+                    File.WriteAllText(path, "a");
+                };
+
+                // Act
+                FileUtility.Replace(action, dest);
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal(1, Directory.GetFiles(testDirectory).Length);
+            }
+        }
+
+        [Fact]
+        public void FileUtility_Replace_AlreadyExistsSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "b");
+
+                Action<string> action = (path) =>
+                {
+                    File.WriteAllText(path, "a");
+                };
+
+                // Act
+                FileUtility.Replace(action, dest);
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal(1, Directory.GetFiles(testDirectory).Length);
+                Assert.Equal("a", File.ReadAllText(dest));
+            }
+        }
+
+        [Fact]
+        public void FileUtility_Replace_Failure()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+
+                Action<string> action = (path) =>
+                {
+                    throw new Exception();
+                };
+
+                Exception exception = null;
+
+                // Act
+                try
+                {
+                    FileUtility.Replace(action, dest);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                // Assert
+                Assert.False(File.Exists(dest));
+                Assert.Equal(0, Directory.GetFiles(testDirectory).Length);
+                Assert.NotNull(exception);
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_ReplaceWithLock_BasicSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+
+                Action<string> action = (path) =>
+                {
+                    File.WriteAllText(path, "a");
+                };
+
+                // Act
+                await FileUtility.ReplaceWithLock(action, dest);
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal(1, Directory.GetFiles(testDirectory).Length);
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_DeleteWithLock_BasicSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "a");
+
+                // Act
+                await FileUtility.DeleteWithLock(dest);
+
+                // Assert
+                Assert.False(File.Exists(dest));
+                Assert.Equal(0, Directory.GetFiles(testDirectory).Length);
+            }
+        }
+
         [Fact]
         public void FileUtility_MoveBasicSuccess()
         {


### PR DESCRIPTION
This change writes the assets files, targets, and props to a temporary file location first. Then moves the file into the intended location. This is done to reduce the risk of an external process trying to read a file as it is being written out by restore. It also reduces the chance of multiple nuget restores conflicting with each other.

Fixes https://github.com/NuGet/Home/issues/3806

//cc @drewgil 
