### PR TITLE
fixed microsoft.build.dll resolving, added msbuildPath to update

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -78,6 +78,7 @@ namespace NuGet.CommandLine
             LoadAssemblies(msbuildDirectory);
 
             // create project
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(AssemblyResolve);
             var project = Activator.CreateInstance(
                 _projectType,
                 path,

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -50,6 +50,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
         public string MSBuildVersion { get; set; }
 
+        [Option(typeof(NuGetCommand), "CommandMSBuildPath")]
+        public string MSBuildPath { get; set; }
+
         // The directory that contains msbuild
         private Lazy<string> _msbuildDirectory;
 
@@ -70,7 +73,7 @@ namespace NuGet.CommandLine
                 throw new CommandLineException(NuGetResources.InvalidFile);
             }
 
-            _msbuildDirectory = new Lazy<string>(() => MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console));
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectoryFromMsbuildPath(MSBuildPath, MSBuildVersion, Console);
             var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
             string inputFileName = Path.GetFileName(inputFile);

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -437,6 +437,7 @@ namespace NuGet.Common
 
         private dynamic GetProject(string projectFile)
         {
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(AssemblyResolve);
             dynamic globalProjectCollection = _projectCollectionType
                 .GetProperty("GlobalProjectCollection")
                 .GetMethod

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 
@@ -33,6 +34,50 @@ namespace NuGet.Common
             _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
 
             LoadTypes();
+        }
+
+        // This handler is called only when the common language runtime tries to bind to the assembly and fails
+        protected Assembly AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            if (string.IsNullOrEmpty(_msbuildDirectory))
+            {
+                return null;
+            }
+
+            var failingAssemblyFilename = args.Name.Substring(0, args.Name.IndexOf(","));
+
+            // If we're failing to load a resource assembly, we need to find it in the appropriate subdir
+            if (failingAssemblyFilename.Length > 10 &&
+                failingAssemblyFilename.Substring(failingAssemblyFilename.Length - 10, 10).Equals(".resources", StringComparison.OrdinalIgnoreCase))
+            {
+                var fallBackToEnglish = false;
+                var cultureName = CultureInfo.CurrentCulture?.TwoLetterISOLanguageName;
+                if (string.IsNullOrEmpty(cultureName))
+                {
+                    fallBackToEnglish = true;
+                }
+
+                var resourceDir = Path.Combine(_msbuildDirectory, cultureName);
+                if (!Directory.Exists(resourceDir))
+                {
+                    fallBackToEnglish = true;
+                }
+
+                if (fallBackToEnglish)
+                {
+                    resourceDir = Path.Combine(_msbuildDirectory, "en");
+                }
+
+                if (!Directory.Exists(resourceDir))
+                {
+                    return null; // no resource directory or fallback resource directory - fail
+                }
+
+                return Assembly.LoadFrom(Path.Combine(resourceDir, failingAssemblyFilename + ".dll"));
+            }
+
+            // Non-resource DLL - attempt to load from MSBuild directory
+            return Assembly.LoadFrom(Path.Combine(_msbuildDirectory, failingAssemblyFilename + ".dll"));
         }
 
         public void LoadTypes()


### PR DESCRIPTION
the issue here is pack and update doesn't work on dev15 for packages.config and uwp.

the fix is to resolve Microsoft.build.dll dependency from msbuildPath.
https://github.com/NuGet/Home/issues/4009