### PR TITLE
add ability to specify contentTargetFolders in a project to determine where the content would go in a nupkg

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -19,6 +19,7 @@ namespace NuGet.Build.Tasks.Pack
         TItem[] AssemblyReferences { get; }
         string[] Authors { get; }
         string BuildOutputFolder { get; }
+        string[] ContentTargetFolders { get; }
         bool ContinuePackingAfterGeneratingNuspec { get; }
         string Copyright { get; }
         string Description { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -28,6 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>
+    <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -106,7 +107,8 @@ Copyright (c) .NET Foundation. All rights reserved.
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
               NuspecOutputPath="$(BaseIntermediateOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
-              BuildOutputFolder="$(BuildOutputTargetFolder)"/>
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"/>
   </Target>
   <!--
     ============================================================

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -47,6 +47,7 @@ namespace NuGet.Build.Tasks.Pack
         public string NuspecOutputPath { get; set; }
         public bool IncludeBuildOutput { get; set; }
         public string BuildOutputFolder { get; set; }
+        public string[] ContentTargetFolders { get; set; }
 
         public ILogger Logger => new MSBuildLogger(Log);
 
@@ -100,6 +101,7 @@ namespace NuGet.Build.Tasks.Pack
                 Authors = MSBuildUtility.TrimAndExcludeNullOrEmpty(Authors),
                 BuildOutputFolder = MSBuildUtility.TrimAndGetNullForEmpty(BuildOutputFolder),
                 ContinuePackingAfterGeneratingNuspec = ContinuePackingAfterGeneratingNuspec,
+                ContentTargetFolders = MSBuildUtility.TrimAndExcludeNullOrEmpty(ContentTargetFolders),
                 Copyright = MSBuildUtility.TrimAndGetNullForEmpty(Copyright),
                 Description = MSBuildUtility.TrimAndGetNullForEmpty(Description),
                 IconUrl = MSBuildUtility.TrimAndGetNullForEmpty(IconUrl),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -265,7 +265,7 @@ namespace NuGet.Build.Tasks.Pack
                         continue;
                     }
 
-                    GetTargetPath(packageFile, sourcePath, currentProjectDirectory, out targetPaths);
+                    GetTargetPath(packageFile, sourcePath, currentProjectDirectory, request.ContentTargetFolders, out targetPaths);
 
                     if (fileModel.ContainsKey(sourcePath))
                     {
@@ -286,9 +286,18 @@ namespace NuGet.Build.Tasks.Pack
 
 
         // The targetpaths returned from this function contain the directory in the nuget package where the file would go to. The filename is added later on to the target path.
-        private void GetTargetPath(IMSBuildItem packageFile, string sourcePath, string currentProjectDirectory, out string[] targetPaths)
+        private void GetTargetPath(IMSBuildItem packageFile, string sourcePath, string currentProjectDirectory, string[] contentTargetFolders, out string[] targetPaths)
         {
-            targetPaths = new string[] { PackagingConstants.Folders.Content + Path.DirectorySeparatorChar, PackagingConstants.Folders.ContentFiles + Path.DirectorySeparatorChar };
+            targetPaths = contentTargetFolders
+                .Where(f => !f.EndsWith(Path.DirectorySeparatorChar.ToString()))
+                .Select(f => string.Concat(f, Path.DirectorySeparatorChar))
+                .ToArray();
+
+            targetPaths = targetPaths
+                .Concat(contentTargetFolders
+                .Where(f => f.EndsWith(Path.DirectorySeparatorChar.ToString())))
+                .ToArray();
+
             // if user specified a PackagePath, then use that. Look for any ** which are indicated by the RecrusiveDir metadata in msbuild.
             if (packageFile.Properties.Contains("PackagePath"))
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -12,6 +12,7 @@ namespace NuGet.Build.Tasks.Pack
         public IMSBuildItem[] AssemblyReferences { get; set; }
         public string[] Authors { get; set; }
         public string BuildOutputFolder { get; set; }
+        public string[] ContentTargetFolders { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string Copyright { get; set; }
         public string Description { get; set; }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -165,6 +165,61 @@ namespace NuGet.Build.Tasks.Pack.Test
             }
         }
 
+        [Fact]
+        public void PackTaskLogic_SupportsContentTargetFolders()
+        {
+            // Arrange
+            using (var testDir = TestDirectory.Create())
+            {
+                var tc = new TestContext(testDir);
+                var msbuildItem =  tc.AddContentToProject("", "abc.txt", "hello world");
+                tc.Request.ContentTargetFolders = new string[] {"folderA", "folderB"};
+                tc.Request.PackageFiles = new MSBuildItem[] { msbuildItem };
+                // Act
+                tc.BuildPackage();
+
+                // Assert
+                Assert.True(File.Exists(tc.NuspecPath), "The intermediate .nuspec file is not in the expected place.");
+                Assert.True(File.Exists(tc.NupkgPath), "The output .nupkg file is not in the expected place.");
+                using (var nupkgReader = new PackageArchiveReader(tc.NupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    // Validate the .nuspec.
+                    Assert.Equal(tc.Request.PackageId, nuspecReader.GetId());
+                    Assert.Equal(tc.Request.PackageVersion, nuspecReader.GetVersion().ToFullString());
+                    Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetAuthors());
+                    Assert.Equal(string.Join(",", tc.Request.Authors), nuspecReader.GetOwners());
+                    Assert.Equal(tc.Request.Description, nuspecReader.GetDescription());
+                    Assert.False(nuspecReader.GetRequireLicenseAcceptance());
+
+                    var dependencyGroups = nuspecReader.GetDependencyGroups().ToList();
+                    Assert.Equal(1, dependencyGroups.Count);
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, dependencyGroups[0].TargetFramework);
+                    var packages = dependencyGroups[0].Packages.ToList();
+                    Assert.Equal(1, packages.Count);
+                    Assert.Equal("Newtonsoft.Json", packages[0].Id);
+                    Assert.Equal(new VersionRange(new NuGetVersion("8.0.1")), packages[0].VersionRange);
+                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Empty(packages[0].Include);
+
+                    // Validate the assets.
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(1, libItems.Count);
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, libItems[0].TargetFramework);
+                    Assert.Equal(new[] { "lib/net45/a.dll" }, libItems[0].Items);
+                    
+                    // Validate the content items
+                    foreach (var contentTargetFolder in tc.Request.ContentTargetFolders)
+                    {
+                        var contentItems = nupkgReader.GetFiles(contentTargetFolder).ToList();
+                        Assert.Equal(1, contentItems.Count);
+                        Assert.Equal(new[] { contentTargetFolder + "/abc.txt" }, contentItems);
+                    }
+                }
+            }
+        }
+
         [Theory]
         [InlineData(null,              null,     null,            true,  "",                                            "Analyzers,Build")]
         [InlineData(null,              "Native", null,            true,  "",                                            "Analyzers,Build,Native")]
@@ -297,6 +352,32 @@ namespace NuGet.Build.Tasks.Pack.Test
                         TestDir,
                         $"{Request.PackageId}.{Request.PackageVersion}.nupkg");
                 }
+            }
+
+            internal MSBuildItem AddContentToProject(string relativePathToDirectory, string fileName, string content)
+            {
+                var fullpath = Path.Combine(TestDir, Path.Combine(relativePathToDirectory, fileName));
+                var pathToDirectory = Path.Combine(TestDir, relativePathToDirectory);
+                if (!Directory.Exists(pathToDirectory))
+                {
+                    Directory.CreateDirectory(pathToDirectory);
+                }
+
+                if (!File.Exists(fullpath))
+                {
+                    // Create a file to write to.
+                    using (StreamWriter sw = File.CreateText(fullpath))
+                    {
+                        sw.WriteLine(content);
+                    }
+                }
+
+                return new MSBuildItem("NuGet.Versioning", new Dictionary<string, string>
+                {
+                    {"Identity", Path.Combine(relativePathToDirectory, fileName)},
+                    {"FullPath", fullpath}
+                });
+
             }
 
             public void BuildPackage()

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -279,6 +279,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 AssemblyReferences = new ITaskItem[0],
                 Authors = new string[0],
                 BuildOutputFolder = "BuildOutputFolder",
+                ContentTargetFolders = new string[] { "ContentTargetFolders" } ,
                 ContinuePackingAfterGeneratingNuspec = true,
                 Copyright = "Copyright",
                 Description = "Description",


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/3718

Updated spec for ContentTargetFolders property :https://github.com/NuGet/Home/wiki/Adding-nuget-pack-as-a-msbuild-target#including-content-in-package

" If you want to copy all your content only to a specific root folder(s) (instead of content and contentFiles both), you can use the msbuild property ContentTargetFolders , which defaults to "content;contentFiles", but can be set to any other folder names. "

@emgarten @joelverhagen @rrelyea @alpaix 