### PR TITLE
Fix VS perf issue for solution load

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -30,9 +30,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="RestoreManagerPackage.cs" />

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
@@ -14,17 +14,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public interface IVsSolutionManager : ISolutionManager
     {
         /// <summary>
-        /// Associates instance with loaded VS extension package.
-        /// Needed mostly to perform initialization actions when environment is fully
-        /// loaded. As a MEF constructor might be called with partially incomplete components.
-        /// For instance, UI thread bound actions can't be invoked in a constructor due to high
-        /// risk of a deadlock.
-        /// </summary>
-        /// <param name="site">VS extension package. Provides async access to VS services.</param>
-        /// <returns>Asyncronous operation.</returns>
-        Task InitializeAsync(IAsyncServiceProvider site);
-
-        /// <summary>
         /// Retrieves <see cref="NuGetProject"/> instance associated with VS project.
         /// Creates new instance if not found in project system cache.
         /// </summary>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionEventsListener.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionEventsListener.cs
@@ -18,16 +18,16 @@ namespace NuGet.PackageManagement.VisualStudio
         private IVsSolution _vsSolution;
         private uint _cookie;
 
-        protected async Task AdviseAsync(IAsyncServiceProvider site)
+        protected void Advise(IServiceProvider serviceProvider)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (site == null)
+            if (serviceProvider == null)
             {
-                throw new ArgumentNullException(nameof(site));
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-            _vsSolution = await site.GetServiceAsync<SVsSolution, IVsSolution>();
+            _vsSolution = serviceProvider.GetService<SVsSolution, IVsSolution>();
             if (_vsSolution != null)
             {
                 var hr = _vsSolution.AdviseSolutionEvents(this, out _cookie);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SolutionRestore/ISolutionRestoreWorker.cs
@@ -24,13 +24,6 @@ namespace NuGet.PackageManagement.VisualStudio
         bool IsBusy { get; }
 
         /// <summary>
-        /// Initializes instance after the hosting package is settled.
-        /// </summary>
-        /// <param name="site">VS extension package hosting the instance.</param>
-        /// <returns>Asyncronous operation task</returns>
-        Task InitializeAsync(IAsyncServiceProvider site);
-
-        /// <summary>
         /// Schedules backgroud restore operation.
         /// </summary>
         /// <param name="request">Restore request.</param>


### PR DESCRIPTION
Instead of initializing core MEF objects at solution load/new which caused this regression, we'll lazy initialize them whenever they are actually needed.

Fix VS issue# 297627 https://github.com/NuGet/Home/issues/4072 

@alpaix @emgarten @rrelyea