### PR TITLE
add basic support for contentFiles in pack

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -263,9 +263,48 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
     <!-- Include PackageFiles and Content of the project being packed -->
     <ItemGroup>
-      <_PackageFiles Include="@(Content)" Condition=" %(Content.Pack) != 'false' " />
-      <_PackageFiles Include="@(Compile)" Condition=" %(Compile.Pack) == 'true' " />
-      <_PackageFiles Include="@(None)" Condition=" %(None.Pack) == 'true' " />
+      <_PackageFiles Include="@(Content)" Condition=" %(Content.Pack) != 'false' ">
+        <BuildAction>Content</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(Compile)" Condition=" %(Compile.Pack) == 'true' ">
+        <BuildAction>Compile</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(None)" Condition=" %(None.Pack) == 'true' ">
+        <BuildAction>None</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(EmbeddedResource)" Condition=" %(EmbeddedResource.Pack) == 'true' ">
+        <BuildAction>EmbeddedResource</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(ApplicationDefinition)" Condition=" %(ApplicationDefinition.Pack) == 'true' ">
+        <BuildAction>ApplicationDefinition</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(Page)" Condition=" %(Page.Pack) == 'true' ">
+        <BuildAction>Page</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(Resource)" Condition=" %(Resource.Pack) == 'true' ">
+        <BuildAction>Resource</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(SplashScreen)" Condition=" %(SplashScreen.Pack) == 'true' ">
+        <BuildAction>SplashScreen</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(DesignData)" Condition=" %(DesignData.Pack) == 'true' ">
+        <BuildAction>DesignData</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(DesignDataWithDesignTimeCreatableTypes)" Condition=" %(DesignDataWithDesignTimeCreatableTypes.Pack) == 'true' ">
+        <BuildAction>DesignDataWithDesignTimeCreatableTypes</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(CodeAnalysisDictionary)" Condition=" %(CodeAnalysisDictionary.Pack) == 'true' ">
+        <BuildAction>CodeAnalysisDictionary</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(AndroidAsset)" Condition=" %(AndroidAsset.Pack) == 'true' ">
+        <BuildAction>AndroidAsset</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(AndroidResource)" Condition=" %(AndroidResource.Pack) == 'true' ">
+        <BuildAction>AndroidResource</BuildAction>
+      </_PackageFiles>
+      <_PackageFiles Include="@(BundleResource)" Condition=" %(BundleResource.Pack) == 'true' ">
+        <BuildAction>BundleResource</BuildAction>
+      </_PackageFiles>
     </ItemGroup>
   </Target>
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -7,16 +7,19 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using NuGet.Commands;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
 using NuGet.Versioning;
 
 namespace NuGet.Build.Tasks.Pack
 {
     public class PackTaskLogic : IPackTaskLogic
     {
+        private const string IdentityProperty = "Identity";
         public PackArgs GetPackArgs(IPackTaskRequest<IMSBuildItem> request)
         {
             var packArgs = new PackArgs
@@ -64,7 +67,7 @@ namespace NuGet.Build.Tasks.Pack
 
             PackCommandRunner.SetupCurrentDirectory(packArgs);
 
-            var contentFiles = ProcessContentToIncludeInPackage(request, packArgs.CurrentDirectory);
+            var contentFiles = ProcessContentToIncludeInPackage(request, packArgs);
             packArgs.PackTargetArgs.ContentFiles = contentFiles;
 
             return packArgs;
@@ -247,36 +250,35 @@ namespace NuGet.Build.Tasks.Pack
             }
         }
 
-        private Dictionary<string, HashSet<string>> ProcessContentToIncludeInPackage(
+        private Dictionary<string, HashSet<ContentMetadata>> ProcessContentToIncludeInPackage(
             IPackTaskRequest<IMSBuildItem> request,
-            string currentProjectDirectory)
+            PackArgs packArgs)
         {
             // This maps from source path on disk to target path inside the nupkg.
-            var fileModel = new Dictionary<string, HashSet<string>>();
+            var fileModel = new Dictionary<string, HashSet<ContentMetadata>>();
             if (request.PackageFiles != null)
             {
                 var excludeFiles = CalculateFilesToExcludeInPack(request);
                 foreach (var packageFile in request.PackageFiles)
                 {
-                    string[] targetPaths;
                     var sourcePath = GetSourcePath(packageFile);
                     if (excludeFiles.Contains(sourcePath))
                     {
                         continue;
                     }
 
-                    GetTargetPath(packageFile, sourcePath, currentProjectDirectory, request.ContentTargetFolders, out targetPaths);
+                    var totalContentMetadata = GetContentMetadata(packageFile, sourcePath, packArgs, request.ContentTargetFolders);
 
                     if (fileModel.ContainsKey(sourcePath))
                     {
-                        var setOfTargetPaths = fileModel[sourcePath];
-                        setOfTargetPaths.AddRange(targetPaths);
+                        var existingContentMetadata = fileModel[sourcePath];
+                        existingContentMetadata.AddRange(totalContentMetadata);
                     }
                     else
                     {
-                        var setOfTargetPaths = new HashSet<string>();
-                        setOfTargetPaths.AddRange(targetPaths);
-                        fileModel.Add(sourcePath, setOfTargetPaths);
+                        var existingContentMetadata = new HashSet<ContentMetadata>();
+                        existingContentMetadata.AddRange(totalContentMetadata);
+                        fileModel.Add(sourcePath, existingContentMetadata);
                     }
                 }
             }
@@ -286,17 +288,17 @@ namespace NuGet.Build.Tasks.Pack
 
         // The targetpaths returned from this function contain the directory in the nuget package where the file would go to. The filename is added later on to the target path.
         // whether or not the filename is added later on is dependent upon the fact that does the targetpath resolved here ends with a directory separator char or not.
-        private void GetTargetPath(IMSBuildItem packageFile, string sourcePath, string currentProjectDirectory, string[] contentTargetFolders, out string[] targetPaths)
+        private IEnumerable<ContentMetadata> GetContentMetadata(IMSBuildItem packageFile, string sourcePath,
+            PackArgs packArgs, string[] contentTargetFolders)
         {
-            targetPaths = contentTargetFolders
+            var targetPaths = contentTargetFolders
                 .Where(f => !f.EndsWith(Path.DirectorySeparatorChar.ToString()))
                 .Select(f => string.Concat(f, Path.DirectorySeparatorChar))
-                .ToArray();
-
-            targetPaths = targetPaths
-                .Concat(contentTargetFolders
-                .Where(f => f.EndsWith(Path.DirectorySeparatorChar.ToString())))
-                .ToArray();
+                .ToList();
+            
+            targetPaths.AddRange(
+                contentTargetFolders
+                .Where(f => f.EndsWith(Path.DirectorySeparatorChar.ToString())));
 
             // if user specified a PackagePath, then use that. Look for any ** which are indicated by the RecrusiveDir metadata in msbuild.
             if (packageFile.Properties.Contains("PackagePath"))
@@ -306,53 +308,70 @@ namespace NuGet.Build.Tasks.Pack
 
                 var packagePathString = packageFile.GetProperty("PackagePath");
                 targetPaths = packagePathString == null
-                    ? new string[] { String.Empty }
-                    : packagePathString 
-                    .Split(';')
-                    .Select(p => p.Trim())
+                    ? new string[] { String.Empty }.ToList()
+                    : StringUtility.Split(packagePathString)
                     .Distinct()
-                    .Where(t => t.Length != 0)
-                    .ToArray();
+                    .ToList();
 
                 var recursiveDir = packageFile.GetProperty("RecursiveDir");
                 if (!string.IsNullOrEmpty(recursiveDir))
                 {
-                    var newTargetPaths = new string[targetPaths.Length];
-                    var i = 0;
+                    var newTargetPaths = new List<string>();
                     foreach (var targetPath in targetPaths)
                     {
                         if (targetPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
                         {
-                            newTargetPaths[i] = Path.Combine(targetPath, recursiveDir);
+                            newTargetPaths.Add(Path.Combine(targetPath, recursiveDir));
                         }
                         else
                         {
-                            newTargetPaths[i] = targetPath;
+                            newTargetPaths.Add(targetPath);
                         }
+                    }
+                    targetPaths = newTargetPaths;
+                }
 
-                        i++;
+                // this else if condition means the file is within the project directory and the target path should preserve this relative directory structure.
+                else if (sourcePath.StartsWith(packArgs.CurrentDirectory, StringComparison.CurrentCultureIgnoreCase) &&
+                         !Path.GetFileName(sourcePath)
+                             .Equals(packageFile.GetProperty(IdentityProperty), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    var newTargetPaths = new List<string>();
+                    var identity = packageFile.GetProperty(IdentityProperty);
+                    if (identity.EndsWith(Path.GetFileName(sourcePath), StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        identity = Path.GetDirectoryName(identity);
+                    }
+                    foreach (var targetPath in targetPaths)
+                    {
+                        newTargetPaths.Add(Path.Combine(targetPath, identity) + Path.DirectorySeparatorChar);
                     }
                     targetPaths = newTargetPaths;
                 }
             }
-            // this else if condition means the file is within the project directory and the target path should preserve this relative directory structure.
-            else if (sourcePath.StartsWith(currentProjectDirectory, StringComparison.CurrentCultureIgnoreCase) &&
-                !Path.GetFileName(sourcePath).Equals(packageFile.GetProperty("Identity"), StringComparison.CurrentCultureIgnoreCase))
+
+            var buildAction = BuildAction.Parse(packageFile.GetProperty("BuildAction"));
+
+            // TODO: Do the work to get the right language of the project, tracked via https://github.com/NuGet/Home/issues/4100
+            var language = buildAction.Equals(BuildAction.Compile) ? "cs" : "any";
+
+            var setOfTargetPaths = new HashSet<string>(targetPaths, StringComparer.Ordinal);
+            if (setOfTargetPaths.Remove("contentFiles" + Path.DirectorySeparatorChar) 
+                || setOfTargetPaths.Remove("contentFiles"))
             {
-                var newTargetPaths = new string[targetPaths.Length];
-                var i = 0;
-                var identity = packageFile.GetProperty("Identity");
-                if (identity.EndsWith(Path.GetFileName(sourcePath), StringComparison.CurrentCultureIgnoreCase))
+                foreach (var framework in packArgs.PackTargetArgs.TargetFrameworks)
                 {
-                    identity = Path.GetDirectoryName(identity);
+                    setOfTargetPaths.Add(Path.Combine("contentFiles",
+                        Path.Combine(language, framework.GetShortFolderName())) + Path.DirectorySeparatorChar);
                 }
-                foreach (var targetPath in targetPaths)
-                {
-                    newTargetPaths[i] = Path.Combine(targetPath, identity) + Path.DirectorySeparatorChar;
-                    i++;
-                }
-                targetPaths = newTargetPaths;
             }
+
+            return setOfTargetPaths.Select(target => new ContentMetadata()
+            {
+                BuildAction = buildAction.IsKnown ? buildAction.Value : null,
+                Source = sourcePath,
+                Target = target
+            });
         }
 
         private string GetSourcePath(IMSBuildItem packageFile)
@@ -361,7 +380,7 @@ namespace NuGet.Build.Tasks.Pack
             if (packageFile.Properties.Contains("MSBuildSourceProjectFile"))
             {
                 string sourceProjectFile = packageFile.GetProperty("MSBuildSourceProjectFile");
-                string identity = packageFile.GetProperty("Identity");
+                string identity = packageFile.GetProperty(IdentityProperty);
                 sourcePath = Path.Combine(sourceProjectFile.Replace(Path.GetFileName(sourceProjectFile), string.Empty), identity);
             }
             return Path.GetFullPath(sourcePath);

--- a/src/NuGet.Core/NuGet.Commands/ContentMetadata.cs
+++ b/src/NuGet.Core/NuGet.Commands/ContentMetadata.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Commands
+{
+    public struct ContentMetadata
+    {
+        public string Target { get; set; }
+        public string Source { get; set; }
+        public string BuildAction { get; set; }
+        public string CopyToOutput { get; set; }
+        public string Flatten { get; set; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using NuGet.Frameworks;
 
@@ -13,7 +14,7 @@ namespace NuGet.Commands
         public string AssemblyName { get; set; }
         public string NuspecOutputPath { get; set; }
         public IEnumerable<ProjectToProjectReference>  ProjectReferences { get; set; }
-        public Dictionary<string, HashSet<string>> ContentFiles { get; set; }
+        public Dictionary<string, HashSet<ContentMetadata>> ContentFiles { get; set; }
         public ISet<NuGetFramework> TargetFrameworks { get; set; }
         public IDictionary<string, string> SourceFiles { get; set; }
         public bool IncludeBuildOutput { get; set; }


### PR DESCRIPTION
This fixes: https://github.com/NuGet/Home/issues/3895 , https://github.com/NuGet/Home/issues/3894

What this fixes is basically that instead of files going by default to the root of contentFolder, they now go to contentFiles/any/<TFM> instead. This also fixes the issue that these contentFiles were not being added to the nuspec.

There is a tracking bug in SDK because of which we are not able to detect Language of the project (https://github.com/dotnet/sdk/issues/485) for files with BuildAction = Compile.

CC: @emgarten @joelverhagen @jainaashish @nkolev92 @rrelyea @mishra14 @alpaix 