### PR TITLE
Fixed project unique name for CPS and Legacy project systems

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -73,7 +73,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 ThreadHelper.ThrowIfNotOnUIThread();
 
                 // Uncached, in case project is renamed
-                return _project.UniqueName;
+                return EnvDTEProjectUtility.GetCustomUniqueName(_project);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -82,7 +82,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             result = new CpsPackageReferenceProject(
                 dteProject.Name,
-                dteProject.UniqueName,
+                EnvDTEProjectUtility.GetCustomUniqueName(dteProject),
                 fullProjectPath,
                 packageSpecFactory,
                 dteProject,


### PR DESCRIPTION
Fixed project unique name for CPS and Legacy project systems similar to existing project systems which is to get the custom unique name based on solution root. And this is the same name then used to access dte project.

Fixes https://github.com/NuGet/Home/issues/3818

@rrelyea @alpaix @emgarten @drewgil @joelverhagen 

Note: These are the only places i saw getting Unique name for new project systems, let me know if there are other places as well? We should have similar behavior across project systems in all scenarios.
