### PR TITLE
Project compile/runtime asset support

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -139,10 +139,7 @@ namespace NuGet.CommandLine
                 argumentBuilder.Append(" /p:ExcludeRestorePackageImports=true ");
 
                 // Add all depenencies as top level restore projects if recursive is set
-                if (recursive)
-                {
-                    argumentBuilder.Append($" /p:RestoreRecursive=true ");
-                }
+                argumentBuilder.Append($" /p:RestoreRecursive={recursive} ");
 
                 // Projects to restore
                 bool isMono = RuntimeEnvironmentHelper.IsMono && !RuntimeEnvironmentHelper.IsWindows;

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -42,6 +42,20 @@ namespace NuGet.Build.Tasks
             }
         }
 
+        public static string GetPropertyIfExists(ITaskItem item, string key)
+        {
+            var wrapper = new MSBuildTaskItem(item);
+
+            var propertyValue = wrapper.GetProperty(key);
+
+            if (!string.IsNullOrEmpty(propertyValue))
+            {
+                return propertyValue;
+            }
+
+            return null;
+        }
+
         public static void AddPropertyIfExists(IDictionary<string, string> properties, string key, string value)
         {
             if (!string.IsNullOrEmpty(value)

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectReferencesTask.cs
@@ -20,6 +20,12 @@ namespace NuGet.Build.Tasks
         public ITaskItem[] ProjectReferences { get; set; }
 
         /// <summary>
+        /// Root project path used for resolving the absolute path.
+        /// </summary>
+        [Required]
+        public string ParentProjectPath { get; set; }
+
+        /// <summary>
         /// Target frameworks to apply this for. If empty this applies to all.
         /// </summary>
         public string TargetFrameworks { get; set; }
@@ -37,29 +43,41 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) ProjectUniqueName '{ProjectUniqueName}'");
             log.LogDebug($"(in) TargetFrameworks '{TargetFrameworks}'");
             log.LogDebug($"(in) ProjectReferences '{string.Join(";", ProjectReferences.Select(p => p.ItemSpec))}'");
+            log.LogDebug($"(in) ParentProjectPath '{ParentProjectPath}'");
 
             var entries = new List<ITaskItem>();
 
+            var parentDirectory = Path.GetDirectoryName(ParentProjectPath);
+
             foreach (var project in ProjectReferences)
             {
-                var referencePath = Path.GetFullPath(project.ItemSpec);
+                var refOutput = BuildTasksUtility.GetPropertyIfExists(project, "ReferenceOutputAssembly");
 
-                var properties = new Dictionary<string, string>();
-                properties.Add("ProjectUniqueName", ProjectUniqueName);
-                properties.Add("Type", "ProjectReference");
-                properties.Add("ProjectPath", referencePath);
-                properties.Add("ProjectReferenceUniqueName", referencePath);
-
-                if (!string.IsNullOrEmpty(TargetFrameworks))
+                // Match the same behavior as NuGet.targets
+                // ReferenceOutputAssembly == '' OR ReferenceOutputAssembly == 'true'
+                if (string.IsNullOrEmpty(refOutput)
+                    || Boolean.TrueString.Equals(refOutput, StringComparison.OrdinalIgnoreCase))
                 {
-                    properties.Add("TargetFrameworks", TargetFrameworks);
+                    // Get the absolute path
+                    var referencePath = Path.GetFullPath(Path.Combine(parentDirectory, project.ItemSpec));
+
+                    var properties = new Dictionary<string, string>();
+                    properties.Add("ProjectUniqueName", ProjectUniqueName);
+                    properties.Add("Type", "ProjectReference");
+                    properties.Add("ProjectPath", referencePath);
+                    properties.Add("ProjectReferenceUniqueName", referencePath);
+
+                    if (!string.IsNullOrEmpty(TargetFrameworks))
+                    {
+                        properties.Add("TargetFrameworks", TargetFrameworks);
+                    }
+
+                    BuildTasksUtility.CopyPropertyIfExists(project, properties, "IncludeAssets");
+                    BuildTasksUtility.CopyPropertyIfExists(project, properties, "ExcludeAssets");
+                    BuildTasksUtility.CopyPropertyIfExists(project, properties, "PrivateAssets");
+
+                    entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
                 }
-
-                BuildTasksUtility.CopyPropertyIfExists(project, properties, "IncludeAssets");
-                BuildTasksUtility.CopyPropertyIfExists(project, properties, "ExcludeAssets");
-                BuildTasksUtility.CopyPropertyIfExists(project, properties, "PrivateAssets");
-
-                entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
             }
 
             RestoreGraphItems = entries.ToArray();

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -510,14 +510,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateRestoreGraphWalkPerFramework"
-    DependsOnTargets="_GenerateRestoreProjectReferencePaths;_GetRestoreProjectStyle"
+    DependsOnTargets="_GetRestoreProjectStyle"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Write out project references -->
     <GetRestoreProjectReferencesTask
       ProjectUniqueName="$(MSBuildProjectFullPath)"
-      ProjectReferences="@(RestoreGraphProjectFullPathForOutput)"
-      TargetFrameworks="$(TargetFramework)">
+      ProjectReferences="@(ProjectReference)"
+      TargetFrameworks="$(TargetFramework)"
+      ParentProjectPath="$(MSBuildProjectFullPath)">
 
       <Output
         TaskParameter="RestoreGraphItems"

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -156,6 +156,8 @@ namespace NuGet.Commands
             var warnForImports = project.TargetFrameworks.Any(framework => framework.Warn);
             var librariesWithWarnings = new HashSet<LibraryIdentity>();
 
+            var rootProjectStyle = project.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
+
             // Add the targets
             foreach (var targetGraph in targetGraphs
                 .OrderBy(graph => graph.Framework.ToString(), StringComparer.Ordinal)
@@ -174,6 +176,13 @@ namespace NuGet.Commands
                 {
                     var library = graphItem.Key;
 
+                    // include flags
+                    LibraryIncludeFlags includeFlags;
+                    if (!flattenedFlags.TryGetValue(library.Name, out includeFlags))
+                    {
+                        includeFlags = ~LibraryIncludeFlags.ContentFiles;
+                    }
+
                     if (library.Type == LibraryType.Project || library.Type == LibraryType.ExternalProject)
                     {
                         if (project.Name.Equals(library.Name, StringComparison.OrdinalIgnoreCase))
@@ -182,64 +191,14 @@ namespace NuGet.Commands
                             continue;
                         }
 
-                        var localMatch = (LocalMatch)graphItem.Data.Match;
+                        var projectLib = LockFileUtils.CreateLockFileTargetProject(
+                            graphItem,
+                            library,
+                            includeFlags,
+                            targetGraph,
+                            rootProjectStyle);
 
-                        // Target framework information is optional and may not exist for csproj projects
-                        // that do not have a project.json file.
-                        string projectFramework = null;
-                        object frameworkInfoObject;
-                        if (localMatch.LocalLibrary.Items.TryGetValue(
-                            KnownLibraryProperties.TargetFrameworkInformation,
-                            out frameworkInfoObject))
-                        {
-                            // Retrieve the resolved framework name, if this is null it means that the
-                            // project is incompatible. This is marked as Unsupported.
-                            var targetFrameworkInformation = (TargetFrameworkInformation)frameworkInfoObject;
-                            projectFramework = targetFrameworkInformation.FrameworkName?.DotNetFrameworkName
-                                ?? NuGetFramework.UnsupportedFramework.DotNetFrameworkName;
-                        }
-
-                        // Create the target entry
-                        var lib = new LockFileTargetLibrary()
-                        {
-                            Name = library.Name,
-                            Version = library.Version,
-                            Type = LibraryType.Project,
-                            Framework = projectFramework,
-
-                            // Find all dependencies which would be in the nuspec
-                            // Include dependencies with no constraints, or package/project/external
-                            // Exclude suppressed dependencies, the top level project is not written 
-                            // as a target so the node depth does not matter.
-                            Dependencies = graphItem.Data.Dependencies
-                                .Where(
-                                    d => (d.LibraryRange.TypeConstraintAllowsAnyOf(
-                                        LibraryDependencyTarget.PackageProjectExternal))
-                                         && d.SuppressParent != LibraryIncludeFlags.All)
-                                .Select(d => GetDependencyVersionRange(d))
-                                .ToList()
-                        };
-
-                        object compileAssetObject;
-                        if (localMatch.LocalLibrary.Items.TryGetValue(
-                            KnownLibraryProperties.CompileAsset,
-                            out compileAssetObject))
-                        {
-                            var item = new LockFileItem((string)compileAssetObject);
-                            lib.CompileTimeAssemblies.Add(item);
-                            lib.RuntimeAssemblies.Add(item);
-                        }
-
-                        // Add frameworkAssemblies for projects
-                        object frameworkAssembliesObject;
-                        if (localMatch.LocalLibrary.Items.TryGetValue(
-                            KnownLibraryProperties.FrameworkAssemblies,
-                            out frameworkAssembliesObject))
-                        {
-                            lib.FrameworkAssemblies.AddRange((List<string>)frameworkAssembliesObject);
-                        }
-
-                        target.Libraries.Add(lib);
+                        target.Libraries.Add(projectLib);
                         continue;
                     }
                     else if (library.Type == LibraryType.Package)
@@ -252,13 +211,6 @@ namespace NuGet.Commands
                         }
 
                         var package = packageInfo.Package;
-
-                        // include flags
-                        LibraryIncludeFlags includeFlags;
-                        if (!flattenedFlags.TryGetValue(library.Name, out includeFlags))
-                        {
-                            includeFlags = ~LibraryIncludeFlags.ContentFiles;
-                        }
 
                         var targetLibrary = LockFileUtils.CreateLockFileTargetLibrary(
                             libraries[Tuple.Create(library.Name, library.Version)],
@@ -431,26 +383,6 @@ namespace NuGet.Commands
             }
 
             return true;
-        }
-
-        private static PackageDependency GetDependencyVersionRange(LibraryDependency dependency)
-        {
-            var range = dependency.LibraryRange.VersionRange ?? VersionRange.All;
-
-            if (VersionRange.All.Equals(range)
-                && (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.ExternalProject)))
-            {
-                // For csproj -> csproj type references where there is no range, use 1.0.0
-                range = VersionRange.Parse("1.0.0");
-            }
-            else
-            {
-                // For project dependencies drop the snapshot version.
-                // Ex: 1.0.0-* -> 1.0.0
-                range = range.ToNonSnapshotRange();
-            }
-
-            return new PackageDependency(dependency.Name, range);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -114,26 +114,13 @@ namespace NuGet.Commands
 
             var type = rootProject.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
-            // Leave the spec null for non-nuget projects.
-            // In the future additional P2P TFM checking could be handled by
-            // creating a spec for non-NuGet projects and including the TFM.
-            PackageSpec projectSpec = null;
-
-            if (type == ProjectStyle.PackageReference
-                || type == ProjectStyle.ProjectJson
-                || type == ProjectStyle.DotnetCliTool
-                || type == ProjectStyle.Standalone)
-            {
-                projectSpec = rootProject;
-            }
-
             var uniqueReferences = projectReferences
                 .Select(p => p.ProjectUniqueName)
                 .Distinct(StringComparer.OrdinalIgnoreCase);
 
             return new ExternalProjectReference(
                 rootProject.RestoreMetadata.ProjectUniqueName,
-                projectSpec,
+                rootProject,
                 rootProject.RestoreMetadata?.ProjectPath,
                 uniqueReferences);
         }

--- a/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/KnownLibraryProperties.cs
@@ -11,8 +11,7 @@ namespace NuGet.LibraryModel
         public static readonly string PackageSpec = "NuGet.ProjectModel.PackageSpec";
         public static readonly string TargetFrameworkInformation = "NuGet.ProjectModel.TargetFrameworkInformation";
         public static readonly string MSBuildProjectPath = "NuGet.ProjectModel.MSBuildProjectPath";
-        public static readonly string CompileAsset = "NuGet.ProjectModel.CompileAsset";
-        public static readonly string RuntimeAsset = "NuGet.ProjectModel.RuntimeAsset";
+        public static readonly string ProjectRestoreMetadataFiles = "NuGet.ProjectModel.ProjectRestoreMetadataFiles";
         public static readonly string FrameworkAssemblies = "NuGet.ProjectModel.FrameworkAssemblies";
         public static readonly string ProjectFrameworks = "NuGet.ProjectModel.ProjectFrameworks";
         public static readonly string ProjectStyle = "NuGet.ProjectModel.RestoreMetadata.ProjectStyle";

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -222,6 +222,15 @@ namespace NuGet.ProjectModel
                 }
             }
 
+            var filesObj = rawMSBuildMetadata.GetValue<JObject>("files");
+            if (filesObj != null)
+            {
+                foreach (var prop in filesObj.Properties())
+                {
+                    msbuildMetadata.Files.Add(new ProjectRestoreMetadataFile(prop.Name, prop.Value.ToObject<string>()));
+                }
+            }
+
             var frameworksObj = rawMSBuildMetadata.GetValue<JObject>("frameworks");
             if (frameworksObj != null)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecReferenceDependencyProvider.cs
@@ -100,8 +100,10 @@ namespace NuGet.ProjectModel
             // create a dictionary of dependencies to make sure that no duplicates exist
             var dependencies = new List<LibraryDependency>();
 
+            var projectStyle = packageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
+
             // Read references from external project
-            if (packageSpec?.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference)
+            if (projectStyle == ProjectStyle.PackageReference)
             {
                 // NETCore
                 dependencies.AddRange(GetDependenciesFromSpecRestoreMetadata(packageSpec, targetFramework));
@@ -131,29 +133,13 @@ namespace NuGet.ProjectModel
                 Identity = new LibraryIdentity
                 {
                     Name = externalReference?.ProjectName ?? packageSpec.Name,
-                    Version = packageSpec?.Version ?? NuGetVersion.Parse("1.0.0"),
+                    Version = packageSpec?.Version ?? new NuGetVersion(1, 0, 0),
                     Type = LibraryType.Project,
                 },
                 Path = packageSpec?.FilePath,
                 Dependencies = uniqueDependencies,
                 Resolved = true
             };
-
-            if (packageSpec != null)
-            {
-                library[KnownLibraryProperties.PackageSpec] = packageSpec;
-
-                var projectStyle = packageSpec.RestoreMetadata?.ProjectStyle;
-
-                if (projectStyle.HasValue)
-                {
-                    library[KnownLibraryProperties.ProjectStyle] = projectStyle.Value.ToString();
-                }
-                else
-                {
-                    library[KnownLibraryProperties.ProjectStyle] = ProjectStyle.Unknown.ToString();
-                }
-            }
 
             // Add msbuild path
             var msbuildPath = externalReference?.MSBuildProjectPath;
@@ -164,23 +150,42 @@ namespace NuGet.ProjectModel
 
             if (packageSpec != null)
             {
-                // Record all frameworks in the project
-                library[KnownLibraryProperties.ProjectFrameworks] = new List<NuGetFramework>(
-                    packageSpec.TargetFrameworks.Select(fw => fw.FrameworkName));
+                // Additional library properties
+                AddLibraryProperties(library, packageSpec, targetFramework, msbuildPath);
             }
-
-            // Additional library properties
-            AddLibraryProperties(library, packageSpec, targetFramework, msbuildPath);
 
             return library;
         }
 
         private static void AddLibraryProperties(Library library, PackageSpec packageSpec, NuGetFramework targetFramework, string msbuildPath)
         {
-            if (packageSpec != null)
-            {
-                var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
+            var projectStyle = packageSpec.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
 
+            library[KnownLibraryProperties.PackageSpec] = packageSpec;
+            library[KnownLibraryProperties.ProjectStyle] = projectStyle;
+
+            if (packageSpec.RestoreMetadata?.Files != null)
+            {
+                // Record all files that would be in a nupkg
+                library[KnownLibraryProperties.ProjectRestoreMetadataFiles]
+                    = packageSpec.RestoreMetadata.Files.ToList();
+            }
+
+            // Avoid adding these properties for class libraries
+            // and other projects which are not fully able to 
+            // participate in restore.
+            if (packageSpec.RestoreMetadata == null
+                || (projectStyle != ProjectStyle.Unknown
+                    && projectStyle != ProjectStyle.PackagesConfig))
+            {
+                var frameworks = new List<NuGetFramework>(
+                    packageSpec.TargetFrameworks.Select(fw => fw.FrameworkName)
+                    .Where(fw => !fw.IsUnsupported));
+
+                // Record all frameworks in the project
+                library[KnownLibraryProperties.ProjectFrameworks] = frameworks;
+
+                var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
                 library[KnownLibraryProperties.TargetFrameworkInformation] = targetFrameworkInfo;
 
                 // Add framework references

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -153,6 +153,18 @@ namespace NuGet.ProjectModel
                 writer.WriteObjectEnd();
             }
 
+            if (msbuildMetadata.Files?.Count > 0)
+            {
+                writer.WriteObjectStart("files");
+
+                foreach (var file in msbuildMetadata.Files)
+                {
+                    SetValue(writer, file.PackagePath, file.AbsolutePath);
+                }
+
+                writer.WriteObjectEnd();
+            }
+
             if (msbuildMetadata.TargetFrameworks?.Count > 0)
             {
                 writer.WriteObjectStart("frameworks");

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -78,6 +78,12 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool LegacyPackagesDirectory { get; set; }
 
+        /// <summary>
+        /// Asset files. These should be equivalent to the files that would be
+        /// in the nupkg after packing the project.
+        /// </summary>
+        public IList<ProjectRestoreMetadataFile> Files { get; set; } = new List<ProjectRestoreMetadataFile>();
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -95,6 +101,7 @@ namespace NuGet.ProjectModel
             hashCode.AddSequence(OriginalTargetFrameworks);
             hashCode.AddObject(CrossTargeting);
             hashCode.AddObject(LegacyPackagesDirectory);
+            hashCode.AddObject(Files);
 
             return hashCode.CombinedHash;
         }
@@ -128,7 +135,8 @@ namespace NuGet.ProjectModel
                    EqualityUtility.SequenceEqualWithNullCheck(TargetFrameworks, other.TargetFrameworks) &&
                    EqualityUtility.SequenceEqualWithNullCheck(OriginalTargetFrameworks, other.OriginalTargetFrameworks) &&
                    CrossTargeting == other.CrossTargeting &&
-                   LegacyPackagesDirectory == other.LegacyPackagesDirectory;
+                   LegacyPackagesDirectory == other.LegacyPackagesDirectory &&
+                   EqualityUtility.SequenceEqualWithNullCheck(Files, other.Files);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadataFile.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Shared;
+
+namespace NuGet.ProjectModel
+{
+    public class ProjectRestoreMetadataFile : IEquatable<ProjectRestoreMetadataFile>, IComparable<ProjectRestoreMetadataFile>
+    {
+        /// <summary>
+        /// Relative path that would be used within a package.
+        /// This will be used to determine the asset type.
+        /// Example: lib/net45/a.dll
+        /// </summary>
+        public string PackagePath { get; }
+
+        /// <summary>
+        /// Absolute path on disk.
+        /// </summary>
+        public string AbsolutePath { get; }
+
+        public ProjectRestoreMetadataFile(string packagePath, string absolutePath)
+        {
+            if (packagePath == null)
+            {
+                throw new ArgumentNullException(nameof(packagePath));
+            }
+
+            if (absolutePath == null)
+            {
+                throw new ArgumentNullException(nameof(absolutePath));
+            }
+
+            PackagePath = packagePath;
+            AbsolutePath = absolutePath;
+        }
+
+        public bool Equals(ProjectRestoreMetadataFile other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return StringComparer.Ordinal.Equals(PackagePath, other.PackagePath)
+                && StringComparer.Ordinal.Equals(AbsolutePath, other.AbsolutePath);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ProjectRestoreMetadataFile);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCodeCombiner();
+
+            hashCode.AddObject(PackagePath);
+            hashCode.AddObject(AbsolutePath);
+
+            return hashCode.CombinedHash;
+        }
+
+        public override string ToString()
+        {
+            return PackagePath;
+        }
+
+        public int CompareTo(ProjectRestoreMetadataFile other)
+        {
+            return StringComparer.Ordinal.Compare(PackagePath, other.PackagePath);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
@@ -10,7 +9,6 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
-using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -20,6 +18,213 @@ namespace NuGet.Commands.Test
 {
     public class NETCoreProject2ProjectTests
     {
+        [Theory]
+        [InlineData("lib/netstandard1.6/b.dll", "bin/debug/b.dll")]
+        [InlineData("lib/netstandard1.3/b.dll", "bin/debug/b.dll")]
+        [InlineData("LIBANY", "bin/debug/b.dll")]
+        [InlineData("lib/netstandard1.7/b.dll", "")]
+        [InlineData("lib/net45/a.dll", "")]
+        [InlineData("build/projectB.targets", "")]
+        [InlineData("unknown/a.dll", "")]
+        public async Task NETCoreProject2Project_VerifyLibFilesUnderCompile(string path, string expected)
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = NETCoreRestoreTestUtility.GetProject(projectName: "projectA", framework: "netstandard1.6");
+                var spec2 = NETCoreRestoreTestUtility.GetProject(projectName: "projectB", framework: "netstandard1.3");
+
+                var specs = new[] { spec1, spec2 };
+
+                // Create fake projects, the real data is in the specs
+                var projects = NETCoreRestoreTestUtility.CreateProjectsFromSpecs(pathContext, specs);
+
+                // Link projects
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
+                });
+
+                var projectDir = Path.GetDirectoryName(spec2.RestoreMetadata.ProjectPath);
+                var absolutePath = Path.Combine(projectDir, "bin", "debug", "b.dll");
+                spec2.RestoreMetadata.Files.Add(new ProjectRestoreMetadataFile(path, Path.Combine(projectDir, absolutePath)));
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+
+                dgFile.AddProject(spec1);
+                dgFile.AddProject(spec2);
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var lockFormat = new LockFileFormat();
+
+                // Act
+                var summaries = await NETCoreRestoreTestUtility.RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var assetsFile = lockFormat.Read(Path.Combine(spec1.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName));
+
+                var projectBTarget = assetsFile.Targets.Single().Libraries.Single(e => e.Type == "project");
+
+                // Verify compile and runtime
+                Assert.Equal(expected, string.Join("|", projectBTarget.CompileTimeAssemblies.Select(e => e.Path)));
+                Assert.Equal(expected, string.Join("|", projectBTarget.RuntimeAssemblies.Select(e => e.Path)));
+            }
+        }
+
+        /// <summary>
+        /// Project graph:
+        /// A -> B -> C -> D
+        ///   -> X -> Y -> D
+        ///   
+        /// Restore A with various
+        /// combinations of transitive edges.
+        /// 
+        /// Verify the compile assets returned to A.
+        /// Verify all runtime assets are returned to A.
+        /// </summary>
+        [Theory]
+        // Flow everything
+        [InlineData("BCDXY", true, true, true, true, true, true)]
+        // All transitive off
+        [InlineData("BX", false, false, false, false, false, false)]
+        // AB, BX has no impact on A
+        [InlineData("BCDXY", false, true, true, true, true, true)]
+        // BC off, D flows through X,Y
+        [InlineData("BDXY", true, false, true, true, true, true)]
+        // XY off, D flows through BC
+        [InlineData("BCDX", true, true, true, true, false, true)]
+        // BC off, XY off, D stops
+        [InlineData("BX", true, false, true, true, false, true)]
+        public async Task NETCoreProject2Project_VerifyCompileForTransitiveSettings(string expected, bool ab, bool bc, bool cd, bool ax, bool xy, bool yd)
+        {
+            // Arrange
+            using (var cacheContext = new SourceCacheContext())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var logger = new TestLogger();
+                var sources = new List<PackageSource>();
+                sources.Add(new PackageSource(pathContext.PackageSource));
+
+                var spec1 = NETCoreRestoreTestUtility.GetProject(projectName: "A", framework: "netstandard1.6");
+                var spec2 = NETCoreRestoreTestUtility.GetProject(projectName: "B", framework: "netstandard1.6");
+                var spec3 = NETCoreRestoreTestUtility.GetProject(projectName: "C", framework: "netstandard1.6");
+                var spec4 = NETCoreRestoreTestUtility.GetProject(projectName: "D", framework: "netstandard1.6");
+                var spec5 = NETCoreRestoreTestUtility.GetProject(projectName: "X", framework: "netstandard1.6");
+                var spec6 = NETCoreRestoreTestUtility.GetProject(projectName: "Y", framework: "netstandard1.6");
+
+                var specs = new[] { spec1, spec2, spec3, spec4, spec5, spec6, };
+
+                // Create fake projects, the real data is in the specs
+                var projects = NETCoreRestoreTestUtility.CreateProjectsFromSpecs(pathContext, specs);
+
+                // Link projects
+                // A -> B
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[1].ProjectPath,
+                    ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = ab ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // B -> C
+                spec2.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[2].ProjectPath,
+                    ProjectUniqueName = spec3.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = bc ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // C -> D
+                spec3.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[3].ProjectPath,
+                    ProjectUniqueName = spec4.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = cd ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // A -> X
+                spec1.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[4].ProjectPath,
+                    ProjectUniqueName = spec5.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = ax ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // X -> Y
+                spec5.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[5].ProjectPath,
+                    ProjectUniqueName = spec6.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = xy ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // Y -> D
+                spec6.RestoreMetadata.TargetFrameworks.Single().ProjectReferences.Add(new ProjectRestoreReference()
+                {
+                    ProjectPath = projects[3].ProjectPath,
+                    ProjectUniqueName = spec4.RestoreMetadata.ProjectUniqueName,
+                    PrivateAssets = yd ? LibraryIncludeFlags.None : LibraryIncludeFlags.Compile
+                });
+
+                // Create dg file
+                var dgFile = new DependencyGraphSpec();
+
+                foreach (var spec in specs)
+                {
+                    dgFile.AddProject(spec);
+
+                    var projectDir = Path.GetDirectoryName(spec.RestoreMetadata.ProjectPath);
+                    var absolutePath = Path.Combine(projectDir, "bin", "debug", "a.dll");
+                    spec.RestoreMetadata.Files.Add(new ProjectRestoreMetadataFile("lib/netstandard1.6/a.dll", Path.Combine(projectDir, absolutePath)));
+                }
+
+                dgFile.AddRestore(spec1.RestoreMetadata.ProjectUniqueName);
+
+                dgFile.Save(Path.Combine(pathContext.WorkingDirectory, "out.dg"));
+
+                var lockFormat = new LockFileFormat();
+
+                // Act
+                var summaries = await NETCoreRestoreTestUtility.RunRestore(pathContext, logger, sources, dgFile, cacheContext);
+                var success = summaries.All(s => s.Success);
+
+                // Assert
+                Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
+
+                var assetsFile = lockFormat.Read(Path.Combine(spec1.RestoreMetadata.OutputPath, LockFileFormat.AssetsFileName));
+
+                // Find all non _._ compile assets
+                var flowingCompile = assetsFile.Targets.Single().Libraries
+                    .Where(e => e.Type == "project")
+                    .Where(e => e.CompileTimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Select(e => e.Name)
+                    .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
+
+                Assert.Equal(expected, string.Join("", flowingCompile));
+
+                // Runtime should always flow
+                var flowingRuntime = assetsFile.Targets.Single().Libraries
+                    .Where(e => e.Type == "project")
+                    .Where(e => e.RuntimeAssemblies.Where(f => !f.Path.EndsWith("_._")).Any())
+                    .Select(e => e.Name)
+                    .OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
+
+                Assert.Equal("BCDXY", string.Join("", flowingRuntime));
+            }
+        }
+
         [Fact]
         public async Task NETCoreProject2Project_IgnoreXproj()
         {
@@ -243,7 +448,7 @@ namespace NuGet.Commands.Test
                     ProjectPath = projects[1].ProjectPath,
                     ProjectUniqueName = spec2.RestoreMetadata.ProjectUniqueName,
                 });
-                
+
                 // Create dg file
                 var dgFile = new DependencyGraphSpec();
 


### PR DESCRIPTION
This change adds compile/runtime assets to project entries in the assets file. Transitive projects will keep their assets and non-transitive projects will be filtered to _._

Added a generic files property to project entries, this can be used as the base for eventually adding all assets that would be packed into a nupkg for a project into the restore entry. A file entry contains both the package path and the file path on disk.

During restore project assets are read and filtered in the same way package assets are consumed.

The current files used for compile are place holders and do not represent the actual project output. This is expected on the build task side and matches the previous xproj behavior.

PackageSpecs from Non-NuGet projects will now flow into the resolver as part of the files change. Support is still needed for getting the correct TFM for these projects, but we are now very close the resolver being able to work with all projects.

Fixed support for Include/Exclude on Project references.
Fixed recursive restore support in nuget.exe

Fixes https://github.com/NuGet/Home/issues/4076

//cc @alpaix @rohit21agrawal @jainaashish @mishra14 @nkolev92 