### PR TITLE
Add support for reading UAP target frameworks from MSBuild

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -43,64 +44,32 @@ namespace NuGet.Common
 
         public string ProjectFileFullPath { get; }
 
+        private NuGetFramework _targetFramework;
+
         public NuGetFramework TargetFramework
         {
             get
             {
-                // this is required to get the right TFM for native or js projects since TargetFrameworkMoniker
-                // property won't give the accurate value for these kind of projects
-                var moniker = GetTargetFrameworkString();
-
-                if (String.IsNullOrEmpty(moniker))
+                if (_targetFramework == null)
                 {
-                    return null;
+                    var frameworkStrings = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                        projectFilePath: ProjectFileFullPath,
+                        targetFrameworks: GetPropertyValue("TargetFrameworks"),
+                        targetFramework: GetPropertyValue("TargetFramework"),
+                        targetFrameworkMoniker: GetPropertyValue("TargetFrameworkMoniker"),
+                        targetPlatformIdentifier: GetPropertyValue("TargetPlatformIdentifier"),
+                        targetPlatformVersion: GetPropertyValue("TargetPlatformVersion"));
+
+                    // Parse the framework of the project or return unsupported.
+                    _targetFramework = MSBuildProjectFrameworkUtility.GetProjectFrameworks(frameworkStrings).FirstOrDefault()
+                        ?? NuGetFramework.UnsupportedFramework;
                 }
 
-                var framework = NuGetFramework.Parse(moniker);
-
-                // further parse framework for .net core 4.5.1 or 4.5 and get compatible framework instance
-                return MSBuildNuGetProjectSystemUtility.GetProjectFrameworkReplacement(framework);
+                return _targetFramework;
             }
         }
 
         private dynamic Project { get; }
-
-        private string GetTargetFrameworkString()
-        {
-            var extension = GetPropertyValue(ProjectManagement.Constants.ProjectExt);
-
-            // Check for JS project
-            if (StringComparer.OrdinalIgnoreCase.Equals(ProjectManagement.Constants.JSProjectExt, extension))
-            {
-                // JavaScript apps do not have a TargetFrameworkMoniker property set.
-                // We read the TargetPlatformIdentifier and TargetPlatformVersion instead
-                var platformIdentifier = GetPropertyValue(ProjectManagement.Constants.TargetPlatformIdentifier);
-                var platformVersion = GetPropertyValue(ProjectManagement.Constants.TargetPlatformVersion);
-
-                // use the default values for JS if they were not given
-                if (string.IsNullOrEmpty(platformVersion))
-                {
-                    platformVersion = "0.0";
-                }
-
-                if (string.IsNullOrEmpty(platformIdentifier))
-                {
-                    platformIdentifier = "Windows";
-                }
-
-                return string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}", platformIdentifier, platformVersion);
-            }
-
-            // Check for C++ project
-            if (StringComparer.OrdinalIgnoreCase.Equals(ProjectManagement.Constants.VCXProjextExt, extension))
-            {
-                // The C++ project does not have a TargetFrameworkMoniker property set. 
-                // We hard-code the return value to Native.
-                return ProjectManagement.Constants.NativeTFM;
-            }
-
-            return GetPropertyValue(ProjectManagement.Constants.TargetFrameworkMoniker);
-        }
 
         public void AddBindingRedirects()
         {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -170,7 +170,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     ThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
                             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                            _targetFramework = EnvDTEProjectUtility.GetTargetNuGetFramework(EnvDTEProject) ?? NuGetFramework.UnsupportedFramework;
+                            _targetFramework = EnvDTEProjectUtility.GetTargetNuGetFramework(EnvDTEProject);
                         });
                 }
 
@@ -791,7 +791,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 // Silverlight projects and Windows Phone projects do not support binding redirect.
                 // They both share the same identifier as "Silverlight"
-                return !SilverlightTargetFrameworkIdentifier.Equals(TargetFramework.DotNetFrameworkName, StringComparison.OrdinalIgnoreCase);
+                return !SilverlightTargetFrameworkIdentifier.Equals(TargetFramework.Framework, StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -18,6 +18,7 @@ using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
@@ -599,18 +600,19 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            string targetFrameworkMoniker = GetTargetFrameworkString(envDTEProject);
-            if (!String.IsNullOrEmpty(targetFrameworkMoniker))
-            {
-                var framework = NuGetFramework.Parse(targetFrameworkMoniker);
+            var targetFrameworkMoniker = GetTargetFrameworkString(envDTEProject);
 
-                // further parse framework for .net core 4.5.1 or 4.5 and get compatible framework instance
-               return MSBuildNuGetProjectSystemUtility.GetProjectFrameworkReplacement(framework);
+            if (!string.IsNullOrEmpty(targetFrameworkMoniker))
+            {
+                return NuGetFramework.Parse(targetFrameworkMoniker);
             }
 
             return NuGetFramework.UnsupportedFramework;
         }
 
+        /// <summary>
+        /// Determine the project framework string based on the project properties.
+        /// </summary>
         public static string GetTargetFrameworkString(EnvDTEProject envDTEProject)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
@@ -620,54 +622,26 @@ namespace NuGet.PackageManagement.VisualStudio
                 return null;
             }
 
-            if (IsJavaScriptProject(envDTEProject))
-            {
-                // JavaScript apps do not have a TargetFrameworkMoniker property set.
-                // We read the TargetPlatformIdentifier and TargetPlatformVersion instead
+            var projectPath = GetFullProjectPath(envDTEProject);
+            var platformIdentifier = GetPropertyValue<string>(envDTEProject, "TargetPlatformIdentifier");
+            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
+            var targetFrameworkMoniker = GetPropertyValue<string>(envDTEProject, "TargetFrameworkMoniker");
+            var targetFramework = GetPropertyValue<string>(envDTEProject, "TargetFramework");
+            var targetFrameworks = GetPropertyValue<string>(envDTEProject, "TargetFrameworks");
+            var isManagementPackProject = IsManagementPackProject(envDTEProject);
+            var isXnaWindowsPhoneProject = IsXnaWindowsPhoneProject(envDTEProject);
 
-                string platformIdentifier = GetPropertyValue<string>(envDTEProject, "TargetPlatformIdentifier");
-                string platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
+            var frameworkStrings = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                projectFilePath: projectPath,
+                targetFrameworks: targetFrameworks,
+                targetFramework: targetFramework,
+                targetFrameworkMoniker: targetFrameworkMoniker,
+                targetPlatformIdentifier: platformIdentifier,
+                targetPlatformVersion: platformVersion,
+                isManagementPackProject: isManagementPackProject,
+                isXnaWindowsPhoneProject: isXnaWindowsPhoneProject);
 
-                // use the default values for JS if they were not given
-                if (String.IsNullOrEmpty(platformVersion))
-                {
-                    platformVersion = "0.0";
-                }
-
-                if (String.IsNullOrEmpty(platformIdentifier))
-                {
-                    platformIdentifier = "Windows";
-                }
-
-                return String.Format(CultureInfo.InvariantCulture, "{0}, Version={1}", platformIdentifier, platformVersion);
-            }
-
-            if (IsManagementPackProject(envDTEProject))
-            {
-                // The MP project does not have a TargetFrameworkMoniker property set. 
-                // We hard-code the return value to SCMPInfra.
-                return "SCMPInfra, Version=0.0";
-            }
-
-            if (IsNativeProject(envDTEProject))
-            {
-                // The C++ project does not have a TargetFrameworkMoniker property set. 
-                // We hard-code the return value to Native.
-                return Constants.NativeTFM;
-            }
-
-            string targetFramework = GetPropertyValue<string>(envDTEProject, "TargetFrameworkMoniker");
-
-            // XNA project lies about its true identity, reporting itself as a normal .NET 4.0 project.
-            // We detect it and changes its target framework to Silverlight4-WindowsPhone71
-            if (".NETFramework,Version=v4.0".Equals(targetFramework, StringComparison.OrdinalIgnoreCase)
-                &&
-                IsXnaWindowsPhoneProject(envDTEProject))
-            {
-                return "Silverlight,Version=v4.0,Profile=WindowsPhone71";
-            }
-
-            return targetFramework;
+            return frameworkStrings.FirstOrDefault();
         }
 
         internal static async Task<bool> ContainsFile(EnvDTEProject envDTEProject, string path)

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectFrameworks.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectFrameworks.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using NuGet.Commands;
+
+namespace NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Determine the project's targetframework(s) based
+    /// on the available properties.
+    /// </summary>
+    public class GetRestoreProjectFrameworks : Task
+    {
+        /// <summary>
+        /// Full path to the msbuild project.
+        /// </summary>
+        [Required]
+        public string ProjectPath { get; set; }
+
+        /// <summary>
+        /// Optional TargetFrameworkMoniker property value.
+        /// </summary>
+        public string TargetFrameworkMoniker { get; set; }
+
+        /// <summary>
+        /// Optional TargetPlatformIdentifier property value.
+        /// </summary>
+        public string TargetPlatformIdentifier { get; set; }
+
+        /// <summary>
+        /// Optional TargetPlatformVersion property value.
+        /// </summary>
+        public string TargetPlatformVersion { get; set; }
+
+        /// <summary>
+        /// Optional TargetFrameworks property value.
+        /// </summary>
+        public string TargetFrameworks { get; set; }
+
+        /// <summary>
+        /// Optional TargetFrameworks property value.
+        /// </summary>
+        public string TargetFramework { get; set; }
+
+        /// <summary>
+        /// ; delimited list of target frameworks for the project.
+        /// </summary>
+        [Output]
+        public string ProjectTargetFrameworks { get; set; }
+
+        public override bool Execute()
+        {
+            var log = new MSBuildLogger(Log);
+            log.LogDebug($"(in) ProjectPath '{ProjectPath}'");
+            log.LogDebug($"(in) TargetFrameworkMoniker '{TargetFrameworkMoniker}'");
+            log.LogDebug($"(in) TargetPlatformIdentifier '{TargetPlatformIdentifier}'");
+            log.LogDebug($"(in) TargetPlatformVersion '{TargetPlatformVersion}'");
+            log.LogDebug($"(in) TargetFrameworks '{TargetFrameworks}'");
+            log.LogDebug($"(in) TargetFramework '{TargetFramework}'");
+
+            // If no framework can be found this will return Unsupported.
+            var frameworks = MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                projectFilePath: ProjectPath,
+                targetFrameworks: TargetFrameworks,
+                targetFramework: TargetFramework,
+                targetFrameworkMoniker: TargetFrameworkMoniker,
+                targetPlatformIdentifier: TargetPlatformIdentifier,
+                targetPlatformVersion: TargetPlatformVersion);
+
+            ProjectTargetFrameworks = string.Join(";", frameworks);
+
+            log.LogDebug($"(out) ProjectTargetFrameworks '{ProjectTargetFrameworks}'");
+
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectJsonPathTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectJsonPathTask.cs
@@ -22,6 +22,9 @@ namespace NuGet.Build.Tasks
 
         public override bool Execute()
         {
+            var log = new MSBuildLogger(Log);
+            log.LogDebug($"(in) ProjectPath '{ProjectPath}'");
+
             var directory = Path.GetDirectoryName(ProjectPath);
             var projectName = Path.GetFileNameWithoutExtension(ProjectPath);
 
@@ -32,6 +35,8 @@ namespace NuGet.Build.Tasks
             {
                 ProjectJsonPath = path;
             }
+
+            log.LogDebug($"(out) ProjectJsonPath '{ProjectJsonPath}'");
 
             return true;
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -50,6 +50,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestorePackageReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreDotnetCliToolsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectFrameworks" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <!--
     ============================================================
@@ -274,31 +275,33 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
     _GetRestoreTargetFrameworksOutput
-    Get frameworks to be passed in as $(TargetFramework)
+    Read target frameworks from the project.
     ============================================================
   -->
   <Target Name="_GetRestoreTargetFrameworksOutput"
     DependsOnTargets="_GetRestoreProjectStyle"
+    Condition=" '$(RestoreProjectStyle)' != 'ProjectJson' "
     Returns="@(_RestoreTargetFrameworksOutputFiltered)">
+    <PropertyGroup>
+      <_RestoreProjectFramework></_RestoreProjectFramework>
+    </PropertyGroup>
 
-    <!-- Loop on target frameworks, if no frameworks exist the targets below will
-         run once using an empty framework string -->
-    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' != '' ">
-      <_RestoreTargetFrameworksOutput Include="$(TargetFrameworks.Split(';'))" />
-    </ItemGroup>
-
-    <!-- Use $(TargetFramework) if $(TargetFrameworks) is empty  -->
-    <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' == '' AND '$(TargetFramework)' != '' ">
-      <_RestoreTargetFrameworksOutput Include="$(TargetFramework)" />
-    </ItemGroup>
-
-    <!-- Remove duplicate frameworks -->
-    <RemoveDuplicates
-      Inputs="@(_RestoreTargetFrameworksOutput)">
+    <!-- For project.json projects target frameworks will be read from project.json. -->
+    <GetRestoreProjectFrameworks
+      ProjectPath="$(MSBuildProjectFullPath)"
+      TargetFrameworks="$(TargetFrameworks)"
+      TargetFramework="$(TargetFramework)"
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+      TargetPlatformVersion="$(TargetPlatformVersion)">
       <Output
-          TaskParameter="Filtered"
-          ItemName="_RestoreTargetFrameworksOutputFiltered" />
-    </RemoveDuplicates>
+        TaskParameter="ProjectTargetFrameworks"
+        PropertyName="_RestoreProjectFramework" />
+    </GetRestoreProjectFrameworks>
+
+    <ItemGroup Condition=" '$(_RestoreProjectFramework)' != '' ">
+      <_RestoreTargetFrameworksOutputFiltered Include="$(_RestoreProjectFramework.Split(';'))" />
+    </ItemGroup>
   </Target>
 
   <!--
@@ -396,7 +399,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ProjectPath>$(MSBuildProjectFullPath)</ProjectPath>
         <ProjectName>$(_RestoreProjectName)</ProjectName>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
-        <TargetFrameworks>$(TargetFrameworkMoniker)</TargetFrameworks>
+        <TargetFrameworks>@(_RestoreTargetFrameworksOutputFiltered)</TargetFrameworks>
       </_RestoreGraphEntry>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace NuGet.Commands
+{
+    public static class MSBuildProjectFrameworkUtility
+    {
+        /// <summary>
+        /// Determine the target framework of an msbuild project.
+        /// </summary>
+        public static IEnumerable<string> GetProjectFrameworkStrings(
+            string projectFilePath,
+            string targetFrameworks,
+            string targetFramework,
+            string targetFrameworkMoniker,
+            string targetPlatformIdentifier,
+            string targetPlatformVersion)
+        {
+            return GetProjectFrameworkStrings(
+                projectFilePath,
+                targetFrameworks,
+                targetFramework,
+                targetFrameworkMoniker,
+                targetPlatformIdentifier,
+                targetPlatformVersion,
+                isManagementPackProject: false,
+                isXnaWindowsPhoneProject: false);
+        }
+
+        /// <summary>
+        /// Determine the target framework of an msbuild project.
+        /// </summary>
+        public static IEnumerable<string> GetProjectFrameworkStrings(
+            string projectFilePath,
+            string targetFrameworks,
+            string targetFramework,
+            string targetFrameworkMoniker,
+            string targetPlatformIdentifier,
+            string targetPlatformVersion,
+            bool isXnaWindowsPhoneProject,
+            bool isManagementPackProject)
+        {
+            if (projectFilePath == null)
+            {
+                throw new ArgumentNullException(nameof(projectFilePath));
+            }
+
+            var frameworks = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // TargetFrameworks property
+            frameworks.UnionWith(MSBuildStringUtility.Split(targetFrameworks));
+
+            if (frameworks.Count > 0)
+            {
+                return frameworks;
+            }
+
+            // TargetFramework property
+            var currentFrameworkString = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFramework);
+
+            if (!string.IsNullOrEmpty(currentFrameworkString))
+            {
+                frameworks.Add(currentFrameworkString);
+
+                return frameworks;
+            }
+
+            // C++ check
+            if (projectFilePath.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase))
+            {
+                // The C++ project does not have a TargetFrameworkMoniker property set. 
+                // We hard-code the return value to Native.
+                frameworks.Add("Native, Version=0.0");
+
+                return frameworks;
+            }
+
+            // The MP project does not have a TargetFrameworkMoniker property set. 
+            // We hard-code the return value to SCMPInfra.
+            if (isManagementPackProject)
+            {
+                frameworks.Add("SCMPInfra, Version=0.0");
+
+                return frameworks;
+            }
+
+            // UAP/Windows store projects
+            var platformIdentifier = MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformIdentifier);
+            var platformVersion = MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformVersion);
+
+            // Check for JS project
+            if (projectFilePath.EndsWith(".jsproj", StringComparison.OrdinalIgnoreCase))
+            {
+                // JavaScript apps do not have a TargetFrameworkMoniker property set.
+                // We read the TargetPlatformIdentifier and TargetPlatformVersion instead
+                // use the default values for JS if they were not given
+                if (string.IsNullOrEmpty(platformVersion))
+                {
+                    platformVersion = "0.0";
+                }
+
+                if (string.IsNullOrEmpty(platformIdentifier))
+                {
+                    platformIdentifier = FrameworkConstants.FrameworkIdentifiers.Windows;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(platformIdentifier)
+                && !string.IsNullOrEmpty(platformVersion))
+            {
+                // Use the platform id and versions, this is done for UAP projects
+                frameworks.Add($"{platformIdentifier}, Version={platformVersion}");
+
+                return frameworks;
+            }
+
+            // TargetFrameworkMoniker
+            currentFrameworkString = MSBuildStringUtility.TrimAndGetNullForEmpty(targetFrameworkMoniker);
+
+            if (!string.IsNullOrEmpty(currentFrameworkString))
+            {
+                // XNA project lies about its true identity, reporting itself as a normal .NET 4.0 project.
+                // We detect it and changes its target framework to Silverlight4-WindowsPhone71
+                if (isXnaWindowsPhoneProject
+                    && ".NETFramework,Version=v4.0".Equals(currentFrameworkString, StringComparison.OrdinalIgnoreCase))
+                {
+                    currentFrameworkString = "Silverlight,Version=v4.0,Profile=WindowsPhone71";
+                }
+
+                frameworks.Add(currentFrameworkString);
+
+                return frameworks;
+            }
+
+            // Default to unsupported it no framework can be found.
+            if (frameworks.Count < 1)
+            {
+                frameworks.Add(NuGetFramework.UnsupportedFramework.ToString());
+            }
+
+            return frameworks;
+        }
+
+        /// <summary>
+        /// Parse project framework strings into NuGetFrameworks.
+        /// </summary>
+        public static IEnumerable<NuGetFramework> GetProjectFrameworks(IEnumerable<string> frameworkStrings)
+        {
+            if (frameworkStrings == null)
+            {
+                throw new ArgumentNullException(nameof(frameworkStrings));
+            }
+
+            var frameworks = new List<NuGetFramework>();
+
+            foreach (var frameworkString in frameworkStrings)
+            {
+                var parsed = NuGetFramework.Parse(frameworkString);
+
+                // Replace if needed
+                parsed = GetProjectFrameworkReplacement(parsed);
+
+                // Add only unique frameworks
+                if (!frameworks.Contains(parsed))
+                {
+                    frameworks.Add(parsed);
+                }
+            }
+
+            return frameworks;
+        }
+
+        /// <summary>
+        /// Parse existing nuget framework for .net core 4.5.1 or 4.5 and return compatible framework instance
+        /// </summary>
+        public static NuGetFramework GetProjectFrameworkReplacement(NuGetFramework framework)
+        {
+            if (framework == null)
+            {
+                throw new ArgumentNullException(nameof(framework));
+            }
+
+            // if the framework is .net core 4.5.1 return windows 8.1
+            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
+                && framework.Version.Equals(Version.Parse("4.5.1.0")))
+            {
+                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
+                       new Version("8.1"), framework.Profile);
+            }
+            // if the framework is .net core 4.5 return 8.0
+            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
+                && framework.Version.Equals(Version.Parse("4.5.0.0")))
+            {
+                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
+                       new Version("8.0"), framework.Profile);
+            }
+
+            return framework;
+        }
+
+        private static string GetPropertyOrNull(string propertyName, IDictionary<string, string> projectProperties)
+        {
+            string value;
+            if (projectProperties.TryGetValue(propertyName, out value)
+                && !string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/Utility/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MsBuildStringUtility.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 
 namespace NuGet.Commands
@@ -55,6 +56,22 @@ namespace NuGet.Commands
                 .Select(s => TrimAndGetNullForEmpty(s))
                 .Where(s => s != null)
                 .ToArray();
+        }
+
+        /// <summary>
+        /// True if the property is set to true
+        /// </summary>
+        public static bool IsTrue(string value)
+        {
+            return Boolean.TrueString.Equals(TrimAndGetNullForEmpty(value), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True if the property is set to true or empty.
+        /// </summary>
+        public static bool IsTrueOrEmpty(string value)
+        {
+            return TrimAndGetNullForEmpty(value) == null || IsTrue(value);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/MSBuildNuGetProjectSystemUtility.cs
@@ -37,36 +37,6 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Parse existing nuget framework for .net core 4.5.1 or 4.5 and return compatible framework instance
-        /// </summary>
-        /// <param name="framework"></param>
-        /// <returns></returns>
-        public static NuGetFramework GetProjectFrameworkReplacement(NuGetFramework framework)
-        {
-            if (framework == null)
-            {
-                throw new ArgumentNullException(nameof(framework));
-            }
-
-            // if the framework is .net core 4.5.1 return windows 8.1
-            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
-                && framework.Version.Equals(Version.Parse("4.5.1.0")))
-            {
-                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
-                       new Version("8.1"), framework.Profile);
-            }
-            // if the framework is .net core 4.5 return 8.0
-            if (framework.Framework.Equals(FrameworkConstants.FrameworkIdentifiers.NetCore)
-                && framework.Version.Equals(Version.Parse("4.5.0.0")))
-            {
-                return new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Windows,
-                       new Version("8.0"), framework.Profile);
-            }
-
-            return framework;
-        }
-
-        /// <summary>
         /// Filter out invalid package items and replace the directory separator with the correct slash for the 
         /// current OS.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -44,6 +44,11 @@ namespace NuGet.Test.Utility
         public Guid ProjectGuid { get; set; } = Guid.NewGuid();
 
         /// <summary>
+        /// True for non-xplat.
+        /// </summary>
+        public bool IsLegacyPackageReference { get; set; }
+
+        /// <summary>
         /// MSBuild project name
         /// </summary>
         public string ProjectName { get; set; }
@@ -275,6 +280,20 @@ namespace NuGet.Test.Utility
             }
         }
 
+        /// <summary>
+        /// Create a UAP package reference project. Framework is only used internally.
+        /// </summary>
+        public static SimpleTestProjectContext CreateLegacyPackageReference(
+            string projectName,
+            string solutionRoot,
+            NuGetFramework framework)
+        {
+            var context = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, solutionRoot);
+            context.Frameworks.Add(new SimpleTestProjectFrameworkContext(framework));
+            context.IsLegacyPackageReference = true;
+            return context;
+        }
+
         public static SimpleTestProjectContext CreateNETCore(
             string projectName,
             string solutionRoot,
@@ -355,9 +374,16 @@ namespace NuGet.Test.Utility
                 AddProperties(xml, new Dictionary<string, string>()
                 {
                     { "Version", Version },
-                    { "DebugType", "portable" },
-                    { "TargetFrameworks", string.Join(";", Frameworks.Select(f => f.Framework.GetShortFolderName())) },
+                    { "DebugType", "portable" }
                 });
+
+                if (!IsLegacyPackageReference)
+                {
+                    AddProperties(xml, new Dictionary<string, string>()
+                    {
+                        { "TargetFrameworks", string.Join(";", Frameworks.Select(f => f.Framework.GetShortFolderName())) },
+                    });
+                }
 
                 var addedToAll = new HashSet<SimpleTestProjectContext>();
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -75,6 +75,7 @@
     <Compile Include="NuGetSetApiKeyTests.cs" />
     <Compile Include="NuGetUpdateCommandTests.cs" />
     <Compile Include="PortReserver.cs" />
+    <Compile Include="RestoreUAPPackageReferenceTests.cs" />
     <Compile Include="RestoreNETCoreTest.cs" />
     <Compile Include="RestoreProjectJsonTest.cs" />
     <Compile Include="NuGetSourcesCommandTest.cs" />

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class RestoreUAPPackageReferenceTests
+    {
+        [Fact]
+        public async Task RestoreUAP_BasicRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.AnyFramework);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                projectA.Properties.Add("TargetPlatformIdentifier", "UAP");
+                projectA.Properties.Add("TargetPlatformVersion", "10.0.14393.0");
+                projectA.Properties.Add("TargetPlatformMinVersion", "10.0.10586.0");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var propsXML = XDocument.Load(projectA.PropsOutput);
+                var styleNode = propsXML.Root.Elements().First().Elements(XName.Get("NuGetProjectStyle", "http://schemas.microsoft.com/developer/msbuild/2003")).FirstOrDefault();
+
+                var projectSpec = dgSpec.Projects.Single();
+
+                // Assert
+                Assert.Equal(ProjectStyle.PackageReference, projectSpec.RestoreMetadata.ProjectStyle);
+                Assert.Equal("PackageReference", styleNode.Value);
+                Assert.Equal(NuGetFramework.Parse("UAP10.0.14393.0"), projectSpec.TargetFrameworks.Single().FrameworkName);
+            }
+        }
+
+        [Fact]
+        public void RestoreUAP_NoPackageReferences_VerifyRestoreStyleIsUsed()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.AnyFramework);
+
+                projectA.Properties.Add("TargetPlatformIdentifier", "UAP");
+                projectA.Properties.Add("TargetPlatformVersion", "10.0.14393.0");
+                projectA.Properties.Add("TargetPlatformMinVersion", "10.0.10586.0");
+                projectA.Properties.Add("RestoreProjectStyle", "PackageReference");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var propsXML = XDocument.Load(projectA.PropsOutput);
+                var styleNode = propsXML.Root.Elements().First().Elements(XName.Get("NuGetProjectStyle", "http://schemas.microsoft.com/developer/msbuild/2003")).FirstOrDefault();
+
+                var projectSpec = dgSpec.Projects.Single();
+
+                // Assert
+                Assert.Equal(ProjectStyle.PackageReference, projectSpec.RestoreMetadata.ProjectStyle);
+                Assert.Equal("PackageReference", styleNode.Value);
+                Assert.Equal(NuGetFramework.Parse("UAP10.0.14393.0"), projectSpec.TargetFrameworks.Single().FrameworkName);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreUAP_VerifyProjectToProjectRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.AnyFramework);
+
+                var projectB = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.AnyFramework);
+
+                projectA.Properties.Add("TargetPlatformIdentifier", "UAP");
+                projectA.Properties.Add("TargetPlatformVersion", "10.0.14393.0");
+                projectA.Properties.Add("TargetPlatformMinVersion", "10.0.10586.0");
+
+                // Set style for A since it has no references
+                projectA.Properties.Add("RestoreProjectStyle", "PackageReference");
+
+
+                projectB.Properties.Add("TargetPlatformIdentifier", "UAP");
+                projectB.Properties.Add("TargetPlatformVersion", "10.0.14393.0");
+                projectB.Properties.Add("TargetPlatformMinVersion", "10.0.10586.0");
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectB.AddPackageToAllFrameworks(packageX);
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var assetsFile = projectA.AssetsFile;
+
+                // Assert
+                Assert.Equal("1.0.0", assetsFile.Libraries.Single(p => p.Name == "x").Version.ToNormalizedString());
+            }
+        }
+
+        private static CommandRunnerResult RestoreSolution(SimpleTestPathContext pathContext, int exitCode = 0)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Store the dg file for debugging
+            var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+            var envVars = new Dictionary<string, string>()
+                {
+                    { "NUGET_PERSIST_DG", "true" },
+                    { "NUGET_PERSIST_DG_PATH", dgPath }
+                };
+
+            string[] args = new string[] {
+                    "restore",
+                    pathContext.SolutionRoot,
+                    "-Verbosity",
+                    "detailed"
+                };
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory.Path,
+                string.Join(" ", args),
+                waitForExit: true,
+                environmentVariables: envVars);
+
+            // Assert
+            Assert.True(exitCode == r.Item1, r.Item3 + "\n\n" + r.Item2);
+
+            return r;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class MSBuildProjectFrameworkUtilityTests
+    {
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyTargetFramworksParsed()
+        {
+            // Arrange & Act
+            var frameworks = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworks: "net45;netcoreapp1.1");
+
+            // Assert
+            Assert.Equal(2, frameworks.Count);
+            Assert.Equal(NuGetFramework.Parse("net45"), frameworks[0]);
+            Assert.Equal(NuGetFramework.Parse("netcoreapp1.1"), frameworks[1]);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyTargetFramworkParsed()
+        {
+            // Arrange & Act
+            var frameworks = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworks: "net45");
+
+            // Assert
+            Assert.Equal(1, frameworks.Count);
+            Assert.Equal(NuGetFramework.Parse("net45"), frameworks[0]);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyTargetFramworksUsedInsteadOfTargetFramework()
+        {
+            // Arrange & Act
+            var frameworks = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworks: "net45;netcoreapp1.1",
+                targetFramework: "net46");
+
+            // Assert
+            Assert.Equal(2, frameworks.Count);
+            Assert.Equal(NuGetFramework.Parse("net45"), frameworks[0]);
+            Assert.Equal(NuGetFramework.Parse("netcoreapp1.1"), frameworks[1]);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyTargetFrameworkMonikerUsed()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworkMoniker: ".NETFramework,Version=v4.5")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("net45"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyUAPFullVersion()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetPlatformIdentifier: "UAP",
+                targetPlatformVersion: "10.0.1.2")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("UAP10.0.1.2"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyPlatformIgnoredWithoutVersion()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetPlatformIdentifier: "UAP",
+                targetFrameworkMoniker: ".NETFramework,Version=v4.5")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("net45"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyUAPFullVersionForJavascript()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.jsproj",
+                targetPlatformIdentifier: "UAP",
+                targetPlatformVersion: "10.0.1.2")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("UAP10.0.1.2"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyJavascriptDefaultsToWindows()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.jsproj")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("win0.0"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyNETCore45ToWin8()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworkMoniker: ".NETCore,Version=v4.5")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("win8"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyNETCore451ToWin81()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworkMoniker: ".NETCore,Version=v4.5.1")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("win81"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyNETCore50IsUnchanged()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworkMoniker: ".NETCore,Version=v5.0")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("netcore5.0"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_IsXnaWindowsPhoneProjectVerifyReplacement()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                isXnaWindowsPhoneProject: true,
+                targetFrameworkMoniker: ".NETFramework,Version=v4.0")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("Silverlight,Version=v4.0,Profile=WindowsPhone71"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_IsManagementPackProject()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                isManagementPackProject: true,
+                targetFrameworkMoniker: ".NETFramework,Version=v4.0")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("SCMPInfra, Version=0.0"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyNativeProjectOverMoniker()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.vcxproj",
+                targetFrameworkMoniker: ".NETFramework,Version=v4.0")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("native"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyUnknownMonikerIsParsed()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj",
+                targetFrameworkMoniker: "Blah,Version=v4.0")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.Parse("Blah,Version=v4.0"), framework);
+        }
+
+        [Fact]
+        public void MSBuildProjectFrameworkUtility_VerifyFallbackToUnsupported()
+        {
+            // Arrange & Act
+            var framework = GetFrameworks(
+                projectFilePath: "/tmp/project.csproj")
+                .SingleOrDefault();
+
+            // Assert
+            Assert.Equal(NuGetFramework.UnsupportedFramework, framework);
+        }
+
+        /// <summary>
+        /// Test helper
+        /// </summary>
+        private static List<NuGetFramework> GetFrameworks(
+            string projectFilePath,
+            string targetFrameworks = "",
+            string targetFramework = "",
+            string targetFrameworkMoniker = "",
+            string targetPlatformIdentifier = "",
+            string targetPlatformVersion="",
+            bool isXnaWindowsPhoneProject=false,
+            bool isManagementPackProject=false)
+        {
+            return MSBuildProjectFrameworkUtility.GetProjectFrameworks(
+                MSBuildProjectFrameworkUtility.GetProjectFrameworkStrings(
+                    projectFilePath,
+                    targetFrameworks,
+                    targetFramework,
+                    targetFrameworkMoniker,
+                    targetPlatformIdentifier,
+                    targetPlatformVersion,
+                    isXnaWindowsPhoneProject,
+                    isManagementPackProject))
+                    .ToList();
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for reading UAP target frameworks from MSBuild. The rest is refactoring to make all parts of NuGet use the same helper methods to determine the target frameworks of a project.

Fixes https://github.com/NuGet/Home/issues/3924
Fixes https://github.com/NuGet/Home/issues/3923

//cc @jainaashish @rohit21agrawal @nkolev92 @zhili1208