### PR TITLE
Fix package spec for legacy csproj

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -264,6 +264,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var projectTfi = new TargetFrameworkInformation()
             {
                 FrameworkName = _project.TargetNuGetFramework,
+                Dependencies = packageReferences,
                 Imports = packageTargetFallback ?? new List<NuGetFramework>()
             };
 


### PR DESCRIPTION
Added dependencies under TagetFrameworkInformation for legacy csproj which will be used to retrieve package references for installed packages.

Fixes https://github.com/NuGet/Home/issues/4015 https://github.com/NuGet/Home/issues/4016

@drewgillies 