### PR TITLE
Read version property from project files

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -326,6 +326,18 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
     </PropertyGroup>
 
+    <!-- 
+      Determine project version for .NETCore projects
+      Default to 1.0.0
+      Use Version if it exists
+      Override with PackageVersion if it exists (same as pack)
+    -->
+    <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
+      <_RestoreProjectVersion>1.0.0</_RestoreProjectVersion>
+      <_RestoreProjectVersion Condition=" '$(Version)' != '' ">$(Version)</_RestoreProjectVersion>
+      <_RestoreProjectVersion Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</_RestoreProjectVersion>
+    </PropertyGroup>
+
     <!-- Determine if this will use cross targeting -->
     <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' != '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
@@ -335,6 +347,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>ProjectSpec</Type>
+        <Version>$(_RestoreProjectVersion)</Version>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -189,6 +189,9 @@ namespace NuGet.Commands
                 if (restoreType == RestoreOutputType.NETCore
                     || restoreType == RestoreOutputType.Standalone)
                 {
+                    // Set project version
+                    result.Version = GetVersion(specItem);
+
                     // Add RIDs and Supports
                     result.RuntimeGraph = GetRuntimeGraph(specItem);
 
@@ -513,6 +516,28 @@ namespace NuGet.Commands
         private static IEnumerable<IMSBuildItem> GetItemByType(IEnumerable<IMSBuildItem> items, string type)
         {
             return items.Where(e => type.Equals(e.GetProperty("Type"), StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Return the parsed version or 1.0.0 if the property does not exist.
+        /// </summary>
+        private static NuGetVersion GetVersion(IMSBuildItem item)
+        {
+            var versionString = item.GetProperty("Version");
+            NuGetVersion version = null;
+
+            if (string.IsNullOrEmpty(versionString))
+            {
+                // Default to 1.0.0 if the property does not exist
+                version = new NuGetVersion(1, 0, 0);
+            }
+            else
+            {
+                // Snapshot versions are not allowed in .NETCore
+                version = NuGetVersion.Parse(versionString);
+            }
+
+            return version;
         }
 
         public static void Dump(IEnumerable<IMSBuildItem> items, ILogger log)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -93,9 +93,9 @@ namespace NuGet.ProjectModel
             {
                 try
                 {
-                    bool hasVersionSnapshot;
-                    packageSpec.Version = SpecifySnapshot(version.Value<string>(), snapshotValue, out hasVersionSnapshot);
-                    packageSpec.HasVersionSnapshot = hasVersionSnapshot;
+                    var versionString = version.Value<string>();
+                    packageSpec.HasVersionSnapshot = PackageSpecUtility.IsSnapshotVersion(versionString);
+                    packageSpec.Version = PackageSpecUtility.SpecifySnapshot(versionString, snapshotValue);
                 }
                 catch (Exception ex)
                 {
@@ -188,25 +188,6 @@ namespace NuGet.ProjectModel
             }
 
             return packageSpec;
-        }
-
-        private static NuGetVersion SpecifySnapshot(string version, string snapshotValue, out bool hasVersionSnapshot)
-        {
-            hasVersionSnapshot = false;
-            if (version.EndsWith("-*"))
-            {
-                if (string.IsNullOrEmpty(snapshotValue))
-                {
-                    version = version.Substring(0, version.Length - 2);
-                }
-                else
-                {
-                    version = version.Substring(0, version.Length - 1) + snapshotValue;
-                    hasVersionSnapshot = true;
-                }
-            }
-
-            return new NuGetVersion(version);
         }
 
         private static ProjectRestoreMetadata GetMSBuildMetadata(PackageSpec packageSpec, JObject rawPackageSpec)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecWriter.cs
@@ -37,7 +37,7 @@ namespace NuGet.ProjectModel
 
             if (!packageSpec.IsDefaultVersion)
             {
-                SetValue(json, "version", packageSpec.Version?.ToNormalizedString());
+                SetValue(json, "version", packageSpec.Version?.ToFullString());
             }
 
             SetValue(json, "description", packageSpec.Description);

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectModel
+{
+    public static class PackageSpecUtility
+    {
+        /// <summary>
+        /// Apply a snapshot value.
+        /// </summary>
+        public static NuGetVersion SpecifySnapshot(string version, string snapshotValue)
+        {
+            // Snapshots should be in the form 1.0.0-*, 1.0.0-beta-*, or 1.0.0-rc.*
+            // Snapshots may not contain metadata such as 1.0.0+5.* or be stable versions such as 1.0.*
+            if (IsSnapshotVersion(version))
+            {
+                if (string.IsNullOrEmpty(snapshotValue))
+                {
+                    version = version.Substring(0, version.Length - 2);
+                }
+                else
+                {
+                    version = version.Substring(0, version.Length - 1) + snapshotValue;
+                }
+            }
+
+            return NuGetVersion.Parse(version);
+        }
+
+        /// <summary>
+        /// True if the string is a snapshot version.
+        /// </summary>
+        public static bool IsSnapshotVersion(string version)
+        {
+            if (version != null
+                && version.EndsWith("*", StringComparison.Ordinal)
+                && version.IndexOf("-", StringComparison.Ordinal) > -1
+                && version.IndexOf("+", StringComparison.Ordinal) < 0
+                && (version.EndsWith("-*", StringComparison.Ordinal)
+                    || (version.EndsWith(".*", StringComparison.Ordinal))))
+            {
+                // Verify the version is valid
+                NuGetVersion parsed = null;
+                return NuGetVersion.TryParse(version.Substring(0, version.Length - 2), out parsed);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -276,7 +276,7 @@ namespace NuGet.Test.Utility
             {
                 AddProperties(xml, new Dictionary<string, string>()
                 {
-                    { "VersionPrefix", Version },
+                    { "Version", Version },
                     { "DebugType", "portable" },
                     { "TargetFrameworks", string.Join(";", Frameworks.Select(f => f.Framework.GetShortFolderName())) },
                 });

--- a/src/NuGet.Core/global.json
+++ b/src/NuGet.Core/global.json
@@ -1,6 +1,9 @@
 {
-    "projects": [
-        "NuGet.Core",
-        "../../lib"
-    ]
+  "projects": [
+    "NuGet.Core",
+    "../../lib"
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }

--- a/test/NuGet.Core.FuncTests/global.json
+++ b/test/NuGet.Core.FuncTests/global.json
@@ -3,5 +3,8 @@
     "../../src/NuGet.Core",
     "../../test/NuGet.Core.Tests",
     "../../lib"
-  ]
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -6,6 +6,7 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Test.Utility;
 using Xunit;
+using NuGet.Versioning;
 
 namespace NuGet.ProjectModel.Test
 {
@@ -193,6 +194,7 @@ namespace NuGet.ProjectModel.Test
             });
 
             var spec = new PackageSpec(frameworks);
+            spec.Version = NuGetVersion.Parse("24.5.1.2-alpha.1.2+a.b.c");
             var msbuildMetadata = new ProjectRestoreMetadata();
             spec.RestoreMetadata = msbuildMetadata;
 
@@ -245,6 +247,9 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B|c:\\a\\a.csproj|78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F|c:\\b\\b.csproj", string.Join("|", msbuildMetadata2.TargetFrameworks.Single().ProjectReferences.Select(e => $"{e.ProjectUniqueName}|{e.ProjectPath}")));
             Assert.True(msbuildMetadata.CrossTargeting);
             Assert.True(msbuildMetadata.LegacyPackagesDirectory);
+
+            // Verify build metadata is not lost.
+            Assert.Equal("24.5.1.2-alpha.1.2+a.b.c", readSpec.Version.ToFullString());
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class PackageSpecUtilityTests
+    {
+        [Theory]
+        [InlineData("1.0-*")]
+        [InlineData("1.0.0-*")]
+        [InlineData("1.0.0-beta-*")]
+        [InlineData("1.2.3.4-beta-*")]
+        [InlineData("1.2.3.4-beta-a-*")]
+        [InlineData("1.2.3.4-beta.*")]
+        [InlineData("1.2.3.4-beta.1.*")]
+        public void PackageSpecUtility_IsSnapshotVersion_True(string version)
+        {
+            Assert.True(PackageSpecUtility.IsSnapshotVersion(version));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("a")]
+        [InlineData("1.0.0-beta.01.*")]
+        [InlineData("1.0.0-beta-*.*")]
+        [InlineData("1.2.3.4-beta*")]
+        [InlineData("1.2.3.4-beta-**")]
+        [InlineData("1.2.3.4-beta.**")]
+        [InlineData("1.2.3.4-beta.1.*+beta")]
+        [InlineData("1.2.3.4-beta.1+5.*")]
+        public void PackageSpecUtility_IsSnapshotVersion_False(string version)
+        {
+            Assert.False(PackageSpecUtility.IsSnapshotVersion(version));
+        }
+
+        [Theory]
+        [InlineData("1.0-*", "", "1.0.0")]
+        [InlineData("2.0.0-beta-*", "", "2.0.0-beta")]
+        [InlineData("2.0.0-beta.*", "", "2.0.0-beta")]
+        [InlineData("2.0.0-beta.*", "2", "2.0.0-beta.2")]
+        [InlineData("2.0.0-beta.5.*", "0", "2.0.0-beta.5.0")]
+        [InlineData("2.0.0-beta.*", "final.release-label+git.hash", "2.0.0-beta.final.release-label+git.hash")]
+        public void PackageSpecUtility_SpecifySnapshotVersion(string version, string snapshotValue, string expected)
+        {
+            // Arrange && Act
+            var actual = PackageSpecUtility.SpecifySnapshot(version, snapshotValue);
+
+            // Assert
+            Assert.Equal(NuGetVersion.Parse(expected), actual);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/global.json
+++ b/test/NuGet.Core.Tests/global.json
@@ -2,5 +2,8 @@
   "projects": [
     "../../src/NuGet.Core",
     "../../lib"
-  ]
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003133"
+  }
 }


### PR DESCRIPTION
This change reads the version or packageVersion property from an msbuild project and adds it to the package spec. This allows the assets file to display the correct version under the library entry.

This contains some additional refactoring around snapshot versions which improves the handling there, but for now those versions will not be allowed in .NETCore projects to match the migrate behavior.

Fixes https://github.com/NuGet/Home/issues/3748

//cc @joelverhagen @mishra14 @drewgil @alpaix @jainaashish 