### PR TITLE
Fix broken unsigned build after delay-signed build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -113,8 +113,8 @@ Invoke-BuildStep 'Cleaning artifacts' {
     -skip:($Fast -or $SkipXProj) `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Configure delay signing' {
-        Configure-DelaySigning -MSPFXPath:$MSPFXPath -NuGetPFXPath:$NuGetPFXPath -CI:$CI
+Invoke-BuildStep 'Set delay signing options' {
+        Set-DelaySigning $MSPFXPath $NuGetPFXPath -CI:$CI
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -114,7 +114,7 @@ Invoke-BuildStep 'Cleaning artifacts' {
     -ev +BuildErrors
 
 Invoke-BuildStep 'Set delay signing options' {
-        Set-DelaySigning $MSPFXPath $NuGetPFXPath -CI:$CI
+        Set-DelaySigning $MSPFXPath $NuGetPFXPath
     } `
     -ev +BuildErrors
 

--- a/build.ps1
+++ b/build.ps1
@@ -113,10 +113,9 @@ Invoke-BuildStep 'Cleaning artifacts' {
     -skip:($Fast -or $SkipXProj) `
     -ev +BuildErrors
 
-Invoke-BuildStep 'Enabling delay-signing' {
-        Enable-DelaySigning $MSPFXPath $NuGetPFXPath
+Invoke-BuildStep 'Configure delay signing' {
+        Configure-DelaySigning -MSPFXPath:$MSPFXPath -NuGetPFXPath:$NuGetPFXPath -CI:$CI
     } `
-    -skip:((-not $MSPFXPath) -and (-not $NuGetPFXPath)) `
     -ev +BuildErrors
 
 Invoke-BuildStep 'Building NuGet.Core projects' {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -364,8 +364,6 @@ Function Set-DelaySigning {
             }
     }
     else {
-        Remove-Item Env:\DNX_BUILD_KEY_FILE -ErrorAction Ignore
-        Remove-Item Env:\DNX_BUILD_DELAY_SIGN -ErrorAction Ignore
         Remove-Item Env:\MS_PFX_PATH -ErrorAction Ignore
     }
 

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -343,8 +343,6 @@ Function Set-DelaySigning {
 
     if ($MSPFXPath -and (Test-Path $MSPFXPath)) {
         Trace-Log "Setting NuGet.Core solution to delay sign using $MSPFXPath"
-        $env:DNX_BUILD_KEY_FILE=$MSPFXPath
-        $env:DNX_BUILD_DELAY_SIGN=$true
 
         Trace-Log "Using the Microsoft Key for NuGet Command line $MSPFXPath"
         $env:MS_PFX_PATH=$MSPFXPath

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -338,8 +338,7 @@ Function Set-DelaySigning {
     [CmdletBinding()]
     param(
         [string]$MSPFXPath,
-        [string]$NuGetPFXPath,
-        [switch]$CI
+        [string]$NuGetPFXPath
     )
 
     if ($MSPFXPath -and (Test-Path $MSPFXPath)) {
@@ -366,17 +365,17 @@ Function Set-DelaySigning {
                 }
             }
     }
-    elseif (!$CI) {
+    else {
         Remove-Item Env:\DNX_BUILD_KEY_FILE -ErrorAction Ignore
         Remove-Item Env:\DNX_BUILD_DELAY_SIGN -ErrorAction Ignore
-        Remove-Item Env:\NUGET_PFX_PATH -ErrorAction Ignore
+        Remove-Item Env:\MS_PFX_PATH -ErrorAction Ignore
     }
 
     if ($NuGetPFXPath -and (Test-Path $NuGetPFXPath)) {
         Trace-Log "Setting NuGet.Clients solution to delay sign using $NuGetPFXPath"
         $env:NUGET_PFX_PATH= $NuGetPFXPath
     }
-    elseif (!$CI) {
+    else {
         Remove-Item Env:\NUGET_PFX_PATH -ErrorAction Ignore
     }
 }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -334,7 +334,7 @@ Function Save-ProjectFile ($xproject, $fileName) {
     $xproject | ConvertTo-Json -Depth 100 | Out-File $fileName
 }
 
-Function Configure-DelaySigning {
+Function Set-DelaySigning {
     [CmdletBinding()]
     param(
         [string]$MSPFXPath,

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -334,14 +334,15 @@ Function Save-ProjectFile ($xproject, $fileName) {
     $xproject | ConvertTo-Json -Depth 100 | Out-File $fileName
 }
 
-# Enables delay signed build
-Function Enable-DelaySigning {
+Function Configure-DelaySigning {
     [CmdletBinding()]
     param(
-        $MSPFXPath,
-        $NuGetPFXPath
+        [string]$MSPFXPath,
+        [string]$NuGetPFXPath,
+        [switch]$CI
     )
-    if (Test-Path $MSPFXPath) {
+
+    if ($MSPFXPath -and (Test-Path $MSPFXPath)) {
         Trace-Log "Setting NuGet.Core solution to delay sign using $MSPFXPath"
         $env:DNX_BUILD_KEY_FILE=$MSPFXPath
         $env:DNX_BUILD_DELAY_SIGN=$true
@@ -365,10 +366,18 @@ Function Enable-DelaySigning {
                 }
             }
     }
+    elseif (!$CI) {
+        Remove-Item Env:\DNX_BUILD_KEY_FILE -ErrorAction Ignore
+        Remove-Item Env:\DNX_BUILD_DELAY_SIGN -ErrorAction Ignore
+        Remove-Item Env:\NUGET_PFX_PATH -ErrorAction Ignore
+    }
 
-    if (Test-Path $NuGetPFXPath) {
+    if ($NuGetPFXPath -and (Test-Path $NuGetPFXPath)) {
         Trace-Log "Setting NuGet.Clients solution to delay sign using $NuGetPFXPath"
         $env:NUGET_PFX_PATH= $NuGetPFXPath
+    }
+    elseif (!$CI) {
+        Remove-Item Env:\NUGET_PFX_PATH -ErrorAction Ignore
     }
 }
 


### PR DESCRIPTION
If one builds with delay signing enabled:

    .\build.ps1 -MSPFXPath <path> -NuGetPFXPath <path>

...then undoes all project.json changes, and builds without delay signing:

    .\build.ps1

...the second build will fail because the first build persisted delay signing arguments as environment variables that apply partially to the second build.

@alpaix