### PR TITLE
Return restore task on nomination

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager.Interop/IVsSolutionRestoreService.cs
@@ -36,8 +36,9 @@ namespace NuGet.SolutionRestoreManager
         /// <param name="projectRestoreInfo">Metadata <see cref="IVsProjectRestoreInfo"/> needed for restoring the project.</param>
         /// <param name="token">Cancellation token.</param>
         /// <returns>
-        /// Returns if the requested nuget restore operation for the given project
-        /// was a success or failure.
+        /// Returns a restore task corresponding to the nominated project request.
+        /// NuGet will batch restore requests so it's possible the same restore task will be returned for multiple projects.
+        /// When the requested restore operation for the given project completes the task will indicate operation success or failure.
         /// </returns>
         Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token);
     }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -80,7 +80,7 @@ namespace NuGet.SolutionRestoreManager
 
         public Task<bool> CurrentRestoreOperation => _restoreWorker.CurrentRestoreOperation;
 
-        public async Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token)
+        public Task<bool> NominateProjectAsync(string projectUniqueName, IVsProjectRestoreInfo projectRestoreInfo, CancellationToken token)
         {
             if (string.IsNullOrEmpty(projectUniqueName))
             {
@@ -111,12 +111,11 @@ namespace NuGet.SolutionRestoreManager
                 _projectSystemCache.AddProjectRestoreInfo(projectNames, packageSpec);
 
                 // returned task completes when scheduled restore operation completes.
-                // it should be discarded as we don't want to block CPS on that.
-                var ignored = _restoreWorker.ScheduleRestoreAsync(
+                var restoreTask = _restoreWorker.ScheduleRestoreAsync(
                     SolutionRestoreRequest.OnUpdate(),
                     token);
 
-                return await System.Threading.Tasks.Task.FromResult(true);
+                return restoreTask;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Resolves NuGet/Home#3780.

`NominateProjectAsync` returns a restore task CPS will use to block
the build by setting it as a critical task.

This change complies with the original design depicted in the
[spec](https://github.com/NuGet/Home/wiki/NuGet-Restore-Manager).

//cc @emgarten @jainaashish @joelverhagen @mishra14 @rrelyea 