### PR TITLE
UI work for package manager format selector

### DIFF
--- a/src/NuGet.Clients/Options/GeneralOptionControl.Designer.cs
+++ b/src/NuGet.Clients/Options/GeneralOptionControl.Designer.cs
@@ -36,6 +36,10 @@
             this.BindingRedirectsHeader = new System.Windows.Forms.Label();
             this.localsCommandButton = new System.Windows.Forms.Button();
             this.localsCommandStatusText = new System.Windows.Forms.RichTextBox();
+            this.PackageManagementHeader = new System.Windows.Forms.Label();
+            this.defaultPackageManagementFormatLabel = new System.Windows.Forms.Label();
+            this.showPackageManagementChooser = new System.Windows.Forms.CheckBox();
+            this.defaultPackageManagementFormatItems = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // skipBindingRedirects
@@ -79,15 +83,43 @@
             this.localsCommandStatusText.BackColor = System.Drawing.SystemColors.Control;
             this.localsCommandStatusText.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.localsCommandStatusText.Name = "localsCommandStatusText";
-            this.localsCommandStatusText.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.localsCommandStatusText_LinkClicked);
             this.localsCommandStatusText.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.localsCommandStatusText_ContentChanged);
-            this.localsCommandStatusText.WordWrap = false;
-            this.localsCommandStatusText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;           
+            this.localsCommandStatusText.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.localsCommandStatusText_LinkClicked);
+            // 
+            // PackageManagementHeader
+            // 
+            resources.ApplyResources(this.PackageManagementHeader, "PackageManagementHeader");
+            this.PackageManagementHeader.Name = "PackageManagementHeader";
+            // 
+            // defaultPackageManagementFormatLabel
+            // 
+            resources.ApplyResources(this.defaultPackageManagementFormatLabel, "defaultPackageManagementFormatLabel");
+            this.defaultPackageManagementFormatLabel.Name = "defaultPackageManagementFormatLabel";
+            // 
+            // showPackageManagementChooser
+            // 
+            resources.ApplyResources(this.showPackageManagementChooser, "showPackageManagementChooser");
+            this.showPackageManagementChooser.Name = "showPackageManagementChooser";
+            this.showPackageManagementChooser.UseVisualStyleBackColor = true;
+            // 
+            // defaultPackageManagementFormatItems
+            // 
+            this.defaultPackageManagementFormatItems.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.defaultPackageManagementFormatItems.FormattingEnabled = true;
+            this.defaultPackageManagementFormatItems.Items.AddRange(new object[] {
+            resources.GetString("defaultPackageManagementFormatItems.Items"),
+            resources.GetString("defaultPackageManagementFormatItems.Items1")});
+            resources.ApplyResources(this.defaultPackageManagementFormatItems, "defaultPackageManagementFormatItems");
+            this.defaultPackageManagementFormatItems.Name = "defaultPackageManagementFormatItems";
             // 
             // GeneralOptionControl
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.defaultPackageManagementFormatItems);
+            this.Controls.Add(this.showPackageManagementChooser);
+            this.Controls.Add(this.defaultPackageManagementFormatLabel);
+            this.Controls.Add(this.PackageManagementHeader);
             this.Controls.Add(this.BindingRedirectsHeader);
             this.Controls.Add(this.skipBindingRedirects);
             this.Controls.Add(this.PackageRestoreHeader);
@@ -110,5 +142,9 @@
         private System.Windows.Forms.Label BindingRedirectsHeader;
         private System.Windows.Forms.Button localsCommandButton;
         private System.Windows.Forms.RichTextBox localsCommandStatusText;
+        private System.Windows.Forms.Label PackageManagementHeader;
+        private System.Windows.Forms.Label defaultPackageManagementFormatLabel;
+        private System.Windows.Forms.CheckBox showPackageManagementChooser;
+        private System.Windows.Forms.ComboBox defaultPackageManagementFormatItems;
     }
 }

--- a/src/NuGet.Clients/Options/GeneralOptionControl.resx
+++ b/src/NuGet.Clients/Options/GeneralOptionControl.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="skipBindingRedirects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 138</value>
+    <value>19, 118</value>
   </data>
   <data name="skipBindingRedirects.Size" type="System.Drawing.Size, System.Drawing">
     <value>169, 17</value>
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;skipBindingRedirects.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="PackageRestoreHeader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -178,7 +178,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;PackageRestoreHeader.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="packageRestoreConsentCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -208,7 +208,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;packageRestoreConsentCheckBox.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>7</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -238,7 +238,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;packageRestoreAutomaticCheckBox.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>8</value>
   </data>
   <data name="BindingRedirectsHeader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +250,7 @@
     <value>NoControl</value>
   </data>
   <data name="BindingRedirectsHeader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 112</value>
+    <value>2, 92</value>
   </data>
   <data name="BindingRedirectsHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -274,13 +274,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BindingRedirectsHeader.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>4</value>
   </data>
   <data name="localsCommandButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="localsCommandButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 194</value>
+    <value>5, 247</value>
   </data>
   <data name="localsCommandButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>134, 23</value>
@@ -301,13 +301,16 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;localsCommandButton.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>9</value>
   </data>
   <data name="localsCommandStatusText.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="localsCommandStatusText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 220</value>
+    <value>5, 276</value>
+  </data>
+  <data name="localsCommandStatusText.ScrollBars" type="System.Windows.Forms.RichTextBoxScrollBars, System.Windows.Forms">
+    <value>None</value>
   </data>
   <data name="localsCommandStatusText.Size" type="System.Drawing.Size, System.Drawing">
     <value>432, 62</value>
@@ -321,6 +324,9 @@
   <data name="localsCommandStatusText.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
+  <data name="localsCommandStatusText.WordWrap" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
   <data name="&gt;&gt;localsCommandStatusText.Name" xml:space="preserve">
     <value>localsCommandStatusText</value>
   </data>
@@ -331,7 +337,127 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;localsCommandStatusText.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>10</value>
+  </data>
+  <data name="PackageManagementHeader.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="PackageManagementHeader.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
+  </data>
+  <data name="PackageManagementHeader.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="PackageManagementHeader.Location" type="System.Drawing.Point, System.Drawing">
+    <value>2, 151</value>
+  </data>
+  <data name="PackageManagementHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="PackageManagementHeader.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 13</value>
+  </data>
+  <data name="PackageManagementHeader.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="PackageManagementHeader.Text" xml:space="preserve">
+    <value>Package Management</value>
+  </data>
+  <data name="&gt;&gt;PackageManagementHeader.Name" xml:space="preserve">
+    <value>PackageManagementHeader</value>
+  </data>
+  <data name="&gt;&gt;PackageManagementHeader.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PackageManagementHeader.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;PackageManagementHeader.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="defaultPackageManagementFormatLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="defaultPackageManagementFormatLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 178</value>
+  </data>
+  <data name="defaultPackageManagementFormatLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>185, 13</value>
+  </data>
+  <data name="defaultPackageManagementFormatLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="defaultPackageManagementFormatLabel.Text" xml:space="preserve">
+    <value>&amp;Default package management format:</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatLabel.Name" xml:space="preserve">
+    <value>defaultPackageManagementFormatLabel</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="showPackageManagementChooser.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showPackageManagementChooser.Location" type="System.Drawing.Point, System.Drawing">
+    <value>19, 206</value>
+  </data>
+  <data name="showPackageManagementChooser.Size" type="System.Drawing.Size, System.Drawing">
+    <value>315, 17</value>
+  </data>
+  <data name="showPackageManagementChooser.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="showPackageManagementChooser.Text" xml:space="preserve">
+    <value>Do not &amp;show the format selector dialog on first package install</value>
+  </data>
+  <data name="&gt;&gt;showPackageManagementChooser.Name" xml:space="preserve">
+    <value>showPackageManagementChooser</value>
+  </data>
+  <data name="&gt;&gt;showPackageManagementChooser.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showPackageManagementChooser.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;showPackageManagementChooser.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="defaultPackageManagementFormatItems.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="defaultPackageManagementFormatItems.Items" xml:space="preserve">
+    <value>Packages.config</value>
+  </data>
+  <data name="defaultPackageManagementFormatItems.Items1" xml:space="preserve">
+    <value>PackageReference</value>
+  </data>
+  <data name="defaultPackageManagementFormatItems.Location" type="System.Drawing.Point, System.Drawing">
+    <value>204, 173</value>
+  </data>
+  <data name="defaultPackageManagementFormatItems.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 21</value>
+  </data>
+  <data name="defaultPackageManagementFormatItems.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Name" xml:space="preserve">
+    <value>defaultPackageManagementFormatItems</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;defaultPackageManagementFormatItems.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -343,7 +469,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>463, 285</value>
+    <value>460, 365</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GeneralOptionControl</value>

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
@@ -268,6 +268,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make this package manager format the default and do not show this dialog again..
+        /// </summary>
+        public static string CheckBox_DefaultPackageFormat {
+            get {
+                return ResourceManager.GetString("CheckBox_DefaultPackageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Force uninstall, even if there are dependencies on it.
         /// </summary>
         public static string Checkbox_ForceRemove {
@@ -882,6 +891,24 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PackageReference in project file.
+        /// </summary>
+        public static string RadioBtn_PackageRef {
+            get {
+                return ResourceManager.GetString("RadioBtn_PackageRef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Packages.config.
+        /// </summary>
+        public static string RadioBtn_PackagesConfig {
+            get {
+                return ResourceManager.GetString("RadioBtn_PackagesConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Multiple packages failed to uninstall. Restart Visual Studio to finish the process..
         /// </summary>
         public static string RequestRestartToCompleteUninstallMultiplePackages {
@@ -1062,6 +1089,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can manage these settings in .
+        /// </summary>
+        public static string Text_ManageSettings {
+            get {
+                return ResourceManager.GetString("Text_ManageSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to multiple versions installed.
         /// </summary>
         public static string Text_MultipleVersionsInstalled {
@@ -1112,6 +1148,60 @@ namespace NuGet.PackageManagement.UI {
         public static string Text_NotInstalled {
             get {
                 return ResourceManager.GetString("Text_NotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NuGet Settings.
+        /// </summary>
+        public static string Text_NuGetSettings {
+            get {
+                return ResourceManager.GetString("Text_NuGetSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package manager format will apply to the following projects in this Solution.
+        /// </summary>
+        public static string Text_PackageFormatApply {
+            get {
+                return ResourceManager.GetString("Text_PackageFormatApply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the NuGet package manager format for {0}.
+        /// </summary>
+        public static string Text_PackageFormatSelection {
+            get {
+                return ResourceManager.GetString("Text_PackageFormatSelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select the NuGet package manager format for this Solution.
+        /// </summary>
+        public static string Text_PackageFormatSelection_Solution {
+            get {
+                return ResourceManager.GetString("Text_PackageFormatSelection_Solution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Projects with PackageReference are not supported in Visual Studio 2015 and earlier..
+        /// </summary>
+        public static string Text_PackageRefSupport {
+            get {
+                return ResourceManager.GetString("Text_PackageRefSupport", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Learn more about package reference.
+        /// </summary>
+        public static string Text_PackageRefSupport_DocumentLink {
+            get {
+                return ResourceManager.GetString("Text_PackageRefSupport_DocumentLink", resourceCulture);
             }
         }
         
@@ -1409,6 +1499,15 @@ namespace NuGet.PackageManagement.UI {
         public static string WindowTitle_LicenseAcceptance {
             get {
                 return ResourceManager.GetString("WindowTitle_LicenseAcceptance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Choose NuGet Package Manager Format.
+        /// </summary>
+        public static string WindowTitle_PackageFormatSelector {
+            get {
+                return ResourceManager.GetString("WindowTitle_PackageFormatSelector", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.resx
@@ -587,4 +587,37 @@ Packages installed into Website projects will not be restored during build. Cons
     <value>.</value>
     <comment>This test goes immediately after the document link.</comment>
   </data>
+  <data name="CheckBox_DefaultPackageFormat" xml:space="preserve">
+    <value>Make this package manager format the default and do not show this dialog again.</value>
+  </data>
+  <data name="RadioBtn_PackageRef" xml:space="preserve">
+    <value>PackageReference in project file</value>
+  </data>
+  <data name="RadioBtn_PackagesConfig" xml:space="preserve">
+    <value>Packages.config</value>
+  </data>
+  <data name="Text_ManageSettings" xml:space="preserve">
+    <value>You can manage these settings in </value>
+  </data>
+  <data name="Text_NuGetSettings" xml:space="preserve">
+    <value>NuGet Settings</value>
+  </data>
+  <data name="Text_PackageFormatSelection" xml:space="preserve">
+    <value>Select the NuGet package manager format for {0}</value>
+  </data>
+  <data name="Text_PackageFormatSelection_Solution" xml:space="preserve">
+    <value>Select the NuGet package manager format for this Solution</value>
+  </data>
+  <data name="Text_PackageRefSupport" xml:space="preserve">
+    <value>Projects with PackageReference are not supported in Visual Studio 2015 and earlier.</value>
+  </data>
+  <data name="Text_PackageRefSupport_DocumentLink" xml:space="preserve">
+    <value>Learn more about package reference</value>
+  </data>
+  <data name="WindowTitle_PackageFormatSelector" xml:space="preserve">
+    <value>Choose NuGet Package Manager Format</value>
+  </data>
+  <data name="Text_PackageFormatApply" xml:space="preserve">
+    <value>The package manager format will apply to the following projects in this Solution</value>
+  </data>
 </root>


### PR DESCRIPTION
There are two parts of this work, first is to get all the strings resources checked into dev for this new UI window for package manager format selector and NuGet Tools options window. So that localization team can pick these up and start with their localization work. Second part is to complete the feature end to end and respect user's choice of package format and create new NuGet project accordingly.

This PR targets first part only. And there will be another PR which will complete this feature end to end.

Spec - https://github.com/NuGet/Home/wiki/Supporting-Package-Reference-in-UWP-WPF-WinForms-and-Classic-Libraries

Fixes https://github.com/NuGet/Home/issues/3921 

@rrelyea @emgarten @rohit21agrawal @nkolev92 @zhili1208 