### PR TITLE
Support for DotNetCliTool references in CPS project

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -3,14 +3,11 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities;
 using NuGet.ProjectManagement;
-using NuGet.ProjectModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -69,22 +66,11 @@ namespace NuGet.PackageManagement.VisualStudio
             var fullProjectPath = EnvDTEProjectUtility.GetFullProjectPath(dteProject);
             var unconfiguredProject = GetUnconfiguredProject(dteProject);
 
-            Func<PackageSpec> packageSpecFactory = () =>
-            {
-                PackageSpec packageSpec;
-                if (_projectSystemCache.TryGetProjectRestoreInfo(fullProjectPath, out packageSpec))
-                {
-                    return packageSpec;
-                }
-
-                return null;
-            };
-
             result = new CpsPackageReferenceProject(
                 dteProject.Name,
                 EnvDTEProjectUtility.GetCustomUniqueName(dteProject),
                 fullProjectPath,
-                packageSpecFactory,
+                _projectSystemCache,
                 dteProject,
                 unconfiguredProject,
                 VsHierarchyUtility.GetProjectId(dteProject));

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/IProjectSystemCache.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/IProjectSystemCache.cs
@@ -34,9 +34,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Retrieves project restore info as of <see cref="PackageSpec"/> associated with project name.
         /// </summary>
         /// <param name="name">Project name, full path or unique name.</param>
-        /// <param name="packageSpec">Desired restore info object, not initialized if not found.</param>
+        /// <param name="projectRestoreInfo">Desired project restore info object, or null if not found.</param>
         /// <returns>True if found, false otherwise.</returns>
-        bool TryGetProjectRestoreInfo(string name, out PackageSpec packageSpec);
+        bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo);
 
         /// <summary>
         /// Finds a project name by short name, unique name or custom unique name.
@@ -92,10 +92,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <summary>
         /// Adds or updates project restore info in the project cache.
         /// </summary>
-        /// <param name="projectName">Primary key.</param>
-        /// <param name="packageSpec">The project restore info.</param>
-        /// <returns>Return true if operation succeeded.</returns>
-        bool AddProjectRestoreInfo(ProjectNames projectName, PackageSpec packageSpec);
+        /// <param name="projectNames">Primary key.</param>
+        /// <param name="projectRestoreInfo">The project restore info including tools.</param>
+        /// <returns>True if operation succeeded.</returns>
+        bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo);
 
         /// <summary>
         /// Removes a project associated with given name out of the cache.

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemCache.cs
@@ -61,22 +61,22 @@ namespace NuGet.PackageManagement.VisualStudio
             return project != null;
         }
 
-        public bool TryGetProjectRestoreInfo(string name, out PackageSpec packageSpec)
+        public bool TryGetProjectRestoreInfo(string name, out DependencyGraphSpec projectRestoreInfo)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, nameof(name));
             }
 
-            packageSpec = null;
+            projectRestoreInfo = null;
 
             CacheEntry cacheEntry;
             if (TryGetCacheEntry(name, out cacheEntry))
             {
-                packageSpec = cacheEntry.ProjectRestoreInfo;
+                projectRestoreInfo = cacheEntry.ProjectRestoreInfo;
             }
 
-            return packageSpec != null;
+            return projectRestoreInfo != null;
         }
 
         public bool TryGetProjectNames(string name, out ProjectNames projectNames)
@@ -251,7 +251,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
-        public bool AddProjectRestoreInfo(ProjectNames projectNames, PackageSpec packageSpec)
+        public bool AddProjectRestoreInfo(ProjectNames projectNames, DependencyGraphSpec projectRestoreInfo)
         {
             if (projectNames == null)
             {
@@ -273,11 +273,11 @@ namespace NuGet.PackageManagement.VisualStudio
                     projectNames.FullName,
                     addEntryFactory: k => new CacheEntry
                     {
-                        ProjectRestoreInfo = packageSpec
+                        ProjectRestoreInfo = projectRestoreInfo
                     },
                     updateEntryFactory: (k, e) =>
                     {
-                        e.ProjectRestoreInfo = packageSpec;
+                        e.ProjectRestoreInfo = projectRestoreInfo;
                         return e;
                     });
             }
@@ -456,7 +456,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             public NuGetProject NuGetProject { get; set; }
             public EnvDTE.Project EnvDTEProject { get; set; }
-            public PackageSpec ProjectRestoreInfo { get; set; }
+            public DependencyGraphSpec ProjectRestoreInfo { get; set; }
             public ProjectNames ProjectNames { get; set; }
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectSystemCacheTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Moq;
-using Newtonsoft.Json.Linq;
 using NuGet.ProjectModel;
 using Xunit;
 
@@ -134,7 +133,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         }
 
         [Fact]
-        public void AddProjectBeforeAddProjectRestoreInfo()
+        public void AddProjectRestoreInfo_AfterAddProject_UpdatesCacheEntry()
         {
             // Arrange
             var target = new ProjectSystemCache();
@@ -144,14 +143,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 shortName: "project",
                 customUniqueName: @"folder\project");
             var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
-            var packageSpec = new PackageSpec(new JObject());
+            var projectRestoreInfo = new DependencyGraphSpec();
+
+            target.AddProject(projectNames, dteProject: null, nuGetProject: null);
 
             // Act
-            target.AddProject(projectNames, dteProject: null, nuGetProject: null);
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, packageSpec);
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
 
             // Assert
-            PackageSpec actual;
+            DependencyGraphSpec actual;
             ProjectNames names;
 
             var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
@@ -159,12 +159,12 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.True(getPackageSpecSuccess);
             Assert.True(getProjectNameSuccess);
-            Assert.Same(packageSpec, actual);
+            Assert.Same(projectRestoreInfo, actual);
             Assert.Equal(@"folder\project", names.CustomUniqueName);
         }
 
         [Fact]
-        public void AddProjectRestoreInfoBeforeAddProject()
+        public void AddProject_AfterAddProjectRestoreInfo_UpdatesCacheEntry()
         {
             // Arrange
             var target = new ProjectSystemCache();
@@ -174,14 +174,15 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 shortName: "project",
                 customUniqueName: @"folder\project");
             var projectNamesFromFullPath = ProjectNames.FromFullProjectPath(@"C:\src\project\project.csproj");
-            var packageSpec = new PackageSpec(new JObject());
+            var projectRestoreInfo = new DependencyGraphSpec();
+
+            target.AddProjectRestoreInfo(projectNamesFromFullPath, projectRestoreInfo);
 
             // Act
-            target.AddProjectRestoreInfo(projectNamesFromFullPath, packageSpec);
             target.AddProject(projectNames, dteProject: null, nuGetProject: null);
 
             // Assert
-            PackageSpec actual;
+            DependencyGraphSpec actual;
             ProjectNames names;
 
             var getPackageSpecSuccess = target.TryGetProjectRestoreInfo(projectNames.FullName, out actual);
@@ -189,7 +190,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             Assert.True(getPackageSpecSuccess);
             Assert.True(getProjectNameSuccess);
-            Assert.Same(packageSpec, actual);
+            Assert.Same(projectRestoreInfo, actual);
             Assert.Equal(@"folder\project", names.CustomUniqueName);
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using NuGet.LibraryModel;
-using NuGet.ProjectModel;
 using System;
 using System.Linq;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
@@ -12,7 +12,7 @@ namespace NuGet.SolutionRestoreManager.Test
     /// Helper class providing a method of building <see cref="IVsProjectRestoreInfo"/>
     /// out of <see cref="PackageSpec"/>.
     /// </summary>
-    public static class ProjectRestoreInfoBuilder
+    internal static class ProjectRestoreInfoBuilder
     {
         /// <summary>
         /// Creates project restore info object to be consumed by <see cref="IVsSolutionRestoreService"/>.
@@ -36,9 +36,17 @@ namespace NuGet.SolutionRestoreManager.Test
                     .TargetFrameworks
                     .Select(ToTargetFrameworkInfo));
 
-            return new VsProjectRestoreInfo(
+            var pri = new VsProjectRestoreInfo(
                 baseIntermediatePath,
                 targetFrameworks);
+
+            if (packageSpec.Tools != null)
+            {
+                pri.ToolReferences = new VsReferenceItems(
+                    packageSpec.Tools.Select(ToToolReference));
+            }
+
+            return pri;
         }
 
         private static VsTargetFrameworkInfo ToTargetFrameworkInfo(TargetFrameworkInformation tfm)
@@ -73,6 +81,14 @@ namespace NuGet.SolutionRestoreManager.Test
                 new[] { new VsReferenceProperty("ProjectFileFullPath", library.LibraryRange.Name) }
             );
             return new VsReferenceItem(library.Name, properties);
+        }
+
+        private static IVsReferenceItem ToToolReference(ToolDependency library)
+        {
+            var properties = new VsReferenceProperties(
+                new[] { new VsReferenceProperty("Version", library.LibraryRange.VersionRange.OriginalString) }
+            );
+            return new VsReferenceItem(library.LibraryRange.Name, properties);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
@@ -18,7 +18,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
         public IVsTargetFrameworks TargetFrameworks { get; }
 
-        public IVsReferenceItems ToolReferences { get; }
+        public IVsReferenceItems ToolReferences { get; set; }
 
         public VsProjectRestoreInfo(string baseIntermediatePath, IVsTargetFrameworks targetFrameworks)
         {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -7,9 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
+using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -17,16 +17,9 @@ using Xunit;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
-    public class VsSolutionRestoreServiceTests:IDisposable
+    public class VsSolutionRestoreServiceTests : IDisposable
     {
         private readonly TestDirectory _testDirectory;
-
-        static VsSolutionRestoreServiceTests()
-        {
-            var mainThread = Thread.CurrentThread;
-            var synchronizationContext = SynchronizationContext.Current;
-            NuGetUIThreadHelper.SetCustomJoinableTaskFactory(mainThread, synchronizationContext);
-        }
 
         public VsSolutionRestoreServiceTests()
         {
@@ -39,108 +32,212 @@ namespace NuGet.SolutionRestoreManager.Test
         }
 
         [Fact]
-        public async Task NominateProjectAsync_ConsoleAppTemplate_Succeeds()
+        public void NominateProjectAsync_Always_SchedulesAutoRestore()
         {
-            var projectLocation = _testDirectory.Path;
-            var projectName = "ConsoleApp1";
-            var projectFullPath = Path.Combine(projectLocation, $"{projectName}.csproj");
-
-            var baseIntermediatePath = Path.Combine(projectLocation, "obj");
-            Directory.CreateDirectory(baseIntermediatePath);
-
-            var consoleAppProjectJson = $@"{{
-    ""frameworks"": {{
-        ""netcoreapp1.0"": {{
-            ""dependencies"": {{
-                ""Microsoft.NET.Sdk"": {{
-                    ""target"": ""Package"",
-                    ""version"": ""1.0.0-alpha-20161019-1""
-                }},
-                ""Microsoft.NETCore.App"": {{
-                    ""target"": ""Package"",
-                    ""version"": ""1.0.1""
-                }}
-            }}
-        }}
-    }}
-}}";
-
-            var spec = JsonPackageSpecReader.GetPackageSpec(consoleAppProjectJson, projectName, projectFullPath);
-
-            var pri = ProjectRestoreInfoBuilder.Build(spec, baseIntermediatePath);
-
-            var dte = Mock.Of<EnvDTE.DTE>();
-
-            var serviceProvider = Mock.Of<IServiceProvider>();
-            Mock.Get(serviceProvider)
-                .Setup(x => x.GetService(typeof(EnvDTE.DTE)))
-                .Returns(dte);
+            var cps = NewCpsProject();
 
             var cache = Mock.Of<IProjectSystemCache>();
 
-            var dteProject = Mock.Of<EnvDTE.Project>();
-            Mock.Get(dteProject)
-                .SetupGet(x => x.UniqueName)
-                .Returns(projectFullPath);
-            Mock.Get(dteProject)
-                .SetupGet(x => x.Name)
-                .Returns(projectName);
-
             Mock.Get(cache)
-                .Setup(x => x.TryGetDTEProject(projectFullPath, out dteProject))
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(),
+                    It.IsAny<DependencyGraphSpec>()))
                 .Returns(true);
 
-            PackageSpec actualRestoreSpec = null;
+            var completedRestoreTask = Task.FromResult(true);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(
+                    It.IsAny<SolutionRestoreRequest>(),
+                    CancellationToken.None))
+                .Returns(completedRestoreTask);
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+
+            // Act
+            var actualRestoreTask = service.NominateProjectAsync(cps.Item1, cps.Item3, CancellationToken.None);
+
+            Assert.Same(completedRestoreTask, actualRestoreTask);
+
+            Mock.Get(restoreWorker)
+                .Verify(
+                    x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), CancellationToken.None),
+                    Times.Once(),
+                    "Service should schedule auto-restore operation.");
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_ConsoleAppTemplate_Succeeds()
+        {
+            var consoleAppProjectJson = @"{
+    ""frameworks"": {
+        ""netcoreapp1.0"": {
+            ""dependencies"": {
+                ""Microsoft.NET.Sdk"": {
+                    ""target"": ""Package"",
+                    ""version"": ""1.0.0-alpha-20161019-1""
+                },
+                ""Microsoft.NETCore.App"": {
+                    ""target"": ""Package"",
+                    ""version"": ""1.0.1""
+                }
+            }
+        }
+    }
+}";
+            var projectName = "ConsoleApp1";
+            var cps = NewCpsProject(projectName, consoleAppProjectJson);
+            var projectFullPath = cps.Item1;
+
+            var cache = Mock.Of<IProjectSystemCache>();
+
+            DependencyGraphSpec actualRestoreSpec = null;
 
             Mock.Get(cache)
-                .Setup(x => x.AddProjectRestoreInfo(It.IsAny<ProjectNames>(),
-                    It.IsAny<PackageSpec>()))
-                .Callback<ProjectNames, PackageSpec>(
-                    (_, ps) => { actualRestoreSpec = ps; }
-                )
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(),
+                    It.IsAny<DependencyGraphSpec>()))
+                .Callback<ProjectNames, DependencyGraphSpec>(
+                    (_, dg) => { actualRestoreSpec = dg; })
                 .Returns(true);
 
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             Mock.Get(restoreWorker)
                 .Setup(x => x.ScheduleRestoreAsync(
-                    It.IsAny<SolutionRestoreRequest>(), CancellationToken.None))
+                    It.IsAny<SolutionRestoreRequest>(),
+                    CancellationToken.None))
                 .ReturnsAsync(true);
 
             var service = new VsSolutionRestoreService(
-                serviceProvider, cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+                cache, restoreWorker, NuGet.Common.NullLogger.Instance);
 
             // Act
-            var result = await service.NominateProjectAsync(projectFullPath, pri, CancellationToken.None);
+            var result = await service.NominateProjectAsync(projectFullPath, cps.Item3, CancellationToken.None);
 
             Assert.True(result, "Project restore nomination should succeed.");
-            Assert.NotNull(actualRestoreSpec?.RestoreMetadata);
+            Assert.NotNull(actualRestoreSpec);
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
 
-            var actualMetadata = actualRestoreSpec.RestoreMetadata;
+            Assert.NotNull(actualRestoreSpec.GetProjectSpec(projectFullPath));
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+
+            var actualMetadata = actualProjectSpec.RestoreMetadata;
             Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
             Assert.Equal(projectName, actualMetadata.ProjectName);
             Assert.Equal(RestoreOutputType.NETCore, actualMetadata.OutputType);
-            Assert.Equal(baseIntermediatePath, actualMetadata.OutputPath);
+            Assert.Equal(cps.Item2, actualMetadata.OutputPath);
 
-            Assert.Single(actualRestoreSpec.TargetFrameworks);
-            var actualTfi = actualRestoreSpec.TargetFrameworks.Single();
+            Assert.Single(actualProjectSpec.TargetFrameworks);
+            var actualTfi = actualProjectSpec.TargetFrameworks.Single();
 
             var expectedFramework = NuGetFramework.Parse("netcoreapp1.0");
             Assert.Equal(expectedFramework, actualTfi.FrameworkName);
 
-            var expectedPackages = new[]
-            {
+            AssertPackages(actualTfi,
                 "Microsoft.NET.Sdk:1.0.0-alpha-20161019-1",
-                "Microsoft.NETCore.App:1.0.1"
-            };
-            var actualPackages = actualTfi.Dependencies
+                "Microsoft.NETCore.App:1.0.1");
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_WithTools_Succeeds()
+        {
+            const string toolProjectJson = @"{
+    ""tools"": {
+        ""Foo.Test.Tools"": ""1.0.0""
+    },
+    ""frameworks"": {
+        ""netcoreapp1.0"": { }
+    }
+}";
+            var cps = NewCpsProject(projectJson: toolProjectJson);
+            var projectFullPath = cps.Item1;
+
+            var cache = Mock.Of<IProjectSystemCache>();
+
+            DependencyGraphSpec actualRestoreSpec = null;
+
+            Mock.Get(cache)
+                .Setup(x => x.AddProjectRestoreInfo(
+                    It.IsAny<ProjectNames>(),
+                    It.IsAny<DependencyGraphSpec>()))
+                .Callback<ProjectNames, DependencyGraphSpec>(
+                    (_, dg) => { actualRestoreSpec = dg; })
+                .Returns(true);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(
+                    It.IsAny<SolutionRestoreRequest>(),
+                    CancellationToken.None))
+                .ReturnsAsync(true);
+
+            var service = new VsSolutionRestoreService(
+                cache, restoreWorker, NuGet.Common.NullLogger.Instance);
+
+            // Act
+            var result = await service.NominateProjectAsync(projectFullPath, cps.Item3, CancellationToken.None);
+
+            Assert.True(result, "Project restore nomination should succeed.");
+            Assert.NotNull(actualRestoreSpec);
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            Assert.NotNull(actualRestoreSpec.GetProjectSpec(projectFullPath));
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+
+            var actualToolSpec = actualRestoreSpec
+                .Projects
+                .Where(p => !object.ReferenceEquals(p, actualProjectSpec))
+                .Single();
+            var actualMetadata = actualToolSpec.RestoreMetadata;
+            Assert.NotNull(actualMetadata);
+            Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
+            Assert.Equal(RestoreOutputType.DotnetCliTool, actualMetadata.OutputType);
+            Assert.Null(actualMetadata.OutputPath);
+        }
+
+        private Tuple<string, string, IVsProjectRestoreInfo> NewCpsProject(
+            string projectName = null, string projectJson = null)
+        {
+            const string DefaultProjectJson = @"{
+    ""frameworks"": {
+        ""netcoreapp1.0"": {
+            ""dependencies"": { }
+        }
+    }
+}";
+            if (projectName == null)
+            {
+                projectName = $"{Guid.NewGuid()}";
+            }
+
+            var projectLocation = _testDirectory.Path;
+            var projectFullPath = Path.Combine(projectLocation, $"{projectName}.csproj");
+            var baseIntermediatePath = Path.Combine(projectLocation, "obj");
+            Directory.CreateDirectory(baseIntermediatePath);
+
+            var spec = JsonPackageSpecReader.GetPackageSpec(projectJson ?? DefaultProjectJson, projectName, projectFullPath);
+            var pri = ProjectRestoreInfoBuilder.Build(spec, baseIntermediatePath);
+            return Tuple.Create(projectFullPath, baseIntermediatePath, pri);
+        }
+
+        private static IVsReferenceItem ToReferenceItem(string itemName, string versionRange)
+        {
+            var properties = new VsReferenceProperties(
+                new[] { new VsReferenceProperty("Version", versionRange) }
+            );
+            return new VsReferenceItem(itemName, properties);
+        }
+
+        private static void AssertPackages(TargetFrameworkInformation actualTfi, params string[] expectedPackages)
+        {
+            var actualPackages = actualTfi
+                .Dependencies
                 .Where(ld => ld.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package)
                 .Select(ld => $"{ld.Name}:{ld.LibraryRange.VersionRange.OriginalString}");
-            Assert.Equal(expectedPackages, actualPackages);
 
-            Mock.Get(restoreWorker)
-                .Verify(
-                    x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), CancellationToken.None), 
-                    Times.Once());
+            Assert.Equal(expectedPackages, actualPackages);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
     "Moq": "4.2.1507.118",
+    "System.ValueTuple": "4.3.0-preview1-24530-04",
     "Test.Utility": "4.0.0-*",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"


### PR DESCRIPTION
Resolves NuGet/Home#3845.

This change adds support for auto-restore of projects with tool references.
`VsSolutionRestoreService` is now capable of generating a `PackageSpec` for
each tool reference passed via the nomination.
As a key part of this change `ProjectSystemCache` has been updated to hold
`DependencyGraphSpec` object as an internal represenation of the project
restore info. All consuming project code has been changed to support the
new type.

//cc @jainaashish @emgarten @joelverhagen @mishra14 @zhili1208 @rrelyea 