### PR TITLE
Enable restore logs without required to build the solution

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/RestoreOperationLogger.cs
@@ -230,6 +230,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     .OutputWindowPanes
                     .Cast<EnvDTE.OutputWindowPane>()
                     .FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.Guid, BuildWindowPaneGuid));
+                pane?.Activate();
                 return pane;
             });
         }


### PR DESCRIPTION
This change will activate build pane since it isn't activated by default and will allow writing restore logs for auto restore, or solution restore. Now we don't write the same restore logs as dotnet tooling use to write with dev14 but write consistent logs across different restores.

Fixes https://github.com/NuGet/Home/issues/3633 

@alpaix @rrelyea @emgarten 
