### PR TITLE
Move lock folder from Temp to NuGetHome

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -575,19 +575,21 @@ namespace NuGet.Commands
         {
             if (_isPersistDGSet.Value)
             {
-                var path = Path.Combine(
-                    NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
-                    "nuget-dg",
-                    $"{Guid.NewGuid()}.dg");
-
+                string path;
                 var envPath = Environment.GetEnvironmentVariable("NUGET_PERSIST_DG_PATH");
-
                 if (!string.IsNullOrEmpty(envPath))
                 {
                     path = envPath;
+                    Directory.CreateDirectory(Path.GetDirectoryName(path));
                 }
-
-                DirectoryUtility.CreateSharedDirectory(Path.GetDirectoryName(path));
+                else
+                {
+                    path = Path.Combine(
+                        NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp),
+                        "nuget-dg",
+                        $"{Guid.NewGuid()}.dg");
+                    DirectoryUtility.CreateSharedDirectory(Path.GetDirectoryName(path));
+                }
 
                 log.LogMinimal(
                     string.Format(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -587,7 +587,7 @@ namespace NuGet.Commands
                     path = envPath;
                 }
 
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                DirectoryUtility.CreateSharedDirectory(Path.GetDirectoryName(path));
 
                 log.LogMinimal(
                     string.Format(

--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -187,7 +187,7 @@ namespace NuGet.Common
                     return _basePath;
                 }
 
-                _basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), "lock");
+                _basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome), "lock");
 
                 Directory.CreateDirectory(_basePath);
 

--- a/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ConcurrencyUtilities.cs
@@ -187,9 +187,9 @@ namespace NuGet.Common
                     return _basePath;
                 }
 
-                _basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.NuGetHome), "lock");
+                _basePath = Path.Combine(NuGetEnvironment.GetFolderPath(NuGetFolderPath.Temp), "lock");
 
-                Directory.CreateDirectory(_basePath);
+                DirectoryUtility.CreateSharedDirectory(_basePath);
 
                 return _basePath;
             }
@@ -199,7 +199,7 @@ namespace NuGet.Common
         {
             // In case the directory was cleaned up, we can choose to fix it (at a cost of another roundtrip to disk
             // or fail, starting with the more expensive path, and we might have to get rid of it if it becomes too hot.
-            Directory.CreateDirectory(BasePath);
+            DirectoryUtility.CreateSharedDirectory(BasePath);
 
             return Path.Combine(BasePath, FilePathToLockName(filePath));
         }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -9,8 +9,6 @@ namespace NuGet.Common
     /// </summary>
     public static class DirectoryUtility
     {
-        private static object s_sharedFolderCreationLock = new object();
-
         /// <summary>
         /// Creates all directories and subdirectories in the specified path unless they already exist.
         /// New directories can be read and written by all users.
@@ -23,28 +21,67 @@ namespace NuGet.Common
             }
             else
             {
-                lock (s_sharedFolderCreationLock)
+                path = Path.GetFullPath(path);
+                var root = Path.GetPathRoot(path);
+                var sepPos = root.Length - 1;
+                do
                 {
-                    path = Path.GetFullPath(path);
-                    var root = Path.GetPathRoot(path);
-                    var sepPos = root.Length - 1;
-                    do
+                    sepPos = path.IndexOf(Path.DirectorySeparatorChar, sepPos + 1);
+                    var currentPath = sepPos == -1 ? path : path.Substring(0, sepPos);
+                    if (!Directory.Exists(currentPath))
                     {
-                        sepPos = path.IndexOf(Path.DirectorySeparatorChar, sepPos + 1);
-                        var currentPath = sepPos == -1 ? path : path.Substring(0, sepPos);
-                        if (!Directory.Exists(currentPath))
-                        {
-                            Directory.CreateDirectory(currentPath);
-                            chmod(currentPath, UGO_RWX);
-                        }
-                    } while (sepPos != -1);
+                        CreateSingleSharedDirectory(currentPath);
+                    }
+                } while (sepPos != -1);
+            }
+        }
+
+        private static void CreateSingleSharedDirectory(string path)
+        {
+            // Creating a directory and setting the permissions are two operations. To avoid race
+            // conditions, we create a different directory, set the permissions and rename it. We
+            // create it under the parent directory to make sure it is on the same volume.
+            var parentDir = Path.GetDirectoryName(path);
+            var tempDir = Path.Combine(parentDir, Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            if (chmod(tempDir, UGO_RWX) == -1)
+            {
+                // it's very unlikely we can't set the permissions of a directory we just created
+                TryDeleteDirectory(tempDir);
+                var errno = Marshal.GetLastWin32Error();
+                throw new InvalidOperationException($"Unable to set permission while creating {path}, errno={errno}.");
+            }
+            try
+            {
+                Directory.Move(tempDir, path);
+            }
+            catch
+            {
+                TryDeleteDirectory(tempDir);
+                if (Directory.Exists(path))
+                {
+                    return;
+                }
+                else
+                {
+                    throw;
                 }
             }
         }
 
-        private const int UGO_RWX = 0x1ff;
+        private static void TryDeleteDirectory(string path)
+        {
+            try
+            {
+                Directory.Delete(path);
+            }
+            catch
+            {}
+        }
 
-        [DllImport("libc")]
+        private const int UGO_RWX = 0x1ff; // 0777
+
+        [DllImport("libc", SetLastError = true)]
         private static extern int chmod(string pathname, int mode);
     }
 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace NuGet.Common
+{
+    /// <summary>
+    /// Directory operation helpers.
+    /// </summary>
+    public static class DirectoryUtility
+    {
+        private static object s_sharedFolderCreationLock = new object();
+
+        /// <summary>
+        /// Creates all directories and subdirectories in the specified path unless they already exist.
+        /// New directories can be read and written by all users.
+        /// </summary>
+        public static void CreateSharedDirectory(string path)
+        {
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                Directory.CreateDirectory(path);
+            }
+            else
+            {
+                lock (s_sharedFolderCreationLock)
+                {
+                    path = Path.GetFullPath(path);
+                    var root = Path.GetPathRoot(path);
+                    var sepPos = root.Length - 1;
+                    do
+                    {
+                        sepPos = path.IndexOf(Path.DirectorySeparatorChar, sepPos + 1);
+                        var currentPath = sepPos == -1 ? path : path.Substring(0, sepPos);
+                        if (!Directory.Exists(currentPath))
+                        {
+                            Directory.CreateDirectory(currentPath);
+                            chmod(currentPath, UGO_RWX);
+                        }
+                    } while (sepPos != -1);
+                }
+            }
+        }
+
+        private const int UGO_RWX = 0x1ff;
+
+        [DllImport("libc")]
+        private static extern int chmod(string pathname, int mode);
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/DirectoryUtility.cs
@@ -22,6 +22,11 @@ namespace NuGet.Common
             else
             {
                 path = Path.GetFullPath(path);
+                if (Directory.Exists(path))
+                {
+                    return;
+                }
+                // ensure directories exists starting from the root
                 var root = Path.GetPathRoot(path);
                 var sepPos = root.Length - 1;
                 do

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
@@ -33,6 +33,25 @@ namespace NuGet.Common.Test
             }
         }
 
+        [Fact]
+        public void DirectoryUtility_CreateSharedDirectory_Idempotent()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var parentDir = Path.Combine(testDirectory, "parent");
+                var childDir = Path.Combine(parentDir, "child");
+                DirectoryUtility.CreateSharedDirectory(childDir);
+
+                // Act
+                DirectoryUtility.CreateSharedDirectory(childDir);
+
+                // Assert
+                Assert.True(Directory.Exists(parentDir));
+                Assert.True(Directory.Exists(childDir));
+            }
+        }
+
         private string StatPermissions(string path)
         {
             string permissions;

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
@@ -62,9 +62,16 @@ namespace NuGet.Common.Test
                 RedirectStandardOutput = true,
                 RedirectStandardInput = true,
                 UseShellExecute = false,
-                Arguments = "-c %a " + path,
                 FileName = "stat"
             };
+            if (RuntimeEnvironmentHelper.IsLinux)
+            {
+                startInfo.Arguments = "-c %a " + path;
+            }
+            else
+            {
+                startInfo.Arguments = "-f %A " + path;
+            }
 
             using (Process process = new Process())
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/DirectoryUtilityTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.Test.Utility;
+using System.IO;
+using Xunit;
+using System.Diagnostics;
+
+namespace NuGet.Common.Test
+{
+    public class DirectoryUtilityTests
+    {
+        [Fact]
+        public void DirectoryUtility_CreateSharedDirectory_BasicSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var parentDir = Path.Combine(testDirectory, "parent");
+                var childDir = Path.Combine(parentDir, "child");
+
+                // Act
+                DirectoryUtility.CreateSharedDirectory(childDir);
+
+                // Assert
+                Assert.True(Directory.Exists(parentDir));
+                Assert.True(Directory.Exists(childDir));
+                if (!RuntimeEnvironmentHelper.IsWindows)
+                {
+                    Assert.Equal("777", StatPermissions(parentDir));
+                    Assert.Equal("777", StatPermissions(childDir));
+                }
+            }
+        }
+
+        private string StatPermissions(string path)
+        {
+            string permissions;
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardInput = true,
+                UseShellExecute = false,
+                Arguments = "-c %a " + path,
+                FileName = "stat"
+            };
+
+            using (Process process = new Process())
+            {
+                process.StartInfo = startInfo;
+
+                process.Start();
+                permissions = process.StandardOutput.ReadLine();
+
+                process.WaitForExit();
+            }
+
+            return permissions;
+        }
+    }
+}


### PR DESCRIPTION
On Linux, NuGetFolderPath.Temp causes the folder to end up at
/tmp/NuGetScratch/lock. After one user creates this folder, other users
can no longer use it because they do not have write permission. Moving
the folder to NuGetFolderPath.NuGetHome places it at ~/.nuget/lock
making it a per-user folder like on Windows.