### PR TITLE
Use the FinalOutputPath instead of the Identity of output items

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -85,7 +85,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               ReleaseNotes="$(PackageReleaseNotes)"
               Tags="$(PackageTags)"
               Configuration="$(Configuration)"
-              TargetPathsToAssemblies="@(_TargetPathsToAssemblies)"
+              TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
               AssemblyName="$(AssemblyName)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -83,7 +83,7 @@ namespace NuGet.Build.Tasks.Pack
             packArgs.NoPackageAnalysis = NoPackageAnalysis;
             packArgs.PackTargetArgs = new MSBuildPackTargetArgs()
             {
-                TargetPathsToAssemblies = TargetPathsToAssemblies,
+                TargetPathsToAssemblies = GetTargetPathsToAssemblies(),
                 TargetPathsToSymbols = TargetPathsToSymbols,
                 Configuration = Configuration,
                 AssemblyName = AssemblyName,
@@ -113,6 +113,21 @@ namespace NuGet.Build.Tasks.Pack
             PackCommandRunner.SetupCurrentDirectory(packArgs);
 
             return packArgs;
+        }
+
+        private string[] GetTargetPathsToAssemblies()
+        {
+            if (TargetPathsToAssemblies == null)
+            {
+                return new string[0];
+            }
+
+            return TargetPathsToAssemblies
+                .Where(path => path != null)
+                .Select(path => path.Trim())
+                .Where(path => path != string.Empty)
+                .Distinct()
+                .ToArray();
         }
 
         private ISet<NuGetFramework> ParseFrameworks()


### PR DESCRIPTION
The targets `BuiltProjectOutputGroup` and `DocumentationProjectOutputGroup` produce the output items.

Fixes NuGet/Home#3880.

The `Identity` of the item points to `obj` for `BuiltProjectOutputGroup`.

/cc @emgarten @mishra14 @rainersigwald @nguerrera
