### PR TITLE
Removing LockFile.IsValidForPackageSpec check

### DIFF
--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -91,18 +91,6 @@ namespace NuGet.ProjectManagement.Projects
                 return true;
             }
 
-            // Ignore tools here
-            var specs = await GetPackageSpecsAsync(context);
-
-            var packageSpec = specs.FirstOrDefault(e => e.RestoreMetadata.OutputType != RestoreOutputType.Standalone
-                && e.RestoreMetadata.OutputType != RestoreOutputType.DotnetCliTool);
-
-            if (!lockFile.IsValidForPackageSpec(packageSpec, LockFileFormat.Version))
-            {
-                // The project.json file has been changed and the lock file needs to be updated.
-                return true;
-            }
-
             // Verify all libraries are on disk
             var packages = lockFile.Libraries.Where(library => library.Type == LibraryType.Package);
 


### PR DESCRIPTION
Detection of project/spec changes is done using the dg file. Individually each project does not need to do this, and in some cases it causes a false positive since the previous way of detecting changes is based on the ``IsLocked=true`` validation which no longer exists.

Projects should check if a restore is needed by just validating that all of their required packages are on disk. The spec validation is no longer needed.

Fixes https://github.com/NuGet/Home/issues/3821

//cc @alpaix @jainaashish @mishra14 @joelverhagen @rrelyea 