### PR TITLE
Accessing Project reference metadata and expose via Package Spec

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -293,15 +293,18 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            foreach (Reference reference in AsVSProject.References)
+            foreach (Reference6 reference in AsVSProject4.References)
             {
                 if (reference.SourceProject != null)
                 {
-                    // When metadata API is available, each project's metadata can be inserted into this instance
+                    Array metadataElements;
+                    Array metadataValues;
+                    reference.GetMetadata(desiredMetadata, out metadataElements, out metadataValues);
+
                     yield return new LegacyCSProjProjectReference(
-                        uniqueName: reference.SourceProject.FullName, 
-                        metadataElements: null, 
-                        metadataValues: null);
+                        uniqueName: reference.SourceProject.FullName,
+                        metadataElements: metadataElements,
+                        metadataValues: metadataValues);
                 }
             }
         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -89,6 +89,9 @@
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
+    <Reference Include="VSLangProj110, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="VSLangProj2, Version=7.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>


### PR DESCRIPTION
This PR is to access Project reference metadata for PackageRef projects (legacy CSproj) and expose them via Package Spec so that we can use them for restore.

Fixes https://github.com/NuGet/Home/issues/3922

@rrelyea @emgarten @alpaix @rohit21agrawal 