### PR TITLE
Adding SDK version to global.json

### DIFF
--- a/src/NuGet.Core/global.json
+++ b/src/NuGet.Core/global.json
@@ -1,6 +1,9 @@
 {
-    "projects": [
-        "NuGet.Core",
-        "../../lib"
-    ]
+  "projects": [
+    "NuGet.Core",
+    "../../lib"
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }

--- a/test/NuGet.Core.FuncTests/global.json
+++ b/test/NuGet.Core.FuncTests/global.json
@@ -3,5 +3,8 @@
     "../../src/NuGet.Core",
     "../../test/NuGet.Core.Tests",
     "../../lib"
-  ]
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }

--- a/test/NuGet.Core.Tests/global.json
+++ b/test/NuGet.Core.Tests/global.json
@@ -2,5 +2,8 @@
   "projects": [
     "../../src/NuGet.Core",
     "../../lib"
-  ]
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }


### PR DESCRIPTION
Visual Studio 2015 is no longer able to provide intellisense for the NuGet.Core.sln after installing dotnet CLI preview3.  The fix for this is to set the version to use in global.json instead of using the latest.

1.0.0-preview2-003133 corresponds to the 1.0.1 preview2 release.

We may need to ensure the CI also has this version, tests are running there now.

//cc @joelverhagen @alpaix @jainaashish @dtivel @drewgil @mishra14 