### PR TITLE
Fixing the help message for dotnet nuget commands

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -52,11 +52,7 @@ namespace NuGet.CommandLine.XPlat
             }
 
             var app = new CommandLineApplication();
-#if IS_CORECLR
             app.Name = "dotnet nuget";
-#else
-            app.Name = "nuget";
-#endif
             app.FullName = Strings.App_FullName;
             app.HelpOption(XPlatUtility.HelpOption);
             app.VersionOption("--version", typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString());

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -52,7 +52,11 @@ namespace NuGet.CommandLine.XPlat
             }
 
             var app = new CommandLineApplication();
+#if CORE_CLR
+            app.Name = "dotnet nuget";
+#else
             app.Name = "nuget";
+#endif
             app.FullName = Strings.App_FullName;
             app.HelpOption(XPlatUtility.HelpOption);
             app.VersionOption("--version", typeof(Program).GetTypeInfo().Assembly.GetName().Version.ToString());

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -52,7 +52,7 @@ namespace NuGet.CommandLine.XPlat
             }
 
             var app = new CommandLineApplication();
-#if CORE_CLR
+#if IS_CORECLR
             app.Name = "dotnet nuget";
 #else
             app.Name = "nuget";


### PR DESCRIPTION
Fixes the remaining part of : https://github.com/NuGet/Home/issues/3919

Currently when we get help for dotnet nuget command, the usage displays `usage: nuget xyz ....` When it should be `usage: dotnet nuget xyz ...`

This fixes that scenario for all nuget commands, current and future, within dotnet.

Current - 
```

PS E:\nuget\NuGet.Client> F:\paths\dotnet-dev-win-x64.latest\dotnet.exe nuget locals -h

Usage: nuget locals [arguments] [options]

Arguments:
  Cache Location(s)  Specifies the cache location(s) to list or clear.
<all | http-cache | global-packages | temp> [-clear | -list]
...
```

Post fix - 

```
PS E:\nuget\NuGet.Client> E:\cli\artifacts\win10-x64\stage2\dotnet.exe nuget locals -h

Usage: dotnet nuget locals [arguments] [options]

Arguments:
  Cache Location(s)  Specifies the cache location(s) to list or clear.
<all | http-cache | global-packages | temp>
...
```


//cc: @drewgil @karann-msft @joelverhagen @emgarten @alpaix 