### PR TITLE
Block Solution Restore while auto-restore is running

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
@@ -17,6 +17,11 @@ namespace NuGet.PackageManagement.VisualStudio
         Task<bool> CurrentRestoreOperation { get; }
 
         /// <summary>
+        /// Returns true when it's executing a restore operation.
+        /// </summary>
+        bool IsBusy { get; }
+
+        /// <summary>
         /// Schedules backgroud restore operation.
         /// </summary>
         /// <param name="request">Restore request.</param>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreWorker.cs
@@ -40,6 +40,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public Task<bool> CurrentRestoreOperation => _activeRestoreTask;
 
+        public bool IsBusy => !_activeRestoreTask.IsCompleted;
+
         [ImportingConstructor]
         public SolutionRestoreWorker(
             [Import(typeof(SVsServiceProvider))]

--- a/src/NuGet.Clients/VsExtension/Commands/RestorePackagesCommand.cs
+++ b/src/NuGet.Clients/VsExtension/Commands/RestorePackagesCommand.cs
@@ -81,7 +81,10 @@ namespace NuGetVSExtension
         /// <param name="e">Event args.</param>
         private void OnRestorePackages(object sender, EventArgs args)
         {
-            SolutionRestoreWorker.Restore(SolutionRestoreRequest.ByMenu());
+            if (!SolutionRestoreWorker.IsBusy)
+            {
+                SolutionRestoreWorker.Restore(SolutionRestoreRequest.ByMenu());
+            }
         }
 
         private void BeforeQueryStatusForPackageRestore(object sender, EventArgs args)
@@ -93,12 +96,14 @@ namespace NuGetVSExtension
                 OleMenuCommand command = (OleMenuCommand)sender;
 
                 // Enable the 'Restore NuGet Packages' dialog menu
-                // a) if the console is NOT busy executing a command, AND
-                // b) if the solution exists and not debugging and not building AND
-                // c) if the solution is DPL enabled or there are NuGetProjects. This means that there loaded, supported projects
+                // - if the console is NOT busy executing a command, AND
+                // - if the restore worker is not executing restore operation, AND
+                // - if the solution exists and not debugging and not building AND
+                // - if the solution is DPL enabled or there are NuGetProjects. This means that there loaded, supported projects
                 // Checking for DPL more is a temporary code until we've the capability to get nuget projects
                 // even in DPL mode. See https://github.com/NuGet/Home/issues/3711
                 command.Enabled = !ConsoleStatus.IsBusy &&
+                    !SolutionRestoreWorker.IsBusy &&
                     _package.IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
                     (SolutionManager.IsSolutionDPLEnabled || SolutionManager.GetNuGetProjects().Any());
             });

--- a/src/NuGet.Clients/VsExtension/NuGetPackage.cs
+++ b/src/NuGet.Clients/VsExtension/NuGetPackage.cs
@@ -270,13 +270,15 @@ namespace NuGetVSExtension
             Styles.LoadVsStyles();
             Brushes.LoadVsBrushes();
 
+            _outputConsoleLogger = new OutputConsoleLogger(this);
+
             // ***
             // VsNuGetDiagnostics.Initialize(
             //    ServiceLocator.GetInstance<IDebugConsoleController>());
 
             // Add our command handlers for menu (commands must exist in the .vsct file)
             await AddMenuCommandHandlersAsync();
-            await RestorePackagesCommand.InitializeAsync(this);
+            await RestorePackagesCommand.InitializeAsync(this, _outputConsoleLogger);
 
             // IMPORTANT: Do NOT do anything that can lead to a call to ServiceLocator.GetGlobalService().
             // Doing so is illegal and may cause VS to hang.
@@ -286,8 +288,6 @@ namespace NuGetVSExtension
 
             _dteEvents = _dte.Events.DTEEvents;
             _dteEvents.OnBeginShutdown += OnBeginShutDown;
-
-            _outputConsoleLogger = new OutputConsoleLogger(this);
 
             SetDefaultCredentialProvider();
 

--- a/src/NuGet.Clients/VsExtension/Resources.Designer.cs
+++ b/src/NuGet.Clients/VsExtension/Resources.Designer.cs
@@ -302,5 +302,14 @@ namespace NuGetVSExtension {
                 return ResourceManager.GetString("SolutionIsNotSavedPromptReopen", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Solution Restore cannot be started while an automatic restore is in progress..
+        /// </summary>
+        internal static string SolutionRestoreFailed_RestoreWorkerIsBusy {
+            get {
+                return ResourceManager.GetString("SolutionRestoreFailed_RestoreWorkerIsBusy", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/VsExtension/Resources.resx
+++ b/src/NuGet.Clients/VsExtension/Resources.resx
@@ -198,4 +198,7 @@
   <data name="CredentialProviderFailed_ImportedProvider" xml:space="preserve">
     <value>Failed to load credential provider from assembly {0}.</value>
   </data>
+  <data name="SolutionRestoreFailed_RestoreWorkerIsBusy" xml:space="preserve">
+    <value>Solution Restore cannot be started while an automatic restore is in progress.</value>
+  </data>
 </root>


### PR DESCRIPTION
Resolves NuGet/Home#3797.

- Disable `Restore packages` menu item when `SolutionRestoreWorker.IsBusy`.
- Print error message when auto-restore is running.
    
    Covers the case when QueryStatus for Solution Restore command is not sent by VS. This happens if NuGetPackage is not loaded in the current UI context.

