### PR TITLE
Add MSBuildAllProjects property

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -14,6 +14,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup Condition="$(NugetTaskAssemblyFile) == ''">
     <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
     <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NugetTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackNuspecTask" AssemblyFile="$(NugetTaskAssemblyFile)" />

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -40,6 +40,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <RestoreTaskAssemblyFile Condition=" '$(RestoreTaskAssemblyFile)' == '' ">NuGet.Build.Tasks.dll</RestoreTaskAssemblyFile>
     <!-- Recurse by default -->
     <RestoreRecursive Condition=" '$(RestoreRecursive)' == '' ">true</RestoreRecursive>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
   <!-- Tasks -->

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -178,7 +178,9 @@ namespace NuGet.Commands
                 new XDeclaration("1.0", "utf-8", "no"),
 
                 new XElement(Namespace + "Project",
-                    new XAttribute("ToolsVersion", "14.0")));
+                    new XAttribute("ToolsVersion", "14.0"),
+                    new XElement(Namespace + "PropertyGroup", 
+                        new XElement("MSBuildAllProjects", "$(MSBuildAllProjects);$(MSBuildThisFileFullPath)"))));
 
             return doc;
         }

--- a/src/NuGet.Core/NuGet.Test.Utility/TargetsUtility.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/TargetsUtility.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -9,6 +10,44 @@ namespace NuGet.Test.Utility
 {
     public static class TargetsUtility
     {
+        /// <summary>
+        /// Read a targets or props file and find all properties.
+        /// </summary>
+        public static Dictionary<string, string> GetMSBuildProperties(string path)
+        {
+            if (File.Exists(path))
+            {
+                return GetMSBuildProperties(XDocument.Load(path));
+            }
+
+            return new Dictionary<string, string>();
+        }
+
+        /// <summary>
+        /// Read a targets or props file and find all properties.
+        /// </summary>
+        public static Dictionary<string, string> GetMSBuildProperties(XDocument doc)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            var propertyGroupName = XName.Get("PropertyGroup", "http://schemas.microsoft.com/developer/msbuild/2003");
+
+            foreach (var group in doc.Root.Elements(propertyGroupName))
+            {
+                foreach (var item in group.Elements())
+                {
+                    var key = item.Name.LocalName;
+
+                    if (!result.ContainsKey(key))
+                    {
+                        result.Add(key, item.Value);
+                    }
+                }
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Read a targets or props file and find all package related items.
         /// </summary>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -17,6 +17,18 @@ namespace NuGet.Commands.Test
     public class BuildAssetsUtilsTests
     {
         [Fact]
+        public void BuildAssetsUtils_GenerateMSBuildAllProjectsProperty()
+        {
+            // Arrange & Act
+            var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+
+            var props = TargetsUtility.GetMSBuildProperties(doc);
+
+            // Assert
+            Assert.Equal("$(MSBuildAllProjects);$(MSBuildThisFileFullPath)", props["MSBuildAllProjects"]);
+        }
+
+        [Fact]
         public void BuildAssetsUtils_GenerateProjectAssetsFilePath()
         {
             // Arrange
@@ -33,7 +45,7 @@ namespace NuGet.Commands.Test
                 path,
                 success: true);
 
-            var props = doc.Root.Elements().First().Elements().ToDictionary(e => e.Name.LocalName, e => e.Value, StringComparer.OrdinalIgnoreCase);
+            var props = TargetsUtility.GetMSBuildProperties(doc);
 
             // Assert
             Assert.Equal(path, props["ProjectAssetsFile"]);


### PR DESCRIPTION
Add MSBuildAllProjects property to all MSBuild related files. This improves support for incremental builds.

Fixes https://github.com/NuGet/Home/issues/3851

//cc @jainaashish @zhili1208 @rohit21agrawal @nkolev92 