### PR TITLE
Support Program Files (x86) for machine wide configurations on x86

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/NuGetEnvironment.cs
@@ -20,6 +20,11 @@ namespace NuGet.Common
                     if (!RuntimeEnvironmentHelper.IsDev14 && RuntimeEnvironmentHelper.IsWindows)
                     {
                         machineWideBaseDir = GetFolderPath(SpecialFolder.ProgramFilesX86);
+                        if (string.IsNullOrEmpty(machineWideBaseDir))
+                        {
+                            // On 32-bit Windows
+                            machineWideBaseDir = GetFolderPath(SpecialFolder.ProgramFiles);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
CoreCLR reads program files (x86) through an environment variable which is null on 32-bit machines.

Fixes https://github.com/NuGet/Home/issues/3853