### PR TITLE
Rename OutputType to ProjectStyle

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -532,11 +532,11 @@ namespace NuGet.CommandLine
                 .Select(GetPackagesConfigFile)
                 .Where(path => path != null));
 
-            // NETCore or UAP
             // Filter down to just the requested projects in the file
+            // that support transitive references.
             var v3RestoreProjects = dgFileOutput.Projects
-                .Where(project => (project.RestoreMetadata.OutputType == RestoreOutputType.NETCore
-                    || project.RestoreMetadata.OutputType == RestoreOutputType.UAP)
+                .Where(project => (project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
+                    || project.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
                     && entryPointProjects.Contains(project));
 
             packageRestoreInputs.RestoreV3Context.Inputs.AddRange(v3RestoreProjects

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -209,7 +209,7 @@ namespace NuGet.SolutionRestoreManager
                         Path.Combine(
                             projectDirectory,
                             projectRestoreInfo.BaseIntermediatePath)),
-                    OutputType = RestoreOutputType.NETCore,
+                    ProjectStyle = ProjectStyle.PackageReference,
                     TargetFrameworks = projectRestoreInfo.TargetFrameworks
                         .Cast<IVsTargetFrameworkInfo>()
                         .Select(item => ToProjectRestoreMetadataFrameworkInfo(item, projectDirectory))

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -294,7 +294,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 RuntimeGraph = runtimeGraph,
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
-                    OutputType = RestoreOutputType.NETCore,
+                    ProjectStyle = ProjectStyle.PackageReference,
                     OutputPath = GetBaseIntermediatePath(),
                     ProjectPath = _projectFullPath,
                     ProjectName = _projectName ?? _projectUniqueName,

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -18,7 +18,7 @@ namespace NuGet.Build.Tasks
         {
             // Add everything from projects except for packages.config and unknown project types
             foreach (var project in spec.Projects
-                .Where(project => RestorableTypes.Contains(project.RestoreMetadata.OutputType)))
+                .Where(project => RestorableTypes.Contains(project.RestoreMetadata.ProjectStyle)))
             {
                 spec.AddRestore(project.RestoreMetadata.ProjectUniqueName);
             }
@@ -51,12 +51,12 @@ namespace NuGet.Build.Tasks
             }
         }
 
-        private static HashSet<RestoreOutputType> RestorableTypes = new HashSet<RestoreOutputType>()
+        private static HashSet<ProjectStyle> RestorableTypes = new HashSet<ProjectStyle>()
         {
-            RestoreOutputType.DotnetCliTool,
-            RestoreOutputType.NETCore,
-            RestoreOutputType.Standalone,
-            RestoreOutputType.UAP
+            ProjectStyle.DotnetCliTool,
+            ProjectStyle.PackageReference,
+            ProjectStyle.Standalone,
+            ProjectStyle.ProjectJson
         };
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -74,7 +74,7 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.AddPropertyIfExists(properties, "FallbackFolders", RestoreFallbackFolders);
                 BuildTasksUtility.AddPropertyIfExists(properties, "PackagesPath", RestorePackagesPath);
                 properties.Add("TargetFrameworks", ToolFramework);
-                properties.Add("OutputType", RestoreOutputType.DotnetCliTool.ToString());
+                properties.Add("OutputType", ProjectStyle.DotnetCliTool.ToString());
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -74,7 +74,7 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.AddPropertyIfExists(properties, "FallbackFolders", RestoreFallbackFolders);
                 BuildTasksUtility.AddPropertyIfExists(properties, "PackagesPath", RestorePackagesPath);
                 properties.Add("TargetFrameworks", ToolFramework);
-                properties.Add("OutputType", ProjectStyle.DotnetCliTool.ToString());
+                properties.Add("ProjectStyle", ProjectStyle.DotnetCliTool.ToString());
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -192,13 +192,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreSpecs"
-      DependsOnTargets="_GetProjectRestoreType"
+      DependsOnTargets="_GetRestoreProjectStyle"
       Returns="@(_RestoreGraphEntry)">
     <Message Text="Restore entry point $(MSBuildProjectFullPath)" Importance="low" />
 
     <!-- Mark entry point -->
     <ItemGroup Condition=" '$(RestoreProjects)' == '' OR '$(RestoreProjects)' == 'true' ">
-      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())" Condition=" '$(_ProjectRestoreType)' != 'Unknown' ">
+      <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())" Condition=" '$(RestoreProjectStyle)' != 'Unknown' ">
         <Type>RestoreSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
       </_RestoreGraphEntry>
@@ -240,26 +240,33 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_GetProjectJsonPath"
     Returns="$(_CurrentProjectJsonPath)">
     <!-- Get project.json path -->
-    <GetRestoreProjectJsonPathTask ProjectPath="$(MSBuildProjectFullPath)">
+    <!-- Skip this if the project style is already set. -->
+    <GetRestoreProjectJsonPathTask 
+      ProjectPath="$(MSBuildProjectFullPath)"
+      Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == '' ">
       <Output TaskParameter="ProjectJsonPath" PropertyName="_CurrentProjectJsonPath" />
     </GetRestoreProjectJsonPathTask>
   </Target>
 
   <!--
     ============================================================
-    _GetProjectRestoreType
+    _GetRestoreProjectStyle
     Determine the project restore type.
     ============================================================
   -->
-  <Target Name="_GetProjectRestoreType"
+  <Target Name="_GetRestoreProjectStyle"
     DependsOnTargets="_GetProjectJsonPath"
-    Returns="$(_ProjectRestoreType)">
-    <!-- Check for project.json and NETCore properties -->
+    Returns="$(RestoreProjectStyle)">
+    <!-- This may be overridden by setting RestoreProjectStyle in the project. -->
     <PropertyGroup>
-      <_ProjectRestoreType>Unknown</_ProjectRestoreType>
-      <_ProjectRestoreType Condition=" '$(_CurrentProjectJsonPath)' != '' ">UAP</_ProjectRestoreType>
-      <_ProjectRestoreType Condition=" '$(TargetFrameworks)' != '' ">NETCore</_ProjectRestoreType>
-      <_ProjectRestoreType Condition=" '$(TargetFramework)' != '' AND @(PackageReference) != '' ">NETCore</_ProjectRestoreType>
+      <!-- .NETCore cross platform projects contain the TargetFrameworks property and must be treated as PackageReference. -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(TargetFrameworks)' != '' ">PackageReference</RestoreProjectStyle>
+      <!-- If any PackageReferences exist treat it as PackageReference. This has priority over project.json. -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
+      <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(_CurrentProjectJsonPath)' != '' ">ProjectJson</RestoreProjectStyle>
+      <!-- This project is either a packages.config project or one that does not use NuGet at all. -->
+      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' ">Unknown</RestoreProjectStyle>
     </PropertyGroup>
   </Target>
 
@@ -270,17 +277,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworksOutput"
-    DependsOnTargets="_GetProjectRestoreType"
+    DependsOnTargets="_GetRestoreProjectStyle"
     Returns="@(_RestoreTargetFrameworksOutputFiltered)">
 
     <!-- Loop on target frameworks, if no frameworks exist the targets below will
          run once using an empty framework string -->
-    <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' != '' ">
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' != '' ">
       <_RestoreTargetFrameworksOutput Include="$(TargetFrameworks.Split(';'))" />
     </ItemGroup>
 
     <!-- Use $(TargetFramework) if $(TargetFrameworks) is empty  -->
-    <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' == '' AND '$(TargetFramework)' != '' ">
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' == '' AND '$(TargetFramework)' != '' ">
       <_RestoreTargetFrameworksOutput Include="$(TargetFramework)" />
     </ItemGroup>
 
@@ -300,15 +307,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreProjectSpec"
-    DependsOnTargets="_GetProjectRestoreType;_GetRestoreTargetFrameworksOutput"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworksOutput"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Determine the restore output path -->
-    <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
+    <PropertyGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' ">
       <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(BaseIntermediateOutputPath)</RestoreOutputPath>
     </PropertyGroup>
 
-    <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
+    <ConvertToAbsolutePath Paths="$(RestoreOutputPath)" Condition=" '$(RestoreProjectStyle)' == 'PackageReference' ">
       <Output TaskParameter="AbsolutePaths" PropertyName="RestoreOutputAbsolutePath" />
     </ConvertToAbsolutePath>
 
@@ -322,8 +329,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
     <PropertyGroup>
       <_RestoreProjectName>$(MSBuildProjectName)</_RestoreProjectName>
-      <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(AssemblyName)' != '' ">$(AssemblyName)</_RestoreProjectName>
-      <_RestoreProjectName Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
+      <_RestoreProjectName Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(AssemblyName)' != '' ">$(AssemblyName)</_RestoreProjectName>
+      <_RestoreProjectName Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(PackageId)' != '' ">$(PackageId)</_RestoreProjectName>
     </PropertyGroup>
 
     <!-- 
@@ -332,19 +339,19 @@ Copyright (c) .NET Foundation. All rights reserved.
       Use Version if it exists
       Override with PackageVersion if it exists (same as pack)
     -->
-    <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
+    <PropertyGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' ">
       <_RestoreProjectVersion>1.0.0</_RestoreProjectVersion>
       <_RestoreProjectVersion Condition=" '$(Version)' != '' ">$(Version)</_RestoreProjectVersion>
       <_RestoreProjectVersion Condition=" '$(PackageVersion)' != '' ">$(PackageVersion)</_RestoreProjectVersion>
     </PropertyGroup>
 
     <!-- Determine if this will use cross targeting -->
-    <PropertyGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' AND '$(TargetFrameworks)' != '' ">
+    <PropertyGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' != '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
     </PropertyGroup>
 
     <!-- Write properties for the top level entry point -->
-    <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'NETCore' ">
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>ProjectSpec</Type>
         <Version>$(_RestoreProjectVersion)</Version>
@@ -354,8 +361,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <Sources>$(RestoreSources)</Sources>
         <FallbackFolders>$(RestoreFallbackFolders)</FallbackFolders>
         <PackagesPath>$(RestorePackagesPath)</PackagesPath>
-        <FallbackFolders>$(RestoreFallbackFolders)</FallbackFolders>
-        <OutputType>$(_ProjectRestoreType)</OutputType>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <OutputPath>$(RestoreOutputAbsolutePath)</OutputPath>
         <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
         <RuntimeIdentifiers>$(RuntimeIdentifiers);$(RuntimeIdentifier)</RuntimeIdentifiers>
@@ -366,7 +372,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ItemGroup>
 
     <!-- Use project.json -->
-    <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'UAP' ">
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>ProjectSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
@@ -377,18 +383,18 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackagesPath>$(RestorePackagesPath)</PackagesPath>
         <FallbackFolders>$(RestoreFallbackFolders)</FallbackFolders>
         <ProjectJsonPath>$(_CurrentProjectJsonPath)</ProjectJsonPath>
-        <OutputType>$(_ProjectRestoreType)</OutputType>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
       </_RestoreGraphEntry>
     </ItemGroup>
 
     <!-- Non-NuGet type -->
-    <ItemGroup Condition=" '$(_ProjectRestoreType)' == 'Unknown' ">
+    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'Unknown' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>ProjectSpec</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
-        <OutputType>$(_ProjectRestoreType)</OutputType>
+        <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
         <TargetFrameworks>$(TargetFrameworkMoniker)</TargetFrameworks>
       </_RestoreGraphEntry>
     </ItemGroup>
@@ -401,7 +407,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreDependencies"
-    DependsOnTargets="_GetProjectRestoreType;_GetRestoreTargetFrameworksOutput"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworksOutput"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Get project and package references  -->
@@ -429,7 +435,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetAllRestoreProjectReferences"
-    DependsOnTargets="_GetProjectRestoreType;_GetRestoreTargetFrameworksOutput"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworksOutput"
     Returns="@(RestoreGraphProjectFullPathForOutput)">
 
     <!-- Get complete set of project references  -->
@@ -458,7 +464,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetChildRestoreProjects"
-    DependsOnTargets="_GetProjectRestoreType;_GetAllRestoreProjectReferences"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetAllRestoreProjectReferences"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Recurse into referenced projects -->
@@ -487,7 +493,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="_GenerateRestoreGraphWalk"
       DependsOnTargets="
-      _GetProjectRestoreType;
+      _GetRestoreProjectStyle;
       _GetRestoreTargetFrameworksOutput;
       _GenerateRestoreProjectSpec;
       _GenerateRestoreDependencies;
@@ -504,7 +510,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreGraphWalkPerFramework"
-    DependsOnTargets="_GenerateRestoreProjectReferencePaths;_GetProjectRestoreType"
+    DependsOnTargets="_GenerateRestoreProjectReferencePaths;_GetRestoreProjectStyle"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Write out project references -->
@@ -520,7 +526,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <!-- Write out package references for NETCore -->
     <GetRestorePackageReferencesTask
-      Condition=" '$(_ProjectRestoreType)' == 'NETCore' "
+      Condition=" '$(RestoreProjectStyle)' == 'PackageReference' "
       ProjectUniqueName="$(MSBuildProjectFullPath)"
       PackageReferences="@(PackageReference)"
       TargetFrameworks="$(TargetFramework)">
@@ -531,7 +537,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </GetRestorePackageReferencesTask>
 
     <!-- Write out target framework information -->
-    <ItemGroup Condition="  '$(_ProjectRestoreType)' == 'NETCore' AND '$(PackageTargetFallback)' != '' ">
+    <ItemGroup Condition="  '$(RestoreProjectStyle)' == 'PackageReference' AND '$(PackageTargetFallback)' != '' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>TargetFrameworkInformation</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -41,7 +41,7 @@ namespace NuGet.Commands
 
             var previousLibraries = previousLockFile?.Libraries.ToDictionary(l => Tuple.Create(l.Name, l.Version));
 
-            if (project.RestoreMetadata?.OutputType == RestoreOutputType.NETCore)
+            if (project.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference)
             {
                 AddProjectFileDependenciesForNETCore(project, lockFile, targetGraphs);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -81,7 +81,7 @@ namespace NuGet.Commands
 
                 var request = Create(rootProject, externalClosure, restoreContext, settingsOverride: _providerSettingsOverride);
 
-                if (request.Request.RestoreOutputType == RestoreOutputType.DotnetCliTool)
+                if (request.Request.RestoreOutputType == ProjectStyle.DotnetCliTool)
                 {
                     // Store tool requests to be filtered later
                     toolRequests.Add(request);
@@ -112,17 +112,17 @@ namespace NuGet.Commands
             var projectReferences = rootProject.RestoreMetadata?.TargetFrameworks.SelectMany(e => e.ProjectReferences)
                 ?? new List<ProjectRestoreReference>();
 
-            var type = rootProject.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
+            var type = rootProject.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
             // Leave the spec null for non-nuget projects.
             // In the future additional P2P TFM checking could be handled by
             // creating a spec for non-NuGet projects and including the TFM.
             PackageSpec projectSpec = null;
 
-            if (type == RestoreOutputType.NETCore
-                || type == RestoreOutputType.UAP
-                || type == RestoreOutputType.DotnetCliTool
-                || type == RestoreOutputType.Standalone)
+            if (type == ProjectStyle.PackageReference
+                || type == ProjectStyle.ProjectJson
+                || type == ProjectStyle.DotnetCliTool
+                || type == ProjectStyle.Standalone)
             {
                 projectSpec = rootProject;
             }
@@ -174,7 +174,7 @@ namespace NuGet.Commands
                 restoreContext.Log);
 
             // Set properties from the restore metadata
-            request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.OutputType ?? RestoreOutputType.Unknown;
+            request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
             request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
             var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory
                 ?? DefaultRestoreLegacyPackagesDirectory;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -81,7 +81,7 @@ namespace NuGet.Commands
 
                 var request = Create(rootProject, externalClosure, restoreContext, settingsOverride: _providerSettingsOverride);
 
-                if (request.Request.RestoreOutputType == ProjectStyle.DotnetCliTool)
+                if (request.Request.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {
                     // Store tool requests to be filtered later
                     toolRequests.Add(request);
@@ -174,7 +174,7 @@ namespace NuGet.Commands
                 restoreContext.Log);
 
             // Set properties from the restore metadata
-            request.RestoreOutputType = project.PackageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
+            request.ProjectStyle = project.PackageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
             request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
             var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory
                 ?? DefaultRestoreLegacyPackagesDirectory;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -166,12 +166,12 @@ namespace NuGet.Commands
         {
             request.PackageSaveMode = PackageSaveMode;
 
-            if (request.RestoreOutputType == RestoreOutputType.NETCore
-                || request.RestoreOutputType == RestoreOutputType.Standalone)
+            if (request.RestoreOutputType == ProjectStyle.PackageReference
+                || request.RestoreOutputType == ProjectStyle.Standalone)
             {
                 request.LockFilePath = Path.Combine(request.RestoreOutputPath, LockFileFormat.AssetsFileName);
             }
-            else if (request.RestoreOutputType != RestoreOutputType.DotnetCliTool)
+            else if (request.RestoreOutputType != ProjectStyle.DotnetCliTool)
             {
                 request.LockFilePath = ProjectJsonPathUtilities.GetLockFilePath(request.Project.FilePath);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -166,12 +166,12 @@ namespace NuGet.Commands
         {
             request.PackageSaveMode = PackageSaveMode;
 
-            if (request.RestoreOutputType == ProjectStyle.PackageReference
-                || request.RestoreOutputType == ProjectStyle.Standalone)
+            if (request.ProjectStyle == ProjectStyle.PackageReference
+                || request.ProjectStyle == ProjectStyle.Standalone)
             {
                 request.LockFilePath = Path.Combine(request.RestoreOutputPath, LockFileFormat.AssetsFileName);
             }
-            else if (request.RestoreOutputType != ProjectStyle.DotnetCliTool)
+            else if (request.ProjectStyle != ProjectStyle.DotnetCliTool)
             {
                 request.LockFilePath = ProjectJsonPathUtilities.GetLockFilePath(request.Project.FilePath);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -129,7 +129,7 @@ namespace NuGet.Commands
 
             // Tool restores are unique since the output path is not known until after restore
             if (_request.LockFilePath == null
-                && _request.RestoreOutputType == ProjectStyle.DotnetCliTool)
+                && _request.ProjectStyle == ProjectStyle.DotnetCliTool)
             {
                 _request.LockFilePath = projectLockFilePath;
             }
@@ -145,7 +145,7 @@ namespace NuGet.Commands
                 lockFile,
                 _request.ExistingLockFile,
                 projectLockFilePath,
-                _request.RestoreOutputType,
+                _request.ProjectStyle,
                 restoreTime.Elapsed);
         }
 
@@ -155,12 +155,12 @@ namespace NuGet.Commands
 
             if (string.IsNullOrEmpty(projectLockFilePath))
             {
-                if (_request.RestoreOutputType == ProjectStyle.PackageReference
-                    || _request.RestoreOutputType == ProjectStyle.Standalone)
+                if (_request.ProjectStyle == ProjectStyle.PackageReference
+                    || _request.ProjectStyle == ProjectStyle.Standalone)
                 {
                     projectLockFilePath = Path.Combine(_request.RestoreOutputPath, LockFileFormat.AssetsFileName);
                 }
-                else if (_request.RestoreOutputType == ProjectStyle.DotnetCliTool)
+                else if (_request.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {
                     var toolName = ToolRestoreUtility.GetToolIdOrNullFromSpec(_request.Project);
                     var lockFileLibrary = ToolRestoreUtility.GetToolTargetLibrary(lockFile, toolName);
@@ -360,7 +360,7 @@ namespace NuGet.Commands
             var updatedExternalProjects = GetProjectReferences(context);
 
             // Determine if the targets and props files should be written out.
-            context.IsMsBuildBased = _request.RestoreOutputType != ProjectStyle.DotnetCliTool;
+            context.IsMsBuildBased = _request.ProjectStyle != ProjectStyle.DotnetCliTool;
 
             // Load repositories
             // the external project provider is specific to the current restore project

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -129,7 +129,7 @@ namespace NuGet.Commands
 
             // Tool restores are unique since the output path is not known until after restore
             if (_request.LockFilePath == null
-                && _request.RestoreOutputType == RestoreOutputType.DotnetCliTool)
+                && _request.RestoreOutputType == ProjectStyle.DotnetCliTool)
             {
                 _request.LockFilePath = projectLockFilePath;
             }
@@ -155,12 +155,12 @@ namespace NuGet.Commands
 
             if (string.IsNullOrEmpty(projectLockFilePath))
             {
-                if (_request.RestoreOutputType == RestoreOutputType.NETCore
-                    || _request.RestoreOutputType == RestoreOutputType.Standalone)
+                if (_request.RestoreOutputType == ProjectStyle.PackageReference
+                    || _request.RestoreOutputType == ProjectStyle.Standalone)
                 {
                     projectLockFilePath = Path.Combine(_request.RestoreOutputPath, LockFileFormat.AssetsFileName);
                 }
-                else if (_request.RestoreOutputType == RestoreOutputType.DotnetCliTool)
+                else if (_request.RestoreOutputType == ProjectStyle.DotnetCliTool)
                 {
                     var toolName = ToolRestoreUtility.GetToolIdOrNullFromSpec(_request.Project);
                     var lockFileLibrary = ToolRestoreUtility.GetToolTargetLibrary(lockFile, toolName);
@@ -360,7 +360,7 @@ namespace NuGet.Commands
             var updatedExternalProjects = GetProjectReferences(context);
 
             // Determine if the targets and props files should be written out.
-            context.IsMsBuildBased = _request.RestoreOutputType != RestoreOutputType.DotnetCliTool;
+            context.IsMsBuildBased = _request.RestoreOutputType != ProjectStyle.DotnetCliTool;
 
             // Load repositories
             // the external project provider is specific to the current restore project

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -148,7 +148,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Defines the paths and behavior for outputs
         /// </summary>
-        public RestoreOutputType RestoreOutputType { get; set; } = RestoreOutputType.Unknown;
+        public ProjectStyle RestoreOutputType { get; set; } = ProjectStyle.Unknown;
 
         /// <summary>
         /// Restore output path

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -148,7 +148,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Defines the paths and behavior for outputs
         /// </summary>
-        public ProjectStyle RestoreOutputType { get; set; } = ProjectStyle.Unknown;
+        public ProjectStyle ProjectStyle { get; set; } = ProjectStyle.Unknown;
 
         /// <summary>
         /// Restore output path

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -37,7 +37,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Restore type.
         /// </summary>
-        public ProjectStyle OutputType { get; }
+        public ProjectStyle ProjectStyle { get; }
 
         /// <summary>
         /// Gets the lock file that was generated during the restore or, in the case of a locked lock file,
@@ -63,7 +63,7 @@ namespace NuGet.Commands
             LockFile lockFile,
             LockFile previousLockFile,
             string lockFilePath,
-            ProjectStyle outputType,
+            ProjectStyle projectStyle,
             TimeSpan elapsedTime)
         {
             Success = success;
@@ -73,7 +73,7 @@ namespace NuGet.Commands
             LockFile = lockFile;
             LockFilePath = lockFilePath;
             PreviousLockFile = previousLockFile;
-            OutputType = outputType;
+            ProjectStyle = projectStyle;
             ElapsedTime = elapsedTime;
         }
 
@@ -124,7 +124,7 @@ namespace NuGet.Commands
             // Write the lock file
             var lockFileFormat = new LockFileFormat();
 
-            var isTool = OutputType == ProjectStyle.DotnetCliTool;
+            var isTool = ProjectStyle == ProjectStyle.DotnetCliTool;
 
             // Commit the assets file to disk.
             await CommitAsync(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -37,7 +37,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Restore type.
         /// </summary>
-        public RestoreOutputType OutputType { get; }
+        public ProjectStyle OutputType { get; }
 
         /// <summary>
         /// Gets the lock file that was generated during the restore or, in the case of a locked lock file,
@@ -63,7 +63,7 @@ namespace NuGet.Commands
             LockFile lockFile,
             LockFile previousLockFile,
             string lockFilePath,
-            RestoreOutputType outputType,
+            ProjectStyle outputType,
             TimeSpan elapsedTime)
         {
             Success = success;
@@ -124,7 +124,7 @@ namespace NuGet.Commands
             // Write the lock file
             var lockFileFormat = new LockFileFormat();
 
-            var isTool = OutputType == RestoreOutputType.DotnetCliTool;
+            var isTool = OutputType == ProjectStyle.DotnetCliTool;
 
             // Commit the assets file to disk.
             await CommitAsync(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -158,7 +158,7 @@ namespace NuGet.Commands
                             GenerateProperty("RestoreTool", "NuGet"),
                             GenerateProperty("NuGetPackageRoot", ReplacePathsWithMacros(repositoryRoot)),
                             GenerateProperty("NuGetPackageFolders", string.Join(";", packageFolders)),
-                            GetProperty("NuGetProjectStyle", projectStyle.ToString()),
+                            GenerateProperty("NuGetProjectStyle", projectStyle.ToString()),
                             GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())));
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -72,7 +72,7 @@ namespace NuGet.Commands
         public static List<MSBuildOutputFile> GenerateMultiTargetFailureFiles(
             string targetsPath,
             string propsPath,
-            RestoreOutputType restoreType)
+            ProjectStyle restoreType)
         {
             XDocument targetsXML = null;
             XDocument propsXML = null;
@@ -80,7 +80,7 @@ namespace NuGet.Commands
             // Create an error file for MSBuild to stop the build.
             targetsXML = GenerateMultiTargetFrameworkWarning();
 
-            if (restoreType == RestoreOutputType.NETCore)
+            if (restoreType == ProjectStyle.PackageReference)
             {
                 propsXML = GenerateEmptyImportsFile();
             }
@@ -131,7 +131,7 @@ namespace NuGet.Commands
         public static void AddNuGetPropertiesToFirstImport(IEnumerable<MSBuildOutputFile> files,
             IEnumerable<string> packageFolders,
             string repositoryRoot,
-            RestoreOutputType outputType,
+            ProjectStyle outputType,
             bool success)
         {
             // For project.json not all files are written out. Find the first one
@@ -149,15 +149,15 @@ namespace NuGet.Commands
         /// <summary>
         /// Apply standard properties in a property group.
         /// </summary>
-        public static void AddNuGetProperties(XDocument doc, IEnumerable<string> packageFolders, string repositoryRoot, RestoreOutputType outputType, bool success)
+        public static void AddNuGetProperties(XDocument doc, IEnumerable<string> packageFolders, string repositoryRoot, ProjectStyle outputType, bool success)
         {
             var projectStyle = "Unknown";
 
-            if (outputType == RestoreOutputType.NETCore)
+            if (outputType == ProjectStyle.PackageReference)
             {
                 projectStyle = "PackageReference";
             }
-            else if (outputType == RestoreOutputType.UAP)
+            else if (outputType == ProjectStyle.ProjectJson)
             {
                 projectStyle = "ProjectJson";
             }
@@ -254,12 +254,12 @@ namespace NuGet.Commands
         /// <summary>
         /// Returns null if the result should not exist on disk.
         /// </summary>
-        public static XDocument GenerateMSBuildFile(List<MSBuildRestoreItemGroup> groups, RestoreOutputType outputType)
+        public static XDocument GenerateMSBuildFile(List<MSBuildRestoreItemGroup> groups, ProjectStyle outputType)
         {
             XDocument doc = null;
 
             // Always write out netcore props/targets. For project.json only write the file if it has items.
-            if (outputType == RestoreOutputType.NETCore || groups.SelectMany(e => e.Items).Any())
+            if (outputType == ProjectStyle.PackageReference || groups.SelectMany(e => e.Items).Any())
             {
                 doc = GenerateEmptyImportsFile();
 
@@ -375,7 +375,7 @@ namespace NuGet.Commands
             var targetsPath = string.Empty;
             var propsPath = string.Empty;
 
-            if (request.RestoreOutputType == RestoreOutputType.NETCore)
+            if (request.RestoreOutputType == ProjectStyle.PackageReference)
             {
                 // PackageReference style projects
                 var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
@@ -520,7 +520,7 @@ namespace NuGet.Commands
 
                 // ContentFiles are read by the build task, not by NuGet
                 // for UAP with project.json.
-                if (request.RestoreOutputType != RestoreOutputType.UAP)
+                if (request.RestoreOutputType != ProjectStyle.ProjectJson)
                 {
                     // Create a group for every package, with the nearest from each of allLanguages
                     props.AddRange(sortedPackages.Select(pkg =>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -131,7 +131,7 @@ namespace NuGet.Commands
         public static void AddNuGetPropertiesToFirstImport(IEnumerable<MSBuildOutputFile> files,
             IEnumerable<string> packageFolders,
             string repositoryRoot,
-            ProjectStyle outputType,
+            ProjectStyle projectStyle,
             bool success)
         {
             // For project.json not all files are written out. Find the first one
@@ -142,26 +142,15 @@ namespace NuGet.Commands
 
             if (firstImport != null)
             {
-                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, outputType, success);
+                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, success);
             }
         }
 
         /// <summary>
         /// Apply standard properties in a property group.
         /// </summary>
-        public static void AddNuGetProperties(XDocument doc, IEnumerable<string> packageFolders, string repositoryRoot, ProjectStyle outputType, bool success)
+        public static void AddNuGetProperties(XDocument doc, IEnumerable<string> packageFolders, string repositoryRoot, ProjectStyle projectStyle, bool success)
         {
-            var projectStyle = "Unknown";
-
-            if (outputType == ProjectStyle.PackageReference)
-            {
-                projectStyle = "PackageReference";
-            }
-            else if (outputType == ProjectStyle.ProjectJson)
-            {
-                projectStyle = "ProjectJson";
-            }
-
             doc.Root.AddFirst(
                 new XElement(Namespace + "PropertyGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
@@ -169,7 +158,7 @@ namespace NuGet.Commands
                             GenerateProperty("RestoreTool", "NuGet"),
                             GenerateProperty("NuGetPackageRoot", ReplacePathsWithMacros(repositoryRoot)),
                             GenerateProperty("NuGetPackageFolders", string.Join(";", packageFolders)),
-                            GenerateProperty("NuGetProjectStyle", projectStyle),
+                            GetProperty("NuGetProjectStyle", projectStyle.ToString()),
                             GenerateProperty("NuGetToolVersion", MinClientVersionUtility.GetNuGetClientVersion().ToFullString())));
         }
 
@@ -375,7 +364,7 @@ namespace NuGet.Commands
             var targetsPath = string.Empty;
             var propsPath = string.Empty;
 
-            if (request.RestoreOutputType == ProjectStyle.PackageReference)
+            if (request.ProjectStyle == ProjectStyle.PackageReference)
             {
                 // PackageReference style projects
                 var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
@@ -403,7 +392,7 @@ namespace NuGet.Commands
                 return GenerateMultiTargetFailureFiles(
                     targetsPath,
                     propsPath,
-                    request.RestoreOutputType);
+                    request.ProjectStyle);
             }
 
             // Add additional conditionals for multi targeting
@@ -520,7 +509,7 @@ namespace NuGet.Commands
 
                 // ContentFiles are read by the build task, not by NuGet
                 // for UAP with project.json.
-                if (request.RestoreOutputType != ProjectStyle.ProjectJson)
+                if (request.ProjectStyle != ProjectStyle.ProjectJson)
                 {
                     // Create a group for every package, with the nearest from each of allLanguages
                     props.AddRange(sortedPackages.Select(pkg =>
@@ -544,8 +533,8 @@ namespace NuGet.Commands
             }
 
             // Create XML, these may be null if the file should be deleted/not written out.
-            var propsXML = GenerateMSBuildFile(props, request.RestoreOutputType);
-            var targetsXML = GenerateMSBuildFile(targets, request.RestoreOutputType);
+            var propsXML = GenerateMSBuildFile(props, request.ProjectStyle);
+            var targetsXML = GenerateMSBuildFile(targets, request.ProjectStyle);
 
             // Return all files to write out or delete.
             var files = new List<MSBuildOutputFile>
@@ -556,7 +545,7 @@ namespace NuGet.Commands
 
             var packageFolders = repositories.Select(e => e.RepositoryRoot);
 
-            AddNuGetPropertiesToFirstImport(files, packageFolders, repositoryRoot, request.RestoreOutputType, restoreSuccess);
+            AddNuGetPropertiesToFirstImport(files, packageFolders, repositoryRoot, request.ProjectStyle, restoreSuccess);
 
             return files;
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -64,10 +64,10 @@ namespace NuGet.Commands
             // Add projects
             foreach (var spec in itemsById.Values.Select(GetPackageSpec))
             {
-                if (spec.RestoreMetadata.OutputType == RestoreOutputType.NETCore
-                    || spec.RestoreMetadata.OutputType == RestoreOutputType.UAP
-                    || spec.RestoreMetadata.OutputType == RestoreOutputType.DotnetCliTool
-                    || spec.RestoreMetadata.OutputType == RestoreOutputType.Standalone)
+                if (spec.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
+                    || spec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson
+                    || spec.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool
+                    || spec.RestoreMetadata.ProjectStyle == ProjectStyle.Standalone)
                 {
                     validForRestore.Add(spec.RestoreMetadata.ProjectUniqueName);
                 }
@@ -125,7 +125,7 @@ namespace NuGet.Commands
             if (specItem != null)
             {
                 var typeString = specItem.GetProperty("OutputType");
-                var restoreType = RestoreOutputType.Unknown;
+                var restoreType = ProjectStyle.Unknown;
 
                 if (!string.IsNullOrEmpty(typeString))
                 {
@@ -133,7 +133,7 @@ namespace NuGet.Commands
                 }
 
                 // Get base spec
-                if (restoreType == RestoreOutputType.UAP)
+                if (restoreType == ProjectStyle.ProjectJson)
                 {
                     result = GetUAPSpec(specItem);
                 }
@@ -144,7 +144,7 @@ namespace NuGet.Commands
                 }
 
                 // Applies to all types
-                result.RestoreMetadata.OutputType = restoreType;
+                result.RestoreMetadata.ProjectStyle = restoreType;
                 result.RestoreMetadata.ProjectPath = specItem.GetProperty("ProjectPath");
                 result.RestoreMetadata.ProjectUniqueName = specItem.GetProperty("ProjectUniqueName");
 
@@ -159,9 +159,9 @@ namespace NuGet.Commands
                 AddProjectReferences(result, items);
 
                 // Read package references for netcore, tools, and standalone
-                if (restoreType == RestoreOutputType.NETCore
-                    || restoreType == RestoreOutputType.Standalone
-                    || restoreType == RestoreOutputType.DotnetCliTool)
+                if (restoreType == ProjectStyle.PackageReference
+                    || restoreType == ProjectStyle.Standalone
+                    || restoreType == ProjectStyle.DotnetCliTool)
                 {
                     AddFrameworkAssemblies(result, items);
                     AddPackageReferences(result, items);
@@ -186,8 +186,8 @@ namespace NuGet.Commands
                     }
                 }
 
-                if (restoreType == RestoreOutputType.NETCore
-                    || restoreType == RestoreOutputType.Standalone)
+                if (restoreType == ProjectStyle.PackageReference
+                    || restoreType == ProjectStyle.Standalone)
                 {
                     // Set project version
                     result.Version = GetVersion(specItem);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -124,7 +124,7 @@ namespace NuGet.Commands
 
             if (specItem != null)
             {
-                var typeString = specItem.GetProperty("OutputType");
+                var typeString = specItem.GetProperty("ProjectStyle");
                 var restoreType = ProjectStyle.Unknown;
 
                 if (!string.IsNullOrEmpty(typeString))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -81,16 +81,16 @@ namespace NuGet.Commands
                 throw RestoreSpecException.Create(message, files);
             }
 
-            var outputType = spec.RestoreMetadata?.OutputType;
+            var outputType = spec.RestoreMetadata?.ProjectStyle;
 
             // Verify required fields for all specs
             ValidateProjectMetadata(spec, files);
 
-            if (outputType == RestoreOutputType.Standalone)
+            if (outputType == ProjectStyle.Standalone)
             {
                 ValidateStandaloneSpec(spec, files);
             }
-            else if (outputType == RestoreOutputType.DotnetCliTool)
+            else if (outputType == ProjectStyle.DotnetCliTool)
             {
                 // Verify tool properties
                 ValidateToolSpec(spec, files);
@@ -106,11 +106,11 @@ namespace NuGet.Commands
                 // Verify based on the type.
                 switch (outputType)
                 {
-                    case RestoreOutputType.NETCore:
+                    case ProjectStyle.PackageReference:
                         ValidateProjectSpecNetCore(spec, files);
                         break;
 
-                    case RestoreOutputType.UAP:
+                    case ProjectStyle.ProjectJson:
                         ValidateProjectSpecUAP(spec, files);
                         break;
 
@@ -166,7 +166,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.PropertyNotAllowedForProjectType,
                     nameof(spec.RestoreMetadata.ProjectJsonPath),
-                    RestoreOutputType.NETCore.ToString());
+                    ProjectStyle.PackageReference.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -178,7 +178,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.MissingRequiredPropertyForProjectType,
                     nameof(spec.RestoreMetadata.OutputPath),
-                    RestoreOutputType.NETCore.ToString());
+                    ProjectStyle.PackageReference.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -190,7 +190,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.MissingRequiredPropertyForProjectType,
                     nameof(spec.RestoreMetadata.OriginalTargetFrameworks),
-                    RestoreOutputType.NETCore.ToString());
+                    ProjectStyle.PackageReference.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -215,7 +215,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.MissingRequiredPropertyForProjectType,
                     nameof(spec.RestoreMetadata.ProjectJsonPath),
-                    RestoreOutputType.UAP.ToString());
+                    ProjectStyle.ProjectJson.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -227,7 +227,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.PropertyNotAllowedForProjectType,
                     nameof(spec.RestoreMetadata.OutputPath),
-                    RestoreOutputType.UAP.ToString());
+                    ProjectStyle.ProjectJson.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }
@@ -242,7 +242,7 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.MissingRequiredPropertyForProjectType,
                     nameof(spec.RestoreMetadata.OutputPath),
-                    RestoreOutputType.Standalone.ToString());
+                    ProjectStyle.Standalone.ToString());
 
                 throw RestoreSpecException.Create(message, files);
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -81,16 +81,16 @@ namespace NuGet.Commands
                 throw RestoreSpecException.Create(message, files);
             }
 
-            var outputType = spec.RestoreMetadata?.ProjectStyle;
+            var projectStyle = spec.RestoreMetadata?.ProjectStyle;
 
             // Verify required fields for all specs
             ValidateProjectMetadata(spec, files);
 
-            if (outputType == ProjectStyle.Standalone)
+            if (projectStyle == ProjectStyle.Standalone)
             {
                 ValidateStandaloneSpec(spec, files);
             }
-            else if (outputType == ProjectStyle.DotnetCliTool)
+            else if (projectStyle == ProjectStyle.DotnetCliTool)
             {
                 // Verify tool properties
                 ValidateToolSpec(spec, files);
@@ -104,7 +104,7 @@ namespace NuGet.Commands
                 ValidateProjectMSBuildMetadata(spec, files);
 
                 // Verify based on the type.
-                switch (outputType)
+                switch (projectStyle)
                 {
                     case ProjectStyle.PackageReference:
                         ValidateProjectSpecNetCore(spec, files);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -40,7 +40,7 @@ namespace NuGet.Commands
                 },
                 RestoreMetadata = new ProjectRestoreMetadata()
                 {
-                    OutputType = RestoreOutputType.DotnetCliTool,
+                    ProjectStyle = ProjectStyle.DotnetCliTool,
                     ProjectName = name,
                     ProjectUniqueName = name,
                     ProjectPath = projectFilePath
@@ -60,7 +60,7 @@ namespace NuGet.Commands
 
             foreach (var requestSummary in requestSummaries)
             {
-                if (requestSummary.Request.Project.RestoreMetadata?.OutputType == RestoreOutputType.DotnetCliTool)
+                if (requestSummary.Request.Project.RestoreMetadata?.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {
                     tools.Add(requestSummary);
                 }

--- a/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
@@ -15,6 +15,6 @@ namespace NuGet.LibraryModel
         public static readonly string RuntimeAsset = "NuGet.ProjectModel.RuntimeAsset";
         public static readonly string FrameworkAssemblies = "NuGet.ProjectModel.FrameworkAssemblies";
         public static readonly string ProjectFrameworks = "NuGet.ProjectModel.ProjectFrameworks";
-        public static readonly string ProjectOutputType = "NuGet.ProjectModel.RestoreMetadata.OutputType";
+        public static readonly string ProjectStyle = "NuGet.ProjectModel.RestoreMetadata.ProjectStyle";
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -226,8 +226,8 @@ namespace NuGet.PackageManagement
         {
             // Restore
             var specs = await project.GetPackageSpecsAsync(context);
-            var spec = specs.Single(e => e.RestoreMetadata.OutputType == RestoreOutputType.NETCore
-                || e.RestoreMetadata.OutputType == RestoreOutputType.UAP);
+            var spec = specs.Single(e => e.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
+                || e.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson);
 
             var result = await PreviewRestoreAsync(
                 solutionManager,
@@ -304,8 +304,8 @@ namespace NuGet.PackageManagement
         {
             var specs = await project.GetPackageSpecsAsync(context);
 
-            return specs.Where(e => e.RestoreMetadata.OutputType != RestoreOutputType.Standalone
-                && e.RestoreMetadata.OutputType != RestoreOutputType.DotnetCliTool)
+            return specs.Where(e => e.RestoreMetadata.ProjectStyle != ProjectStyle.Standalone
+                && e.RestoreMetadata.ProjectStyle != ProjectStyle.DotnetCliTool)
                 .FirstOrDefault();
         }
 
@@ -324,10 +324,10 @@ namespace NuGet.PackageManagement
                 {
                     dgSpec.AddProject(packageSpec);
 
-                    if (packageSpec.RestoreMetadata.OutputType == RestoreOutputType.NETCore ||
-                        packageSpec.RestoreMetadata.OutputType == RestoreOutputType.UAP ||
-                        packageSpec.RestoreMetadata.OutputType == RestoreOutputType.DotnetCliTool ||
-                        packageSpec.RestoreMetadata.OutputType == RestoreOutputType.Standalone)
+                    if (packageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference ||
+                        packageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson ||
+                        packageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool ||
+                        packageSpec.RestoreMetadata.ProjectStyle == ProjectStyle.Standalone)
                     {
                         dgSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
                     }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -624,7 +624,7 @@ namespace NuGet.ProjectManagement
                 var metadata = new ProjectRestoreMetadata();
                 packageSpec.RestoreMetadata = metadata;
 
-                metadata.OutputType = RestoreOutputType.Unknown;
+                metadata.ProjectStyle = ProjectStyle.Unknown;
                 metadata.ProjectPath = MSBuildNuGetProjectSystem.ProjectFileFullPath;
                 metadata.ProjectName = MSBuildNuGetProjectSystem.ProjectName;
                 metadata.ProjectUniqueName = MSBuildNuGetProjectSystem.ProjectFileFullPath;

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -198,7 +198,7 @@ namespace NuGet.ProjectManagement.Projects
                 var metadata = new ProjectRestoreMetadata();
                 packageSpec.RestoreMetadata = metadata;
 
-                metadata.OutputType = RestoreOutputType.UAP;
+                metadata.ProjectStyle = ProjectStyle.ProjectJson;
                 metadata.ProjectPath = MSBuildProjectPath;
                 metadata.ProjectJsonPath = packageSpec.FilePath;
                 metadata.ProjectName = packageSpec.Name;

--- a/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/DependencyGraphSpec.cs
@@ -384,7 +384,7 @@ namespace NuGet.ProjectModel
 
             foreach (var project in Projects)
             {
-                if (project.RestoreMetadata.OutputType != RestoreOutputType.DotnetCliTool)
+                if (project.RestoreMetadata.ProjectStyle != ProjectStyle.DotnetCliTool)
                 {
                     // Add all non-tool projects
                     newSpec.AddProject(project);

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -195,13 +195,13 @@ namespace NuGet.ProjectModel
             msbuildMetadata.ProjectUniqueName = rawMSBuildMetadata.GetValue<string>("projectUniqueName");
             msbuildMetadata.OutputPath = rawMSBuildMetadata.GetValue<string>("outputPath");
 
-            var outputTypeString = rawMSBuildMetadata.GetValue<string>("outputType");
+            var projectStyleString = rawMSBuildMetadata.GetValue<string>("projectStyle");
 
-            ProjectStyle outputType;
-            if (!string.IsNullOrEmpty(outputTypeString)
-                && Enum.TryParse<ProjectStyle>(outputTypeString, ignoreCase: true, result: out outputType))
+            ProjectStyle projectStyle;
+            if (!string.IsNullOrEmpty(projectStyleString)
+                && Enum.TryParse<ProjectStyle>(projectStyleString, ignoreCase: true, result: out projectStyle))
             {
-                msbuildMetadata.ProjectStyle = outputType;
+                msbuildMetadata.ProjectStyle = projectStyle;
             }
 
             msbuildMetadata.PackagesPath = rawMSBuildMetadata.GetValue<string>("packagesPath");

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -197,11 +197,11 @@ namespace NuGet.ProjectModel
 
             var outputTypeString = rawMSBuildMetadata.GetValue<string>("outputType");
 
-            RestoreOutputType outputType;
+            ProjectStyle outputType;
             if (!string.IsNullOrEmpty(outputTypeString)
-                && Enum.TryParse<RestoreOutputType>(outputTypeString, ignoreCase: true, result: out outputType))
+                && Enum.TryParse<ProjectStyle>(outputTypeString, ignoreCase: true, result: out outputType))
             {
-                msbuildMetadata.OutputType = outputType;
+                msbuildMetadata.ProjectStyle = outputType;
             }
 
             msbuildMetadata.PackagesPath = rawMSBuildMetadata.GetValue<string>("packagesPath");

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -143,15 +143,15 @@ namespace NuGet.ProjectModel
             {
                 library[KnownLibraryProperties.PackageSpec] = packageSpec;
 
-                var outputType = packageSpec.RestoreMetadata?.ProjectStyle;
+                var projectStyle = packageSpec.RestoreMetadata?.ProjectStyle;
 
-                if (outputType.HasValue)
+                if (projectStyle.HasValue)
                 {
-                    library[KnownLibraryProperties.ProjectOutputType] = outputType.Value.ToString();
+                    library[KnownLibraryProperties.ProjectStyle] = projectStyle.Value.ToString();
                 }
                 else
                 {
-                    library[KnownLibraryProperties.ProjectOutputType] = "unknown";
+                    library[KnownLibraryProperties.ProjectStyle] = ProjectStyle.Unknown.ToString();
                 }
             }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -101,7 +101,7 @@ namespace NuGet.ProjectModel
             var dependencies = new List<LibraryDependency>();
 
             // Read references from external project
-            if (packageSpec?.RestoreMetadata?.OutputType == RestoreOutputType.NETCore)
+            if (packageSpec?.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference)
             {
                 // NETCore
                 dependencies.AddRange(GetDependenciesFromSpecRestoreMetadata(packageSpec, targetFramework));
@@ -143,7 +143,7 @@ namespace NuGet.ProjectModel
             {
                 library[KnownLibraryProperties.PackageSpec] = packageSpec;
 
-                var outputType = packageSpec.RestoreMetadata?.OutputType;
+                var outputType = packageSpec.RestoreMetadata?.ProjectStyle;
 
                 if (outputType.HasValue)
                 {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -120,7 +120,7 @@ namespace NuGet.ProjectModel
 
             if (msbuildMetadata.ProjectStyle != ProjectStyle.Unknown)
             {
-                SetValue(writer, "outputType", msbuildMetadata.ProjectStyle.ToString());
+                SetValue(writer, "projectStyle", msbuildMetadata.ProjectStyle.ToString());
             }
 
             if (msbuildMetadata.CrossTargeting)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -118,9 +118,9 @@ namespace NuGet.ProjectModel
             SetValue(writer, "packagesPath", msbuildMetadata.PackagesPath);
             SetValue(writer, "outputPath", msbuildMetadata.OutputPath);
 
-            if (msbuildMetadata.OutputType != RestoreOutputType.Unknown)
+            if (msbuildMetadata.ProjectStyle != ProjectStyle.Unknown)
             {
-                SetValue(writer, "outputType", msbuildMetadata.OutputType.ToString());
+                SetValue(writer, "outputType", msbuildMetadata.ProjectStyle.ToString());
             }
 
             if (msbuildMetadata.CrossTargeting)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Restore behavior type.
         /// </summary>
-        public RestoreOutputType OutputType { get; set; } = RestoreOutputType.Unknown;
+        public ProjectStyle ProjectStyle { get; set; } = ProjectStyle.Unknown;
 
         /// <summary>
         /// MSBuild project file path.
@@ -82,7 +82,7 @@ namespace NuGet.ProjectModel
         {
             var hashCode = new HashCodeCombiner();
 
-            hashCode.AddObject(OutputType);
+            hashCode.AddObject(ProjectStyle);
             hashCode.AddObject(ProjectPath);
             hashCode.AddObject(ProjectJsonPath);
             hashCode.AddObject(OutputPath);
@@ -116,7 +116,7 @@ namespace NuGet.ProjectModel
                 return true;
             }
 
-            return OutputType == other.OutputType &&
+            return ProjectStyle == other.ProjectStyle &&
                    ProjectPath == other.ProjectPath &&
                    ProjectJsonPath == other.ProjectJsonPath &&
                    OutputPath == other.OutputPath &&

--- a/src/NuGet.Core/NuGet.ProjectModel/RestoreOutputType.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/RestoreOutputType.cs
@@ -1,6 +1,6 @@
 ﻿namespace NuGet.ProjectModel
 {
-    public enum RestoreOutputType : ushort
+    public enum ProjectStyle : ushort
     {
         /// <summary>
         /// Unknown
@@ -10,12 +10,12 @@
         /// <summary>
         /// UAP style, project.lock.json is generated next to project.json
         /// </summary>
-        UAP = 1,
+        ProjectJson = 1,
 
         /// <summary>
         /// MSBuild style, project.assets.json is generated in the RestoreOutputPath folder
         /// </summary>
-        NETCore = 2,
+        PackageReference = 2,
 
         /// <summary>
         /// Tool

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -19,7 +19,7 @@ namespace NuGet.Test.Utility
 {
     public class SimpleTestProjectContext
     {
-        public SimpleTestProjectContext(string projectName, RestoreOutputType type, string solutionRoot)
+        public SimpleTestProjectContext(string projectName, ProjectStyle type, string solutionRoot)
         {
             if (string.IsNullOrWhiteSpace(projectName))
             {
@@ -69,7 +69,7 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// Project type
         /// </summary>
-        public RestoreOutputType Type { get; set; }
+        public ProjectStyle Type { get; set; }
 
         /// <summary>
         /// Tool references
@@ -105,9 +105,9 @@ namespace NuGet.Test.Utility
             {
                 switch (Type)
                 {
-                    case RestoreOutputType.NETCore:
+                    case ProjectStyle.PackageReference:
                         return Path.Combine(OutputPath, "project.assets.json");
-                    case RestoreOutputType.UAP:
+                    case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), "project.lock.json");
                     default:
                         return null;
@@ -121,9 +121,9 @@ namespace NuGet.Test.Utility
             {
                 switch (Type)
                 {
-                    case RestoreOutputType.NETCore:
+                    case ProjectStyle.PackageReference:
                         return Path.Combine(OutputPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.targets");
-                    case RestoreOutputType.UAP:
+                    case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), $"{Path.GetFileNameWithoutExtension(ProjectPath)}.nuget.targets");
                     default:
                         return ProjectPath;
@@ -137,9 +137,9 @@ namespace NuGet.Test.Utility
             {
                 switch (Type)
                 {
-                    case RestoreOutputType.NETCore:
+                    case ProjectStyle.PackageReference:
                         return Path.Combine(OutputPath, $"{Path.GetFileName(ProjectPath)}.nuget.g.props");
-                    case RestoreOutputType.UAP:
+                    case ProjectStyle.ProjectJson:
                         return Path.Combine(Path.GetDirectoryName(ProjectPath), $"{Path.GetFileNameWithoutExtension(ProjectPath)}.nuget.props");
                     default:
                         return ProjectPath;
@@ -231,7 +231,7 @@ namespace NuGet.Test.Utility
             string solutionRoot,
             params NuGetFramework[] frameworks)
         {
-            var context = new SimpleTestProjectContext(projectName, RestoreOutputType.NETCore, solutionRoot);
+            var context = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, solutionRoot);
             context.Frameworks.AddRange(frameworks.Select(e => new SimpleTestProjectFrameworkContext(e)));
             return context;
         }
@@ -241,7 +241,7 @@ namespace NuGet.Test.Utility
             string solutionRoot,
             NuGetFramework framework)
         {
-            var context = new SimpleTestProjectContext(projectName, RestoreOutputType.Unknown, solutionRoot);
+            var context = new SimpleTestProjectContext(projectName, ProjectStyle.Unknown, solutionRoot);
             context.Frameworks.Add(new SimpleTestProjectFrameworkContext(framework));
             return context;
         }
@@ -252,7 +252,7 @@ namespace NuGet.Test.Utility
             NuGetFramework framework,
             JObject projectJson)
         {
-            var context = new SimpleTestProjectContext(projectName, RestoreOutputType.UAP, solutionRoot);
+            var context = new SimpleTestProjectContext(projectName, ProjectStyle.ProjectJson, solutionRoot);
             context.Frameworks.Add(new SimpleTestProjectFrameworkContext(framework));
             context.ProjectJson = projectJson;
             return context;
@@ -272,7 +272,7 @@ namespace NuGet.Test.Utility
 
             AddProperties(xml, Properties);
 
-            if (Type == RestoreOutputType.NETCore)
+            if (Type == ProjectStyle.PackageReference)
             {
                 AddProperties(xml, new Dictionary<string, string>()
                 {

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -17,6 +18,126 @@ namespace NuGet.CommandLine.Test
 {
     public class RestoreNetCoreTest
     {
+        [Fact]
+        public async Task RestoreNetCore_SetProjectStyleWithProperty_PackageReference()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Add a project.json file which will be ignored
+                var projectJson = JObject.Parse(@"{
+                                                    'dependencies': {
+                                                    },
+                                                    'frameworks': {
+                                                        'net45': {
+                                                            'y': '1.0.0'
+                                                    }
+                                                  }
+                                               }");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.Properties.Add("RestoreProjectStyle", "PackageReference");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                File.WriteAllText(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "project.json"), projectJson.ToString());
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var propsXML = XDocument.Load(projectA.PropsOutput);
+                var styleNode = propsXML.Root.Elements().First().Elements(XName.Get("NuGetProjectStyle", "http://schemas.microsoft.com/developer/msbuild/2003")).FirstOrDefault();
+
+                // Assert
+                Assert.Equal(ProjectStyle.PackageReference, dgSpec.Projects.Single().RestoreMetadata.ProjectStyle);
+                Assert.Equal("PackageReference", styleNode.Value);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_SetProjectStyleWithProperty_ProjectJson()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                // Create a .NETCore project, but add a project.json file to it.
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"));
+
+                var projectJson = JObject.Parse(@"{
+                                                    'dependencies': {
+                                                        'x': '1.0.0'
+                                                    },
+                                                    'frameworks': {
+                                                        'net45': { }                                                            
+                                                    }
+                                                  }");
+
+                // Force this project to ProjectJson
+                projectA.Properties.Add("RestoreProjectStyle", "ProjectJson");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                File.WriteAllText(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "project.json"), projectJson.ToString());
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("build/net45/x.targets");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                XDocument projectXML = XDocument.Load(projectA.ProjectPath);
+                projectXML.Root.AddFirst(new XElement(XName.Get("Target", "http://schemas.microsoft.com/developer/msbuild/2003"), new XAttribute(XName.Get("Name"), "_SplitProjectReferencesByFileExistence")));
+                projectXML.Save(projectA.ProjectPath);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                // Assert
+                Assert.Equal(ProjectStyle.ProjectJson, dgSpec.Projects.Single().RestoreMetadata.ProjectStyle);
+                Assert.True(File.Exists(Path.Combine(Path.GetDirectoryName(projectA.ProjectPath), "project.lock.json")));
+            }
+        }
+
         [Fact]
         public void RestoreNetCore_ProjectToProject_Recursive()
         {

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -128,7 +128,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var actualMetadata = actualProjectSpec.RestoreMetadata;
             Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
             Assert.Equal(projectName, actualMetadata.ProjectName);
-            Assert.Equal(RestoreOutputType.NETCore, actualMetadata.OutputType);
+            Assert.Equal(ProjectStyle.PackageReference, actualMetadata.ProjectStyle);
             Assert.Equal(cps.Item2, actualMetadata.OutputPath);
 
             Assert.Single(actualProjectSpec.TargetFrameworks);
@@ -200,7 +200,7 @@ namespace NuGet.SolutionRestoreManager.Test
             var actualMetadata = actualToolSpec.RestoreMetadata;
             Assert.NotNull(actualMetadata);
             Assert.Equal(projectFullPath, actualMetadata.ProjectPath);
-            Assert.Equal(RestoreOutputType.DotnetCliTool, actualMetadata.OutputType);
+            Assert.Equal(ProjectStyle.DotnetCliTool, actualMetadata.ProjectStyle);
             Assert.Null(actualMetadata.OutputPath);
             var toolLibrary = actualToolSpec
                 .TargetFrameworks

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/ProjectJsonTestHelpers.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test.Utility/ProjectJsonTestHelpers.cs
@@ -100,7 +100,7 @@ namespace NuGet.Commands.Test
             updated.RestoreMetadata.CrossTargeting = updated.TargetFrameworks.Count > 0;
             updated.RestoreMetadata.OriginalTargetFrameworks = updated.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName()).ToList();
             updated.RestoreMetadata.OutputPath = projectDir;
-            updated.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            updated.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             updated.RestoreMetadata.ProjectName = spec.Name;
             updated.RestoreMetadata.ProjectUniqueName = spec.Name;
             updated.RestoreMetadata.ProjectPath = projectPath;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -123,7 +123,7 @@ namespace NuGet.Commands.Test
                         xml,
                         new[] { globalPackagesFolder },
                         globalPackagesFolder,
-                        RestoreOutputType.NETCore,
+                        ProjectStyle.PackageReference,
                         success: true);
 
                     // Assert
@@ -261,11 +261,11 @@ namespace NuGet.Commands.Test
                 // Act
                 var targetsXML = BuildAssetsUtils.GenerateMSBuildFile(
                     targetGroups,
-                    RestoreOutputType.NETCore);
+                    ProjectStyle.PackageReference);
 
                 var propsXML = BuildAssetsUtils.GenerateMSBuildFile(
                     propGroups,
-                    RestoreOutputType.NETCore);
+                    ProjectStyle.PackageReference);
 
                 // Assert
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -341,7 +341,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var targetsXML = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.NETCore);
+                    ProjectStyle.PackageReference);
 
                 // Assert
                 var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -372,7 +372,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var xml = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.NETCore);
+                    ProjectStyle.PackageReference);
 
                 // Assert
                 Assert.NotNull(xml);
@@ -392,7 +392,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var xml = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.UAP);
+                    ProjectStyle.ProjectJson);
 
                 // Assert
                 Assert.Null(xml);
@@ -438,7 +438,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var xml = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.NETCore);
+                    ProjectStyle.PackageReference);
 
                 // Assert
                 var targetItemGroups = xml.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -485,7 +485,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var xml = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.UAP);
+                    ProjectStyle.ProjectJson);
 
                 // Assert
                 var targetItemGroups = xml.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
@@ -563,7 +563,7 @@ namespace NuGet.Commands.Test
                 // Act
                 var xml = BuildAssetsUtils.GenerateMSBuildFile(
                     targets,
-                    RestoreOutputType.UAP);
+                    ProjectStyle.ProjectJson);
 
                 // Assert
                 var targetItemGroups = xml.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -240,7 +240,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(project1Path, project1Spec.FilePath);
                 Assert.Equal("a", project1Spec.Name);
                 Assert.Equal("2.0.0-rc.2+a.b.c", project1Spec.Version.ToFullString());
-                Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", project1Spec.RestoreMetadata.ProjectUniqueName);
                 Assert.Equal(project1Path, project1Spec.RestoreMetadata.ProjectPath);
                 Assert.Equal(0, project1Spec.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).Count());
@@ -375,7 +375,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.Equal(project1Path, project1Spec.FilePath);
                 Assert.Equal("a", project1Spec.Name);
-                Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.False(project1Spec.RestoreMetadata.CrossTargeting);
@@ -419,7 +419,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.Equal(project1Path, project1Spec.FilePath);
                 Assert.Equal("a", project1Spec.Name);
-                Assert.Equal(RestoreOutputType.NETCore, project1Spec.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.PackageReference, project1Spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("netstandard1.6", string.Join("|", project1Spec.TargetFrameworks.Select(e => e.FrameworkName.GetShortFolderName())));
                 Assert.Equal("netstandard16", string.Join("|", project1Spec.RestoreMetadata.OriginalTargetFrameworks));
                 Assert.False(project1Spec.RestoreMetadata.LegacyPackagesDirectory);
@@ -1030,7 +1030,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.Equal(projectJsonPath, spec.FilePath);
                 Assert.Equal("a", spec.Name);
-                Assert.Equal(RestoreOutputType.UAP, spec.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.ProjectJson, spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", spec.RestoreMetadata.ProjectUniqueName);
                 Assert.Equal(projectPath, spec.RestoreMetadata.ProjectPath);
                 Assert.Equal(0, spec.RestoreMetadata.TargetFrameworks.SelectMany(e => e.ProjectReferences).Count());
@@ -1111,7 +1111,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.Equal(projectPath, spec.FilePath);
                 Assert.Equal("a", spec.Name);
-                Assert.Equal(RestoreOutputType.Unknown, spec.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.Unknown, spec.RestoreMetadata.ProjectStyle);
                 Assert.Equal("482C20DE-DFF9-4BD0-B90A-BD3201AA351A", spec.RestoreMetadata.ProjectUniqueName);
                 Assert.Equal(projectPath, spec.RestoreMetadata.ProjectPath);
                 Assert.Equal(NuGetFramework.Parse("net462"), spec.TargetFrameworks.Single().FrameworkName);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -38,7 +38,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "ProjectJsonPath", project1JsonPath },
                     { "ProjectName", "a" },
-                    { "OutputType", "uap" },
+                    { "ProjectStyle", "ProjectJson" },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                 });
@@ -86,7 +86,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "DotnetCliTool" },
+                    { "ProjectStyle", "DotnetCliTool" },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                     { "TargetFrameworks", "netcoreapp1.0" },
@@ -132,7 +132,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -218,7 +218,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "Version", "2.0.0-rc.2+a.b.c" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -276,7 +276,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -318,7 +318,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "Version", "notaversionstring" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -356,7 +356,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -400,7 +400,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -444,7 +444,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -515,7 +515,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -571,7 +571,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "  a\n  " },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -647,7 +647,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -691,7 +691,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -738,7 +738,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "a" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath1 },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
@@ -750,7 +750,7 @@ namespace NuGet.Commands.Test
                 {
                     { "Type", "ProjectSpec" },
                     { "ProjectName", "b" },
-                    { "OutputType", "netcore" },
+                    { "ProjectStyle", "PackageReference" },
                     { "OutputPath", outputPath2 },
                     { "ProjectUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project2Path },
@@ -905,7 +905,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "ProjectJsonPath", project1JsonPath },
                     { "ProjectName", "a" },
-                    { "OutputType", "uap" },
+                    { "ProjectStyle", "ProjectJson" },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project1Path },
                 });
@@ -915,7 +915,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "ProjectJsonPath", project2JsonPath },
                     { "ProjectName", "b" },
-                    { "OutputType", "uap" },
+                    { "ProjectStyle", "ProjectJson" },
                     { "ProjectUniqueName", "AA2C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", project2Path },
                 });
@@ -1003,7 +1003,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "ProjectJsonPath", projectJsonPath },
                     { "ProjectName", "a" },
-                    { "OutputType", "uap" },
+                    { "ProjectStyle", "ProjectJson" },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", projectPath },
                 });
@@ -1054,7 +1054,7 @@ namespace NuGet.Commands.Test
                     { "Type", "ProjectSpec" },
                     { "ProjectJsonPath", projectJsonPath },
                     { "ProjectName", "a" },
-                    { "OutputType", "uap" },
+                    { "ProjectStyle", "ProjectJson" },
                     { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
                     { "ProjectPath", projectPath },
                     { "CrossTargeting", "true" },

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
@@ -17,7 +17,7 @@ namespace NuGet.Commands.Test
 
             foreach (var spec in specs)
             {
-                var project = new SimpleTestProjectContext(spec.Name, RestoreOutputType.NETCore, pathContext.SolutionRoot);
+                var project = new SimpleTestProjectContext(spec.Name, ProjectStyle.PackageReference, pathContext.SolutionRoot);
 
                 // Set proj properties
                 spec.FilePath = project.ProjectPath;
@@ -68,7 +68,7 @@ namespace NuGet.Commands.Test
             spec.RestoreMetadata = new ProjectRestoreMetadata();
             spec.RestoreMetadata.ProjectUniqueName = $"{projectName}-UNIQUENAME";
             spec.RestoreMetadata.ProjectName = projectName;
-            spec.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec.RestoreMetadata.OriginalTargetFrameworks.Add(framework);
             spec.Name = projectName;
             spec.RestoreMetadata.TargetFrameworks.Add(new ProjectRestoreMetadataFrameworkInfo(targetFrameworkInfo.FrameworkName));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -400,7 +400,7 @@ namespace NuGet.Commands.Test
 
             foreach (var spec in specs)
             {
-                var project = new SimpleTestProjectContext(spec.Name, RestoreOutputType.NETCore, pathContext.SolutionRoot);
+                var project = new SimpleTestProjectContext(spec.Name, ProjectStyle.PackageReference, pathContext.SolutionRoot);
 
                 // Set proj properties
                 spec.FilePath = project.ProjectPath;
@@ -454,7 +454,7 @@ namespace NuGet.Commands.Test
             spec.RestoreMetadata = new ProjectRestoreMetadata();
             spec.RestoreMetadata.ProjectUniqueName = $"{projectName}-UNIQUENAME";
             spec.RestoreMetadata.ProjectName = projectName;
-            spec.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec.Name = projectName;
 
             foreach (var framework in frameworks)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands.Test
                     previousLockFile: null, // different lock file
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
-                    outputType: ProjectStyle.Unknown,
+                    projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
                 // Act
@@ -62,7 +62,7 @@ namespace NuGet.Commands.Test
                     previousLockFile: new LockFile(), // same lock file
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
-                    outputType: ProjectStyle.Unknown,
+                    projectStyle: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreResultTests.cs
@@ -31,7 +31,7 @@ namespace NuGet.Commands.Test
                     previousLockFile: null, // different lock file
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
-                    outputType: RestoreOutputType.Unknown,
+                    outputType: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
                 // Act
@@ -62,7 +62,7 @@ namespace NuGet.Commands.Test
                     previousLockFile: new LockFile(), // same lock file
                     lockFilePath: path,
                     msbuildFiles: Enumerable.Empty<MSBuildOutputFile>(),
-                    outputType: RestoreOutputType.Unknown,
+                    outputType: ProjectStyle.Unknown,
                     elapsedTime: TimeSpan.MinValue);
 
                 // Act

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -230,7 +230,7 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
                 spec1.RestoreMetadata = new ProjectRestoreMetadata();
                 spec1.RestoreMetadata.OutputPath = Path.Combine(project1.FullName, "obj");
-                spec1.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+                spec1.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
                 spec1.RestoreMetadata.ProjectName = "project1";
                 spec1.RestoreMetadata.ProjectPath = Path.Combine(project1.FullName, "project1.csproj");
                 spec1.RestoreMetadata.ProjectUniqueName = spec1.RestoreMetadata.ProjectPath;
@@ -376,14 +376,14 @@ namespace NuGet.Commands.Test
             spec1.RestoreMetadata = new ProjectRestoreMetadata();
             spec1.RestoreMetadata.ProjectUniqueName = "project1";
             spec1.RestoreMetadata.ProjectName = "project1";
-            spec1.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec1.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec1.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             var spec2 = new PackageSpec(frameworks2);
             spec2.RestoreMetadata = new ProjectRestoreMetadata();
             spec2.RestoreMetadata.ProjectUniqueName = "project2";
             spec2.RestoreMetadata.ProjectName = "project2";
-            spec2.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec2.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec2.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             var specs = new[] { spec1, spec2 };
@@ -513,14 +513,14 @@ namespace NuGet.Commands.Test
             spec1.RestoreMetadata = new ProjectRestoreMetadata();
             spec1.RestoreMetadata.ProjectUniqueName = "project1";
             spec1.RestoreMetadata.ProjectName = "project1";
-            spec1.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec1.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec1.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             var spec2 = new PackageSpec(frameworks2);
             spec2.RestoreMetadata = new ProjectRestoreMetadata();
             spec2.RestoreMetadata.ProjectUniqueName = "project2";
             spec2.RestoreMetadata.ProjectName = "project2";
-            spec2.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            spec2.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             spec2.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             var specs = new[] { spec1, spec2 };

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectUniqueName = "a";
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
 
             spec.AddProject(project);
@@ -86,7 +86,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectUniqueName = "a";
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
 
             spec.AddProject(project);
@@ -121,7 +121,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectUniqueName = "a";
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
 
             spec.AddProject(project);
@@ -258,7 +258,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
 
             spec.AddProject(project);
 
@@ -289,7 +289,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
             project.RestoreMetadata.OutputPath = Directory.GetCurrentDirectory();
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
             project.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             spec.AddProject(project);
@@ -321,7 +321,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
             project.RestoreMetadata.OutputPath = Directory.GetCurrentDirectory();
-            project.RestoreMetadata.OutputType = RestoreOutputType.UAP;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.ProjectJson;
             project.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             spec.AddProject(project);
@@ -352,7 +352,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
             project.RestoreMetadata.ProjectJsonPath = Path.Combine(Directory.GetCurrentDirectory(), "project.json");
-            project.RestoreMetadata.OutputType = RestoreOutputType.Unknown;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.Unknown;
 
             spec.AddProject(project);
 
@@ -381,7 +381,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectUniqueName = "a";
             project.RestoreMetadata.ProjectName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
-            project.RestoreMetadata.OutputType = RestoreOutputType.Unknown;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.Unknown;
 
             targetFramework1.Dependencies.Add(new LibraryDependency()
             {
@@ -444,7 +444,7 @@ namespace NuGet.Commands.Test
             project.RestoreMetadata.ProjectUniqueName = "a";
             project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
             project.RestoreMetadata.OutputPath = Directory.GetCurrentDirectory();
-            project.RestoreMetadata.OutputType = RestoreOutputType.NETCore;
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.PackageReference;
             project.RestoreMetadata.OriginalTargetFrameworks.Add("net45");
 
             return project;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -295,7 +295,7 @@ namespace NuGet.Commands.Test
             spec.AddProject(project);
 
             // Act && Assert
-            AssertError(spec, "Invalid input combination. Property 'OutputPath' is not allowed for project type 'UAP'.");
+            AssertError(spec, "Invalid input combination. Property 'OutputPath' is not allowed for project type 'ProjectJson'.");
         }
 
         [Fact]
@@ -327,7 +327,7 @@ namespace NuGet.Commands.Test
             spec.AddProject(project);
 
             // Act && Assert
-            AssertError(spec, "Property 'OutputPath' is not allowed for project type 'UAP'", "project.json");
+            AssertError(spec, "Property 'OutputPath' is not allowed for project type 'ProjectJson'", "project.json");
         }
 
         [Fact]
@@ -402,7 +402,7 @@ namespace NuGet.Commands.Test
             spec.Projects.First().RestoreMetadata.OutputPath = null;
 
             // Act && Assert
-            AssertError(spec, "Missing required property 'OutputPath' for project type 'NETCore'.", "a.csproj");
+            AssertError(spec, "Missing required property 'OutputPath' for project type 'PackageReference'.", "a.csproj");
         }
 
         [Fact]
@@ -413,7 +413,7 @@ namespace NuGet.Commands.Test
             spec.Projects.First().RestoreMetadata.OriginalTargetFrameworks.Clear();
 
             // Act && Assert
-            AssertError(spec, "Missing required property 'OriginalTargetFrameworks' for project type 'NETCore'.", "a.csproj");
+            AssertError(spec, "Missing required property 'OriginalTargetFrameworks' for project type 'PackageReference'.", "a.csproj");
         }
 
         [Fact]
@@ -424,7 +424,7 @@ namespace NuGet.Commands.Test
             spec.Projects.First().RestoreMetadata.ProjectJsonPath = "project.json";
 
             // Act && Assert
-            AssertError(spec, "Property 'ProjectJsonPath' is not allowed for project type 'NETCore'.", "a.csproj");
+            AssertError(spec, "Property 'ProjectJsonPath' is not allowed for project type 'PackageReference'.", "a.csproj");
         }
 
         private static PackageSpec GetProjectA()

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/StandaloneProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/StandaloneProjectTests.cs
@@ -40,7 +40,7 @@ namespace NuGet.Commands.Test
 
                 var spec = JsonPackageSpecReader.GetPackageSpec(projectJson, "x", Path.Combine(pathContext.SolutionRoot, "project.json"));
                 spec.RestoreMetadata = new ProjectRestoreMetadata();
-                spec.RestoreMetadata.OutputType = RestoreOutputType.Standalone;
+                spec.RestoreMetadata.ProjectStyle = ProjectStyle.Standalone;
                 spec.RestoreMetadata.OutputPath = Path.Combine(pathContext.SolutionRoot, "x");
                 spec.RestoreMetadata.ProjectUniqueName = "x";
                 spec.RestoreMetadata.ProjectName = "x";

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -147,7 +147,7 @@ namespace NuGet.Test
                             {
                                 ProjectName = "myproj",
                                 ProjectUniqueName = myProjPath,
-                                OutputType = RestoreOutputType.Unknown,
+                                ProjectStyle = ProjectStyle.Unknown,
                                 ProjectPath = myProjPath
                             },
                             Name = myProjPath,
@@ -289,7 +289,7 @@ namespace NuGet.Test
                             {
                                 ProjectName = "myproj",
                                 ProjectUniqueName = myProjPath,
-                                OutputType = RestoreOutputType.Unknown,
+                                ProjectStyle = ProjectStyle.Unknown,
                                 ProjectPath = myProjPath
                             },
                             Name = myProjPath,

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/InstallationCompatibilityTests.cs
@@ -452,7 +452,7 @@ namespace NuGet.PackageManagement.Test
                     null,
                     null,
                     null,
-                    RestoreOutputType.Unknown,
+                    ProjectStyle.Unknown,
                     TimeSpan.MinValue);
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -49,7 +49,7 @@ namespace ProjectManagement.Test
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectName, actual.Name);
                 Assert.Equal(projectJsonPath, actual.FilePath);
                 Assert.NotNull(actual.RestoreMetadata);
-                Assert.Equal(RestoreOutputType.UAP, actual.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.ProjectJson, actual.RestoreMetadata.ProjectStyle);
                 Assert.Equal(projectFilePath, actual.RestoreMetadata.ProjectPath);
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectName, actual.RestoreMetadata.ProjectName);
                 Assert.Equal(projectFilePath, actual.RestoreMetadata.ProjectUniqueName);

--- a/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectManagement.Test/MSBuildNuGetProjectTests.cs
@@ -54,7 +54,7 @@ namespace ProjectManagement.Test
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectName, actual.Name);
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectFileFullPath, actual.FilePath);
                 Assert.NotNull(actual.RestoreMetadata);
-                Assert.Equal(RestoreOutputType.Unknown, actual.RestoreMetadata.OutputType);
+                Assert.Equal(ProjectStyle.Unknown, actual.RestoreMetadata.ProjectStyle);
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectFileFullPath, actual.RestoreMetadata.ProjectPath);
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectName, actual.RestoreMetadata.ProjectName);
                 Assert.Equal(msBuildNuGetProjectSystem.ProjectFileFullPath, actual.RestoreMetadata.ProjectUniqueName);

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -107,7 +107,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("c:\\x\\x.csproj", msbuildMetadata.ProjectPath);
             Assert.Equal("x", msbuildMetadata.ProjectName);
             Assert.Equal("c:\\x\\project.json", msbuildMetadata.ProjectJsonPath);
-            Assert.Equal(RestoreOutputType.NETCore, msbuildMetadata.OutputType);
+            Assert.Equal(ProjectStyle.PackageReference, msbuildMetadata.ProjectStyle);
             Assert.Equal("c:\\packages", msbuildMetadata.PackagesPath);
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata.FallbackFolders));
@@ -132,7 +132,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("c:\\x\\x.csproj", msbuildMetadata.ProjectPath);
             Assert.Equal("x", msbuildMetadata.ProjectName);
             Assert.Equal("c:\\x\\project.json", msbuildMetadata.ProjectJsonPath);
-            Assert.Equal(RestoreOutputType.NETCore, msbuildMetadata.OutputType);
+            Assert.Equal(ProjectStyle.PackageReference, msbuildMetadata.ProjectStyle);
             Assert.Equal("c:\\packages", msbuildMetadata.PackagesPath);
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata.FallbackFolders));
@@ -151,7 +151,7 @@ namespace NuGet.ProjectModel.Test
             msbuildMetadata.ProjectPath = "c:\\x\\x.csproj";
             msbuildMetadata.ProjectName = "x";
             msbuildMetadata.ProjectJsonPath = "c:\\x\\project.json";
-            msbuildMetadata.OutputType = RestoreOutputType.NETCore;
+            msbuildMetadata.ProjectStyle = ProjectStyle.PackageReference;
             msbuildMetadata.PackagesPath = "c:\\packages";
             msbuildMetadata.Sources = new[] { new PackageSource("https://api.nuget.org/v3/index.json") };
 
@@ -180,7 +180,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("c:\\x\\x.csproj", msbuildMetadata.ProjectPath);
             Assert.Equal("x", msbuildMetadata.ProjectName);
             Assert.Equal("c:\\x\\project.json", msbuildMetadata.ProjectJsonPath);
-            Assert.Equal(RestoreOutputType.NETCore, msbuildMetadata.OutputType);
+            Assert.Equal(ProjectStyle.PackageReference, msbuildMetadata.ProjectStyle);
             Assert.Equal("c:\\packages", msbuildMetadata.PackagesPath);
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata.FallbackFolders));
@@ -206,7 +206,7 @@ namespace NuGet.ProjectModel.Test
             msbuildMetadata.ProjectPath = "c:\\x\\x.csproj";
             msbuildMetadata.ProjectName = "x";
             msbuildMetadata.ProjectJsonPath = "c:\\x\\project.json";
-            msbuildMetadata.OutputType = RestoreOutputType.NETCore;
+            msbuildMetadata.ProjectStyle = ProjectStyle.PackageReference;
             msbuildMetadata.PackagesPath = "c:\\packages";
             msbuildMetadata.Sources = new[] { new PackageSource("https://api.nuget.org/v3/index.json") };
 
@@ -244,7 +244,7 @@ namespace NuGet.ProjectModel.Test
             Assert.Equal("c:\\x\\x.csproj", msbuildMetadata2.ProjectPath);
             Assert.Equal("x", msbuildMetadata2.ProjectName);
             Assert.Equal("c:\\x\\project.json", msbuildMetadata2.ProjectJsonPath);
-            Assert.Equal(RestoreOutputType.NETCore, msbuildMetadata2.OutputType);
+            Assert.Equal(ProjectStyle.PackageReference, msbuildMetadata2.ProjectStyle);
             Assert.Equal("c:\\packages", msbuildMetadata2.PackagesPath);
             Assert.Equal("https://api.nuget.org/v3/index.json", string.Join("|", msbuildMetadata.Sources.Select(s => s.Source)));
             Assert.Equal("c:\\fallback1|c:\\fallback2", string.Join("|", msbuildMetadata2.FallbackFolders));
@@ -273,7 +273,7 @@ namespace NuGet.ProjectModel.Test
             msbuildMetadata.ProjectUniqueName = "A55205E7-4D08-4672-8011-0925467CC45F";
             msbuildMetadata.ProjectPath = "c:\\x\\x.csproj";
             msbuildMetadata.ProjectName = "x";
-            msbuildMetadata.OutputType = RestoreOutputType.NETCore;
+            msbuildMetadata.ProjectStyle = ProjectStyle.PackageReference;
 
             var tfmGroup = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("net45"));
             var tfmGroup2 = new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("netstandard1.3"));

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -435,7 +435,7 @@ namespace NuGet.ProjectModel.Test
                     ProjectName = "ProjectPath",
                     ProjectPath = @"X:\ProjectPath\ProjectPath.csproj",
                     OutputPath = @"X:\ProjectPath\obj\",
-                    OutputType = RestoreOutputType.NETCore,
+                    ProjectStyle = ProjectStyle.PackageReference,
                     OriginalTargetFrameworks = new[] { "netcoreapp1.0" },
                     TargetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>
                     {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -368,7 +368,7 @@ namespace NuGet.ProjectModel.Test
       ""projectName"": ""ProjectPath"",
       ""projectPath"": ""X:\\ProjectPath\\ProjectPath.csproj"",
       ""outputPath"": ""X:\\ProjectPath\\obj\\"",
-      ""outputType"": ""NETCore"",
+      ""projectStyle"": ""PackageReference"",
       ""originalTargetFrameworks"": [
         ""netcoreapp1.0""
       ],

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileTests.cs
@@ -58,7 +58,7 @@ namespace NuGet.ProjectModel.Test
                         ProjectName = "ProjectPath",
                         ProjectPath = @"X:\ProjectPath\ProjectPath.csproj",
                         OutputPath = @"X:\ProjectPath\obj\",
-                        OutputType = RestoreOutputType.NETCore,
+                        ProjectStyle = ProjectStyle.PackageReference,
                         OriginalTargetFrameworks = new[] { "netcoreapp1.0" },
                         TargetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>
                     {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -195,7 +195,7 @@ namespace NuGet.ProjectModel.Test
                     LegacyPackagesDirectory = false,
                     OriginalTargetFrameworks = unsortedReadOnlyList,
                     OutputPath = "outputPath",
-                    OutputType = RestoreOutputType.NETCore,
+                    ProjectStyle = ProjectStyle.PackageReference,
                     PackagesPath = "packagesPath",
                     ProjectJsonPath = "projectJsonPath",
                     ProjectName = "projectName",

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
@@ -44,7 +44,7 @@
     "projectJsonPath": "projectJsonPath",
     "packagesPath": "packagesPath",
     "outputPath": "outputPath",
-    "outputType": "NETCore",
+    "projectStyle": "PackageReference",
     "crossTargeting": "True",
     "fallbackFolders": [
       "b",

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project1.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project1.json
@@ -20,7 +20,7 @@
     "projectName": "x",
     "projectPath": "c:\\x\\x.csproj",
     "projectJsonPath": "c:\\x\\project.json",
-    "outputType": "netcore",
+    "projectStyle": "PackageReference",
     "outputPath": "c:\\x\\obj\\bin",
     "packagesPath": "c:\\packages",
     "crossTargeting": true,

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project2.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/project2.json
@@ -20,7 +20,7 @@
     "projectName": "x",
     "projectPath": "c:\\x\\x.csproj",
     "projectJsonPath": "c:\\x\\project.json",
-    "outputType": "netcore",
+    "projectStyle": "PackageReference",
     "outputPath": "c:\\x\\obj\\bin",
     "packagesPath": "c:\\packages",
     "sources": {

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
@@ -22,7 +22,7 @@
         "projectName": "x",
         "projectPath": "c:\\x\\x.csproj",
         "projectJsonPath": "c:\\x\\project.json",
-        "outputType": "netcore",
+        "projectStyle": "PackageReference",
         "outputPath": "c:\\x\\obj\\bin",
         "packagesPath": "c:\\packages",
         "sources": {


### PR DESCRIPTION
This is primarily a big find and replace and the addition of a public property to set the restore type.

In MSBuild the restore type can now be set externally:
_ProjectRestoreType -> RestoreProjectType

Other renames:
OutputType -> ProjectStyle
NETCore -> PackageReference
UAP -> ProjectJson

Fixes https://github.com/NuGet/Home/issues/4047
Fixes https://github.com/NuGet/Home/issues/4046 
Fixes https://github.com/NuGet/Home/issues/3504

//cc @alpaix @mishra14 @rohit21agrawal @nkolev92 @jainaashish 