### PR TITLE
Fixes to add package command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -91,7 +91,7 @@ namespace NuGet.CommandLine.XPlat
                         NoVersion = noVersion,
                         DgFilePath = dgFilePath.Value()
                     };
-                    var msBuild = new MSBuildAPIUtility();
+                    var msBuild = new MSBuildAPIUtility(logger);
                     var addPackageRefCommandRunner = getCommandRunner();
                     return addPackageRefCommandRunner.ExecuteCommand(packageRefArgs, msBuild);
                 });

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -15,8 +15,6 @@ namespace NuGet.CommandLine.XPlat
 {
     public static class AddPackageReferenceCommand
     {
-        private const string MSBuildExeName = "MSBuild.dll";
-
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
             Func<IAddPackageReferenceCommandRunner> getCommandRunner)
         {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -91,6 +91,7 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.Logger.LogError(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgIncompatibleWithAllFrameworks,
                     packageReferenceArgs.PackageDependency.Id,
+                    packageReferenceArgs.Frameworks?.Any() == true ? Strings.AddPkg_UserSpecified : Strings.AddPkg_All,
                     packageReferenceArgs.ProjectPath));
 
                 return 1;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -134,7 +134,7 @@ namespace NuGet.CommandLine.XPlat
             return 0;
         }
 
-        private async Task<RestoreResultPair> PreviewAddPackageReference(PackageReferenceArgs packageReferenceArgs,
+        private static async Task<RestoreResultPair> PreviewAddPackageReference(PackageReferenceArgs packageReferenceArgs,
             DependencyGraphSpec dgSpec,
             PackageSpec originalPackageSpec)
         {
@@ -179,7 +179,7 @@ namespace NuGet.CommandLine.XPlat
             }
         }
 
-        private DependencyGraphSpec ReadProjectDependencyGraph(PackageReferenceArgs packageReferenceArgs)
+        private static DependencyGraphSpec ReadProjectDependencyGraph(PackageReferenceArgs packageReferenceArgs)
         {
             DependencyGraphSpec spec = null;
 
@@ -191,14 +191,14 @@ namespace NuGet.CommandLine.XPlat
             return spec;
         }
 
-        private void UpdatePackageVersionIfNeeded(RestoreResultPair restorePreviewResult,
+        private static void UpdatePackageVersionIfNeeded(RestoreResultPair restorePreviewResult,
             PackageReferenceArgs packageReferenceArgs)
         {
             // If the user did not specify a version then write the exact resolved version
             if (packageReferenceArgs.NoVersion)
             {
                 // Get the package version from the graph
-                var resolvedVersion = privateGetPackageVersionFromRestoreResult(restorePreviewResult, packageReferenceArgs);
+                var resolvedVersion = GetPackageVersionFromRestoreResult(restorePreviewResult, packageReferenceArgs);
 
                 if (resolvedVersion != null)
                 {
@@ -209,7 +209,7 @@ namespace NuGet.CommandLine.XPlat
             }
         }
 
-        private NuGetVersion privateGetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
+        private static NuGetVersion GetPackageVersionFromRestoreResult(RestoreResultPair restorePreviewResult,
             PackageReferenceArgs packageReferenceArgs)
         {
             // Get the restore graphs from the restore result
@@ -236,7 +236,7 @@ namespace NuGet.CommandLine.XPlat
                     .Select(p => p)
                     .Where(p => p.Key.Name.Equals(packageReferenceArgs.PackageDependency.Id, StringComparison.OrdinalIgnoreCase));
 
-                if (matchingPackageEntries.Count() > 0)
+                if (matchingPackageEntries.Any())
                 {
                     return matchingPackageEntries
                         .First()

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -204,7 +204,7 @@ namespace NuGet.CommandLine.XPlat
                 {
                     //Update the packagedependency with the new version
                     packageReferenceArgs.PackageDependency = new PackageDependency(packageReferenceArgs.PackageDependency.Id,
-                        VersionRange.Parse(resolvedVersion.ToString()));
+                        new VersionRange(resolvedVersion));
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -60,6 +60,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to all.
+        /// </summary>
+        public static string AddPkg_All {
+            get {
+                return ResourceManager.GetString("AddPkg_All", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Adds a package reference to a project..
         /// </summary>
         public static string AddPkg_Description {
@@ -146,6 +155,15 @@ namespace NuGet.CommandLine.XPlat {
         public static string AddPkg_SourcesDescription {
             get {
                 return ResourceManager.GetString("AddPkg_SourcesDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to user specified.
+        /// </summary>
+        public static string AddPkg_UserSpecified {
+            get {
+                return ResourceManager.GetString("AddPkg_UserSpecified", resourceCulture);
             }
         }
         
@@ -267,7 +285,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package &apos;{0}&apos; is incompatible with all the frameworks in project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is incompatible with &apos;{1}&apos; frameworks in project &apos;{2}&apos;.
         /// </summary>
         public static string Error_AddPkgIncompatibleWithAllFrameworks {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -249,7 +249,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Item : {0} for {1} in Imported file : {2}.
+        ///    Looks up a localized string similar to Item &apos;{0}&apos; for &apos;{1}&apos; in Imported file &apos;{2}&apos;.
         /// </summary>
         public static string Error_AddPkgErrorStringForImportedEdit {
             get {
@@ -258,7 +258,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Error while performing : {0} for package : {1}. Cannot edit items in imported files - {2}{3}.
+        ///    Looks up a localized string similar to Error while performing  &apos;{0}&apos; for package &apos;{1}&apos;. Cannot edit items in imported files - {2}{3}.
         /// </summary>
         public static string Error_AddPkgFailOnImportEdit {
             get {
@@ -267,7 +267,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package : &apos;{0}&apos; is incompatible with all the frameworks in project : &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is incompatible with all the frameworks in project &apos;{1}&apos;.
         /// </summary>
         public static string Error_AddPkgIncompatibleWithAllFrameworks {
             get {
@@ -339,7 +339,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to PackageReference for package : {0} version : {1} added to file : {2}.
+        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; added to file &apos;{2}&apos;.
         /// </summary>
         public static string Info_AddPkgAdded {
             get {
@@ -348,7 +348,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Adding PackageReference for package : &apos;{0}&apos;, into project : &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Adding PackageReference for package &apos;{0}&apos;, into project &apos;{1}&apos;.
         /// </summary>
         public static string Info_AddPkgAddingReference {
             get {
@@ -357,7 +357,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package : &apos;{0}&apos; is compatible with all the specified frameworks in project : &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with all the specified frameworks in project &apos;{1}&apos;.
         /// </summary>
         public static string Info_AddPkgCompatibleWithAllFrameworks {
             get {
@@ -366,7 +366,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package : &apos;{0}&apos; is compatible with a subset of the specified frameworks in project : &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with a subset of the specified frameworks in project &apos;{1}&apos;.
         /// </summary>
         public static string Info_AddPkgCompatibleWithSubsetFrameworks {
             get {
@@ -375,7 +375,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to PackageReference for package : {0} version : {1} updated in file : {2}.
+        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; updated in file &apos;{2}&apos;.
         /// </summary>
         public static string Info_AddPkgUpdated {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -249,6 +249,24 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Item : {0} for {1} in Imported file : {2}.
+        /// </summary>
+        public static string Error_AddPkgErrorStringForImportedEdit {
+            get {
+                return ResourceManager.GetString("Error_AddPkgErrorStringForImportedEdit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Error while performing : {0} for package : {1}. Cannot edit items in imported files - {2}{3}.
+        /// </summary>
+        public static string Error_AddPkgFailOnImportEdit {
+            get {
+                return ResourceManager.GetString("Error_AddPkgFailOnImportEdit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Package : &apos;{0}&apos; is incompatible with all the frameworks in project : &apos;{1}&apos;.
         /// </summary>
         public static string Error_AddPkgIncompatibleWithAllFrameworks {
@@ -321,6 +339,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to PackageReference for package : {0} version : {1} added to file : {2}.
+        /// </summary>
+        public static string Info_AddPkgAdded {
+            get {
+                return ResourceManager.GetString("Info_AddPkgAdded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Adding PackageReference for package : &apos;{0}&apos;, into project : &apos;{1}&apos;.
         /// </summary>
         public static string Info_AddPkgAddingReference {
@@ -344,6 +371,15 @@ namespace NuGet.CommandLine.XPlat {
         public static string Info_AddPkgCompatibleWithSubsetFrameworks {
             get {
                 return ResourceManager.GetString("Info_AddPkgCompatibleWithSubsetFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to PackageReference for package : {0} version : {1} updated in file : {2}.
+        /// </summary>
+        public static string Info_AddPkgUpdated {
+            get {
+                return ResourceManager.GetString("Info_AddPkgUpdated", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -342,9 +342,10 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Project/csproj path</comment>
   </data>
   <data name="Error_AddPkgIncompatibleWithAllFrameworks" xml:space="preserve">
-    <value>Package '{0}' is incompatible with all the frameworks in project '{1}'</value>
+    <value>Package '{0}' is incompatible with '{1}' frameworks in project '{2}'</value>
     <comment>{0} - Package Id
-{1} - Project Path</comment>
+{1} - all / user specified
+{2} - Project Path</comment>
   </data>
   <data name="Info_AddPkgAddingReference" xml:space="preserve">
     <value>Adding PackageReference for package '{0}', into project '{1}'</value>
@@ -422,5 +423,11 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Package Id
 {1} - package version
 {2} - project file path</comment>
+  </data>
+  <data name="AddPkg_All" xml:space="preserve">
+    <value>all</value>
+  </data>
+  <data name="AddPkg_UserSpecified" xml:space="preserve">
+    <value>user specified</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -342,22 +342,22 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Project/csproj path</comment>
   </data>
   <data name="Error_AddPkgIncompatibleWithAllFrameworks" xml:space="preserve">
-    <value>Package : '{0}' is incompatible with all the frameworks in project : '{1}'</value>
+    <value>Package '{0}' is incompatible with all the frameworks in project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="Info_AddPkgAddingReference" xml:space="preserve">
-    <value>Adding PackageReference for package : '{0}', into project : '{1}'</value>
+    <value>Adding PackageReference for package '{0}', into project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="Info_AddPkgCompatibleWithAllFrameworks" xml:space="preserve">
-    <value>Package : '{0}' is compatible with all the specified frameworks in project : '{1}'</value>
+    <value>Package '{0}' is compatible with all the specified frameworks in project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="Info_AddPkgCompatibleWithSubsetFrameworks" xml:space="preserve">
-    <value>Package : '{0}' is compatible with a subset of the specified frameworks in project : '{1}'</value>
+    <value>Package '{0}' is compatible with a subset of the specified frameworks in project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
@@ -399,26 +399,26 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>None or invalid DgSpec was passed to NuGet add package command.</value>
   </data>
   <data name="Error_AddPkgErrorStringForImportedEdit" xml:space="preserve">
-    <value>Item : {0} for {1} in Imported file : {2}</value>
+    <value>Item '{0}' for '{1}' in Imported file '{2}'</value>
     <comment>{0} - ItemType
 {1} - Package Id
 {2} - Imported File Path</comment>
   </data>
   <data name="Error_AddPkgFailOnImportEdit" xml:space="preserve">
-    <value>Error while performing : {0} for package : {1}. Cannot edit items in imported files - {2}{3}</value>
+    <value>Error while performing  '{0}' for package '{1}'. Cannot edit items in imported files - {2}{3}</value>
     <comment>{0} - Operation Name
 {1} - packageId
 {2} - New line
 {3} - Error string</comment>
   </data>
   <data name="Info_AddPkgAdded" xml:space="preserve">
-    <value>PackageReference for package : {0} version : {1} added to file : {2}</value>
+    <value>PackageReference for package '{0}' version '{1}' added to file '{2}'</value>
     <comment>{0} - Package Id
 {1} - package version
 {2} - project file path</comment>
   </data>
   <data name="Info_AddPkgUpdated" xml:space="preserve">
-    <value>PackageReference for package : {0} version : {1} updated in file : {2}</value>
+    <value>PackageReference for package '{0}' version '{1}' updated in file '{2}'</value>
     <comment>{0} - Package Id
 {1} - package version
 {2} - project file path</comment>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -398,4 +398,29 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_NoDgSpec" xml:space="preserve">
     <value>None or invalid DgSpec was passed to NuGet add package command.</value>
   </data>
+  <data name="Error_AddPkgErrorStringForImportedEdit" xml:space="preserve">
+    <value>Item : {0} for {1} in Imported file : {2}</value>
+    <comment>{0} - ItemType
+{1} - Package Id
+{2} - Imported File Path</comment>
+  </data>
+  <data name="Error_AddPkgFailOnImportEdit" xml:space="preserve">
+    <value>Error while performing : {0} for package : {1}. Cannot edit items in imported files - {2}{3}</value>
+    <comment>{0} - Operation Name
+{1} - packageId
+{2} - New line
+{3} - Error string</comment>
+  </data>
+  <data name="Info_AddPkgAdded" xml:space="preserve">
+    <value>PackageReference for package : {0} version : {1} added to file : {2}</value>
+    <comment>{0} - Package Id
+{1} - package version
+{2} - project file path</comment>
+  </data>
+  <data name="Info_AddPkgUpdated" xml:space="preserve">
+    <value>PackageReference for package : {0} version : {1} updated in file : {2}</value>
+    <comment>{0} - Package Id
+{1} - package version
+{2} - project file path</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -198,8 +198,10 @@ namespace NuGet.CommandLine.XPlat
 
         private void AddPackageReferenceIntoItemGroup(ProjectItemGroupElement itemGroup, PackageDependency packageDependency)
         {
+            var packageVersion = packageDependency.VersionRange.OriginalString ??
+                packageDependency.VersionRange.MinVersion.ToString();
             var packageMetadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            { { VERSION_TAG, packageDependency.VersionRange.OriginalString } };
+            { { VERSION_TAG, packageVersion } };
 
             // Currently metadata is added as a metadata. As opposed to an attribute
             // Due to https://github.com/Microsoft/msbuild/issues/1393

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -39,7 +39,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         /// <param name="projectCSProjPath">CSProj file which needs to be evaluated</param>
         /// <returns>MSBuild.Evaluation.Project</returns>
-        private Project GetProject(string projectCSProjPath)
+        private static Project GetProject(string projectCSProjPath)
         {
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
@@ -55,7 +55,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="projectCSProjPath">CSProj file which needs to be evaluated</param>
         /// <param name="globalProperties">Global properties that should be used to evaluate the project while opening.</param>
         /// <returns>MSBuild.Evaluation.Project</returns>
-        private Project GetProject(string projectCSProjPath, IDictionary<string, string> globalProperties)
+        private static Project GetProject(string projectCSProjPath, IDictionary<string, string> globalProperties)
         {
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
@@ -123,7 +123,7 @@ namespace NuGet.CommandLine.XPlat
             project.Save();
         }
 
-        private IEnumerable<ProjectItemGroupElement> GetItemGroups(Project project)
+        private static IEnumerable<ProjectItemGroupElement> GetItemGroups(Project project)
         {
             return project
                 .Items
@@ -139,7 +139,7 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="itemGroups">List of all item groups in the project</param>
         /// <param name="itemType">An item type tag that must be in the item group. It if PackageReference in this case.</param>
         /// <returns>An ItemGroup, which could be null.</returns>
-        private ProjectItemGroupElement GetItemGroup(Project project, IEnumerable<ProjectItemGroupElement> itemGroups,
+        private static ProjectItemGroupElement GetItemGroup(Project project, IEnumerable<ProjectItemGroupElement> itemGroups,
             string itemType)
         {
             var itemGroup = itemGroups?
@@ -149,7 +149,7 @@ namespace NuGet.CommandLine.XPlat
             return itemGroup;
         }
 
-        private ProjectItemGroupElement CreateItemGroup(Project project, string framework = null)
+        private static ProjectItemGroupElement CreateItemGroup(Project project, string framework = null)
         {
             // Create a new item group and add a condition if given
             var itemGroup = project.Xml.AddItemGroup();
@@ -221,7 +221,7 @@ namespace NuGet.CommandLine.XPlat
         /// The project should have the global property set to have a specific framework</param>
         /// <param name="packageDependency">Dependency of the package.</param>
         /// <returns>List of Items containing the package reference for the package.</returns>
-        private IEnumerable<ProjectItem> GetPackageReferences(Project project, PackageDependency packageDependency)
+        private static IEnumerable<ProjectItem> GetPackageReferences(Project project, PackageDependency packageDependency)
         {
             return project.AllEvaluatedItems
                 .Where(item => item.ItemType.Equals(PACKAGE_REFERENCE_TYPE_TAG, StringComparison.OrdinalIgnoreCase) &&
@@ -237,7 +237,7 @@ namespace NuGet.CommandLine.XPlat
         /// The project should have the global property set to have a specific framework</param>
         /// <param name="packageDependency">Dependency of the package.</param>
         /// <returns>List of Items containing the package reference for the package.</returns>
-        private IEnumerable<ProjectItem> GetPackageReferencesForAllFrameworks(Project project,
+        private static IEnumerable<ProjectItem> GetPackageReferencesForAllFrameworks(Project project,
             PackageDependency packageDependency)
         {
             var frameworks = GetProjectFrameworks(project);
@@ -254,7 +254,7 @@ namespace NuGet.CommandLine.XPlat
             return mergedPackageReferences;
         }
 
-        private IEnumerable<string> GetProjectFrameworks(Project project)
+        private static IEnumerable<string> GetProjectFrameworks(Project project)
         {
             var frameworks = project
                 .AllEvaluatedProperties
@@ -273,7 +273,7 @@ namespace NuGet.CommandLine.XPlat
             return frameworks;
         }
 
-        private ProjectRootElement TryOpenProjectRootElement(string filename)
+        private static ProjectRootElement TryOpenProjectRootElement(string filename)
         {
             try
             {
@@ -287,7 +287,7 @@ namespace NuGet.CommandLine.XPlat
             }
         }
 
-        private string GetTargetFrameworkCondition(string targetFramework)
+        private static string GetTargetFrameworkCondition(string targetFramework)
         {
             return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -10,8 +10,6 @@ using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Commands;
-using NuGet.Common;
-using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -24,7 +22,11 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatAddPkgTests
     {
         private static readonly string projectName = "test_project_addpkg";
-        private static MSBuildAPIUtility msBuild = new MSBuildAPIUtility(new TestCommandOutputLogger());
+
+        private static MSBuildAPIUtility MsBuild
+        {
+            get { return new MSBuildAPIUtility(new TestCommandOutputLogger()); }
+        }
 
         // Argument parsing related tests
 
@@ -132,7 +134,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild).Result;
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild).Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -170,7 +172,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -206,7 +208,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -242,7 +244,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -281,7 +283,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -326,7 +328,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -366,7 +368,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -396,7 +398,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -430,6 +432,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
+                var msBuild = MsBuild;
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
@@ -478,6 +481,7 @@ namespace NuGet.XPlat.FuncTest
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA, frameworks: userInputFrameworks);
                 var commandRunner = new AddPackageReferenceCommandRunner();
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
+                var msBuild = MsBuild;
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
@@ -520,7 +524,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
@@ -561,6 +565,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
+                var msBuild = MsBuild;
 
                 // Create a package ref with the old version
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
@@ -632,6 +637,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
+                var msBuild = MsBuild;
 
                 // Create a package ref with old version
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -432,17 +432,16 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var msBuild = MsBuild;
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
                 packageArgs = GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
 
                 // Act
-                result = commandRunner.ExecuteCommand(packageArgs, msBuild)
+                result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
                 projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -24,6 +24,7 @@ namespace NuGet.XPlat.FuncTest
     public class XPlatAddPkgTests
     {
         private static readonly string projectName = "test_project_addpkg";
+        private static MSBuildAPIUtility msBuild = new MSBuildAPIUtility(new TestCommandOutputLogger());
 
         // Argument parsing related tests
 
@@ -131,7 +132,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility()).Result;
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild).Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -169,7 +170,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -205,7 +206,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -241,7 +242,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -280,7 +281,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -325,7 +326,7 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -365,7 +366,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -395,7 +396,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -431,14 +432,14 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
                 packageArgs = GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
 
                 // Act
-                result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -479,14 +480,14 @@ namespace NuGet.XPlat.FuncTest
                 var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
                 packageArgs = GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
 
                 // Act
-                result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
@@ -519,7 +520,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
@@ -562,7 +563,7 @@ namespace NuGet.XPlat.FuncTest
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Create a package ref with the old version
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -571,7 +572,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 // Create a package ref with the new version
-                result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -631,10 +632,9 @@ namespace NuGet.XPlat.FuncTest
 
                 var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var msBuild = new MSBuildAPIUtility();
 
                 // Create a package ref with old version
-                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 
@@ -644,7 +644,7 @@ namespace NuGet.XPlat.FuncTest
 
                 // Act
                 // Create a package ref with new version
-                result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility())
+                result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
                 projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
 


### PR DESCRIPTION
Finishes work for : https://github.com/NuGet/Home/issues/3751

Changes -
1. Add logs to MsBuildAPIUtility.cs
2. Fixed the way we read resolved version for a package from the restore result.
3. Changed MsBuildAPIUtility to not add/update references in an imported file.

@emgarten @rrelyea 