### PR TITLE
Avoid throwing unknown package error when installed package is prerelease

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -243,7 +243,7 @@ namespace NuGet.CommandLine
             if (version == null)
             {
                 // Find the latest version using NuGetPackageManager
-                version = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvePackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageId,
                     folderProject,
                     resolutionContext,
@@ -251,7 +251,7 @@ namespace NuGet.CommandLine
                     Console,
                     CancellationToken.None);
 
-                if (version == null)
+                if (resolvePackage == null || resolvePackage.LatestVersion == null)
                 {
                     var message = string.Format(
                         CultureInfo.CurrentCulture,
@@ -260,6 +260,8 @@ namespace NuGet.CommandLine
 
                     throw new CommandLineException(message);
                 }
+
+                version = resolvePackage.LatestVersion;
             }
 
             var packageIdentity = new PackageIdentity(packageId, version);

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -272,8 +272,9 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             foreach (var project in Projects)
             {
                 var installedPackages = await project.GetInstalledPackagesAsync(Token);
+
                 if (installedPackages.Select(installedPackage => installedPackage.PackageIdentity.Id)
-                                     .Any(installedPackageId => installedPackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase)))
+                    .Any(installedPackageId => installedPackageId.Equals(packageId, StringComparison.OrdinalIgnoreCase)))
                 {
                     return true;
                 }

--- a/src/NuGet.Core/NuGet.PackageManagement/ResolvedPackage.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ResolvedPackage.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement
+{
+    public class ResolvedPackage
+    {
+        public ResolvedPackage(NuGetVersion latestVersion, bool exists)
+        {
+            LatestVersion = latestVersion;
+            Exists = exists;
+        }
+
+        public NuGetVersion LatestVersion { get; }
+
+        public bool Exists { get; }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -928,7 +928,7 @@ namespace NuGet.Test
                 var projectA = testSolutionManager.AddNewMSBuildProject();
                 var packageIdentity0 = PackageWithDependents[0];
 
-                var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageIdentity0.Id,
                     projectA,
                     resolutionContext,
@@ -936,7 +936,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     token);
 
-                var packageLatest = new PackageIdentity(packageIdentity0.Id, latestVersion);
+                var packageLatest = new PackageIdentity(packageIdentity0.Id, resolvedPackage.LatestVersion);
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(projectA, packageIdentity0,
@@ -986,7 +986,7 @@ namespace NuGet.Test
                 var packageIdentity0 = PackageWithDependents[0];
                 var dependentPackage = PackageWithDependents[2];
 
-                var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageIdentity0.Id,
                     projectA,
                     resolutionContext,
@@ -994,7 +994,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     token);
 
-                var packageLatest = new PackageIdentity(packageIdentity0.Id, latestVersion);
+                var packageLatest = new PackageIdentity(packageIdentity0.Id, resolvedPackage.LatestVersion);
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(projectA, dependentPackage,
@@ -1101,7 +1101,7 @@ namespace NuGet.Test
                 var packageIdentity0 = PackageWithDependents[0];
                 var dependentPackage = PackageWithDependents[2];
 
-                var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageIdentity0.Id,
                     projectA,
                     resolutionContext,
@@ -1109,7 +1109,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     token);
 
-                var packageLatest = new PackageIdentity(packageIdentity0.Id, latestVersion);
+                var packageLatest = new PackageIdentity(packageIdentity0.Id, resolvedPackage.LatestVersion);
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(projectA, dependentPackage,
@@ -1410,7 +1410,7 @@ namespace NuGet.Test
                 var packageIdentity2 = PackageWithDependents[2];
                 var packageIdentity3 = PackageWithDependents[3];
 
-                var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageIdentity0.Id,
                     projectA,
                     resolutionContext,
@@ -1418,7 +1418,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     token);
 
-                var packageLatest = new PackageIdentity(packageIdentity0.Id, latestVersion);
+                var packageLatest = new PackageIdentity(packageIdentity0.Id, resolvedPackage.LatestVersion);
 
                 // Act
                 await nuGetPackageManager.InstallPackageAsync(projectA, packageIdentity3,
@@ -2228,7 +2228,7 @@ namespace NuGet.Test
                 var packageIdentity0 = PackageWithDependents[0]; // jQuery.1.4.4
 
                 var resolutionContext = new ResolutionContext();
-                var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageIdentity0.Id,
                     msBuildNuGetProject,
                     new ResolutionContext(),
@@ -2236,7 +2236,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     token);
 
-                var packageLatest = new PackageIdentity(packageIdentity0.Id, latestVersion);
+                var packageLatest = new PackageIdentity(packageIdentity0.Id, resolvedPackage.LatestVersion);
 
                 // Pre-Assert
                 // Check that the packages.config file does not exist
@@ -3414,7 +3414,7 @@ namespace NuGet.Test
                 var newtonsoftJsonPackageId = "newtonsoft.json";
 
                 // Act
-                var latestNewtonsoftPrereleaseVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     newtonsoftJsonPackageId,
                     msBuildNuGetProject,
                     resolutionContext,
@@ -3422,7 +3422,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     CancellationToken.None);
 
-                var newtonsoftJsonPackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, latestNewtonsoftPrereleaseVersion);
+                var newtonsoftJsonPackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, resolvedPackage.LatestVersion);
 
                 var nuGetProjectActions = (await nuGetPackageManager.PreviewInstallPackageAsync(msBuildNuGetProject, dotnetrdfPackageIdentity, resolutionContext,
                     new TestNuGetProjectContext(), primarySourceRepository, null, CancellationToken.None)).ToList();
@@ -3462,7 +3462,7 @@ namespace NuGet.Test
                 var newtonsoftJsonPackageId = "newtonsoft.json";
 
                 // Act
-                var latestNewtonsoftPrereleaseVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(
                     newtonsoftJsonPackageId,
                     msBuildNuGetProject,
                     resolutionContext,
@@ -3470,7 +3470,7 @@ namespace NuGet.Test
                     Common.NullLogger.Instance,
                     CancellationToken.None);
 
-                var newtonsoftJsonLatestPrereleasePackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, latestNewtonsoftPrereleaseVersion);
+                var newtonsoftJsonLatestPrereleasePackageIdentity = new PackageIdentity(newtonsoftJsonPackageId, resolvedPackage.LatestVersion);
 
                 await nuGetPackageManager.InstallPackageAsync(msBuildNuGetProject, webgreasePackageIdentity, resolutionContext,
                     new TestNuGetProjectContext(), primarySourceRepository, null, CancellationToken.None);


### PR DESCRIPTION
This code change will not throw unknown package error when prerelease version is installed but -includeprerelease flag isn't passed with update-package command, rather it will simply say no updates available if there isn't any latest non prerelease version available.

Fixes https://github.com/NuGet/Home/issues/3827 

@rrelyea @emgarten @alpaix @joelverhagen @mishra14 @drewgil 