### PR TITLE
Improve failed project reference item

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -268,11 +268,11 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to resolve all project references. The package restore result for &apos;{0}&apos; or a dependent project may be incomplete..
+        ///   Looks up a localized string similar to Failed to resolve all items referenced by &apos;{0}&apos;. This message can typically be ignored. The issue may be resolved by fully restoring and building the solution. If the unresolved item is a project reference this can lead to an incomplete NuGet restore result and missing package references. To ensure that restore is able to find all projects verify that all projects are referenced correctly and exist on disk..
         /// </summary>
-        public static string Warning_ErrorDuringProjectClosureWalk {
+        public static string UnresolvedItemDuringProjectClosureWalk {
             get {
-                return ResourceManager.GetString("Warning_ErrorDuringProjectClosureWalk", resourceCulture);
+                return ResourceManager.GetString("UnresolvedItemDuringProjectClosureWalk", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -177,8 +177,8 @@
   <data name="Warning_FailedToMarkPackageDirectoryForDeletion" xml:space="preserve">
     <value>Failed to mark package directory '{0}' for deletion on Visual Studio restart: {1}</value>
   </data>
-  <data name="Warning_ErrorDuringProjectClosureWalk" xml:space="preserve">
-    <value>Failed to resolve all project references. The package restore result for '{0}' or a dependent project may be incomplete.</value>
+  <data name="UnresolvedItemDuringProjectClosureWalk" xml:space="preserve">
+    <value>Failed to resolve all items referenced by '{0}'. This message can typically be ignored. The issue may be resolved by fully restoring and building the solution. If the unresolved item is a project reference this can lead to an incomplete NuGet restore result and missing package references. To ensure that restore is able to find all projects verify that all projects are referenced correctly and exist on disk.</value>
   </data>
   <data name="SolutionIsNotSaved" xml:space="preserve">
     <value>Solution is not saved. Please save your solution before managing NuGet packages.</value>

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSProjectRestoreReferenceUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSProjectRestoreReferenceUtility.cs
@@ -93,16 +93,15 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 if (hasMissingReferences)
                 {
-                    // Log a warning message once per project
-                    // This warning contains only the names of the root project and the project with the
-                    // broken reference. Attempting to display more details on the actual reference
-                    // that has the problem may lead to another exception being thrown.
-                    var warning = string.Format(
+                    // Log a generic message once per project if any items could not be resolved.
+                    // In most cases this can be ignored, but in the rare case where the unresolved
+                    // item is actually a project the restore result will be incomplete.
+                    var message = string.Format(
                         CultureInfo.CurrentCulture,
-                        Strings.Warning_ErrorDuringProjectClosureWalk,
+                        Strings.UnresolvedItemDuringProjectClosureWalk,
                         EnvDTEProjectUtility.GetUniqueName(project));
 
-                    log.LogWarning(warning);
+                    log.LogVerbose(message);
                 }
 
                 return results;


### PR DESCRIPTION
This message can occur when any item in a project fails to resolve and Visual Studio DTE is unable to return it. This is a problem if the item is a project reference, but the rest of the time it does not impact NuGet. Based on the current feedback this message is appearing much more frequently and leading users to believe that there was a restore error when there was not.

The intent of the actual message is just to inform users that if they do see missing packages that it could have been caused by a broken project reference.

The fix for this is to move the message from warning to verbose. If a user does hit the rare scenario of getting an incomplete restore they can debug it by increasing their verbosity and reading the new, more helpful, message.

Fixes https://github.com/NuGet/Home/issues/3955

//cc @jainaashish @zhili1208 @nkolev92 @rohit21agrawal @rrelyea