### PR TITLE
Fix the help output for xplat nuget pack command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackCommand.cs
@@ -65,7 +65,7 @@ namespace NuGet.CommandLine.XPlat
 
                 var properties = pack.Option(
                     "-p|--properties <properties>",
-                    Strings.OutputDirectory_Description,
+                    Strings.Properties_Description,
                     CommandOptionType.SingleValue);
 
                 var serviceable = pack.Option(

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -471,7 +471,16 @@ namespace NuGet.CommandLine.XPlat {
                 return ResourceManager.GetString("PackCommand_Description", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///    Looks up a localized string similar to Specifies a semicolon ";" delimited list of properties used when creating a package.
+        /// </summary>
+        public static string Properties_Description {
+            get {
+                return ResourceManager.GetString("Properties_Description", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///    Looks up a localized string similar to Pushes a package to the server and publishes it..
         /// </summary>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -293,6 +293,9 @@
   <data name="OutputNuGetVersion" xml:space="preserve">
     <value>{0} Version: {1}</value>
   </data>
+  <data name="Properties_Description" xml:space="preserve">
+    <value>Specifies a semicolon ";" delimited list of properties used when creating a package.</value>
+  </data>
   <data name="Serviceable_Description" xml:space="preserve">
     <value>Sets the nuspec serviceable element to true.</value>
   </data>


### PR DESCRIPTION
dotnet nuget pack --help displays the incorrect description of the '--properties' flag.