### PR TITLE
Remove unnecessary code to get target frameworks during get-package cmd

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
@@ -192,7 +192,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         /// <param name="packagesToDisplay"></param>
         private async Task WriteUpdatePackagesFromRemoteSourceAsync(NuGetProject project)
         {
-            var frameworks = PowerShellCmdletsUtility.GetProjectTargetFrameworks(project);
             var installedPackages = await project.GetInstalledPackagesAsync(Token);
 
             VersionType versionType;


### PR DESCRIPTION
Remove unnecessary code to get target frameworks during get-package cmd which throw error for CPS project system.

Fixes https://github.com/NuGet/Home/issues/3828

@emgarten @alpaix @rrelyea @joelverhagen @drewgil 