### PR TITLE
Add RestoreLegacyPackagesDirectory MSBuild property to restore original case packages

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -75,8 +75,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreConfigFile="$(RestoreConfigFile)"
       RestoreNoCache="$(RestoreNoCache)"
       RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
-      RestoreRecursive="$(RestoreRecursive)"
-      RestoreLegacyPackagesDirectory="$(RestoreLegacyPackagesDirectory)" />
+      RestoreRecursive="$(RestoreRecursive)" />
   </Target>
 
   <!--
@@ -349,6 +348,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RuntimeIdentifiers>$(RuntimeIdentifiers);$(RuntimeIdentifier)</RuntimeIdentifiers>
         <RuntimeSupports>$(RuntimeSupports)</RuntimeSupports>
         <CrossTargeting>$(_RestoreCrossTargeting)</CrossTargeting>
+        <RestoreLegacyPackagesDirectory>$(RestoreLegacyPackagesDirectory)</RestoreLegacyPackagesDirectory>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -75,7 +75,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreConfigFile="$(RestoreConfigFile)"
       RestoreNoCache="$(RestoreNoCache)"
       RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
-      RestoreRecursive="$(RestoreRecursive)" />
+      RestoreRecursive="$(RestoreRecursive)"
+      RestoreLegacyPackagesDirectory="$(RestoreLegacyPackagesDirectory)" />
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -66,11 +66,6 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestoreRecursive { get; set; }
 
-        /// <summary>
-        /// Restore the legacy packages directory format, which has original case paths instead of lowercase.
-        /// </summary>
-        public bool RestoreLegacyPackagesDirectory { get; set; }
-
         public override bool Execute()
         {
             if (RestoreGraphItems.Length < 1)
@@ -91,7 +86,6 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreNoCache '{RestoreNoCache}'");
             log.LogDebug($"(in) RestoreIgnoreFailedSources '{RestoreIgnoreFailedSources}'");
             log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
-            log.LogDebug($"(in) RestoreLegacyPackagesDirectory '{RestoreLegacyPackagesDirectory}'");
 
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(GetMSBuildItem);
@@ -137,8 +131,7 @@ namespace NuGet.Build.Tasks
                     Log = log,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider,
-                    IsLowercaseGlobalPackagesFolder = !RestoreLegacyPackagesDirectory
+                    CachingSourceProvider = sourceProvider
                 };
 
                 if (!string.IsNullOrEmpty(RestoreSources))

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -63,6 +66,11 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestoreRecursive { get; set; }
 
+        /// <summary>
+        /// Restore the legacy packages directory format, which has original case paths instead of lowercase.
+        /// </summary>
+        public bool RestoreLegacyPackagesDirectory { get; set; }
+
         public override bool Execute()
         {
             if (RestoreGraphItems.Length < 1)
@@ -83,6 +91,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreNoCache '{RestoreNoCache}'");
             log.LogDebug($"(in) RestoreIgnoreFailedSources '{RestoreIgnoreFailedSources}'");
             log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
+            log.LogDebug($"(in) RestoreLegacyPackagesDirectory '{RestoreLegacyPackagesDirectory}'");
 
             // Convert to the internal wrapper
             var wrappedItems = RestoreGraphItems.Select(GetMSBuildItem);
@@ -128,7 +137,8 @@ namespace NuGet.Build.Tasks
                     Log = log,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider
+                    CachingSourceProvider = sourceProvider,
+                    IsLowercaseGlobalPackagesFolder = !RestoreLegacyPackagesDirectory
                 };
 
                 if (!string.IsNullOrEmpty(RestoreSources))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -176,7 +176,7 @@ namespace NuGet.Commands
             // Set properties from the restore metadata
             request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
             request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
-            var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.RestoreLegacyPackagesDirectory
+            var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory
                 ?? DefaultRestoreLegacyPackagesDirectory;
             request.IsLowercasePackagesDirectory = !restoreLegacyPackagesDirectory;
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -17,6 +17,8 @@ namespace NuGet.Commands
     /// </summary>
     public class DependencyGraphSpecRequestProvider : IPreLoadedRestoreRequestProvider
     {
+        private const bool DefaultRestoreLegacyPackagesDirectory = false;
+
         private readonly DependencyGraphSpec _dgFile;
         private readonly RestoreCommandProvidersCache _providerCache;
         private readonly Dictionary<string, PackageSpec> _projectJsonCache = new Dictionary<string, PackageSpec>(StringComparer.Ordinal);
@@ -174,7 +176,9 @@ namespace NuGet.Commands
             // Set properties from the restore metadata
             request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
             request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
-            request.IsLowercasePackagesDirectory = !(project.PackageSpec?.RestoreMetadata?.RestoreLegacyPackagesDirectory ?? false);
+            var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.RestoreLegacyPackagesDirectory
+                ?? DefaultRestoreLegacyPackagesDirectory;
+            request.IsLowercasePackagesDirectory = !restoreLegacyPackagesDirectory;
 
             // Standard properties
             restoreContext.ApplyStandardProperties(request);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -6,7 +9,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
-using NuGet.Protocol.Core.Types;
 
 namespace NuGet.Commands
 {
@@ -169,9 +171,10 @@ namespace NuGet.Commands
                 restoreContext.CacheContext,
                 restoreContext.Log);
 
-            // Set output type
+            // Set properties from the restore metadata
             request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
             request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
+            request.IsLowercasePackagesDirectory = !(project.PackageSpec?.RestoreMetadata?.RestoreLegacyPackagesDirectory ?? false);
 
             // Standard properties
             restoreContext.ApplyStandardProperties(request);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -23,7 +23,7 @@ namespace NuGet.Commands
 
         public string GlobalPackagesFolder { get; set; }
 
-        public bool IsLowercaseGlobalPackagesFolder { get; set; } = true;
+        public bool? IsLowercaseGlobalPackagesFolder { get; set; }
 
         public bool DisableParallel { get; set; }
 
@@ -182,7 +182,10 @@ namespace NuGet.Commands
             request.RequestedRuntimes.UnionWith(Runtimes);
             request.FallbackRuntimes.UnionWith(FallbackRuntimes);
 
-            request.IsLowercasePackagesDirectory = IsLowercaseGlobalPackagesFolder;
+            if (IsLowercaseGlobalPackagesFolder.HasValue)
+            {
+                request.IsLowercasePackagesDirectory = IsLowercaseGlobalPackagesFolder.Value;
+            }
 
             if (LockFileVersion.HasValue && LockFileVersion.Value > 0)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -126,7 +129,7 @@ namespace NuGet.Commands
 
                 if (!string.IsNullOrEmpty(typeString))
                 {
-                    Enum.TryParse<RestoreOutputType>(typeString, ignoreCase: true, result: out restoreType);
+                    Enum.TryParse(typeString, ignoreCase: true, result: out restoreType);
                 }
 
                 // Get base spec
@@ -194,6 +197,11 @@ namespace NuGet.Commands
 
                     // Add CrossTargeting flag
                     result.RestoreMetadata.CrossTargeting = IsPropertyTrue(specItem, "CrossTargeting");
+
+                    // Add RestoreLegacyPackagesDirectory flag
+                    result.RestoreMetadata.RestoreLegacyPackagesDirectory = IsPropertyTrue(
+                        specItem,
+                        "RestoreLegacyPackagesDirectory");
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -199,7 +199,7 @@ namespace NuGet.Commands
                     result.RestoreMetadata.CrossTargeting = IsPropertyTrue(specItem, "CrossTargeting");
 
                     // Add RestoreLegacyPackagesDirectory flag
-                    result.RestoreMetadata.RestoreLegacyPackagesDirectory = IsPropertyTrue(
+                    result.RestoreMetadata.LegacyPackagesDirectory = IsPropertyTrue(
                         specItem,
                         "RestoreLegacyPackagesDirectory");
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -236,6 +236,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.ProjectName = rawMSBuildMetadata.GetValue<string>("projectName");
             msbuildMetadata.ProjectPath = rawMSBuildMetadata.GetValue<string>("projectPath");
             msbuildMetadata.CrossTargeting = rawMSBuildMetadata.GetValue<bool>("crossTargeting");
+            msbuildMetadata.LegacyPackagesDirectory = rawMSBuildMetadata.GetValue<bool>("legacyPackagesDirectory");
 
             msbuildMetadata.Sources = new List<PackageSource>();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
@@ -118,6 +118,14 @@ namespace NuGet.ProjectModel
                 SetValue(rawMSBuildMetadata, "crossTargeting", msbuildMetadata.CrossTargeting.ToString());
             }
 
+            if (msbuildMetadata.LegacyPackagesDirectory)
+            {
+                SetValue(
+                    rawMSBuildMetadata,
+                    "legacyPackagesDirectory",
+                    msbuildMetadata.LegacyPackagesDirectory.ToString());
+            }
+
             SetValue(rawMSBuildMetadata, "packagesPath", msbuildMetadata.PackagesPath);
 
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using NuGet.Configuration;
 
 namespace NuGet.ProjectModel
@@ -66,5 +69,11 @@ namespace NuGet.ProjectModel
         /// True if $(TargetFrameworks) is used and the build is using Cross Targeting.
         /// </summary>
         public bool CrossTargeting { get; set; }
+
+        /// <summary>
+        /// Whether or not to restore the packages directory using the legacy format, which write original case paths
+        /// instead of lowercase.
+        /// </summary>
+        public bool RestoreLegacyPackagesDirectory { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -74,6 +74,6 @@ namespace NuGet.ProjectModel
         /// Whether or not to restore the packages directory using the legacy format, which write original case paths
         /// instead of lowercase.
         /// </summary>
-        public bool RestoreLegacyPackagesDirectory { get; set; }
+        public bool LegacyPackagesDirectory { get; set; }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
@@ -171,7 +170,8 @@ namespace NuGet.Commands.Test
                     { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
                     { "FallbackFolders", fallbackFolder },
                     { "PackagesPath", packagesFolder },
-                    { "CrossTargeting", "true" }
+                    { "CrossTargeting", "true" },
+                    { "RestoreLegacyPackagesDirectory", "true" }
                 });
 
                 var wrappedItems = items.Select(CreateItems).ToList();
@@ -197,6 +197,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, project1Spec.RuntimeGraph.Runtimes.Count);
                 Assert.Equal(0, project1Spec.RuntimeGraph.Supports.Count);
                 Assert.True(project1Spec.RestoreMetadata.CrossTargeting);
+                Assert.True(project1Spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
             }
         }
 
@@ -241,6 +242,50 @@ namespace NuGet.Commands.Test
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.False(project1Spec.RestoreMetadata.CrossTargeting);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreNonLegacyPackagesDirectory()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "OutputType", "netcore" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                // Assert
+                Assert.Equal(project1Path, project1Spec.FilePath);
+                Assert.Equal("a", project1Spec.Name);
+                Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
+                Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
+                Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
+                Assert.False(project1Spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
             }
         }
 
@@ -778,6 +823,53 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, spec.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).Count());
                 Assert.Equal(projectJsonPath, spec.RestoreMetadata.ProjectJsonPath);
                 Assert.Equal(NuGetFramework.Parse("net45"), spec.TargetFrameworks.Single().FrameworkName);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_UAP_IgnoresUnexpectedProperties()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var projectJsonPath = Path.Combine(workingDir, "project.json");
+                var projectPath = Path.Combine(workingDir, "a.csproj");
+
+                var items = new List<IDictionary<string, string>>();
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectJsonPath", projectJsonPath },
+                    { "ProjectName", "a" },
+                    { "OutputType", "uap" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", projectPath },
+                    { "CrossTargeting", "true" },
+                    { "RestoreLegacyPackagesDirectory", "true" },
+                });
+
+                var projectJson = @"
+                {
+                    ""version"": ""1.0.0"",
+                    ""description"": """",
+                    ""authors"": [ ""author"" ],
+                    ""tags"": [ """" ],
+                    ""projectUrl"": """",
+                    ""licenseUrl"": """",
+                    ""frameworks"": {
+                        ""net45"": {
+                        }
+                    }
+                }";
+
+                File.WriteAllText(projectJsonPath, projectJson);
+
+                // Act
+                var spec = MSBuildRestoreUtility.GetPackageSpec(items.Select(CreateItems));
+
+                // Assert
+                Assert.False(spec.RestoreMetadata.CrossTargeting);
+                Assert.False(spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -197,7 +197,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, project1Spec.RuntimeGraph.Runtimes.Count);
                 Assert.Equal(0, project1Spec.RuntimeGraph.Supports.Count);
                 Assert.True(project1Spec.RestoreMetadata.CrossTargeting);
-                Assert.True(project1Spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
+                Assert.True(project1Spec.RestoreMetadata.LegacyPackagesDirectory);
             }
         }
 
@@ -285,7 +285,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
-                Assert.False(project1Spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
+                Assert.False(project1Spec.RestoreMetadata.LegacyPackagesDirectory);
             }
         }
 
@@ -869,7 +869,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.False(spec.RestoreMetadata.CrossTargeting);
-                Assert.False(spec.RestoreMetadata.RestoreLegacyPackagesDirectory);
+                Assert.False(spec.RestoreMetadata.LegacyPackagesDirectory);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -107,6 +107,33 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata.FallbackFolders));
             Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B|c:\\a\\a.csproj|78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F|c:\\b\\b.csproj", string.Join("|", msbuildMetadata.TargetFrameworks.Single().ProjectReferences.Select(e => $"{e.ProjectUniqueName}|{e.ProjectPath}")));
+            Assert.True(msbuildMetadata.CrossTargeting);
+            Assert.True(msbuildMetadata.LegacyPackagesDirectory);
+        }
+
+        [Fact]
+        public void DependencyGraphSpec_ReadMSBuildMetadata_WithProperDefaults()
+        {
+            // Arrange
+            var json = ResourceTestUtility.GetResource("NuGet.ProjectModel.Test.compiler.resources.project2.json", typeof(DependencyGraphSpecTests));
+
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "x", "c:\\fake\\project.json");
+            var msbuildMetadata = spec.RestoreMetadata;
+
+            // Assert
+            Assert.NotNull(msbuildMetadata);
+            Assert.Equal("A55205E7-4D08-4672-8011-0925467CC45F", msbuildMetadata.ProjectUniqueName);
+            Assert.Equal("c:\\x\\x.csproj", msbuildMetadata.ProjectPath);
+            Assert.Equal("x", msbuildMetadata.ProjectName);
+            Assert.Equal("c:\\x\\project.json", msbuildMetadata.ProjectJsonPath);
+            Assert.Equal(RestoreOutputType.NETCore, msbuildMetadata.OutputType);
+            Assert.Equal("c:\\packages", msbuildMetadata.PackagesPath);
+            Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
+            Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata.FallbackFolders));
+            Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B|c:\\a\\a.csproj|78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F|c:\\b\\b.csproj", string.Join("|", msbuildMetadata.TargetFrameworks.Single().ProjectReferences.Select(e => $"{e.ProjectUniqueName}|{e.ProjectPath}")));
+            Assert.False(msbuildMetadata.CrossTargeting);
+            Assert.False(msbuildMetadata.LegacyPackagesDirectory);
         }
 
         [Fact]
@@ -195,6 +222,9 @@ namespace NuGet.ProjectModel.Test
             msbuildMetadata.FallbackFolders.Add("c:\\fallback1");
             msbuildMetadata.FallbackFolders.Add("c:\\fallback2");
 
+            msbuildMetadata.CrossTargeting = true;
+            msbuildMetadata.LegacyPackagesDirectory = true;
+
             JObject json = new JObject();
 
             // Act
@@ -213,6 +243,8 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata2.FallbackFolders));
             Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B|c:\\a\\a.csproj|78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F|c:\\b\\b.csproj", string.Join("|", msbuildMetadata2.TargetFrameworks.Single().ProjectReferences.Select(e => $"{e.ProjectUniqueName}|{e.ProjectPath}")));
+            Assert.True(msbuildMetadata.CrossTargeting);
+            Assert.True(msbuildMetadata.LegacyPackagesDirectory);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project2.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project2.json
@@ -23,8 +23,6 @@
     "outputType": "netcore",
     "outputPath": "c:\\x\\obj\\bin",
     "packagesPath": "c:\\packages",
-    "crossTargeting": true,
-    "legacyPackagesDirectory": true,
     "sources": {
       "https://api.nuget.org/v3/index.json": {}
     },


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/3618.

/cc @emgarten

A follow-up step would be updating the version in dotnet/sdk and dotnet/cli repos, right?