### PR TITLE
Fixed recursive lock exception in ProjectSystemCache.TryGetProjectNames

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemCache.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemCache.cs
@@ -91,7 +91,7 @@ namespace NuGet.PackageManagement.VisualStudio
             try
             {
                 return _projectNamesCache.TryGetValue(name, out projectNames) ||
-                       TryGetProjectNameByShortName(name, out projectNames);
+                       TryGetProjectNameByShortNameWithoutLock(name, out projectNames);
             }
             finally
             {


### PR DESCRIPTION
Fixed recursive lock exception by using private non-lock api to get project name by short name. This looks the right way to fix this recursive exception instead of allowing recursion policy (which has a slight overhead) and also confirmed that lock has been used correctly at all places in here.

I also did some profiling with SemaphoreSlim vs ReaderWriterLockSlim and didn't notice much difference (slight overhead in SemaphoreSlim for roslyn.sln) so didn't want to change too much in here given its already been tested for RC.

Fixes https://github.com/NuGet/Home/issues/3861

@rrelyea @emgarten @joelverhagen @yishaigalatzer @alpaix 