### PR TITLE
Fixing BindingRedirect related E2E failures for dev15

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -376,8 +376,9 @@ namespace NuGet.PackageManagement.VisualStudio
             var projectFullPath = string.Empty;
             var assemblyFullPath = string.Empty;
             var dteProjectFullName = string.Empty;
+            var dteOriginalPath = string.Empty;
 
-            var resolvedToGac = false;
+            var resolvedToPackage = false;
 
             try
             {
@@ -401,7 +402,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     if (reference != null)
                     {
-                        var path = GetReferencePath(reference);
+                        dteOriginalPath = GetReferencePath(reference);
 
                         // If path != fullPath, we need to set CopyLocal thru msbuild by setting Private
                         // to true.
@@ -409,19 +410,18 @@ namespace NuGet.PackageManagement.VisualStudio
                         // locate assembly references.
                         // Most commonly, it happens if this assembly is in the GAC or in the output path.
                         // The path may be null or for some project system it can be "".
-                        resolvedToGac = (!string.IsNullOrWhiteSpace(path)
-                            && !StringComparer.OrdinalIgnoreCase.Equals(path, assemblyFullPath));
+                        resolvedToPackage = IsSamePath(dteOriginalPath, assemblyFullPath);
 
-                        if (!resolvedToGac)
+                        if (resolvedToPackage)
                         {
-                            // Set reference properties
+                            // Set reference properties (if needed)
                             TrySetCopyLocal(reference);
                             TrySetSpecificVersion(reference);
                         }
                     }
                 });
 
-                if (resolvedToGac)
+                if (!resolvedToPackage)
                 {
                     // This should be done off the UI thread
 
@@ -435,8 +435,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
                         // Try to find the item for the assembly name
                         var item = (from assemblyReferenceNode in buildProject.GetAssemblyReferences()
-                                                                    where AssemblyNamesMatch(assemblyName, assemblyReferenceNode.Item2)
-                                                                    select assemblyReferenceNode.Item1).FirstOrDefault();
+                                    where AssemblyNamesMatch(assemblyName, assemblyReferenceNode.Item2)
+                                    select assemblyReferenceNode.Item1).FirstOrDefault();
 
                         if (item != null)
                         {
@@ -481,7 +481,22 @@ namespace NuGet.PackageManagement.VisualStudio
                     string.Format(CultureInfo.CurrentCulture, Strings.FailedToAddReference, name), e);
             }
 
-            NuGetProjectContext.Log(ProjectManagement.MessageLevel.Debug, Strings.Debug_AddReference, name, projectName);
+            NuGetProjectContext.Log(
+                ProjectManagement.MessageLevel.Debug,
+                $"Added reference '{name}' to project:'{projectName}' resolvedToPackage:{resolvedToPackage} dteOriginalPath:{dteOriginalPath} assemblyFullPath:{assemblyFullPath}.");
+        }
+
+        private static bool IsSamePath(string path1, string path2)
+        {
+            if (string.IsNullOrWhiteSpace(path1)
+                || string.IsNullOrWhiteSpace(path2))
+            {
+                return false;
+            }
+
+            // Exact match or match after normalizing both paths
+            return StringComparer.OrdinalIgnoreCase.Equals(path1, path2)
+                || StringComparer.OrdinalIgnoreCase.Equals(Path.GetFullPath(path1), Path.GetFullPath(path2));
         }
 
         private static bool AssemblyNamesMatch(AssemblyName name1, AssemblyName name2)
@@ -617,8 +632,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 // In order to properly write this to MSBuild in ALL cases, we have to trigger the Property Change
                 // notification with a new value of "true". However, "true" is the default value, so in order to
                 // cause a notification to fire, we have to set it to false and then back to true
-                reference.CopyLocal = false;
-                reference.CopyLocal = true;
+                if (!reference.CopyLocal)
+                {
+                    reference.CopyLocal = false;
+                    reference.CopyLocal = true;
+                }
             }
             catch (NotSupportedException)
             {
@@ -662,8 +680,11 @@ namespace NuGet.PackageManagement.VisualStudio
             // Always set SpecificVersion to true for references that we add
             try
             {
-                reference.SpecificVersion = false;
-                reference.SpecificVersion = true;
+                if (!reference.SpecificVersion)
+                {
+                    reference.SpecificVersion = false;
+                    reference.SpecificVersion = true;
+                }
             }
             catch (NotSupportedException)
             {
@@ -839,7 +860,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        #endregion
+        #endregion Binding Redirects Stuff
 
         public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure)
         {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -410,7 +410,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         // locate assembly references.
                         // Most commonly, it happens if this assembly is in the GAC or in the output path.
                         // The path may be null or for some project system it can be "".
-                        resolvedToPackage = IsSamePath(dteOriginalPath, assemblyFullPath);
+                        resolvedToPackage = !string.IsNullOrWhiteSpace(dteOriginalPath) && IsSamePath(dteOriginalPath, assemblyFullPath);
 
                         if (resolvedToPackage)
                         {
@@ -489,12 +489,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static bool IsSamePath(string path1, string path2)
         {
-            if (string.IsNullOrWhiteSpace(path1)
-                || string.IsNullOrWhiteSpace(path2))
-            {
-                return false;
-            }
-
             // Exact match or match after normalizing both paths
             return StringComparer.OrdinalIgnoreCase.Equals(path1, path2)
                 || StringComparer.OrdinalIgnoreCase.Equals(Path.GetFullPath(path1), Path.GetFullPath(path2));

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -483,7 +483,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             NuGetProjectContext.Log(
                 ProjectManagement.MessageLevel.Debug,
-                $"Added reference '{name}' to project:'{projectName}' resolvedToPackage:{resolvedToPackage} dteOriginalPath:{dteOriginalPath} assemblyFullPath:{assemblyFullPath}.");
+                $"Added reference '{name}' to project:'{projectName}'. Was the Reference Resolved To Package (resolvedToPackage):'{resolvedToPackage}', "+
+                "where Reference Path from DTE(dteOriginalPath):'{dteOriginalPath}' and Reference Path from package reference(assemblyFullPath):'{assemblyFullPath}'.");
         }
 
         private static bool IsSamePath(string path1, string path2)
@@ -629,12 +630,10 @@ namespace NuGet.PackageManagement.VisualStudio
             // Always set copy local to true for references that we add
             try
             {
-                // In order to properly write this to MSBuild in ALL cases, we have to trigger the Property Change
-                // notification with a new value of "true". However, "true" is the default value, so in order to
-                // cause a notification to fire, we have to set it to false and then back to true
+                // Setting copyLocal to "true" only if it is "false".
+                // This should trigger an event which will result in successful writing to msbuild.
                 if (!reference.CopyLocal)
                 {
-                    reference.CopyLocal = false;
                     reference.CopyLocal = true;
                 }
             }
@@ -680,9 +679,10 @@ namespace NuGet.PackageManagement.VisualStudio
             // Always set SpecificVersion to true for references that we add
             try
             {
+                // Setting SpecificVersion to "true" only if it is "false".
+                // This should trigger an event which will result in successful writing to msbuild.
                 if (!reference.SpecificVersion)
                 {
-                    reference.SpecificVersion = false;
                     reference.SpecificVersion = true;
                 }
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         // This may result in deployment issues. To work around ths, we'll always attempt to add a file to the bin.
                         RefreshFileUtility.CreateRefreshFile(ProjectFullPath, PathUtility.GetAbsolutePath(ProjectFullPath, referencePath), this);
 
-                        NuGetProjectContext.Log(ProjectManagement.MessageLevel.Debug, Strings.Debug_AddReference, name, ProjectName);
+                        NuGetProjectContext.Log(ProjectManagement.MessageLevel.Debug, $"Added reference '{name}' to project:'{ProjectName}' ");
                     }
                     catch (Exception e)
                     {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -106,15 +106,6 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Added reference &apos;{0}&apos; to project &apos;{1}&apos;..
-        /// </summary>
-        public static string Debug_AddReference {
-            get {
-                return ResourceManager.GetString("Debug_AddReference", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Removed file &apos;{0}&apos;.
         /// </summary>
         public static string Debug_RemovedFile {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Debug_AddReference" xml:space="preserve">
-    <value>Added reference '{0}' to project '{1}'.</value>
-  </data>
   <data name="DTE_ProjectUnsupported" xml:space="preserve">
     <value>The project '{0}' is unsupported</value>
   </data>


### PR DESCRIPTION
Fixing: https://github.com/NuGet/Home/issues/3847

This PR fixes the Binding Redirects related test failures in dev15, where, for some packages, `Reference.CopyLocal` was being set to false. To fix it, we first check the value of `Reference.CopyLocal` before trying to set it. Plus some refactoring after chatting with @emgarten to improve the readability of the code.

//cc: @emgarten @joelverhagen @jainaashish @alpaix @drewgil @zhili1208 @rrelyea 