### PR TITLE
Consume RestoreProjectStyle property to construct specific NuGet project

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -50,14 +51,21 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // The project must be an IVsHierarchy.
             var hierarchy = VsHierarchyUtility.ToVsHierarchy(dteProject);
-            
+
             if (hierarchy == null)
             {
                 return false;
             }
 
-            if (!hierarchy.IsCapabilityMatch("CPS") ||
-                !hierarchy.IsCapabilityMatch("PackageReferences"))
+            // check for RestoreProjectStyle property
+            var restoreProjectStyle = EnvDTEProjectUtility.GetPropertyValue<string>(dteProject, "RestoreProjectStyle");
+
+            if (!string.IsNullOrEmpty(restoreProjectStyle) &&
+                !restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            else if(!hierarchy.IsCapabilityMatch("CPS"))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -325,7 +325,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return nuGetProject;
         }
 
-        private static T GetPropertyValue<T>(EnvDTEProject envDTEProject, string propertyName)
+        public static T GetPropertyValue<T>(EnvDTEProject envDTEProject, string propertyName)
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 


### PR DESCRIPTION
This PR is to consume RestoreProjectStyle property, if defined, to construct NuGet project instance, otherwise it will simply fallback to existing mechanism, which is to check for CPS or PackageReference existence to decide the type of NuGet project.

Fixes https://github.com/NuGet/Home/issues/4134

@rrelyea @emgarten   