### PR TITLE
Block Solution Restore while auto restore is running

### DIFF
--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25806.0
+VisualStudioVersion = 15.0.25807.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
@@ -17,6 +17,11 @@ namespace NuGet.PackageManagement.VisualStudio
         Task<bool> CurrentRestoreOperation { get; }
 
         /// <summary>
+        /// Returns true when it's executing a restore operation.
+        /// </summary>
+        bool IsBusy { get; }
+
+        /// <summary>
         /// Schedules backgroud restore operation.
         /// </summary>
         /// <param name="request">Restore request.</param>

--- a/src/NuGet.Clients/VsExtension/Commands/RestorePackagesCommand.cs
+++ b/src/NuGet.Clients/VsExtension/Commands/RestorePackagesCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.ComponentModel.Design;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -93,12 +92,14 @@ namespace NuGetVSExtension
                 OleMenuCommand command = (OleMenuCommand)sender;
 
                 // Enable the 'Restore NuGet Packages' dialog menu
-                // a) if the console is NOT busy executing a command, AND
-                // b) if the solution exists and not debugging and not building AND
-                // c) if the solution is DPL enabled or there are NuGetProjects. This means that there loaded, supported projects
+                // - if the console is NOT busy executing a command, AND
+                // - if the restore worker is not executing restore operation, AND
+                // - if the solution exists and not debugging and not building AND
+                // - if the solution is DPL enabled or there are NuGetProjects. This means that there loaded, supported projects
                 // Checking for DPL more is a temporary code until we've the capability to get nuget projects
                 // even in DPL mode. See https://github.com/NuGet/Home/issues/3711
                 command.Enabled = !ConsoleStatus.IsBusy &&
+                    !SolutionRestoreWorker.IsBusy &&
                     _package.IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
                     (SolutionManager.IsSolutionDPLEnabled || SolutionManager.GetNuGetProjects().Any());
             });


### PR DESCRIPTION
Resolves NuGet/Home#3797.

Added `IsBusy` attribute to evaluate active restore operation is
in-progress.

Refactored restore operation implementation to use `JoinableTask` when
chaining subsequent operations. This technique is supposed to prevent
deadlocks we were seeing lately.

//cc @rrelyea @emgarten @joelverhagen @jainaashish 
