### PR TITLE
Fix .NET Core VS 2015 Tooling SDK version

### DIFF
--- a/src/NuGet.Core/global.json
+++ b/src/NuGet.Core/global.json
@@ -4,6 +4,6 @@
     "../../lib"
   ],
   "sdk": {
-    "version": "1.0.0-preview2-003133"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/test/NuGet.Core.FuncTests/global.json
+++ b/test/NuGet.Core.FuncTests/global.json
@@ -5,6 +5,6 @@
     "../../lib"
   ],
   "sdk": {
-    "version": "1.0.0-preview2-003133"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/test/NuGet.Core.Tests/global.json
+++ b/test/NuGet.Core.Tests/global.json
@@ -4,6 +4,6 @@
     "../../lib"
   ],
   "sdk": {
-    "version": "1.0.0-preview2-003133"
+    "version": "1.0.0-preview2-003131"
   }
 }


### PR DESCRIPTION
See #998.

The .NET Core VS 2015 Tooling Preview 2 release is [1.0.0-preview2-003131](https://github.com/aspnet/Tooling/blob/master/known-issues.md#net-core-101-sdk-100-preview2-003131-download-links) not 1.0.0-preview2-003133.

@emgarten