### PR TITLE
Removing options from xplat locals arg description

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -213,8 +213,8 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Specifies the cache location(s) to list or clear. 
-        ///&lt;all | http-cache | global-packages | temp&gt; [-clear | -list].
+        ///    Looks up a localized string similar to Specifies the cache location(s) to list or clear.
+        ///&lt;all | http-cache | global-packages | temp&gt;.
         /// </summary>
         public static string LocalsCommand_ArgumentDescription {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -306,8 +306,8 @@
     <value>Use legacy behavior when the restore operation is interacting with the global packages directory. This means the ID and version folder names are written with the original package case rather than being normalized to lowercase.</value>
   </data>
   <data name="LocalsCommand_ArgumentDescription" xml:space="preserve">
-    <value>Specifies the cache location(s) to list or clear. 
-&lt;all | http-cache | global-packages | temp&gt; [-clear | -list]</value>
+    <value>Specifies the cache location(s) to list or clear.
+&lt;all | http-cache | global-packages | temp&gt;</value>
   </data>
   <data name="LocalsCommand_ClearDescription" xml:space="preserve">
     <value>Clear the selected local resources or cache location(s).</value>


### PR DESCRIPTION
Fixes the help part of https://github.com/NuGet/Home/issues/3919

Removing redundant options from the argument error message.


//cc: @joelverhagen @emgarten @alpaix @karann-msft @drewgil @NuGet/core-team 


