### PR TITLE
Fixing failure to set DGSpecHash on a forcedRestore for UWP

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
@@ -40,16 +40,12 @@ namespace NuGet.PackageManagement.VisualStudio
         // Restore summary
         // True if any of restores had errors
         private bool _hasErrors;
-
         // True if any of the restores were canceled
         private bool _cancelled;
-
         // True if any restores failed to restore all packages
         private bool _hasMissingPackages;
-
         // True if restore actions were taken and the summary should be displayed
         private bool _displayRestoreSummary;
-
         // If false the opt out message should be displayed
         private bool _hasOptOutBeenShown;
 
@@ -254,6 +250,7 @@ namespace NuGet.PackageManagement.VisualStudio
             RestoreTelemetryService.Instance.EmitRestoreEvent(restoreTelemetryEvent);
         }
 
+
         private async Task DisplayOptOutMessageAsync()
         {
             if (!_hasOptOutBeenShown)
@@ -373,7 +370,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var packageIdentity = args.Package;
                 Interlocked.Increment(ref _currentCount);
 
-                _logger.Do((_, progress) =>
+                _logger.Do((_, progress) => 
                 {
                     progress?.ReportProgress(
                         string.Format(

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
@@ -315,8 +315,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 // No-op all project closures are up to date and all packages exist on disk.
                 if (isRestoreRequired)
                 {
-                    // Save the project between operations.
-                    _dependencyGraphProjectCacheHash = cacheContext.SolutionSpecHash;
+                    if(!forceRestore)
+                    {
+                        // Save the project between operations.
+                        _dependencyGraphProjectCacheHash = cacheContext.SolutionSpecHash;
+                    }
 
                     // NOTE: During restore for build integrated projects,
                     //       We might show the dialog even if there are no packages to restore

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/SolutionRestoreJob.cs
@@ -40,12 +40,16 @@ namespace NuGet.PackageManagement.VisualStudio
         // Restore summary
         // True if any of restores had errors
         private bool _hasErrors;
+
         // True if any of the restores were canceled
         private bool _cancelled;
+
         // True if any restores failed to restore all packages
         private bool _hasMissingPackages;
+
         // True if restore actions were taken and the summary should be displayed
         private bool _displayRestoreSummary;
+
         // If false the opt out message should be displayed
         private bool _hasOptOutBeenShown;
 
@@ -250,7 +254,6 @@ namespace NuGet.PackageManagement.VisualStudio
             RestoreTelemetryService.Instance.EmitRestoreEvent(restoreTelemetryEvent);
         }
 
-
         private async Task DisplayOptOutMessageAsync()
         {
             if (!_hasOptOutBeenShown)
@@ -315,11 +318,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 // No-op all project closures are up to date and all packages exist on disk.
                 if (isRestoreRequired)
                 {
-                    if(!forceRestore)
-                    {
-                        // Save the project between operations.
-                        _dependencyGraphProjectCacheHash = cacheContext.SolutionSpecHash;
-                    }
+                    // Save the project between operations.
+                    _dependencyGraphProjectCacheHash = cacheContext.SolutionSpecHash;
 
                     // NOTE: During restore for build integrated projects,
                     //       We might show the dialog even if there are no packages to restore
@@ -373,7 +373,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var packageIdentity = args.Package;
                 Interlocked.Increment(ref _currentCount);
 
-                _logger.Do((_, progress) => 
+                _logger.Do((_, progress) =>
                 {
                     progress?.ReportProgress(
                         string.Format(

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -273,6 +273,9 @@ namespace NuGet.PackageManagement
             cacheContext.SolutionSpec = solutionDgSpec;
             cacheContext.SolutionSpecHash = newDependencyGraphSpecHash;
 
+            // Comment by @emgarten from PR -
+            // Force is only done during a rebuild, all of the work done here to build the dg file is stored in the cache context and used again later on.
+            // The time different should only be the time it takes to create the hash, which @dtivel has perf numbers on.
             if (forceRestore || (oldDependencyGraphSpecHash != newDependencyGraphSpecHash))
             {
                 // A new project has been added

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -259,12 +259,6 @@ namespace NuGet.PackageManagement
             DependencyGraphCacheContext cacheContext,
             int oldDependencyGraphSpecHash)
         {
-            if (forceRestore)
-            {
-                // The cache has been updated, now skip the check since we are doing a restore anyways.
-                return true;
-            }
-
             var projects = solutionManager.GetNuGetProjects().OfType<IDependencyGraphProject>().ToArray();
 
             var solutionDgSpec = await GetSolutionRestoreSpec(solutionManager, cacheContext);
@@ -279,7 +273,7 @@ namespace NuGet.PackageManagement
             cacheContext.SolutionSpec = solutionDgSpec;
             cacheContext.SolutionSpecHash = newDependencyGraphSpecHash;
 
-            if (oldDependencyGraphSpecHash != newDependencyGraphSpecHash)
+            if (forceRestore || (oldDependencyGraphSpecHash != newDependencyGraphSpecHash))
             {
                 // A new project has been added
                 return true;


### PR DESCRIPTION
Seems to be the cause for NuGet/Home#3814.

Currently, if a UWP project is rebuilt, the `forcedRestore `bool is set to true and we return from `DependencyGraphRestoreUtility.IsRestoreRequiredAsync` without populating `cacheContext`.
Thus when we return from `DependencyGraphRestoreUtility.IsRestoreRequiredAsync` the `cacheContext.SolutionSpecHash` is 0 and is assigned to `_dependencyGraphProjectCacheHash`. This causes the next restore to never no-op.

//cc: @alpaix @emgarten @rrelyea @jainaashish @joelverhagen @drewgil @zhili1208 @dtivel 