### PR TITLE
Fixed typo in DefaultSpecValueSolution in AnalysisResources

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
+++ b/src/NuGet.Core/NuGet.Commands/Rules/AnalysisResources.resx
@@ -139,7 +139,7 @@
     <value>The value "{0}" for {1} is a sample value and should be removed.</value>
   </data>
   <data name="DefaultSpecValueSolution" xml:space="preserve">
-    <value>Replace with an appropriate value or remove and it and rebuild your package.</value>
+    <value>Replace it with an appropriate value or remove it and rebuild your package.</value>
   </data>
   <data name="DefaultSpecValueTitle" xml:space="preserve">
     <value>Remove sample nuspec values.</value>


### PR DESCRIPTION
I was running some functional tests and noticed this typo.

Before:
```
Issue: Remove sample nuspec values.
Description: The value "Tag1 Tag2" for Tags is a sample value and should be removed.
Solution: Replace with an appropriate value or remove and it and rebuild your package.
```

Now:
```
Issue: Remove sample nuspec values.
Description: The value "Tag1 Tag2" for Tags is a sample value and should be removed.
Solution: Replace it with an appropriate value or remove it and rebuild your package.
```