### PR TITLE
Supporting NuGet restore in DPL mode

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -7,6 +10,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using NuGet.Commands;
 using NuGet.Frameworks;
+using NuGet.PackageManagement;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -90,12 +90,6 @@ namespace NuGet.SolutionRestoreManager
                 return;
             }
 
-            // Check if solution is DPL enabled, then don't restore
-            if (SolutionManager.IsSolutionDPLEnabled)
-            {
-                return;
-            }
-
             if (!ShouldRestoreOnBuild)
             {
                 return;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -16,8 +16,10 @@ using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
+using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
 using Strings = NuGet.PackageManagement.VisualStudio.Strings;
 using Task = System.Threading.Tasks.Task;
@@ -34,9 +36,10 @@ namespace NuGet.SolutionRestoreManager
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IPackageRestoreManager _packageRestoreManager;
-        private readonly ISolutionManager _solutionManager;
+        private readonly IVsSolutionManager _solutionManager;
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
         private readonly ISettings _settings;
+        private readonly IDeferredProjectWorkspaceService _deferredWorkspaceService;
 
         private RestoreOperationLogger _logger;
         private string _dependencyGraphProjectCacheHash;
@@ -56,7 +59,8 @@ namespace NuGet.SolutionRestoreManager
             IPackageRestoreManager packageRestoreManager,
             IVsSolutionManager solutionManager,
             ISourceRepositoryProvider sourceRepositoryProvider,
-            ISettings settings)
+            ISettings settings,
+            IDeferredProjectWorkspaceService deferredWorkspaceService)
         {
             if (serviceProvider == null)
             {
@@ -88,6 +92,7 @@ namespace NuGet.SolutionRestoreManager
             _solutionManager = solutionManager;
             _sourceRepositoryProvider = sourceRepositoryProvider;
             _settings = settings;
+			_deferredWorkspaceService = deferredWorkspaceService;
         }
 
         /// <summary>
@@ -159,21 +164,29 @@ namespace NuGet.SolutionRestoreManager
                 var solutionDirectory = _solutionManager.SolutionDirectory;
                 var isSolutionAvailable = _solutionManager.IsSolutionAvailable;
 
-                // make sure all projects are loaded before start to restore. Since
-                // projects might not be loaded when DPL is enabled.
-                _solutionManager.EnsureSolutionIsLoaded();
+                // Check if solution has deferred projects
+                var deferredProjectsData = new DeferredProjectRestoreData(new Dictionary<PackageReference, List<string>>(), new List<PackageSpec>());
+                if (await _solutionManager.SolutionHasDeferredProjectsAsync())
+                {
+                    var deferredProjectsPath = await _solutionManager.GetDeferredProjectsFilePathAsync();
+
+                    deferredProjectsData = await DeferredProjectRestoreUtility.GetDeferredProjectsData(_deferredWorkspaceService, deferredProjectsPath, token);
+                }
 
                 // Get the projects from the SolutionManager
                 // Note that projects that are not supported by NuGet, will not show up in this list
                 projects = _solutionManager.GetNuGetProjects();
 
                 // Check if there are any projects that are not INuGetIntegratedProject, that is,
-                // projects with packages.config. If so, perform package restore on them
-                if (projects.Any(project => !(project is INuGetIntegratedProject)))
+                // projects with packages.config. OR 
+                // any of the deferred project is type of packages.config, If so, perform package restore on them
+                if (projects.Any(project => !(project is INuGetIntegratedProject)) ||
+                    deferredProjectsData.PackageReferenceDict.Count > 0)
                 {
                     await RestorePackagesOrCheckForMissingPackagesAsync(
                         solutionDirectory,
                         isSolutionAvailable,
+                        deferredProjectsData.PackageReferenceDict,
                         token);
                 }
 
@@ -185,6 +198,7 @@ namespace NuGet.SolutionRestoreManager
                     dependencyGraphProjects,
                     forceRestore,
                     isSolutionAvailable,
+                    deferredProjectsData.PackageSpecs,
                     token);
             }
             finally
@@ -237,10 +251,12 @@ namespace NuGet.SolutionRestoreManager
             List<IDependencyGraphProject> projects,
             bool forceRestore,
             bool isSolutionAvailable,
+            IReadOnlyList<PackageSpec> packageSpecs,
             CancellationToken token)
         {
-            // Only continue if there are some projects.
-            if (!projects.Any())
+            // Only continue if there are some build integrated type projects.
+            if (!(projects.Any(project => project is BuildIntegratedNuGetProject) || 
+                packageSpecs.Any(project => IsProjectBuildIntegrated(project))))
             {
                 return;
             }
@@ -271,6 +287,9 @@ namespace NuGet.SolutionRestoreManager
                 // Cache p2ps discovered from DTE
                 var cacheContext = new DependencyGraphCacheContext(_logger);
                 var pathContext = NuGetPathContext.Create(_settings);
+
+                // add deferred projects package spec in cacheContext packageSpecCache
+                cacheContext.DeferredPackageSpecs.AddRange(packageSpecs);
 
                 var isRestoreRequired = await DependencyGraphRestoreUtility.IsRestoreRequiredAsync(
                     _solutionManager,
@@ -321,6 +340,13 @@ namespace NuGet.SolutionRestoreManager
                         token);
                 }
             }
+        }
+
+        private bool IsProjectBuildIntegrated(PackageSpec packageSpec)
+        {
+            return packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference ||
+                packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.ProjectJson ||
+                packageSpec.RestoreMetadata?.ProjectStyle == ProjectStyle.DotnetCliTool;
         }
 
         // This event could be raised from multiple threads. Only perform thread-safe operations
@@ -386,6 +412,7 @@ namespace NuGet.SolutionRestoreManager
         private async Task RestorePackagesOrCheckForMissingPackagesAsync(
             string solutionDirectory,
             bool isSolutionAvailable,
+            IReadOnlyDictionary<PackageReference, List<string>> packageReferencesDict,
             CancellationToken token)
         {
             if (string.IsNullOrEmpty(solutionDirectory))
@@ -396,6 +423,10 @@ namespace NuGet.SolutionRestoreManager
 
             var packages = (await _packageRestoreManager.GetPackagesInSolutionAsync(
                 solutionDirectory, token)).ToList();
+
+            packages.AddRange(
+                _packageRestoreManager.GetPackagesRestoreData(
+                    solutionDirectory, packageReferencesDict.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToList())));
 
             if (IsConsentGranted(_settings))
             {

--- a/src/NuGet.Clients/NuGet.Tools/.vsixignore.vs14
+++ b/src/NuGet.Clients/NuGet.Tools/.vsixignore.vs14
@@ -52,6 +52,10 @@ Microsoft.VisualStudio.Services.Common.dll
 Microsoft.VisualStudio.Services.WebApi.dll
 Microsoft.VisualStudio.Telemetry.dll
 Microsoft.VisualStudio.Utilities.Internal.dll
+Microsoft.VisualStudio.Workspace.dll
+Microsoft.VisualStudio.Workspace.Extensions.dll
+Microsoft.VisualStudio.Workspace.Extensions.VS.dll
+Microsoft.VisualStudio.Workspace.VSIntegration.Contracts.dll
 Microsoft.WindowsAzure.Configuration.dll
 Newtonsoft.Json.dll
 System.ComponentModel.Composition.dll

--- a/src/NuGet.Clients/NuGet.Tools/.vsixignore.vs15
+++ b/src/NuGet.Clients/NuGet.Tools/.vsixignore.vs15
@@ -52,6 +52,10 @@ Microsoft.VisualStudio.Services.Common.dll
 Microsoft.VisualStudio.Services.WebApi.dll
 Microsoft.VisualStudio.Telemetry.dll
 Microsoft.VisualStudio.Utilities.Internal.dll
+Microsoft.VisualStudio.Workspace.dll
+Microsoft.VisualStudio.Workspace.Extensions.dll
+Microsoft.VisualStudio.Workspace.Extensions.VS.dll
+Microsoft.VisualStudio.Workspace.VSIntegration.Contracts.dll
 Microsoft.WindowsAzure.Configuration.dll
 System.dll
 System.IdentityModel.dll

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/DeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/DeferredProjectWorkspaceService.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.Extensions.MSBuild;
+using Microsoft.VisualStudio.Workspace.Indexing;
+using Microsoft.VisualStudio.Workspace.VSIntegration;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    [Export(typeof(IDeferredProjectWorkspaceService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal sealed class DeferredProjectWorkspaceService : IDeferredProjectWorkspaceService
+    {
+        private readonly AsyncLazy<IVsSolutionWorkspaceService> _solutionWorkspaceService;
+
+        private IVsSolutionWorkspaceService SolutionWorkspaceService => ThreadHelper.JoinableTaskFactory.Run(_solutionWorkspaceService.GetValueAsync);
+
+        [ImportingConstructor]
+        public DeferredProjectWorkspaceService(
+            [Import(typeof(SVsServiceProvider))]
+            IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            _solutionWorkspaceService = new AsyncLazy<IVsSolutionWorkspaceService>(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return (IVsSolutionWorkspaceService)serviceProvider.GetService(typeof(SVsSolutionWorkspaceService));
+            });
+        }
+
+        public async Task<bool> EntityExists(string filePath)
+        {
+            var workspace = SolutionWorkspaceService.CurrentWorkspace;
+            var indexService = workspace.GetIndexWorkspaceService();
+            var filePathExists = await indexService.EntityExists(filePath);
+            return filePathExists;
+        }
+
+        public async Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath)
+        {
+            var workspace = SolutionWorkspaceService.CurrentWorkspace;
+            var indexService = workspace.GetIndexWorkspaceService();
+            var fileReferenceResult = await indexService.GetFileReferencesAsync(projectFilePath, referenceTypes: (int)FileReferenceInfoType.ProjectReference);
+            return fileReferenceResult.Select(f => workspace.MakeRooted(f.Path));
+        }
+
+        public async Task<IMSBuildProjectDataService> GetMSBuildProjectDataService(string projectFilePath, string targetFramework = "")
+        {
+            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var factory = SolutionWorkspaceService.GetService(typeof(IVsSolutionMSBuildProjectServiceFactory)) as IVsSolutionMSBuildProjectServiceFactory;
+
+                if (factory == null)
+                {
+                    throw new ArgumentNullException(nameof(factory));
+                }
+
+                if (string.IsNullOrEmpty(targetFramework))
+                {
+                    return await factory.GetMSBuildProjectDataServiceAsync(projectFilePath);
+                }
+                else
+                {
+                    var projectProperties = new Dictionary<string, string>
+                    {
+                        { "TargetFramework", targetFramework }
+                    };
+                    return await factory.GetMSBuildProjectDataServiceAsync(projectFilePath, projectProperties: projectProperties);
+                }
+            });
+        }
+
+        public async Task<IEnumerable<MSBuildProjectItemData>> GetProjectItemsAsync(IMSBuildProjectDataService dataService, string itemType)
+        {
+            if (dataService == null)
+            {
+                throw new ArgumentNullException(nameof(dataService));
+            }
+
+            return await dataService.GetProjectItems(itemType);
+        }
+
+        public async Task<string> GetProjectPropertyAsync(IMSBuildProjectDataService dataService, string propertyName)
+        {
+            if (dataService == null)
+            {
+                throw new ArgumentNullException(nameof(dataService));
+            }
+
+            return (await dataService.GetProjectProperty(propertyName)).EvaluatedValue;
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IDeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IDeferredProjectWorkspaceService.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Workspace.Extensions.MSBuild;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public interface IDeferredProjectWorkspaceService
+    {
+        Task<bool> EntityExists(string filePath);
+
+        Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath);
+
+        Task<IMSBuildProjectDataService> GetMSBuildProjectDataService(string projectFilePath, string targetFramework = "");
+
+        Task<IEnumerable<MSBuildProjectItemData>> GetProjectItemsAsync(IMSBuildProjectDataService dataService, string itemType);
+
+        Task<string> GetProjectPropertyAsync(IMSBuildProjectDataService dataService, string propertyName);
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using NuGet.ProjectManagement;
@@ -33,5 +34,17 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return true if all projects in the solution have been loaded in background.
         /// </summary>
         bool IsSolutionFullyLoaded { get; }
+
+        /// <summary>
+        /// Returns true if solution has any project in deferred state.
+        /// </summary>
+        /// <returns>Deferred projects state.</returns>
+        Task<bool> SolutionHasDeferredProjectsAsync();
+
+        /// <summary>
+        /// Retrieves deferred projects file path from current solution.
+        /// </summary>
+        /// <returns>Deferred prokects file path.</returns>
+        Task<IEnumerable<string>> GetDeferredProjectsFilePathAsync();
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -124,6 +124,8 @@
   <ItemGroup>
     <Compile Include="BindingRedirectBehavior.cs" />
     <Compile Include="CommonResources.cs" />
+    <Compile Include="IDE\DeferredProjectWorkspaceService.cs" Condition="'$(VisualStudioVersion)' == '15.0'" />
+    <Compile Include="IDE\IDeferredProjectWorkspaceService.cs" />
     <Compile Include="IDE\IVsSolutionManager.cs" />
     <Compile Include="ProjectSystems\CpsPackageReferenceProject.cs" Condition="'$(VisualStudioVersion)' == '15.0'" />
     <Compile Include="ProjectSystems\IProjectSystemProvider.cs" />
@@ -136,6 +138,7 @@
     <Compile Include="ProjectSystems\CpsPackageReferenceProjectProvider.cs" Condition="'$(VisualStudioVersion)' == '15.0'" />
     <Compile Include="ProjectSystems\ProjectSystemProviderContext.cs" />
     <Compile Include="SolutionEventsListener.cs" />
+    <Compile Include="SolutionRestore\DeferredProjectRestoreData.cs" />
     <Compile Include="SolutionRestore\SolutionRestoreRequest.cs" />
     <Compile Include="ScriptExecutionRequest.cs" />
     <Compile Include="ProjectSystems\VSMSBuildNuGetProject.cs" />
@@ -189,6 +192,7 @@
     <Compile Include="Telemetry\ProjectTelemetryEvent.cs" />
     <Compile Include="Telemetry\NuGetProjectTelemetryService.cs" />
     <Compile Include="Utility\EnvDTEExtensions.cs" />
+    <Compile Include="Utility\DeferredProjectRestoreUtility.cs" />
     <Compile Include="Utility\EnvDTESolutionUtility.cs" />
     <Compile Include="Utility\FrameworkAssembly.cs" />
     <Compile Include="Utility\FrameworkAssemblyResolver.cs" />
@@ -233,6 +237,7 @@
     <EmbeddedResource Include="Strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
@@ -73,7 +73,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return VSProjectRestoreReferenceUtility.GetDirectProjectReferences(_envDTEProject, context.Logger);
+            var resolvedProjects = context.DeferredPackageSpecs.Select(project => project.Name);
+            return VSProjectRestoreReferenceUtility.GetDirectProjectReferences(_envDTEProject, resolvedProjects, context.Logger);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProject.cs
@@ -43,7 +43,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return VSProjectRestoreReferenceUtility.GetDirectProjectReferences(_project, context.Logger);
+            var resolvedProjects = context.DeferredPackageSpecs.Select(project => project.Name);
+            return VSProjectRestoreReferenceUtility.GetDirectProjectReferences(_project, resolvedProjects, context.Logger);
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/DeferredProjectRestoreData.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/DeferredProjectRestoreData.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    /// <summary>
+    /// Data model class to store deferred projects data.
+    /// </summary>
+    public sealed class DeferredProjectRestoreData
+    {
+        public DeferredProjectRestoreData(
+            IReadOnlyDictionary<PackageReference, List<string>> packageReferenceDict,
+            IReadOnlyList<PackageSpec> packageSpecs)
+        {
+            PackageReferenceDict = packageReferenceDict;
+            PackageSpecs = packageSpecs;
+        }
+
+        public IReadOnlyDictionary<PackageReference, List<string>> PackageReferenceDict { get; }
+
+        public IReadOnlyList<PackageSpec> PackageSpecs { get; }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/DeferredProjectRestoreUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/DeferredProjectRestoreUtility.cs
@@ -1,0 +1,472 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Workspace.Extensions.MSBuild;
+using NuGet.Commands;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
+using NuGet.RuntimeModel;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    /// <summary>
+    /// Utility class to construct restore data for deferred projects.
+    /// </summary>
+    public static class DeferredProjectRestoreUtility
+    {
+        private static readonly string IncludeAssets = "IncludeAssets";
+        private static readonly string ExcludeAssets = "ExcludeAssets";
+        private static readonly string PrivateAssets = "PrivateAssets";
+        private static readonly string BaseIntermediateOutputPath = "BaseIntermediateOutputPath";
+        private static readonly string PackageReference = "PackageReference";
+        private static readonly string ProjectReference = "ProjectReference";
+        private static readonly string RuntimeIdentifier = "RuntimeIdentifier";
+        private static readonly string RuntimeIdentifiers = "RuntimeIdentifiers";
+        private static readonly string RuntimeSupports = "RuntimeSupports";
+        private static readonly string TargetFramework = "TargetFramework";
+        private static readonly string TargetFrameworks = "TargetFrameworks";
+        private static readonly string NuGetTargetFramework = "NuGetTargetFramework";
+        private static readonly string PackageTargetFallback = "PackageTargetFallback";
+        private static readonly string TargetPlatformIdentifier = "TargetPlatformIdentifier";
+        private static readonly string TargetPlatformVersion = "TargetPlatformVersion";
+        private static readonly string TargetFrameworkMoniker = "TargetFrameworkMoniker";
+
+
+        public static async Task<DeferredProjectRestoreData> GetDeferredProjectsData(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IEnumerable<string> deferredProjectsPath,
+            CancellationToken token)
+        {
+            var packageReferencesDict = new Dictionary<PackageReference, List<string>>(new PackageReferenceComparer());
+            var packageSpecs = new List<PackageSpec>();
+
+            foreach (var projectPath in deferredProjectsPath)
+            {
+                // packages.config
+                string packagesConfigFilePath = Path.Combine(Path.GetDirectoryName(projectPath), "packages.config");
+                bool packagesConfigFileExists = await deferredWorkspaceService.EntityExists(packagesConfigFilePath);
+
+                if (packagesConfigFileExists)
+                {
+                    // read packages.config and get all package references.
+                    var projectName = Path.GetFileNameWithoutExtension(projectPath);
+                    using (var stream = new FileStream(packagesConfigFilePath, FileMode.Open, FileAccess.Read))
+                    {
+                        var reader = new PackagesConfigReader(stream);
+                        var packageReferences = reader.GetPackages();
+
+                        foreach (var packageRef in packageReferences)
+                        {
+                            List<string> projectNames = null;
+                            if (!packageReferencesDict.TryGetValue(packageRef, out projectNames))
+                            {
+                                projectNames = new List<string>();
+                                packageReferencesDict.Add(packageRef, projectNames);
+                            }
+
+                            projectNames.Add(projectName);
+                        }
+                    }
+
+                    // create package spec for packages.config based project
+                    var packageSpec = await GetPackageSpecForPackagesConfigAsync(deferredWorkspaceService, projectPath);
+                    if (packageSpec != null)
+                    {
+                        packageSpecs.Add(packageSpec);
+                    }
+                }
+                else
+                {
+
+                    // project.json
+                    string projectJsonFilePath = Path.Combine(Path.GetDirectoryName(projectPath), "project.json");
+                    bool projectJsonFileExists = await deferredWorkspaceService.EntityExists(projectJsonFilePath);
+
+                    if (projectJsonFileExists)
+                    {
+                        // create package spec for project.json based project
+                        var packageSpec = await GetPackageSpecForProjectJsonAsync(deferredWorkspaceService, projectPath, projectJsonFilePath);
+                        packageSpecs.Add(packageSpec);
+                    }
+                    else
+                    {
+                        // package references (CPS or Legacy CSProj)
+                        var packageSpec = await GetPackageSpecForPackageReferencesAsync(deferredWorkspaceService, projectPath);
+                        if (packageSpec != null)
+                        {
+                            packageSpecs.Add(packageSpec);
+                        }
+                    }
+                }
+            }
+
+            return new DeferredProjectRestoreData(packageReferencesDict, packageSpecs);
+        }
+
+        private static async Task<PackageSpec> GetPackageSpecForPackagesConfigAsync(IDeferredProjectWorkspaceService deferredWorkspaceService, string projectPath)
+        {
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+
+            var msbuildProjectDataService = await deferredWorkspaceService.GetMSBuildProjectDataService(projectPath);
+
+            var nuGetFramework = await GetNuGetFramework(deferredWorkspaceService, msbuildProjectDataService, projectPath);
+
+            var packageSpec = new PackageSpec(
+                new List<TargetFrameworkInformation>
+                {
+                    new TargetFrameworkInformation
+                    {
+                        FrameworkName = nuGetFramework
+                    }
+                });
+
+            packageSpec.Name = projectName;
+            packageSpec.FilePath = projectPath;
+
+            var metadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata = metadata;
+
+            metadata.ProjectStyle = ProjectStyle.PackagesConfig;
+            metadata.ProjectPath = projectPath;
+            metadata.ProjectName = projectName;
+            metadata.ProjectUniqueName = projectPath;
+            metadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(nuGetFramework));
+
+            await AddProjectReferencesAsync(deferredWorkspaceService, metadata, projectPath);
+
+            return packageSpec;
+        }
+
+        private static async Task<PackageSpec> GetPackageSpecForProjectJsonAsync(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            string projectPath,
+            string projectJsonFilePath)
+        {
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+            var packageSpec = JsonPackageSpecReader.GetPackageSpec(projectName, projectJsonFilePath);
+
+            var metadata = new ProjectRestoreMetadata();
+            packageSpec.RestoreMetadata = metadata;
+
+            metadata.ProjectStyle = ProjectStyle.ProjectJson;
+            metadata.ProjectPath = projectPath;
+            metadata.ProjectJsonPath = packageSpec.FilePath;
+            metadata.ProjectName = packageSpec.Name;
+            metadata.ProjectUniqueName = projectPath;
+
+            foreach (var framework in packageSpec.TargetFrameworks.Select(e => e.FrameworkName))
+            {
+                metadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
+            }
+
+            await AddProjectReferencesAsync(deferredWorkspaceService, metadata, projectPath);
+
+            return packageSpec;
+        }
+
+        private static async Task<PackageSpec> GetPackageSpecForPackageReferencesAsync(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            string projectPath)
+        {
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+            var projectDirectory = Path.GetDirectoryName(projectPath);
+
+            var msbuildProjectDataService = await deferredWorkspaceService.GetMSBuildProjectDataService(projectPath);
+
+            var packageReferences = (await deferredWorkspaceService.GetProjectItemsAsync(msbuildProjectDataService, PackageReference)).ToList();
+            if (packageReferences.Count == 0)
+            {
+                return null;
+            }
+
+            var targetFrameworks = await GetNuGetFrameworks(deferredWorkspaceService, msbuildProjectDataService, projectPath);
+            if (targetFrameworks.Count == 0)
+            {
+                return null;
+            }
+
+            var outputPath = Path.GetFullPath(
+                Path.Combine(
+                    projectDirectory,
+                    await GetProjectPropertyOrDefault(deferredWorkspaceService, msbuildProjectDataService, BaseIntermediateOutputPath)));
+
+            var crossTargeting = targetFrameworks.Count > 1;
+
+            var tfis = new List<TargetFrameworkInformation>();
+            var projectsByFramework = new Dictionary<NuGetFramework, IEnumerable<ProjectRestoreReference>>();
+            var runtimes = new List<string>();
+            var supports = new List<string>();
+
+            foreach (var targetFramework in targetFrameworks)
+            {
+                var tfi = new TargetFrameworkInformation
+                {
+                    FrameworkName = targetFramework
+                };
+
+                // re-evaluate msbuild project data service if there are multi-targets
+                if (targetFrameworks.Count > 1)
+                {
+                    msbuildProjectDataService = await deferredWorkspaceService.GetMSBuildProjectDataService(
+                        projectPath,
+                        targetFramework.GetShortFolderName());
+
+                    packageReferences = (await deferredWorkspaceService.GetProjectItemsAsync(msbuildProjectDataService, PackageReference)).ToList();
+                }
+
+                // Package target fallback per target framework
+                var ptf = await deferredWorkspaceService.GetProjectPropertyAsync(msbuildProjectDataService, PackageTargetFallback);
+                if (!string.IsNullOrEmpty(ptf))
+                {
+                    var fallBackList = ptf.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(NuGetFramework.Parse).ToList();
+
+                    if (fallBackList.Count > 0)
+                    {
+                        tfi.FrameworkName = new FallbackFramework(tfi.FrameworkName, fallBackList);
+                    }
+
+                    tfi.Imports = fallBackList;
+                }
+
+                // package references per target framework
+                tfi.Dependencies.AddRange(
+                    packageReferences.Select(ToPackageLibraryDependency));
+
+                // Project references per target framework
+                var projectReferences = (await deferredWorkspaceService.GetProjectItemsAsync(msbuildProjectDataService, ProjectReference))
+                    .Select(item => ToProjectRestoreReference(item, projectDirectory));
+                projectsByFramework.Add(tfi.FrameworkName, projectReferences);
+
+                // Runtimes, Supports per target framework
+                runtimes.AddRange(await GetRuntimeIdentifiers(deferredWorkspaceService, msbuildProjectDataService));
+                supports.AddRange(await GetRuntimeSupports(deferredWorkspaceService, msbuildProjectDataService));
+
+                tfis.Add(tfi);
+            }
+
+            var packageSpec = new PackageSpec(tfis)
+            {
+                Name = projectName,
+                FilePath = projectPath,
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    ProjectName = projectName,
+                    ProjectUniqueName = projectPath,
+                    ProjectPath = projectPath,
+                    OutputPath = outputPath,
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    TargetFrameworks = (projectsByFramework.Select(
+                        kvp => new ProjectRestoreMetadataFrameworkInfo(kvp.Key)
+                        {
+                            ProjectReferences = kvp.Value?.ToList()
+                        }
+                    )).ToList(),
+                    OriginalTargetFrameworks = tfis
+                        .Select(tf => tf.FrameworkName.GetShortFolderName())
+                        .ToList(),
+                    CrossTargeting = crossTargeting
+                },
+                RuntimeGraph = new RuntimeGraph(
+                    runtimes.Distinct(StringComparer.Ordinal).Select(rid => new RuntimeDescription(rid)),
+                    supports.Distinct(StringComparer.Ordinal).Select(s => new CompatibilityProfile(s)))
+            };
+
+            return packageSpec;
+        }
+
+        private static async Task<List<string>> GetRuntimeIdentifiers(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IMSBuildProjectDataService dataService)
+        {
+            var runtimeIdentifier = await GetProjectPropertyOrDefault(deferredWorkspaceService, dataService, RuntimeIdentifier);
+            var runtimeIdentifiers = await GetProjectPropertyOrDefault(deferredWorkspaceService, dataService, RuntimeIdentifiers);
+
+            var runtimes = (new[] { runtimeIdentifier, runtimeIdentifiers })
+                .SelectMany(s => s.Split(';'))
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToList();
+
+            return runtimes;
+        }
+
+        private static async Task<List<string>> GetRuntimeSupports(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IMSBuildProjectDataService dataService)
+        {
+            var supports = (await GetProjectPropertyOrDefault(deferredWorkspaceService, dataService, RuntimeSupports))
+                .Split(';')
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToList();
+
+            return supports;
+        }
+
+        private static async Task<string> GetProjectPropertyOrDefault(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IMSBuildProjectDataService dataService,
+            string projectPropertyName,
+            string defaultValue = "")
+        {
+            var propertyValue = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, projectPropertyName);
+
+            if (!string.IsNullOrEmpty(propertyValue))
+            {
+                return propertyValue;
+            }
+
+            return defaultValue;
+        }
+
+        private static ProjectRestoreReference ToProjectRestoreReference(MSBuildProjectItemData item, string projectDirectory)
+        {
+            var referencePath = Path.GetFullPath(
+                Path.Combine(
+                    projectDirectory, item.EvaluatedInclude));
+
+            var reference = new ProjectRestoreReference()
+            {
+                ProjectUniqueName = referencePath,
+                ProjectPath = referencePath
+            };
+
+            MSBuildRestoreUtility.ApplyIncludeFlags(
+                reference,
+                includeAssets: GetPropertyValueOrDefault(item, IncludeAssets),
+                excludeAssets: GetPropertyValueOrDefault(item, ExcludeAssets),
+                privateAssets: GetPropertyValueOrDefault(item, PrivateAssets));
+
+            return reference;
+        }
+
+        private static LibraryDependency ToPackageLibraryDependency(MSBuildProjectItemData item)
+        {
+            var dependency = new LibraryDependency
+            {
+                LibraryRange = new LibraryRange(
+                    name: item.EvaluatedInclude,
+                    versionRange: GetVersionRange(item),
+                    typeConstraint: LibraryDependencyTarget.Package)
+            };
+
+            MSBuildRestoreUtility.ApplyIncludeFlags(
+                dependency,
+                includeAssets: GetPropertyValueOrDefault(item, IncludeAssets),
+                excludeAssets: GetPropertyValueOrDefault(item, ExcludeAssets),
+                privateAssets: GetPropertyValueOrDefault(item, PrivateAssets));
+
+            return dependency;
+        }
+
+        private static VersionRange GetVersionRange(MSBuildProjectItemData item)
+        {
+            var versionRange = GetPropertyValueOrDefault(item, "Version");
+
+            if (!string.IsNullOrEmpty(versionRange))
+            {
+                return VersionRange.Parse(versionRange);
+            }
+
+            return VersionRange.All;
+        }
+
+        private static string GetPropertyValueOrDefault(
+            MSBuildProjectItemData item, string propertyName, string defaultValue = "")
+        {
+            if (item.Metadata.Keys.Contains(propertyName))
+            {
+                return item.Metadata[propertyName];
+            }
+
+            return defaultValue;
+        }
+
+        private static async Task<List<NuGetFramework>> GetNuGetFrameworks(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IMSBuildProjectDataService dataService,
+            string projectPath)
+        {
+            var targetFrameworks = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetFrameworks);
+            if (!string.IsNullOrEmpty(targetFrameworks))
+            {
+                return targetFrameworks
+                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(NuGetFramework.Parse).ToList();
+            }
+
+            var targetFramework = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetFramework);
+            if (!string.IsNullOrEmpty(targetFramework))
+            {
+                return new List<NuGetFramework> { NuGetFramework.Parse(targetFramework) };
+            }
+
+            var nuGetTargetFramework = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, NuGetTargetFramework);
+            if (!string.IsNullOrEmpty(nuGetTargetFramework))
+            {
+                return new List<NuGetFramework> { NuGetFramework.ParseFrameworkName(nuGetTargetFramework, DefaultFrameworkNameProvider.Instance) };
+            }
+
+            // old packages.config style
+            return new List<NuGetFramework> { await GetNuGetFramework(deferredWorkspaceService, dataService, projectPath) };
+        }
+
+        private static async Task<NuGetFramework> GetNuGetFramework(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            IMSBuildProjectDataService dataService,
+            string projectPath)
+        {
+            var targetPlatformIdentifier = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetPlatformIdentifier);
+            var targetPlatformVersion = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetPlatformVersion);
+            var targetFrameworkMoniker = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetFrameworkMoniker);
+
+            var frameworkStrings = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                projectFilePath: projectPath,
+                targetFrameworks: null,
+                targetFramework: null,
+                targetFrameworkMoniker: targetFrameworkMoniker,
+                targetPlatformIdentifier: targetPlatformIdentifier,
+                targetPlatformVersion: targetPlatformVersion);
+
+            var frameworkString = frameworkStrings.FirstOrDefault();
+
+            if (!string.IsNullOrEmpty(frameworkString))
+            {
+                return NuGetFramework.Parse(frameworkString);
+            }
+
+            return NuGetFramework.UnsupportedFramework;
+        }
+
+        private static async Task AddProjectReferencesAsync(
+            IDeferredProjectWorkspaceService deferredWorkspaceService,
+            ProjectRestoreMetadata metadata,
+            string projectPath)
+        {
+            var references = await deferredWorkspaceService.GetProjectReferencesAsync(projectPath);
+
+            foreach (var reference in references)
+            {
+                var restoreReference = new ProjectRestoreReference()
+                {
+                    ProjectPath = reference,
+                    ProjectUniqueName = reference
+                };
+
+                foreach (var frameworkInfo in metadata.TargetFrameworks)
+                {
+                    frameworkInfo.ProjectReferences.Add(restoreReference);
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
+++ b/src/NuGet.Clients/VisualStudio.Facade/VisualStudio15.Packages/project.json
@@ -16,6 +16,7 @@
     "Microsoft.VisualStudio.Threading": "15.0.20-pre",
     "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4",
     "Microsoft.VisualStudio.Telemetry": "15.0.691-master31907920",
+    "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.171-pre",
     "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/IPackageRestoreManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
@@ -52,6 +53,15 @@ namespace NuGet.PackageManagement
         /// each package is installed, alongwith a bool which determines if the package is missing
         /// </returns>
         Task<IEnumerable<PackageRestoreData>> GetPackagesInSolutionAsync(string solutionDirectory, CancellationToken token);
+
+        /// <summary>
+        /// Get packages restore data for given package references.
+        /// </summary>
+        /// <param name="solutionDirectory">Current solution directory</param>
+        /// <param name="packageReferencesDict">Dictionary of package reference with project names</param>
+        /// <returns>List of packages restore data with missing package details.</returns>
+	    IEnumerable<PackageRestoreData> GetPackagesRestoreData(string solutionDirectory,
+            Dictionary<PackageReference, List<string>> packageReferencesDict);
 
         /// <summary>
         /// Checks the current solution if there is any package missing.

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -114,11 +114,28 @@ namespace NuGet.PackageManagement
         {
             var packageReferencesDictionary = await GetPackagesReferencesDictionaryAsync(token);
 
-            var nuGetPackageManager = GetNuGetPackageManager(solutionDirectory);
+            return GetPackagesRestoreData(solutionDirectory, packageReferencesDictionary);
+        }
 
+        /// <summary>
+        /// Get packages restore data for given package references.
+        /// </summary>
+        /// <param name="solutionDirectory">Current solution directory</param>
+        /// <param name="packageReferencesDict">Dictionary of package reference with project names</param>
+        /// <returns>List of packages restore data with missing package details.</returns>
+	    public IEnumerable<PackageRestoreData> GetPackagesRestoreData(string solutionDirectory,
+        Dictionary<PackageReference, List<string>> packageReferencesDict)
+        {
             var packages = new List<PackageRestoreData>();
 
-            foreach (var packageReference in packageReferencesDictionary.Keys)
+            if(packageReferencesDict == null || !packageReferencesDict.Any())
+            {
+                return packages;
+            }
+
+            var nuGetPackageManager = GetNuGetPackageManager(solutionDirectory);
+
+            foreach (var packageReference in packageReferencesDict.Keys)
             {
                 var isMissing = false;
                 if (!nuGetPackageManager.PackageExistsInPackagesFolder(packageReference.PackageIdentity))
@@ -126,7 +143,7 @@ namespace NuGet.PackageManagement
                     isMissing = true;
                 }
 
-                var projectNames = packageReferencesDictionary[packageReference];
+                var projectNames = packageReferencesDict[packageReference];
 
                 Debug.Assert(projectNames != null);
                 packages.Add(new PackageRestoreData(packageReference, projectNames, isMissing));

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/MSBuildProjectUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/MSBuildProjectUtility.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace NuGet.PackageManagement
+{
+    public static class MSBuildProjectUtility
+    {
+        public static string GetTargetFrameworkString(dynamic msbuildProject)
+        {
+            if (msbuildProject == null)
+            {
+                return null;
+            }
+
+            var extension = msbuildProject.GetPropertyValue(ProjectManagement.Constants.ProjectExt);
+
+            // Check for JS project
+            if (StringComparer.OrdinalIgnoreCase.Equals(ProjectManagement.Constants.JSProjectExt, extension))
+            {
+                // JavaScript apps do not have a TargetFrameworkMoniker property set.
+                // We read the TargetPlatformIdentifier and TargetPlatformVersion instead
+                var platformIdentifier = msbuildProject.GetPropertyValue(ProjectManagement.Constants.TargetPlatformIdentifier);
+                var platformVersion = msbuildProject.GetPropertyValue(ProjectManagement.Constants.TargetPlatformVersion);
+
+                // use the default values for JS if they were not given
+                if (string.IsNullOrEmpty(platformVersion))
+                {
+                    platformVersion = "0.0";
+                }
+
+                if (string.IsNullOrEmpty(platformIdentifier))
+                {
+                    platformIdentifier = "Windows";
+                }
+
+                return string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}", platformIdentifier, platformVersion);
+            }
+
+            // Check for C++ project
+            if (StringComparer.OrdinalIgnoreCase.Equals(ProjectManagement.Constants.VCXProjextExt, extension))
+            {
+                // The C++ project does not have a TargetFrameworkMoniker property set. 
+                // We hard-code the return value to Native.
+                return ProjectManagement.Constants.NativeTFM;
+            }
+
+            return msbuildProject.GetPropertyValue(ProjectManagement.Constants.TargetFrameworkMoniker);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/project.json
+++ b/src/NuGet.Core/NuGet.PackageManagement/project.json
@@ -35,7 +35,10 @@
   "frameworks": {
     "net45": {
       "frameworkAssemblies": {
-        "System.ComponentModel.Composition": ""
+        "System.ComponentModel.Composition": "",
+        "Microsoft.Build": {
+          "type": "build"
+        }
       },
       "buildOptions": {
         "define": [

--- a/src/NuGet.Core/NuGet.ProjectManagement/DependencyGraphCacheContext.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/DependencyGraphCacheContext.cs
@@ -20,6 +20,8 @@ namespace NuGet.ProjectManagement
             Logger = NullLogger.Instance;
         }
 
+        public List<PackageSpec> DeferredPackageSpecs { get; set; } = new List<PackageSpec>();
+
         /// <summary>
         /// Unique name to dg
         /// </summary>

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -199,6 +198,153 @@ namespace NuGet.Test
                     "EntityFramework.5.0.0.nupkg")));
 
                 Assert.True(testLogger.Errors == 0, testLogger.ShowErrors());
+            }
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_RestoreDeferredProjectLoad()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net45"": {
+                  ""dependencies"": {
+                    ""packageA"": ""1.0.0""
+                  }
+                }
+              }
+            }";
+
+            using (var packageSource = TestDirectory.Create())
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateSourceRepositoryProvider(
+                    new List<PackageSource>()
+                    {
+                        new PackageSource(packageSource.Path)
+                    });
+
+                var packageContext = new SimpleTestPackageContext("packageA");
+                packageContext.AddFile("lib/net45/a.dll");
+                SimpleTestPackageUtility.CreateOPCPackage(packageContext, packageSource);
+
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                projectFolder.Create();
+                var projectConfig = Path.Combine(projectFolder.FullName, "project.json");
+                var projectPath = Path.Combine(projectFolder.FullName, $"{projectName}.csproj");
+
+                var packageSpec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", projectConfig);
+                var metadata = new ProjectRestoreMetadata();
+                packageSpec.RestoreMetadata = metadata;
+
+                metadata.OutputType = RestoreOutputType.UAP;
+                metadata.ProjectPath = projectPath;
+                metadata.ProjectJsonPath = packageSpec.FilePath;
+                metadata.ProjectName = packageSpec.Name;
+                metadata.ProjectUniqueName = projectPath;
+                foreach (var framework in packageSpec.TargetFrameworks.Select(e => e.FrameworkName))
+                {
+                    metadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
+                }
+
+                var solutionManager = new TestSolutionManager(false);
+
+                var testLogger = new TestLogger();
+
+                var restoreContext = new DependencyGraphCacheContext(testLogger);
+                restoreContext.DeferredPackageSpecs.Add(packageSpec);
+
+                // Act
+                await DependencyGraphRestoreUtility.RestoreAsync(
+                    solutionManager,
+                    restoreContext,
+                    new RestoreCommandProvidersCache(),
+                    (c) => { },
+                    sourceRepositoryProvider.GetRepositories(),
+                    NullSettings.Instance,
+                    testLogger,
+                    CancellationToken.None);
+
+                // Assert
+                Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));
+                Assert.True(testLogger.Errors == 0);
+            }
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequired_DeferredProjectLoad()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""net45"": {
+                }
+              }
+            }";
+
+            using (var rootFolder = TestDirectory.Create())
+            {
+                var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+                projectFolder.Create();
+                var projectConfig = Path.Combine(projectFolder.FullName, "project.json");
+                var projectPath = Path.Combine(projectFolder.FullName, $"{projectName}.csproj");
+
+                var packageSpec = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", projectConfig);
+                var metadata = new ProjectRestoreMetadata();
+                packageSpec.RestoreMetadata = metadata;
+
+                metadata.OutputType = RestoreOutputType.UAP;
+                metadata.ProjectPath = projectPath;
+                metadata.ProjectJsonPath = packageSpec.FilePath;
+                metadata.ProjectName = packageSpec.Name;
+                metadata.ProjectUniqueName = projectPath;
+
+                foreach (var framework in packageSpec.TargetFrameworks.Select(e => e.FrameworkName))
+                {
+                    metadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(framework));
+                }
+
+                var solutionManager = new TestSolutionManager(false);
+
+                var testLogger = new TestLogger();
+
+                var restoreContext = new DependencyGraphCacheContext(testLogger);
+                restoreContext.DeferredPackageSpecs.Add(packageSpec);
+
+                var pathContext = NuGetPathContext.Create(NullSettings.Instance);
+
+                var oldHash = restoreContext.SolutionSpecHash;
+
+                // Act
+                var result = await DependencyGraphRestoreUtility.IsRestoreRequiredAsync(
+                    solutionManager,
+                    forceRestore: false,
+                    pathContext: pathContext,
+                    cacheContext: restoreContext,
+                    oldDependencyGraphSpecHash: oldHash);
+
+                // Assert
+                Assert.Equal(true, result);
+                Assert.Equal(0, testLogger.Errors);
+                Assert.Equal(0, testLogger.Warnings);
             }
         }
     }


### PR DESCRIPTION
This PR targets supporting NuGet restore (on build or solution) in DPL mode without loading projects. At high level, design is during onbuild or solution restore, we check for all the deferred projects, get their details from DPL apis, contruct package spec for each of these project, and update dg spec with all these packages spec for deferred projects.

Currently it supports Packages.config and Project.json based projects. Next target is to support CPS and legacy project systems.

Fixes https://github.com/NuGet/Home/issues/3711 https://github.com/NuGet/Home/issues/4003

@rrelyea @emgarten @joelverhagen @alpaix 