### PR TITLE
Trim whitespace from MSBuild properties

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/MSBuildTaskItem.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/MSBuildTaskItem.cs
@@ -31,7 +31,18 @@ namespace NuGet.Build.Tasks
 
         public string GetProperty(string property)
         {
+            return GetProperty(property, trim: true);
+        }
+
+        public string GetProperty(string property, bool trim)
+        {
             var val = Item.GetMetadata(property);
+
+            if (trim && val != null)
+            {
+                // Trim whitespace, MSBuild leaves this in place.
+                val = val.Trim();
+            }
 
             if (!string.IsNullOrEmpty(val))
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -136,7 +136,7 @@ namespace NuGet.Build.Tasks
 
                 if (!string.IsNullOrEmpty(RestoreSources))
                 {
-                    var sources = RestoreSources.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                    var sources = MSBuildRestoreUtility.Split(RestoreSources);
                     restoreContext.Sources.AddRange(sources);
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/IMSBuildItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/IMSBuildItem.cs
@@ -7,10 +7,24 @@ namespace NuGet.Commands
     /// </summary>
     public interface IMSBuildItem
     {
+        /// <summary>
+        /// Include attribute value.
+        /// </summary>
         string Identity { get; }
 
+        /// <summary>
+        /// Retrieve property value and trim.
+        /// </summary>
         string GetProperty(string property);
 
+        /// <summary>
+        /// Retrieve property value with optional trimming.
+        /// </summary>
+        string GetProperty(string property, bool trim);
+
+        /// <summary>
+        /// Raw untrimmed properties.
+        /// </summary>
         IReadOnlyList<string> Properties { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildItem.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/MSBuildItem.cs
@@ -38,13 +38,33 @@ namespace NuGet.Commands
         }
 
         /// <summary>
+        /// Get property or null if empty. Trims whitespace from values.
+        /// </summary>
+        public string GetProperty(string property)
+        {
+            return GetProperty(property, trim: true);
+        }
+
+        /// <summary>
         /// Get property or null if empty.
         /// </summary>
-        public string GetProperty(string key)
+        public string GetProperty(string property, bool trim)
         {
             string val;
-            if (_metadata.TryGetValue(key, out val) && !string.IsNullOrEmpty(val))
+            if (_metadata.TryGetValue(property, out val) && val != null)
             {
+                if (trim)
+                {
+                    // Remove whitespace that occurs due to msbuild formatting.
+                    val = val.Trim();
+                }
+
+                if (string.IsNullOrEmpty(val))
+                {
+                    // Normalize empty values to null for consistency.
+                    val = null;
+                }
+
                 return val;
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -398,11 +398,20 @@ namespace NuGet.Commands
             }
         }
 
-        private static string[] Split(string s)
+        /// <summary>
+        /// Split on ; and trim. Null or empty inputs will return an 
+        /// empty array.
+        /// </summary>
+        public static string[] Split(string s)
         {
             if (!string.IsNullOrEmpty(s))
             {
-                return s.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                // Split on ; and trim all entries
+                // After trimming remove any entries that are now empty due to trim.
+                return s.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(entry => entry.Trim())
+                    .Where(entry => !string.IsNullOrEmpty(entry))
+                    .ToArray();
             }
 
             return new string[0];
@@ -507,7 +516,7 @@ namespace NuGet.Commands
             var frameworksString = item.GetProperty("TargetFrameworks");
             if (!string.IsNullOrEmpty(frameworksString))
             {
-                frameworks.UnionWith(frameworksString.Split(';'));
+                frameworks.UnionWith(Split(frameworksString));
             }
 
             return frameworks;


### PR DESCRIPTION
Trim whitespace from MSBuild properties

* MSBuildRestoreUtility.Split now performs additional trimming on items in the set.
* IMSBuildItem.GetProperty now trims values by default, an optional bool may be passed to get the original value if needed.

Fixes https://github.com/NuGet/Home/issues/3819

//cc @joelverhagen @alpaix @jainaashish @dtivel @drewgil @zhili1208 