### PR TITLE
Set UserAgent and network settings for the msbuild restore task

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -64,7 +64,7 @@ namespace NuGet.CommandLine.XPlat
             TryParseVerbosity(args, verbosity, out logLevel);
             log.LogLevel = logLevel;
 
-            XPlatUtility.SetConnectionLimit();
+            NetworkProtocolUtility.SetConnectionLimit();
 
             XPlatUtility.SetUserAgent();
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/XPlatUtility.cs
@@ -44,21 +44,5 @@ namespace NuGet.CommandLine.XPlat
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("NuGet xplat"));
 #endif
         }
-
-        public static void SetConnectionLimit()
-        {
-#if !IS_CORECLR
-            // Increase the maximum number of connections per server.
-            if (!RuntimeEnvironmentHelper.IsMono)
-            {
-                ServicePointManager.DefaultConnectionLimit = 64;
-            }
-            else
-            {
-                // Keep mono limited to a single download to avoid issues.
-                ServicePointManager.DefaultConnectionLimit = 1;
-            }
-#endif
-        }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/NetworkProtocolUtility.cs
@@ -21,5 +21,24 @@ namespace NuGet.Common
                 SecurityProtocolType.Tls12;
 #endif
         }
+
+        /// <summary>
+        /// Set ServicePointManager.DefaultConnectionLimit
+        /// </summary>
+        public static void SetConnectionLimit()
+        {
+#if !IS_CORECLR
+            // Increase the maximum number of connections per server.
+            if (!RuntimeEnvironmentHelper.IsMono)
+            {
+                ServicePointManager.DefaultConnectionLimit = 64;
+            }
+            else
+            {
+                // Keep mono limited to a single download to avoid issues.
+                ServicePointManager.DefaultConnectionLimit = 1;
+            }
+#endif
+        }
     }
 }


### PR DESCRIPTION
Set UserAgent and network settings for the msbuild restore task

Copying XPlat network settings over to the MSBuild RestoreTask. This includes:
* UserAgent
* Allowed SSL protocols
* Connection limit

Fixes https://github.com/NuGet/Home/issues/3905

//cc @joelverhagen @mishra14 @alpaix @drewgil @dtivel @jainaashish @zhili1208 