### PR TITLE
add minClientVersion to package builder so it is present in generated nuspec

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -129,6 +129,20 @@ namespace NuGet.Build.Tasks.Pack
             {
                 builder.Repository = new RepositoryMetadata(request.RepositoryType, request.RepositoryUrl);
             }
+            if (request.MinClientVersion != null)
+            {
+                Version version;
+                if (!Version.TryParse(request.MinClientVersion, out version))
+                {
+                    throw new ArgumentException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.InvalidMinClientVersion,
+                        request.MinClientVersion));
+                }
+
+                builder.MinClientVersion = version;
+            }
+
             ParseProjectToProjectReferences(request, builder);
             GetPackageReferences(request, builder);
             return builder;


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/4135

The issue here is that MinClientVersion was being set on package builder after the intermediate nuspec was written out. This fixes that.

CC : @emgarten @alpaix @mishra14 @nkolev92 @zhili1208 