### PR TITLE
return empty versions list if server doesn't return any package versions

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -80,7 +80,13 @@ namespace NuGet.PackageManagement.UI
             // installVersion is null if the package is not installed
             var installedVersion = installedDependency?.VersionRange?.MinVersion;
 
-            var allVersions = _allPackageVersions.OrderByDescending(v => v).ToArray();
+            var allVersions = _allPackageVersions?.OrderByDescending(v => v).ToArray();
+
+            // allVersions is null if server doesn't return any versions.
+            if (allVersions == null)
+            {
+                return;
+            }
 
             // null, if no version constraint defined in package.config
             var allowedVersions = _projectVersionRangeDict.Select(kvp => kvp.Value).FirstOrDefault() ?? VersionRange.All;

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -131,7 +131,13 @@ namespace NuGet.PackageManagement.UI
         protected override void CreateVersions()
         {
             _versions = new List<DisplayVersion>();
-            var allVersions = _allPackageVersions.OrderByDescending(v => v);
+            var allVersions = _allPackageVersions?.OrderByDescending(v => v);
+
+            // allVersions is null if server doesn't return any versions.
+            if (allVersions == null)
+            {
+                return;
+            }
 
             // null, if no version constraint defined in package.config
             var allowedVersions = GetAllowedVersions();


### PR DESCRIPTION
fixed https://github.com/NuGet/Home/issues/4191

the bug is if package source is bad, server will not return any package versions, package versions will be null. throw null ref exception

fix is to check null and return empty list
@jainaashish @emgarten 