### PR TITLE
Consume RestoreProjectStyle property to construct specific NuGet project instance

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -9,6 +9,7 @@ using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
+using NuGet.ProjectModel;
 using NuGet.RuntimeModel;
 using VSLangProj;
 using VSLangProj150;
@@ -95,7 +96,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                var baseIntermediateOutputPath = GetMSBuildProperty(AsIVsBuildPropertyStorage, "BaseIntermediateOutputPath");
+                var baseIntermediateOutputPath = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "BaseIntermediateOutputPath");
 
                 if (string.IsNullOrEmpty(baseIntermediateOutputPath))
                 {
@@ -116,12 +117,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                if (AsIVsBuildPropertyStorage == null)
-                {
-                    return String.Empty;
-                }
-
-                return GetMSBuildProperty(AsIVsBuildPropertyStorage, "PackageTargetFallback");
+                return VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "PackageTargetFallback");
             }
         }
 
@@ -133,24 +129,35 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 if (!_isLegacyCSProjPackageReferenceProject.HasValue)
                 {
-                    // A legacy CSProj can't be CPS, must cast to VSProject4 and *must* have at least one package
-                    // reference already in the CSProj. In the future this logic may change. For now a user must
-                    // hand code their first package reference. Laid out in longhand for readability.
-                    if (AsIVsHierarchy?.IsCapabilityMatch("CPS") ?? true)
+                    // check for RestoreProjectStyle property
+                    var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "RestoreProjectStyle");
+
+                    if (string.IsNullOrEmpty(restoreProjectStyle))
                     {
-                        _isLegacyCSProjPackageReferenceProject = false;
+                        // A legacy CSProj can't be CPS, must cast to VSProject4 and *must* have at least one package
+                        // reference already in the CSProj. In the future this logic may change. For now a user must
+                        // hand code their first package reference. Laid out in longhand for readability.
+                        if (AsIVsHierarchy?.IsCapabilityMatch("CPS") ?? true)
+                        {
+                            _isLegacyCSProjPackageReferenceProject = false;
+                        }
+                        else if (AsVSProject4 == null ||
+                            (AsVSProject4.PackageReferences?.InstalledPackages?.Length ?? 0) == 0)
+                        {
+                            _isLegacyCSProjPackageReferenceProject = false;
+                        }
+                        else
+                        {
+                            _isLegacyCSProjPackageReferenceProject = true;
+                        }
                     }
-                    else if (AsVSProject4 == null)
+                    else if(restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
-                        _isLegacyCSProjPackageReferenceProject = false;
-                    }
-                    else if ((AsVSProject4.PackageReferences?.InstalledPackages?.Length ?? 0) == 0)
-                    {
-                        _isLegacyCSProjPackageReferenceProject = false;
+                        _isLegacyCSProjPackageReferenceProject = true;
                     }
                     else
                     {
-                        _isLegacyCSProjPackageReferenceProject = true;
+                        _isLegacyCSProjPackageReferenceProject = false;
                     }
                 }
 
@@ -166,7 +173,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 // Uncached, in case project file edited
                 // ex-project.json (e.g. UWP)
-                var nuGetTargetFramework = GetMSBuildProperty(AsIVsBuildPropertyStorage, "NuGetTargetFramework");
+                var nuGetTargetFramework = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "NuGetTargetFramework");
                 if (!string.IsNullOrEmpty(nuGetTargetFramework))
                 {
                     return NuGetFramework.ParseFrameworkName(nuGetTargetFramework, DefaultFrameworkNameProvider.Instance);
@@ -183,8 +190,8 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                var unparsedRuntimeIdentifer = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeIdentifier");
-                var unparsedRuntimeIdentifers = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeIdentifiers");
+                var unparsedRuntimeIdentifer = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "RuntimeIdentifier");
+                var unparsedRuntimeIdentifers = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "RuntimeIdentifiers");
 
                 var runtimes = Enumerable.Empty<string>();
 
@@ -213,12 +220,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                if (AsIVsBuildPropertyStorage == null)
-                {
-                    return Enumerable.Empty<CompatibilityProfile>();
-                }
-
-                var unparsedRuntimeSupports = GetMSBuildProperty(AsIVsBuildPropertyStorage, "RuntimeSupports");
+                var unparsedRuntimeSupports = VsHierarchyUtility.GetMSBuildProperty(AsIVsHierarchy, "RuntimeSupports");
                 
                 if (unparsedRuntimeSupports == null)
                 {
@@ -240,27 +242,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 ThreadHelper.ThrowIfNotOnUIThread();
 
                 return _asIVsHierarchy ?? (_asIVsHierarchy = VsHierarchyUtility.ToVsHierarchy(_project));
-            }
-        }
-
-        private IVsBuildPropertyStorage AsIVsBuildPropertyStorage
-        {
-            get
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-
-                var output =
-                    _asIVsBuildPropertyStorage ??
-                    (_asIVsBuildPropertyStorage = AsIVsHierarchy as IVsBuildPropertyStorage);
-
-                if (output == null)
-                {
-                    throw new InvalidOperationException(string.Format(
-                        Strings.ProjectCouldNotBeCastedToBuildPropertyStorage,
-                        ProjectFullPath));
-                }
-
-                return output;
             }
         }
 
@@ -367,25 +348,6 @@ namespace NuGet.PackageManagement.VisualStudio
             ThreadHelper.ThrowIfNotOnUIThread();
 
             AsVSProject4.PackageReferences.Remove(packageName);
-        }
-
-        private static string GetMSBuildProperty(IVsBuildPropertyStorage buildPropertyStorage, string name)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            string output;
-            var result = buildPropertyStorage.GetPropertyValue(
-                name,
-                string.Empty,
-                (uint)_PersistStorageType.PST_PROJECT_FILE,
-                out output);
-
-            if (result != NuGetVSConstants.S_OK || string.IsNullOrWhiteSpace(output))
-            {
-                return null;
-            }
-
-            return output;
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -6,8 +6,10 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -50,14 +52,21 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // The project must be an IVsHierarchy.
             var hierarchy = VsHierarchyUtility.ToVsHierarchy(dteProject);
-            
+
             if (hierarchy == null)
             {
                 return false;
             }
 
-            if (!hierarchy.IsCapabilityMatch("CPS") ||
-                !hierarchy.IsCapabilityMatch("PackageReferences"))
+            // check for RestoreProjectStyle property
+            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(hierarchy, "RestoreProjectStyle");
+
+            if (!string.IsNullOrEmpty(restoreProjectStyle) &&
+                !restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            else if(!hierarchy.IsCapabilityMatch("CPS"))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -59,6 +59,30 @@ namespace NuGet.PackageManagement.VisualStudio
             return id.ToString();
         }
 
+        public static string GetMSBuildProperty(IVsHierarchy pHierarchy, string name)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var buildPropertyStorage = pHierarchy as IVsBuildPropertyStorage;
+            string output = null;
+
+            if (buildPropertyStorage != null)
+            {
+                var result = buildPropertyStorage.GetPropertyValue(
+                    name,
+                    string.Empty,
+                    (uint)_PersistStorageType.PST_PROJECT_FILE,
+                    out output);
+
+                if (result != NuGetVSConstants.S_OK || string.IsNullOrWhiteSpace(output))
+                {
+                    return null;
+                }
+            }
+
+            return output;
+        }
+
         public static string[] GetProjectTypeGuids(Project project)
         {
             ThreadHelper.ThrowIfNotOnUIThread();


### PR DESCRIPTION
This PR is to consume RestoreProjectStyle property, if defined, to construct NuGet project instance, otherwise it will simply fallback to existing mechanism, which is to check for CPS or PackageReference existence to decide the type of NuGet project.

Fixes NuGet/Home#4134

@rrelyea @emgarten