### PR TITLE
Fix auto restore to wait until normal solution load is completed

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
@@ -26,5 +26,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="name">Project name, full path or unique name.</param>
         /// <returns>Desired project object.</returns>
         EnvDTE.Project GetDTEProject(string name);
+
+        /// <summary>
+        /// Return true if all projects in the solution have been loaded in background.
+        /// </summary>
+        bool IsSolutionFullyLoaded { get; }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -319,6 +319,21 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        public bool IsSolutionFullyLoaded
+        {
+            get
+            {
+                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    object value;
+                    _vsSolution.GetProperty((int)(__VSPROPID4.VSPROPID_IsSolutionFullyLoaded), out value);
+                    return (bool)value;
+                });
+            }
+        }
+
         public void EnsureSolutionIsLoaded()
         {
             ThreadHelper.JoinableTaskFactory.Run(async delegate


### PR DESCRIPTION
Since we call EnsureSolutionIsLoaded() api before restore to make sure all projects are loaded, regressed solution load time when solution was already being loaded in background. So this code change will make auto restore to wait until solution load is completed via OnAfterBackgroundSolutionLoadComplete event handler.

Fixes https://github.com/NuGet/Home/issues/3844 

@rrelyea @emgarten @alpaix @mishra14