### PR TITLE
Add support for ProjectAssetsFile

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.DependencyResolver;
@@ -132,6 +131,7 @@ namespace NuGet.Commands
             IEnumerable<string> packageFolders,
             string repositoryRoot,
             ProjectStyle projectStyle,
+            string assetsFilePath,
             bool success)
         {
             // For project.json not all files are written out. Find the first one
@@ -142,20 +142,27 @@ namespace NuGet.Commands
 
             if (firstImport != null)
             {
-                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, success);
+                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, assetsFilePath, success);
             }
         }
 
         /// <summary>
         /// Apply standard properties in a property group.
         /// </summary>
-        public static void AddNuGetProperties(XDocument doc, IEnumerable<string> packageFolders, string repositoryRoot, ProjectStyle projectStyle, bool success)
+        public static void AddNuGetProperties(
+            XDocument doc,
+            IEnumerable<string> packageFolders,
+            string repositoryRoot,
+            ProjectStyle projectStyle,
+            string assetsFilePath,
+            bool success)
         {
             doc.Root.AddFirst(
                 new XElement(Namespace + "PropertyGroup",
                             new XAttribute("Condition", $" {ExcludeAllCondition} "),
                             GenerateProperty("RestoreSuccess", success.ToString()),
                             GenerateProperty("RestoreTool", "NuGet"),
+                            GenerateProperty("ProjectAssetsFile", assetsFilePath),
                             GenerateProperty("NuGetPackageRoot", ReplacePathsWithMacros(repositoryRoot)),
                             GenerateProperty("NuGetPackageFolders", string.Join(";", packageFolders)),
                             GenerateProperty("NuGetProjectStyle", projectStyle.ToString()),
@@ -227,7 +234,7 @@ namespace NuGet.Commands
             entry.Add(new XElement(Namespace + "Private", privateFlag.ToString()));
 
             // Remove contentFile/lang/tfm/ from start of the path
-            var linkPath = string.Join(string.Empty + Path.DirectorySeparatorChar, 
+            var linkPath = string.Join(string.Empty + Path.DirectorySeparatorChar,
                     item.Path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
                         .Skip(3)
                         .ToArray());
@@ -357,6 +364,7 @@ namespace NuGet.Commands
             IEnumerable<RestoreTargetGraph> targetGraphs,
             IReadOnlyList<NuGetv3LocalRepository> repositories,
             RestoreRequest request,
+            string assetsFilePath,
             bool restoreSuccess,
             ILogger log)
         {
@@ -545,7 +553,7 @@ namespace NuGet.Commands
 
             var packageFolders = repositories.Select(e => e.RepositoryRoot);
 
-            AddNuGetPropertiesToFirstImport(files, packageFolders, repositoryRoot, request.ProjectStyle, restoreSuccess);
+            AddNuGetPropertiesToFirstImport(files, packageFolders, repositoryRoot, request.ProjectStyle, assetsFilePath, restoreSuccess);
 
             return files;
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -17,6 +17,29 @@ namespace NuGet.Commands.Test
     public class BuildAssetsUtilsTests
     {
         [Fact]
+        public void BuildAssetsUtils_GenerateProjectAssetsFilePath()
+        {
+            // Arrange
+            var path = "/tmp/test/project.assets.json";
+
+            var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+
+            // Act
+            BuildAssetsUtils.AddNuGetProperties(
+                doc,
+                Enumerable.Empty<string>(),
+                string.Empty,
+                ProjectStyle.PackageReference,
+                path,
+                success: true);
+
+            var props = doc.Root.Elements().First().Elements().ToDictionary(e => e.Name.LocalName, e => e.Value, StringComparer.OrdinalIgnoreCase);
+
+            // Assert
+            Assert.Equal(path, props["ProjectAssetsFile"]);
+        }
+
+        [Fact]
         public void BuildAssetsUtils_GenerateContentFilesItem_CompileAsset()
         {
             // Arrange
@@ -124,6 +147,7 @@ namespace NuGet.Commands.Test
                         new[] { globalPackagesFolder },
                         globalPackagesFolder,
                         ProjectStyle.PackageReference,
+                        assetsFilePath: string.Empty,
                         success: true);
 
                     // Assert


### PR DESCRIPTION
Add support for the ProjectAssetsFile property in the props/targets output. This will be read by the build task.

Fixes https://github.com/NuGet/Home/issues/4158

//cc @jainaashish 