### PR TITLE
Avoid stomping on *DependsOn properties

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -22,7 +22,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
-    <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFiles</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFiles; $(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
     <Description Condition="'$(Description)'==''">Package Description</Description>
     <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
@@ -37,10 +37,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <GenerateNuspecDependsOn>Build;$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NuspecFile)' == ''">
-    <PackDependsOn>GenerateNuspec</PackDependsOn>
+    <PackDependsOn>GenerateNuspec; $(PackDependsOn)</PackDependsOn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NuspecFile)' != ''">
-    <PackDependsOn>PackUsingNuspec</PackDependsOn>
+    <PackDependsOn>PackUsingNuspec; $(PackDependsOn)</PackDependsOn>
   </PropertyGroup>
   <ItemGroup>
     <_TargetFrameworks Condition="'$(TargetFramework)' == ''" Include="$(TargetFrameworks.Split(';'))"/>


### PR DESCRIPTION
Build authoring written by others may add targets to the `$(GenerateNuspecDependsOn)` property. Generally, these properties should always be appended or prepended to, and not overwritten.

I discovered this while validating NuGet/Home#4123