### PR TITLE
Adding dotnet remove package command to NuGet.Xplat

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -16,7 +16,7 @@ namespace NuGet.CommandLine.XPlat
     public static class AddPackageReferenceCommand
     {
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
-            Func<IAddPackageReferenceCommandRunner> getCommandRunner)
+            Func<IPackageReferenceCommandRunner> getCommandRunner)
         {
             app.Command("add", addpkg =>
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -70,11 +70,12 @@ namespace NuGet.CommandLine.XPlat
 
                 addpkg.OnExecute(() =>
                 {
-                    ValidateArgument(id, id.Template);
-                    ValidateArgument(projectPath, projectPath.Template);
+                    ValidateArgument(id, addpkg.Name);
+                    ValidateArgument(projectPath, addpkg.Name);
+                    ValidateProjectPath(projectPath, addpkg.Name);
                     if (!noRestore.HasValue())
                     {
-                        ValidateArgument(dgFilePath, dgFilePath.Template);
+                        ValidateArgument(dgFilePath, addpkg.Name);
                     }
                     var logger = getLogger();
                     var noVersion = !version.HasValue();
@@ -96,11 +97,24 @@ namespace NuGet.CommandLine.XPlat
             });
         }
 
-        private static void ValidateArgument(CommandOption arg, string argName)
+        private static void ValidateArgument(CommandOption arg, string commandName)
         {
             if (arg.Values.Count < 1)
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.AddPkg_MissingArgument, argName));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PkgMissingArgument,
+                    commandName,
+                    arg.Template));
+            }
+        }
+
+        private static void ValidateProjectPath(CommandOption projectPath, string commandName)
+        {
+            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj"))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_PkgMissingOrInvalidProjectFile,
+                    commandName,
+                    projectPath.Value()));
             }
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommand.cs
@@ -109,7 +109,7 @@ namespace NuGet.CommandLine.XPlat
 
         private static void ValidateProjectPath(CommandOption projectPath, string commandName)
         {
-            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj"))
+            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_PkgMissingOrInvalidProjectFile,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -19,9 +19,6 @@ namespace NuGet.CommandLine.XPlat
 {
     public class AddPackageReferenceCommandRunner : IPackageReferenceCommandRunner
     {
-        private const string NUGET_RESTORE_MSBUILD_VERBOSITY = "NUGET_RESTORE_MSBUILD_VERBOSITY";
-        private const int MSBUILD_WAIT_TIME = 2 * 60 * 1000; // 2 minutes in milliseconds
-
         public async Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
         {
             packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -17,7 +17,7 @@ using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public class AddPackageReferenceCommandRunner : IAddPackageReferenceCommandRunner
+    public class AddPackageReferenceCommandRunner : IPackageReferenceCommandRunner
     {
         private const string NUGET_RESTORE_MSBUILD_VERBOSITY = "NUGET_RESTORE_MSBUILD_VERBOSITY";
         private const int MSBUILD_WAIT_TIME = 2 * 60 * 1000; // 2 minutes in milliseconds

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/IPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/IPackageReferenceCommandRunner.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat
 {
-    public interface IAddPackageReferenceCommandRunner
+    public interface IPackageReferenceCommandRunner
     {
         Task<int> ExecuteCommand(PackageReferenceArgs packageRefArgs, MSBuildAPIUtility msBuild);
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
@@ -13,15 +13,15 @@ namespace NuGet.CommandLine.XPlat
     {
         public string ProjectPath { get; }
         public ILogger Logger { get; }
-        public string DgFilePath { get; set; }
+        public bool NoVersion { get; set; }
         public PackageDependency PackageDependency { get; set; }
+        public string DgFilePath { get; set; }
         public string[] Frameworks { get; set; }
         public string[] Sources { get; set; }
         public string PackageDirectory { get; set; }
         public bool NoRestore { get; set; }
-        public bool NoVersion { get; set; }
 
-        public PackageReferenceArgs(string projectPath, PackageDependency packageDependency, ILogger logger)
+        public PackageReferenceArgs(string projectPath, PackageDependency packageDependency, ILogger logger, bool noVersion)
         {
             ValidateArgument(projectPath);
             ValidateArgument(packageDependency);
@@ -30,6 +30,17 @@ namespace NuGet.CommandLine.XPlat
             ProjectPath = projectPath;
             PackageDependency = packageDependency;
             Logger = logger;
+            NoVersion = noVersion;
+        }
+
+        public PackageReferenceArgs(string projectPath, PackageDependency packageDependency, ILogger logger) :
+            this(projectPath, packageDependency, logger, noVersion: false)
+        {
+        }
+
+        public PackageReferenceArgs(string projectPath, string packageId, ILogger logger) :
+            this(projectPath, new PackageDependency(packageId), logger, noVersion: true)
+        {
         }
 
         private void ValidateArgument(object arg)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Common;
+
+namespace NuGet.CommandLine.XPlat
+{
+    public class RemovePackageReferenceCommand
+    {
+        public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
+            Func<IPackageReferenceCommandRunner> getCommandRunner)
+        {
+            app.Command("remove", removePkg =>
+            {
+                removePkg.Description = Strings.RemovePkg_Description;
+                removePkg.HelpOption(XPlatUtility.HelpOption);
+
+                removePkg.Option(
+                    CommandConstants.ForceEnglishOutputOption,
+                    Strings.ForceEnglishOutput_Description,
+                    CommandOptionType.NoValue);
+
+                var id = removePkg.Option(
+                    "--package",
+                    Strings.AddPkg_PackageIdDescription,
+                    CommandOptionType.SingleValue);
+
+                var projectPath = removePkg.Option(
+                    "-p|--project",
+                    Strings.AddPkg_ProjectPathDescription,
+                    CommandOptionType.SingleValue);
+
+                removePkg.OnExecute(() =>
+                {
+                    ValidateArgument(id, id.Template);
+                    ValidateArgument(projectPath, projectPath.Template);
+                    var logger = getLogger();
+                    var packageRefArgs = new PackageReferenceArgs(projectPath.Value(), id.Value(), logger);
+                    var msBuild = new MSBuildAPIUtility();
+                    var removePackageRefCommandRunner = getCommandRunner();
+                    return removePackageRefCommandRunner.ExecuteCommand(packageRefArgs, msBuild);
+                });
+            });
+        }
+
+        private static void ValidateArgument(CommandOption arg, string argName)
+        {
+            if (arg.Values.Count < 1)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.AddPkg_MissingArgument, argName));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
@@ -25,12 +25,12 @@ namespace NuGet.CommandLine.XPlat
 
                 var id = removePkg.Option(
                     "--package",
-                    Strings.AddPkg_PackageIdDescription,
+                    Strings.RemovePkg_PackageIdDescription,
                     CommandOptionType.SingleValue);
 
                 var projectPath = removePkg.Option(
                     "-p|--project",
-                    Strings.AddPkg_ProjectPathDescription,
+                    Strings.RemovePkg_ProjectPathDescription,
                     CommandOptionType.SingleValue);
 
                 removePkg.OnExecute(() =>
@@ -50,7 +50,7 @@ namespace NuGet.CommandLine.XPlat
         {
             if (arg.Values.Count < 1)
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.AddPkg_MissingArgument, argName));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.RemovePkg_MissingArgument, argName));
             }
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommand.cs
@@ -60,7 +60,7 @@ namespace NuGet.CommandLine.XPlat
 
         private static void ValidateProjectPath(CommandOption projectPath, string commandName)
         {
-            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj"))
+            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_PkgMissingOrInvalidProjectFile,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.CommandLine.XPlat
+{
+    public class RemovePackageReferenceCommandRunner : IPackageReferenceCommandRunner
+    {
+        public Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
+        {
+            packageReferenceArgs.Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
+                Strings.Info_RemovePkgRemovingReference,
+                packageReferenceArgs.PackageDependency.Id,
+                packageReferenceArgs.ProjectPath));
+
+            // Remove reference from the project
+            msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath, packageReferenceArgs.PackageDependency);
+
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/RemovePackageReferenceCommandRunner.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace NuGet.CommandLine.XPlat
@@ -19,9 +17,10 @@ namespace NuGet.CommandLine.XPlat
                 packageReferenceArgs.ProjectPath));
 
             // Remove reference from the project
-            msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath, packageReferenceArgs.PackageDependency);
+            var result = msBuild.RemovePackageReference(packageReferenceArgs.ProjectPath,
+                packageReferenceArgs.PackageDependency);
 
-            return Task.FromResult(0);
+            return Task.FromResult(result);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -142,6 +142,7 @@ namespace NuGet.CommandLine.XPlat
             if (app.Name == DotnetPackageAppName)
             {
                 AddPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
+                RemovePackageReferenceCommand.Register(app, () => log, () => new RemovePackageReferenceCommandRunner());
             }
             else
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -96,15 +96,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unable to add package Reference, argument &apos;{0}&apos; not provided. Please use -h|--help for help..
-        /// </summary>
-        public static string AddPkg_MissingArgument {
-            get {
-                return ResourceManager.GetString("AddPkg_MissingArgument", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///    Looks up a localized string similar to Do not perform restore preview and compatibility check. The added package reference will be unconditional..
         /// </summary>
         public static string AddPkg_NoRestoreDescription {
@@ -321,6 +312,33 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Unable to &apos;{0}&apos; package Reference, argument &apos;{1}&apos; not provided. Please use -h|--help for help..
+        /// </summary>
+        public static string Error_PkgMissingArgument {
+            get {
+                return ResourceManager.GetString("Error_PkgMissingArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Unable to &apos;{0}&apos; package. Missing or Invalid project file &apos;{1}&apos;..
+        /// </summary>
+        public static string Error_PkgMissingOrInvalidProjectFile {
+            get {
+                return ResourceManager.GetString("Error_PkgMissingOrInvalidProjectFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Project &apos;{0}&apos; does not contain any PackageReference &apos;{1}&apos; to &apos;{2}&apos;.
+        /// </summary>
+        public static string Error_UpdatePkgNoSuchPackage {
+            get {
+                return ResourceManager.GetString("Error_UpdatePkgNoSuchPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Specifies one or more wildcard patterns to exclude when creating a package..
         /// </summary>
         public static string Exclude_Description {
@@ -366,7 +384,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Adding PackageReference for package &apos;{0}&apos;, into project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Adding PackageReference for package &apos;{0}&apos; into project &apos;{1}&apos;.
         /// </summary>
         public static string Info_AddPkgAddingReference {
             get {
@@ -402,7 +420,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Removing PackageReference for package &apos;{0}&apos;, from project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Removing PackageReference for package &apos;{0}&apos; from project &apos;{1}&apos;.
         /// </summary>
         public static string Info_RemovePkgRemovingReference {
             get {
@@ -739,15 +757,6 @@ namespace NuGet.CommandLine.XPlat {
         public static string RemovePkg_Description {
             get {
                 return ResourceManager.GetString("RemovePkg_Description", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to Unable to remove package reference, argument &apos;{0}&apos; not provided. Please use -h|--help for help..
-        /// </summary>
-        public static string RemovePkg_MissingArgument {
-            get {
-                return ResourceManager.GetString("RemovePkg_MissingArgument", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -132,7 +132,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Path to the project..
+        ///    Looks up a localized string similar to Path to the project file..
         /// </summary>
         public static string AddPkg_ProjectPathDescription {
             get {
@@ -258,7 +258,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Item &apos;{0}&apos; for &apos;{1}&apos; in Imported file &apos;{2}&apos;.
+        ///    Looks up a localized string similar to Item &apos;{0}&apos; for &apos;{1}&apos; in Imported file &apos;{2}&apos;..
         /// </summary>
         public static string Error_AddPkgErrorStringForImportedEdit {
             get {
@@ -267,7 +267,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Error while performing  &apos;{0}&apos; for package &apos;{1}&apos;. Cannot edit items in imported files - {2}{3}.
+        ///    Looks up a localized string similar to Error while performing {0} for package &apos;{1}&apos;. Cannot edit items in imported files - {2}{3}.
         /// </summary>
         public static string Error_AddPkgFailOnImportEdit {
             get {
@@ -276,7 +276,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package &apos;{0}&apos; is incompatible with &apos;{1}&apos; frameworks in project &apos;{2}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is incompatible with &apos;{1}&apos; frameworks in project &apos;{2}&apos;..
         /// </summary>
         public static string Error_AddPkgIncompatibleWithAllFrameworks {
             get {
@@ -312,7 +312,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unable to &apos;{0}&apos; package Reference, argument &apos;{1}&apos; not provided. Please use -h|--help for help..
+        ///    Looks up a localized string similar to Unable to {0} package. Argument &apos;{1}&apos; not provided..
         /// </summary>
         public static string Error_PkgMissingArgument {
             get {
@@ -321,7 +321,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Unable to &apos;{0}&apos; package. Missing or Invalid project file &apos;{1}&apos;..
+        ///    Looks up a localized string similar to Unable to {0} package. Missing or Invalid project file &apos;{1}&apos;..
         /// </summary>
         public static string Error_PkgMissingOrInvalidProjectFile {
             get {
@@ -330,7 +330,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Project &apos;{0}&apos; does not contain any PackageReference &apos;{1}&apos; to &apos;{2}&apos;.
+        ///    Looks up a localized string similar to Project &apos;{0}&apos; does not contain any PackageReference &apos;{1}&apos; to {2}..
         /// </summary>
         public static string Error_UpdatePkgNoSuchPackage {
             get {
@@ -375,7 +375,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; added to file &apos;{2}&apos;.
+        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; added to file &apos;{2}&apos;..
         /// </summary>
         public static string Info_AddPkgAdded {
             get {
@@ -384,7 +384,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Adding PackageReference for package &apos;{0}&apos; into project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Adding PackageReference for package &apos;{0}&apos; into project &apos;{1}&apos;..
         /// </summary>
         public static string Info_AddPkgAddingReference {
             get {
@@ -393,7 +393,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with all the specified frameworks in project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with all the specified frameworks in project &apos;{1}&apos;..
         /// </summary>
         public static string Info_AddPkgCompatibleWithAllFrameworks {
             get {
@@ -402,7 +402,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with a subset of the specified frameworks in project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Package &apos;{0}&apos; is compatible with a subset of the specified frameworks in project &apos;{1}&apos;..
         /// </summary>
         public static string Info_AddPkgCompatibleWithSubsetFrameworks {
             get {
@@ -411,7 +411,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; updated in file &apos;{2}&apos;.
+        ///    Looks up a localized string similar to PackageReference for package &apos;{0}&apos; version &apos;{1}&apos; updated in file &apos;{2}&apos;..
         /// </summary>
         public static string Info_AddPkgUpdated {
             get {
@@ -420,7 +420,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Removing PackageReference for package &apos;{0}&apos; from project &apos;{1}&apos;.
+        ///    Looks up a localized string similar to Removing PackageReference for package &apos;{0}&apos; from project &apos;{1}&apos;..
         /// </summary>
         public static string Info_RemovePkgRemovingReference {
             get {
@@ -770,7 +770,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to Path to the project..
+        ///    Looks up a localized string similar to Path to the project file..
         /// </summary>
         public static string RemovePkg_ProjectPathDescription {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -743,6 +743,33 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Unable to remove package reference, argument &apos;{0}&apos; not provided. Please use -h|--help for help..
+        /// </summary>
+        public static string RemovePkg_MissingArgument {
+            get {
+                return ResourceManager.GetString("RemovePkg_MissingArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Id of the package to be removed..
+        /// </summary>
+        public static string RemovePkg_PackageIdDescription {
+            get {
+                return ResourceManager.GetString("RemovePkg_PackageIdDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Path to the project..
+        /// </summary>
+        public static string RemovePkg_ProjectPathDescription {
+            get {
+                return ResourceManager.GetString("RemovePkg_ProjectPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to List of projects and project folders to restore. Each value can be: a path to a project.json or global.json file, or a folder to recursively search for project.json files..
         /// </summary>
         public static string Restore_Arg_ProjectName_Description {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -402,6 +402,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Removing PackageReference for package &apos;{0}&apos;, from project &apos;{1}&apos;.
+        /// </summary>
+        public static string Info_RemovePkgRemovingReference {
+            get {
+                return ResourceManager.GetString("Info_RemovePkgRemovingReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Specify the location of the nuspec or project file to create a package..
         /// </summary>
         public static string InputFile_Description {
@@ -721,6 +730,15 @@ namespace NuGet.CommandLine.XPlat {
         public static string Push_Timeout_Error {
             get {
                 return ResourceManager.GetString("Push_Timeout_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Removes a package reference from a project..
+        /// </summary>
+        public static string RemovePkg_Description {
+            get {
+                return ResourceManager.GetString("RemovePkg_Description", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -342,23 +342,23 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Project/csproj path</comment>
   </data>
   <data name="Error_AddPkgIncompatibleWithAllFrameworks" xml:space="preserve">
-    <value>Package '{0}' is incompatible with '{1}' frameworks in project '{2}'</value>
+    <value>Package '{0}' is incompatible with '{1}' frameworks in project '{2}'.</value>
     <comment>{0} - Package Id
 {1} - all / user specified
 {2} - Project Path</comment>
   </data>
   <data name="Info_AddPkgAddingReference" xml:space="preserve">
-    <value>Adding PackageReference for package '{0}' into project '{1}'</value>
+    <value>Adding PackageReference for package '{0}' into project '{1}'.</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="Info_AddPkgCompatibleWithAllFrameworks" xml:space="preserve">
-    <value>Package '{0}' is compatible with all the specified frameworks in project '{1}'</value>
+    <value>Package '{0}' is compatible with all the specified frameworks in project '{1}'.</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="Info_AddPkgCompatibleWithSubsetFrameworks" xml:space="preserve">
-    <value>Package '{0}' is compatible with a subset of the specified frameworks in project '{1}'</value>
+    <value>Package '{0}' is compatible with a subset of the specified frameworks in project '{1}'.</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
@@ -372,8 +372,8 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Frameworks for which the package reference should be added.</value>
   </data>
   <data name="Error_PkgMissingArgument" xml:space="preserve">
-    <value>Unable to '{0}' package Reference, argument '{1}' not provided. Please use -h|--help for help.</value>
-    <comment>{0} - operation type
+    <value>Unable to {0} package. Argument '{1}' not provided.</value>
+    <comment>{0} - Operation Name
 {1} - Argument which was not provided</comment>
   </data>
   <data name="AddPkg_NoRestoreDescription" xml:space="preserve">
@@ -389,7 +389,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Version of the package to be added.</value>
   </data>
   <data name="AddPkg_ProjectPathDescription" xml:space="preserve">
-    <value>Path to the project.</value>
+    <value>Path to the project file.</value>
   </data>
   <data name="AddPkg_SourcesDescription" xml:space="preserve">
     <value>Specifies NuGet package sources to use during the restore.</value>
@@ -401,26 +401,26 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>None or invalid DgSpec was passed to NuGet add package command.</value>
   </data>
   <data name="Error_AddPkgErrorStringForImportedEdit" xml:space="preserve">
-    <value>Item '{0}' for '{1}' in Imported file '{2}'</value>
+    <value>Item '{0}' for '{1}' in Imported file '{2}'.</value>
     <comment>{0} - ItemType
 {1} - Package Id
 {2} - Imported File Path</comment>
   </data>
   <data name="Error_AddPkgFailOnImportEdit" xml:space="preserve">
-    <value>Error while performing  '{0}' for package '{1}'. Cannot edit items in imported files - {2}{3}</value>
+    <value>Error while performing {0} for package '{1}'. Cannot edit items in imported files - {2}{3}</value>
     <comment>{0} - Operation Name
 {1} - packageId
 {2} - New line
 {3} - Error string</comment>
   </data>
   <data name="Info_AddPkgAdded" xml:space="preserve">
-    <value>PackageReference for package '{0}' version '{1}' added to file '{2}'</value>
+    <value>PackageReference for package '{0}' version '{1}' added to file '{2}'.</value>
     <comment>{0} - Package Id
 {1} - package version
 {2} - project file path</comment>
   </data>
   <data name="Info_AddPkgUpdated" xml:space="preserve">
-    <value>PackageReference for package '{0}' version '{1}' updated in file '{2}'</value>
+    <value>PackageReference for package '{0}' version '{1}' updated in file '{2}'.</value>
     <comment>{0} - Package Id
 {1} - package version
 {2} - project file path</comment>
@@ -432,7 +432,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>user specified</value>
   </data>
   <data name="Info_RemovePkgRemovingReference" xml:space="preserve">
-    <value>Removing PackageReference for package '{0}' from project '{1}'</value>
+    <value>Removing PackageReference for package '{0}' from project '{1}'.</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
@@ -443,16 +443,16 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Id of the package to be removed.</value>
   </data>
   <data name="RemovePkg_ProjectPathDescription" xml:space="preserve">
-    <value>Path to the project.</value>
+    <value>Path to the project file.</value>
   </data>
   <data name="Error_UpdatePkgNoSuchPackage" xml:space="preserve">
-    <value>Project '{0}' does not contain any PackageReference '{1}' to '{2}'</value>
+    <value>Project '{0}' does not contain any PackageReference '{1}' to {2}.</value>
     <comment>{0} - project path
 {1} - package id
 {2} - operation name</comment>
   </data>
   <data name="Error_PkgMissingOrInvalidProjectFile" xml:space="preserve">
-    <value>Unable to '{0}' package. Missing or Invalid project file '{1}'.</value>
+    <value>Unable to {0} package. Missing or Invalid project file '{1}'.</value>
     <comment>{0} - Operation Name
 {1} - project file path</comment>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -438,4 +438,14 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="RemovePkg_Description" xml:space="preserve">
     <value>Removes a package reference from a project.</value>
   </data>
+  <data name="RemovePkg_MissingArgument" xml:space="preserve">
+    <value>Unable to remove package reference, argument '{0}' not provided. Please use -h|--help for help.</value>
+    <comment>{0} - Argument which was not provided</comment>
+  </data>
+  <data name="RemovePkg_PackageIdDescription" xml:space="preserve">
+    <value>Id of the package to be removed.</value>
+  </data>
+  <data name="RemovePkg_ProjectPathDescription" xml:space="preserve">
+    <value>Path to the project.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -430,4 +430,12 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="AddPkg_UserSpecified" xml:space="preserve">
     <value>user specified</value>
   </data>
+  <data name="Info_RemovePkgRemovingReference" xml:space="preserve">
+    <value>Removing PackageReference for package '{0}', from project '{1}'</value>
+    <comment>{0} - Package Id
+{1} - Project Path</comment>
+  </data>
+  <data name="RemovePkg_Description" xml:space="preserve">
+    <value>Removes a package reference from a project.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -348,7 +348,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {2} - Project Path</comment>
   </data>
   <data name="Info_AddPkgAddingReference" xml:space="preserve">
-    <value>Adding PackageReference for package '{0}', into project '{1}'</value>
+    <value>Adding PackageReference for package '{0}' into project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
@@ -371,9 +371,10 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="AddPkg_FrameworksDescription" xml:space="preserve">
     <value>Frameworks for which the package reference should be added.</value>
   </data>
-  <data name="AddPkg_MissingArgument" xml:space="preserve">
-    <value>Unable to add package Reference, argument '{0}' not provided. Please use -h|--help for help.</value>
-    <comment>{0} - Argument which was not provided</comment>
+  <data name="Error_PkgMissingArgument" xml:space="preserve">
+    <value>Unable to '{0}' package Reference, argument '{1}' not provided. Please use -h|--help for help.</value>
+    <comment>{0} - operation type
+{1} - Argument which was not provided</comment>
   </data>
   <data name="AddPkg_NoRestoreDescription" xml:space="preserve">
     <value>Do not perform restore preview and compatibility check. The added package reference will be unconditional.</value>
@@ -431,21 +432,28 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>user specified</value>
   </data>
   <data name="Info_RemovePkgRemovingReference" xml:space="preserve">
-    <value>Removing PackageReference for package '{0}', from project '{1}'</value>
+    <value>Removing PackageReference for package '{0}' from project '{1}'</value>
     <comment>{0} - Package Id
 {1} - Project Path</comment>
   </data>
   <data name="RemovePkg_Description" xml:space="preserve">
     <value>Removes a package reference from a project.</value>
   </data>
-  <data name="RemovePkg_MissingArgument" xml:space="preserve">
-    <value>Unable to remove package reference, argument '{0}' not provided. Please use -h|--help for help.</value>
-    <comment>{0} - Argument which was not provided</comment>
-  </data>
   <data name="RemovePkg_PackageIdDescription" xml:space="preserve">
     <value>Id of the package to be removed.</value>
   </data>
   <data name="RemovePkg_ProjectPathDescription" xml:space="preserve">
     <value>Path to the project.</value>
+  </data>
+  <data name="Error_UpdatePkgNoSuchPackage" xml:space="preserve">
+    <value>Project '{0}' does not contain any PackageReference '{1}' to '{2}'</value>
+    <comment>{0} - project path
+{1} - package id
+{2} - operation name</comment>
+  </data>
+  <data name="Error_PkgMissingOrInvalidProjectFile" xml:space="preserve">
+    <value>Unable to '{0}' package. Missing or Invalid project file '{1}'.</value>
+    <comment>{0} - Operation Name
+{1} - project file path</comment>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -74,20 +74,12 @@ namespace NuGet.CommandLine.XPlat
         {
             var project = GetProject(projectPath);
 
-            // Here we get package references for any framework.
-            // If the project has a conditional reference, then an unconditional reference is not added.
-
             var existingPackageReferences = project.ItemsIgnoringCondition
                 .Where(item => item.ItemType.Equals(PACKAGE_REFERENCE_TYPE_TAG, StringComparison.OrdinalIgnoreCase) &&
                                item.EvaluatedInclude.Equals(packageDependency.Id, StringComparison.OrdinalIgnoreCase));
 
-            foreach (var packageReference in existingPackageReferences)
-            {
-                if (project.ItemsIgnoringCondition.Contains(packageReference))
-                {
-                    project.ItemsIgnoringCondition.Remove(packageReference);
-                }
-            }
+            project.RemoveItems(existingPackageReferences);
+
             project.Save();
             ProjectCollection.GlobalProjectCollection.UnloadProject(project);
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -207,11 +207,13 @@ namespace NuGet.CommandLine.XPlat
 
             foreach (var packageReferenceItem in packageReferencesItems)
             {
-                packageReferenceItem.SetMetadataValue(VERSION_TAG, packageDependency.VersionRange.OriginalString);
+                var packageVersion = packageDependency.VersionRange.OriginalString ??
+                    packageDependency.VersionRange.MinVersion.ToString();
+                packageReferenceItem.SetMetadataValue(VERSION_TAG, packageVersion);
                 Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                     Strings.Info_AddPkgUpdated,
                     packageDependency.Id,
-                    packageDependency.VersionRange.OriginalString,
+                    packageVersion,
                     packageReferenceItem.Xml.ContainingProject.FullPath));
             }
         }
@@ -232,7 +234,7 @@ namespace NuGet.CommandLine.XPlat
             Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                 Strings.Info_AddPkgAdded,
                 packageDependency.Id,
-                packageDependency.VersionRange.OriginalString,
+                packageVersion,
                 itemGroup.ContainingProject.FullPath));
         }
 
@@ -241,7 +243,8 @@ namespace NuGet.CommandLine.XPlat
             string operationType)
         {
             var importedPackageReferences = packageReferencesItems
-                .Where(i => i.IsImported);
+                .Where(i => i.IsImported)
+                .ToArray();
 
             // Throw if any of the package references to be updated are imported.
             if (importedPackageReferences.Any())

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -66,6 +66,33 @@ namespace NuGet.CommandLine.XPlat
         }
 
         /// <summary>
+        /// Remove all package references to the project.
+        /// </summary>
+        /// <param name="projectPath">Path to the csproj file of the project.</param>
+        /// <param name="packageDependency">Package Dependency of the package to be removed.</param>
+        public void RemovePackageReference(string projectPath, PackageDependency packageDependency)
+        {
+            var project = GetProject(projectPath);
+
+            // Here we get package references for any framework.
+            // If the project has a conditional reference, then an unconditional reference is not added.
+
+            var existingPackageReferences = project.ItemsIgnoringCondition
+                .Where(item => item.ItemType.Equals(PACKAGE_REFERENCE_TYPE_TAG, StringComparison.OrdinalIgnoreCase) &&
+                               item.EvaluatedInclude.Equals(packageDependency.Id, StringComparison.OrdinalIgnoreCase));
+
+            foreach (var packageReference in existingPackageReferences)
+            {
+                if (project.ItemsIgnoringCondition.Contains(packageReference))
+                {
+                    project.ItemsIgnoringCondition.Remove(packageReference);
+                }
+            }
+            project.Save();
+            ProjectCollection.GlobalProjectCollection.UnloadProject(project);
+        }
+
+        /// <summary>
         /// Add an unconditional package reference to the project.
         /// </summary>
         /// <param name="projectPath">Path to the csproj file of the project.</param>

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -226,6 +226,14 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public void AddPackageToFramework(string packageFramework, params SimpleTestPackageContext[] packages)
+        {
+            var framework = Frameworks
+                .Where(f => f.Framework == NuGetFramework.Parse(packageFramework))
+                .First();
+            framework.PackageReferences.AddRange(packages);
+        }
+
         public void AddProjectToAllFrameworks(params SimpleTestProjectContext[] projects)
         {
             foreach (var framework in Frameworks)
@@ -550,7 +558,7 @@ namespace NuGet.Test.Utility
 
             if (framework?.IsSpecificFramework == true)
             {
-                entry.Add(new XAttribute(XName.Get("Condition"), $" '$(TargetFramework)' == '{framework.GetShortFolderName()}' "));
+                itemGroup.Add(new XAttribute(XName.Get("Condition"), $" '$(TargetFramework)' == '{framework.GetShortFolderName()}' "));
             }
 
             foreach (var pair in properties)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -81,7 +81,7 @@ namespace NuGet.XPlat.FuncTest
 
             var logger = new TestCommandOutputLogger();
             var testApp = new CommandLineApplication();
-            var mockCommandRunner = new Mock<IAddPackageReferenceCommandRunner>();
+            var mockCommandRunner = new Mock<IPackageReferenceCommandRunner>();
             mockCommandRunner
                 .Setup(m => m.ExecuteCommand(It.IsAny<PackageReferenceArgs>(), It.IsAny<MSBuildAPIUtility>()))
                 .ReturnsAsync(0);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -121,8 +121,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46");
-                var packageX = CreatePackage();
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage();
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -130,18 +130,18 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild).Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
             }
         }
 
@@ -159,8 +159,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, projectFrameworks);
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -168,22 +168,22 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA, noRestore: true);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA, noRestore: true);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // If noRestore is set, then we do not perform compatibility check.
                 // The added package reference will be unconditional
-                var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
             }
         }
 
@@ -194,8 +194,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46");
-                var packageX = CreatePackage();
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage();
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -204,19 +204,19 @@ namespace NuGet.XPlat.FuncTest
                     packageX);
 
                 // Since user is not inputing a version, it is converted to a "*"
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, "*", projectA, noVersion: true);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, "*", projectA, noVersion: true);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(0, result);
 
                 // Since user did not specify a version, the package reference will contain the resolved version
-                Assert.True(ValidateReference(projectXmlRoot, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, "1.0.0"));
             }
         }
 
@@ -230,8 +230,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, projectFrameworks);
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -239,20 +239,20 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks);
+                var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks);
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
             }
         }
 
@@ -268,8 +268,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -277,21 +277,21 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA,
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA,
                     frameworks: userInputFrameworks);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
+                var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, packageX.Version));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, packageX.Version));
             }
         }
 
@@ -309,8 +309,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, projectFrameworks);
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -319,26 +319,26 @@ namespace NuGet.XPlat.FuncTest
                     packageX);
 
                 // Since user is not inputing a version, it is converted to a "*" in the command
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, "*",
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, "*",
                     projectA,
                     frameworks: userInputFrameworks,
                     noVersion: true);
 
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
+                var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
 
                 // Since user did not specify a version, the package reference will contain the resolved version
-                Assert.True(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
             }
         }
 
@@ -354,8 +354,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -363,18 +363,18 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA,
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA,
                     frameworks: userInputFrameworks);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(1, result);
-                Assert.True(ValidateNoReference(projectXmlRoot, packageX.Id));
+                Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, packageX.Id));
             }
         }
 
@@ -385,8 +385,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
-                var packageX = CreatePackage();
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
+                var packageX = XPlatTestUtils.CreatePackage();
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -394,18 +394,18 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs("unknown_package_id", "1.0.0", projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs("unknown_package_id", "1.0.0", projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(1, result);
-                Assert.True(ValidateNoReference(projectXmlRoot, packageX.Id));
-                Assert.True(ValidateNoReference(projectXmlRoot, "unknown_package_id"));
+                Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, packageX.Id));
+                Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, "unknown_package_id"));
             }
         }
 
@@ -416,9 +416,9 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46");
-                var packageX = CreatePackage("PkgX");
-                var packageY = CreatePackage("PkgY");
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage("PkgX");
+                var packageY = XPlatTestUtils.CreatePackage("PkgY");
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -430,24 +430,24 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageY);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
-                packageArgs = GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
+                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
 
                 // Act
                 result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(0, result);
-                Assert.True(ValidateTwoReferences(projectXmlRoot, packageX, packageY));
+                Assert.True(XPlatTestUtils.ValidateTwoReferences(projectXmlRoot, packageX, packageY));
             }
         }
 
@@ -463,9 +463,9 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, projectFrameworks);
-                var packageX = CreatePackage("PkgX", frameworkString: packageFrameworks);
-                var packageY = CreatePackage("PkgY", frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage("PkgX", frameworkString: packageFrameworks);
+                var packageY = XPlatTestUtils.CreatePackage("PkgY", frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -477,27 +477,32 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageY);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA, frameworks: userInputFrameworks);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id,
+                    packageX.Version,
+                    projectA,
+                    frameworks: userInputFrameworks);
                 var commandRunner = new AddPackageReferenceCommandRunner();
-                var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
                 var msBuild = MsBuild;
+                var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks,
+                    projectFrameworks,
+                    userInputFrameworks);
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
-                packageArgs = GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
+                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageY.Id, packageY.Version, projectA);
 
                 // Act
                 result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForFramework(projectXmlRoot, commonFramework);
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, commonFramework);
 
                 // Assert
                 Assert.Equal(0, result);
-                Assert.True(ValidateTwoReferences(projectXmlRoot, packageX, packageY));
+                Assert.True(XPlatTestUtils.ValidateTwoReferences(projectXmlRoot, packageX, packageY));
             }
         }
 
@@ -509,8 +514,8 @@ namespace NuGet.XPlat.FuncTest
             using (var tempGlobalPackagesDirectory = TestDirectory.Create())
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46");
-                var packageX = CreatePackage();
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+                var packageX = XPlatTestUtils.CreatePackage();
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -518,23 +523,25 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, packageX.Version, projectA,
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id,
+                    packageX.Version,
+                    projectA,
                     packageDirectory: tempGlobalPackagesDirectory.Path);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, packageX.Version));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, packageX.Version));
 
                 // Since user provided packge directory, assert if package is present
-                Assert.True(ValidatePackageDownload(tempGlobalPackagesDirectory.Path, packageX));
+                Assert.True(XPlatTestUtils.ValidatePackageDownload(tempGlobalPackagesDirectory.Path, packageX));
             }
         }
 
@@ -553,8 +560,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
-                var packageX = CreatePackage();
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46; netcoreapp1.0");
+                var packageX = XPlatTestUtils.CreatePackage();
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -562,28 +569,28 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
                 var msBuild = MsBuild;
 
                 // Create a package ref with the old version
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
-                packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionNew, projectA);
+                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersionNew, projectA);
                 commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 // Create a package ref with the new version
                 result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 // Verify that the only package reference is with the new version
                 Assert.Equal(0, result);
-                Assert.True(ValidateReference(projectXmlRoot, packageX.Id, userInputVersionNew));
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, userInputVersionNew));
             }
         }
 
@@ -625,8 +632,8 @@ namespace NuGet.XPlat.FuncTest
 
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = CreateProject(projectName, pathContext, projectFrameworks);
-                var packageX = CreatePackage(frameworkString: packageFrameworks);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageFrameworks);
 
                 // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
@@ -634,209 +641,30 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersionOld, projectA);
                 var commandRunner = new AddPackageReferenceCommandRunner();
                 var msBuild = MsBuild;
 
                 // Create a package ref with old version
                 var result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
-                packageArgs = GetPackageReferenceArgs(packageX.Id, userInputVersionNew, projectA);
+                packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersionNew, projectA);
                 commandRunner = new AddPackageReferenceCommandRunner();
-                var commonFramework = GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
+                var commonFramework = XPlatTestUtils.GetCommonFramework(packageFrameworks, projectFrameworks, userInputFrameworks);
 
                 // Act
                 // Create a package ref with new version
                 result = commandRunner.ExecuteCommand(packageArgs, msBuild)
                     .Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 // Verify that the only package reference is with the new version
                 Assert.Equal(0, result);
-                Assert.True(ValidateReference(projectXmlRoot, packageX.Id, userInputVersionNew));
+                Assert.True(XPlatTestUtils.ValidateReference(projectXmlRoot, packageX.Id, userInputVersionNew));
             }
-        }
-
-        // Helper Methods
-
-        // Arrange Helper Methods
-
-        private SimpleTestProjectContext CreateProject(string projectName, SimpleTestPathContext pathContext, string projectFrameworks)
-        {
-            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
-                    projectName: projectName,
-                    solutionRoot: pathContext.SolutionRoot,
-                    isToolingVersion15: true,
-                    frameworks: MSBuildStringUtility.Split(projectFrameworks));
-
-            project.Save();
-            return project;
-        }
-
-        private string CreateDGFileForProject(SimpleTestProjectContext project)
-        {
-            var dgSpec = new DependencyGraphSpec();
-            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
-            dgSpec.AddRestore(project.ProjectName);
-            dgSpec.AddProject(project.PackageSpec);
-            dgSpec.Save(dgFilePath);
-            return dgFilePath;
-        }
-
-        private SimpleTestPackageContext CreatePackage(string packageId = "packageX", string packageVersion = "1.0.0", string frameworkString = null)
-        {
-            var package = new SimpleTestPackageContext()
-            {
-                Id = packageId,
-                Version = packageVersion
-            };
-            var frameworks = MSBuildStringUtility.Split(frameworkString);
-
-            // Make the package Compatible with specific frameworks
-            frameworks?
-                .ToList()
-                .ForEach(f => package.AddFile($"lib/{f}/a.dll"));
-
-            // To ensure that the nuspec does not have System.Runtime.dll
-            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion);
-
-            return package;
-        }
-
-        private PackageReferenceArgs GetPackageReferenceArgs(string packageId, string packageVersion, SimpleTestProjectContext project,
-            string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false)
-        {
-            var logger = new TestCommandOutputLogger();
-            var packageDependency = new PackageDependency(packageId, VersionRange.Parse(packageVersion));
-            var dgFilePath = string.Empty;
-            if (!noRestore)
-            {
-                dgFilePath = CreateDGFileForProject(project);
-            }
-            return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger)
-            {
-                Frameworks = MSBuildStringUtility.Split(frameworks),
-                Sources = MSBuildStringUtility.Split(sources),
-                PackageDirectory = packageDirectory,
-                NoRestore = noRestore,
-                NoVersion = noVersion,
-                DgFilePath = dgFilePath
-            };
-        }
-
-        private string GetCommonFramework(string frameworkStringA, string frameworkStringB, string frameworkStringC)
-        {
-            var frameworksA = MSBuildStringUtility.Split(frameworkStringA);
-            var frameworksB = MSBuildStringUtility.Split(frameworkStringB);
-            var frameworksC = MSBuildStringUtility.Split(frameworkStringC);
-            return frameworksA.ToList()
-                .Intersect(frameworksB.ToList())
-                .Intersect(frameworksC.ToList())
-                .First();
-        }
-
-        private string GetCommonFramework(string frameworkStringA, string frameworkStringB)
-        {
-            var frameworksA = MSBuildStringUtility.Split(frameworkStringA);
-            var frameworksB = MSBuildStringUtility.Split(frameworkStringB);
-            return frameworksA.ToList()
-                .Intersect(frameworksB.ToList())
-                .First();
-        }
-
-        private XDocument GetNetCoreNuspec(string package, string packageVersion)
-        {
-            return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <package>
-                        <metadata>
-                            <id>{package}</id>
-                            <version>{packageVersion}</version>
-                            <title />
-                        </metadata>
-                        </package>");
-        }
-
-        // Assert Helper Methods
-
-        private bool ValidateReference(XElement root, string packageId, string version)
-        {
-            var packageReferences = root
-                    .Descendants("PackageReference")
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
-
-            if (packageReferences.Count() != 1)
-            {
-                return false;
-            }
-
-            var versions = packageReferences
-                .First()
-                .Descendants("Version");
-
-            if (versions.Count() != 1 ||
-                !versions.First().Value.Equals(version, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            return true;
-        }
-
-        private bool ValidateTwoReferences(XElement root, SimpleTestPackageContext packageX, SimpleTestPackageContext packageY)
-        {
-            return ValidateReference(root, packageX.Id, packageX.Version) &&
-                ValidateReference(root, packageY.Id, packageY.Version);
-        }
-
-        private bool ValidateNoReference(XElement root, string packageId)
-        {
-            var packageReferences = root
-                    .Descendants("PackageReference")
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
-
-            return !(packageReferences.Count() > 0);
-        }
-
-        private bool ValidatePackageDownload(string packageDirectoryPath, SimpleTestPackageContext package)
-        {
-            return Directory.Exists(packageDirectoryPath) &&
-                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower())) &&
-                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())) &&
-                Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Count() > 0;
-        }
-
-        private XElement GetItemGroupForFramework(XElement root, string framework)
-        {
-            var itemGroups = root.Descendants("ItemGroup");
-
-            return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
-                                i.FirstAttribute != null &&
-                                i.FirstAttribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
-                                i.FirstAttribute.Value.Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase))
-                     .First();
-        }
-
-        private XElement GetItemGroupForAllFrameworks(XElement root)
-        {
-            var itemGroups = root.Descendants("ItemGroup");
-
-            return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
-                                i.FirstAttribute == null)
-                     .First();
-        }
-
-        private XDocument LoadCSProj(string path)
-        {
-            return XPlatTestUtils.LoadSafe(path);
-        }
-
-        private string GetTargetFrameworkCondition(string targetFramework)
-        {
-            return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -4,11 +4,17 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.CommandLine.XPlat;
 using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
 
 namespace NuGet.XPlat.FuncTest
 {
@@ -119,6 +125,215 @@ namespace NuGet.XPlat.FuncTest
             };
 
             return safeSettings;
+        }
+
+        public static SimpleTestProjectContext CreateProject(string projectName,
+            SimpleTestPathContext pathContext,
+            SimpleTestPackageContext package,
+            string projectFrameworks,
+            string packageFramework = null)
+        {
+            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    isToolingVersion15: true,
+                    frameworks: StringUtility.Split(projectFrameworks));
+
+            if (packageFramework == null)
+            {
+                project.AddPackageToAllFrameworks(package);
+            }
+            else
+            {
+                project.AddPackageToFramework(packageFramework, package);
+            }
+            project.Save();
+            return project;
+        }
+
+        public static SimpleTestProjectContext CreateProject(string projectName,
+            SimpleTestPathContext pathContext,
+            string projectFrameworks)
+        {
+            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    isToolingVersion15: true,
+                    frameworks: StringUtility.Split(projectFrameworks));
+
+            project.Save();
+            return project;
+        }
+
+        public static SimpleTestPackageContext CreatePackage(string packageId = "packageX",
+            string packageVersion = "1.0.0",
+            string frameworkString = null)
+        {
+            var package = new SimpleTestPackageContext()
+            {
+                Id = packageId,
+                Version = packageVersion
+            };
+            var frameworks = StringUtility.Split(frameworkString);
+
+            // Make the package Compatible with specific frameworks
+            frameworks?
+                .ToList()
+                .ForEach(f => package.AddFile($"lib/{f}/a.dll"));
+
+            // To ensure that the nuspec does not have System.Runtime.dll
+            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion);
+
+            return package;
+        }
+
+        public static PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
+        {
+            var logger = new TestCommandOutputLogger();
+            var packageDependency = new PackageDependency(packageId);
+            return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger);
+        }
+
+        public static PackageReferenceArgs GetPackageReferenceArgs(string packageId, string packageVersion, SimpleTestProjectContext project,
+            string frameworks = "", string packageDirectory = "", string sources = "", bool noRestore = false, bool noVersion = false)
+        {
+            var logger = new TestCommandOutputLogger();
+            var packageDependency = new PackageDependency(packageId, VersionRange.Parse(packageVersion));
+            var dgFilePath = string.Empty;
+            if (!noRestore)
+            {
+                dgFilePath = CreateDGFileForProject(project);
+            }
+            return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger)
+            {
+                Frameworks = StringUtility.Split(frameworks),
+                Sources = StringUtility.Split(sources),
+                PackageDirectory = packageDirectory,
+                NoRestore = noRestore,
+                NoVersion = noVersion,
+                DgFilePath = dgFilePath
+            };
+        }
+
+        public static XDocument GetNetCoreNuspec(string package, string packageVersion)
+        {
+            return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>{package}</id>
+                            <version>{packageVersion}</version>
+                            <title />
+                        </metadata>
+                        </package>");
+        }
+
+        // Assert Helper Methods
+
+        public static bool ValidateReference(XElement root, string packageId, string version)
+        {
+            var packageReferences = root
+                    .Descendants("PackageReference")
+                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+            if (packageReferences.Count() != 1)
+            {
+                return false;
+            }
+
+            var versions = packageReferences
+                .First()
+                .Descendants("Version");
+
+            if (versions.Count() != 1 ||
+                !versions.First().Value.Equals(version, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static bool ValidateNoReference(XElement root, string packageId)
+        {
+            var packageReferences = root
+                    .Descendants("PackageReference")
+                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+            return !(packageReferences.Count() > 0);
+        }
+
+        public static XElement GetItemGroupForFramework(XElement root, string framework)
+        {
+            var itemGroups = root.Descendants("ItemGroup");
+            return itemGroups
+                    .Where(i => i.Descendants("PackageReference").Any() &&
+                                i.FirstAttribute != null &&
+                                i.FirstAttribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
+                                i.FirstAttribute.Value.Trim().Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase))
+                     .First();
+        }
+
+        public static XElement GetItemGroupForAllFrameworks(XElement root)
+        {
+            var itemGroups = root.Descendants("ItemGroup");
+
+            return itemGroups
+                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
+                                i.FirstAttribute == null)
+                     .First();
+        }
+
+        public static bool ValidateTwoReferences(XElement root, SimpleTestPackageContext packageX, SimpleTestPackageContext packageY)
+        {
+            return ValidateReference(root, packageX.Id, packageX.Version) &&
+                ValidateReference(root, packageY.Id, packageY.Version);
+        }
+
+        public static bool ValidatePackageDownload(string packageDirectoryPath, SimpleTestPackageContext package)
+        {
+            return Directory.Exists(packageDirectoryPath) &&
+                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower())) &&
+                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())) &&
+                Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Count() > 0;
+        }
+
+        public static string CreateDGFileForProject(SimpleTestProjectContext project)
+        {
+            var dgSpec = new DependencyGraphSpec();
+            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
+            dgSpec.AddRestore(project.ProjectName);
+            dgSpec.AddProject(project.PackageSpec);
+            dgSpec.Save(dgFilePath);
+            return dgFilePath;
+        }
+
+        public static string GetCommonFramework(string frameworkStringA, string frameworkStringB, string frameworkStringC)
+        {
+            var frameworksA = StringUtility.Split(frameworkStringA);
+            var frameworksB = StringUtility.Split(frameworkStringB);
+            var frameworksC = StringUtility.Split(frameworkStringC);
+            return frameworksA.ToList()
+                .Intersect(frameworksB.ToList())
+                .Intersect(frameworksC.ToList())
+                .First();
+        }
+
+        public static string GetCommonFramework(string frameworkStringA, string frameworkStringB)
+        {
+            var frameworksA = StringUtility.Split(frameworkStringA);
+            var frameworksB = StringUtility.Split(frameworkStringB);
+            return frameworksA.ToList()
+                .Intersect(frameworksB.ToList())
+                .First();
+        }
+
+        public static XDocument LoadCSProj(string path)
+        {
+            return LoadSafe(path);
+        }
+
+        public static string GetTargetFrameworkCondition(string targetFramework)
+        {
+            return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -10,6 +10,7 @@ using System.Xml.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.CommandLine.XPlat;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -137,7 +138,7 @@ namespace NuGet.XPlat.FuncTest
                     projectName: projectName,
                     solutionRoot: pathContext.SolutionRoot,
                     isToolingVersion15: true,
-                    frameworks: StringUtility.Split(projectFrameworks));
+                    frameworks: MSBuildStringUtility.Split(projectFrameworks));
 
             if (packageFramework == null)
             {
@@ -159,7 +160,7 @@ namespace NuGet.XPlat.FuncTest
                     projectName: projectName,
                     solutionRoot: pathContext.SolutionRoot,
                     isToolingVersion15: true,
-                    frameworks: StringUtility.Split(projectFrameworks));
+                    frameworks: MSBuildStringUtility.Split(projectFrameworks));
 
             project.Save();
             return project;
@@ -174,7 +175,7 @@ namespace NuGet.XPlat.FuncTest
                 Id = packageId,
                 Version = packageVersion
             };
-            var frameworks = StringUtility.Split(frameworkString);
+            var frameworks = MSBuildStringUtility.Split(frameworkString);
 
             // Make the package Compatible with specific frameworks
             frameworks?
@@ -206,8 +207,8 @@ namespace NuGet.XPlat.FuncTest
             }
             return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger)
             {
-                Frameworks = StringUtility.Split(frameworks),
-                Sources = StringUtility.Split(sources),
+                Frameworks = MSBuildStringUtility.Split(frameworks),
+                Sources = MSBuildStringUtility.Split(sources),
                 PackageDirectory = packageDirectory,
                 NoRestore = noRestore,
                 NoVersion = noVersion,
@@ -308,9 +309,9 @@ namespace NuGet.XPlat.FuncTest
 
         public static string GetCommonFramework(string frameworkStringA, string frameworkStringB, string frameworkStringC)
         {
-            var frameworksA = StringUtility.Split(frameworkStringA);
-            var frameworksB = StringUtility.Split(frameworkStringB);
-            var frameworksC = StringUtility.Split(frameworkStringC);
+            var frameworksA = MSBuildStringUtility.Split(frameworkStringA);
+            var frameworksB = MSBuildStringUtility.Split(frameworkStringB);
+            var frameworksC = MSBuildStringUtility.Split(frameworkStringC);
             return frameworksA.ToList()
                 .Intersect(frameworksB.ToList())
                 .Intersect(frameworksC.ToList())
@@ -319,8 +320,8 @@ namespace NuGet.XPlat.FuncTest
 
         public static string GetCommonFramework(string frameworkStringA, string frameworkStringB)
         {
-            var frameworksA = StringUtility.Split(frameworkStringA);
-            var frameworksB = StringUtility.Split(frameworkStringB);
+            var frameworksA = MSBuildStringUtility.Split(frameworkStringA);
+            var frameworksB = MSBuildStringUtility.Split(frameworkStringB);
             return frameworksA.ToList()
                 .Intersect(frameworksB.ToList())
                 .First();
@@ -334,6 +335,14 @@ namespace NuGet.XPlat.FuncTest
         public static string GetTargetFrameworkCondition(string targetFramework)
         {
             return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
+        }
+
+        public static void DisposeTemporaryFile(string filePath)
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -1,0 +1,303 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Extensions.CommandLineUtils;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XPlatRemovePkgTests
+    {
+        private static readonly string projectName = "test_project_removepkg";
+
+        // Argument parsing related tests
+
+        [Theory]
+        [InlineData("--package", "package_foo", "--project", "project_foo")]
+        [InlineData("--package", "package_foo", "-p", "project_foo")]
+        public void AddPkg_ArgParsing(string packageOption, string package, 
+            string projectOption, string project)
+        {
+            // Arrange
+
+            var argList = new List<string>() {
+                "remove",
+                packageOption,
+                package,
+                projectOption,
+                project};
+
+            var logger = new TestCommandOutputLogger();
+            var testApp = new CommandLineApplication();
+            var mockCommandRunner = new Mock<IPackageReferenceCommandRunner>();
+            mockCommandRunner
+                .Setup(m => m.ExecuteCommand(It.IsAny<PackageReferenceArgs>(), It.IsAny<MSBuildAPIUtility>()))
+                .ReturnsAsync(0);
+
+            testApp.Name = "dotnet nuget_test";
+            RemovePackageReferenceCommand.Register(testApp,
+                () => logger,
+                () => mockCommandRunner.Object);
+
+            // Act
+            var result = testApp.Execute(argList.ToArray());
+
+            // Assert
+            mockCommandRunner.Verify(m => m.ExecuteCommand(It.Is<PackageReferenceArgs>(p => 
+            p.PackageDependency.Id == package &&
+            p.ProjectPath == project),
+            It.IsAny<MSBuildAPIUtility>()));
+
+            Assert.Equal(0, result);
+        }
+
+        // Remove Related Tests
+
+        [Fact]
+        public async void RemovePkg_UnconditionalRemove_Success()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = CreatePackage();
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = CreateProject(projectName, pathContext, packageX, "net46");
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                Assert.NotNull(itemGroup);
+                Assert.True(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+
+
+                var packageArgs = GetPackageReferenceArgs(packageX.Id, projectA);
+                var commandRunner = new RemovePackageReferenceCommandRunner();
+
+                // Act
+                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility()).Result;
+                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+
+                // Assert
+                Assert.Equal(0, result);
+                Assert.False(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+            }
+        }
+
+        [Theory]
+        [InlineData("net46")]
+        [InlineData("netcoreapp1.0")]
+        public async void RemovePkg_ConditionalRemove_Success(string packageframework)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = CreatePackage(frameworkString: packageframework);
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = CreateProject(projectName, pathContext, packageX, "net46; netcoreapp1.0", packageframework);
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = GetItemGroupForFramework(projectXmlRoot, packageframework);
+
+                Assert.NotNull(itemGroup);
+                Assert.True(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+
+
+                var packageArgs = GetPackageReferenceArgs(packageX.Id, projectA);
+                var commandRunner = new RemovePackageReferenceCommandRunner();
+
+                // Act
+                var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility()).Result;
+                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                itemGroup = GetItemGroupForFramework(projectXmlRoot, packageframework);
+
+                // Assert
+                Assert.Equal(0, result);
+                Assert.Null(itemGroup);
+                Assert.False(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+            }
+        }
+
+        // Helper Methods
+
+        // Arrange Helper Methods
+
+        private SimpleTestProjectContext CreateProject(string projectName, 
+            SimpleTestPathContext pathContext,
+            SimpleTestPackageContext package,
+            string projectFrameworks,
+            string packageFramework = null)
+        {
+            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    isToolingVersion15: true,
+                    frameworks: StringUtility.Split(projectFrameworks));
+
+            if(packageFramework == null)
+            {
+                project.AddPackageToAllFrameworks(package);
+            }
+            else
+            {
+                project.AddPackageToFramework(packageFramework, package);
+            }
+            project.Save();
+            return project;
+        }
+
+        private string CreateDGFileForProject(SimpleTestProjectContext project)
+        {
+            var dgSpec = new DependencyGraphSpec();
+            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
+            dgSpec.AddRestore(project.ProjectName);
+            dgSpec.AddProject(project.PackageSpec);
+            dgSpec.Save(dgFilePath);
+            return dgFilePath;
+        }
+
+        private SimpleTestPackageContext CreatePackage(string packageId = "packageX", string packageVersion = "1.0.0", string frameworkString = null)
+        {
+            var package = new SimpleTestPackageContext()
+            {
+                Id = packageId,
+                Version = packageVersion
+            };
+            var frameworks = StringUtility.Split(frameworkString);
+
+            // Make the package Compatible with specific frameworks
+            frameworks?
+                .ToList()
+                .ForEach(f => package.AddFile($"lib/{f}/a.dll"));
+
+            // To ensure that the nuspec does not have System.Runtime.dll
+            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion);
+
+            return package;
+        }
+
+        private PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
+        {
+            var logger = new TestCommandOutputLogger();
+            var packageDependency = new PackageDependency(packageId);
+            return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger);
+        }
+
+        private XDocument GetNetCoreNuspec(string package, string packageVersion)
+        {
+            return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>{package}</id>
+                            <version>{packageVersion}</version>
+                            <title />
+                        </metadata>
+                        </package>");
+        }
+
+        // Assert Helper Methods
+
+        private bool ValidateReference(XElement root, string packageId, string version)
+        {
+            var packageReferences = root
+                    .Descendants("PackageReference")
+                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+            if (packageReferences.Count() != 1)
+            {
+                return false;
+            }
+
+            var versions = packageReferences
+                .First()
+                .Descendants("Version");
+
+            if (versions.Count() != 1 ||
+                !versions.First().Value.Equals(version, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private bool ValidateTwoReferences(XElement root, SimpleTestPackageContext packageX, SimpleTestPackageContext packageY)
+        {
+            return ValidateReference(root, packageX.Id, packageX.Version) &&
+                ValidateReference(root, packageY.Id, packageY.Version);
+        }
+
+        private bool ValidateNoReference(XElement root, string packageId)
+        {
+            var packageReferences = root
+                    .Descendants("PackageReference")
+                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+            return !(packageReferences.Count() > 0);
+        }
+
+        private bool ValidatePackageDownload(string packageDirectoryPath, SimpleTestPackageContext package)
+        {
+            return Directory.Exists(packageDirectoryPath) &&
+                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower())) &&
+                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())) &&
+                Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Count() > 0;
+        }
+
+        private XElement GetItemGroupForFramework(XElement root, string framework)
+        {
+            var itemGroups = root.Descendants("ItemGroup");
+
+            return itemGroups
+                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
+                                i.FirstAttribute != null &&
+                                i.FirstAttribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
+                                i.FirstAttribute.Value.Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase))
+                     .First();
+        }
+
+        private XElement GetItemGroupForAllFrameworks(XElement root)
+        {
+            var itemGroups = root.Descendants("ItemGroup");
+
+            return itemGroups
+                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
+                                i.FirstAttribute == null)
+                     .First();
+        }
+
+        private XDocument LoadCSProj(string path)
+        {
+            return XPlatTestUtils.LoadSafe(path);
+        }
+
+        private string GetTargetFrameworkCondition(string targetFramework)
+        {
+            return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -3,19 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Xml.Linq;
 using Microsoft.Extensions.CommandLineUtils;
 using Moq;
 using NuGet.CommandLine.XPlat;
-using NuGet.Common;
-using NuGet.Frameworks;
 using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.ProjectModel;
 using NuGet.Test.Utility;
-using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.XPlat.FuncTest
@@ -29,7 +21,7 @@ namespace NuGet.XPlat.FuncTest
         [Theory]
         [InlineData("--package", "package_foo", "--project", "project_foo")]
         [InlineData("--package", "package_foo", "-p", "project_foo")]
-        public void AddPkg_ArgParsing(string packageOption, string package, 
+        public void AddPkg_ArgParsing(string packageOption, string package,
             string projectOption, string project)
         {
             // Arrange
@@ -57,7 +49,7 @@ namespace NuGet.XPlat.FuncTest
             var result = testApp.Execute(argList.ToArray());
 
             // Assert
-            mockCommandRunner.Verify(m => m.ExecuteCommand(It.Is<PackageReferenceArgs>(p => 
+            mockCommandRunner.Verify(m => m.ExecuteCommand(It.Is<PackageReferenceArgs>(p =>
             p.PackageDependency.Id == package &&
             p.ProjectPath == project),
             It.IsAny<MSBuildAPIUtility>()));
@@ -71,35 +63,35 @@ namespace NuGet.XPlat.FuncTest
         public async void RemovePkg_UnconditionalRemove_Success()
         {
             // Arrange
+
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Generate Package
-                var packageX = CreatePackage();
+                var packageX = XPlatTestUtils.CreatePackage();
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var projectA = CreateProject(projectName, pathContext, packageX, "net46");
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, "net46");
 
                 // Verify that the package reference exists before removing.
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForAllFrameworks(projectXmlRoot);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
 
-
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility()).Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(0, result);
-                Assert.False(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, packageX.Id));
             }
         }
 
@@ -109,195 +101,36 @@ namespace NuGet.XPlat.FuncTest
         public async void RemovePkg_ConditionalRemove_Success(string packageframework)
         {
             // Arrange
+
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Generate Package
-                var packageX = CreatePackage(frameworkString: packageframework);
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: packageframework);
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var projectA = CreateProject(projectName, pathContext, packageX, "net46; netcoreapp1.0", packageframework);
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, "net46; netcoreapp1.0", packageframework);
 
                 // Verify that the package reference exists before removing.
-                var projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = GetItemGroupForFramework(projectXmlRoot, packageframework);
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, packageframework);
 
                 Assert.NotNull(itemGroup);
-                Assert.True(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
 
-
-                var packageArgs = GetPackageReferenceArgs(packageX.Id, projectA);
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, projectA);
                 var commandRunner = new RemovePackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, new MSBuildAPIUtility()).Result;
-                projectXmlRoot = LoadCSProj(projectA.ProjectPath).Root;
-                itemGroup = GetItemGroupForFramework(projectXmlRoot, packageframework);
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
 
                 // Assert
                 Assert.Equal(0, result);
-                Assert.Null(itemGroup);
-                Assert.False(ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+                Assert.True(XPlatTestUtils.ValidateNoReference(projectXmlRoot, packageX.Id));
             }
-        }
-
-        // Helper Methods
-
-        // Arrange Helper Methods
-
-        private SimpleTestProjectContext CreateProject(string projectName, 
-            SimpleTestPathContext pathContext,
-            SimpleTestPackageContext package,
-            string projectFrameworks,
-            string packageFramework = null)
-        {
-            var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
-                    projectName: projectName,
-                    solutionRoot: pathContext.SolutionRoot,
-                    isToolingVersion15: true,
-                    frameworks: StringUtility.Split(projectFrameworks));
-
-            if(packageFramework == null)
-            {
-                project.AddPackageToAllFrameworks(package);
-            }
-            else
-            {
-                project.AddPackageToFramework(packageFramework, package);
-            }
-            project.Save();
-            return project;
-        }
-
-        private string CreateDGFileForProject(SimpleTestProjectContext project)
-        {
-            var dgSpec = new DependencyGraphSpec();
-            var dgFilePath = Path.Combine(Directory.GetParent(project.ProjectPath).FullName, "temp.dg");
-            dgSpec.AddRestore(project.ProjectName);
-            dgSpec.AddProject(project.PackageSpec);
-            dgSpec.Save(dgFilePath);
-            return dgFilePath;
-        }
-
-        private SimpleTestPackageContext CreatePackage(string packageId = "packageX", string packageVersion = "1.0.0", string frameworkString = null)
-        {
-            var package = new SimpleTestPackageContext()
-            {
-                Id = packageId,
-                Version = packageVersion
-            };
-            var frameworks = StringUtility.Split(frameworkString);
-
-            // Make the package Compatible with specific frameworks
-            frameworks?
-                .ToList()
-                .ForEach(f => package.AddFile($"lib/{f}/a.dll"));
-
-            // To ensure that the nuspec does not have System.Runtime.dll
-            package.Nuspec = GetNetCoreNuspec(packageId, packageVersion);
-
-            return package;
-        }
-
-        private PackageReferenceArgs GetPackageReferenceArgs(string packageId, SimpleTestProjectContext project)
-        {
-            var logger = new TestCommandOutputLogger();
-            var packageDependency = new PackageDependency(packageId);
-            return new PackageReferenceArgs(project.ProjectPath, packageDependency, logger);
-        }
-
-        private XDocument GetNetCoreNuspec(string package, string packageVersion)
-        {
-            return XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
-                        <package>
-                        <metadata>
-                            <id>{package}</id>
-                            <version>{packageVersion}</version>
-                            <title />
-                        </metadata>
-                        </package>");
-        }
-
-        // Assert Helper Methods
-
-        private bool ValidateReference(XElement root, string packageId, string version)
-        {
-            var packageReferences = root
-                    .Descendants("PackageReference")
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
-
-            if (packageReferences.Count() != 1)
-            {
-                return false;
-            }
-
-            var versions = packageReferences
-                .First()
-                .Descendants("Version");
-
-            if (versions.Count() != 1 ||
-                !versions.First().Value.Equals(version, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            return true;
-        }
-
-        private bool ValidateTwoReferences(XElement root, SimpleTestPackageContext packageX, SimpleTestPackageContext packageY)
-        {
-            return ValidateReference(root, packageX.Id, packageX.Version) &&
-                ValidateReference(root, packageY.Id, packageY.Version);
-        }
-
-        private bool ValidateNoReference(XElement root, string packageId)
-        {
-            var packageReferences = root
-                    .Descendants("PackageReference")
-                    .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
-
-            return !(packageReferences.Count() > 0);
-        }
-
-        private bool ValidatePackageDownload(string packageDirectoryPath, SimpleTestPackageContext package)
-        {
-            return Directory.Exists(packageDirectoryPath) &&
-                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower())) &&
-                Directory.Exists(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())) &&
-                Directory.EnumerateFiles(Path.Combine(packageDirectoryPath, package.Id.ToLower(), package.Version.ToLower())).Count() > 0;
-        }
-
-        private XElement GetItemGroupForFramework(XElement root, string framework)
-        {
-            var itemGroups = root.Descendants("ItemGroup");
-
-            return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
-                                i.FirstAttribute != null &&
-                                i.FirstAttribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
-                                i.FirstAttribute.Value.Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase))
-                     .First();
-        }
-
-        private XElement GetItemGroupForAllFrameworks(XElement root)
-        {
-            var itemGroups = root.Descendants("ItemGroup");
-
-            return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
-                                i.FirstAttribute == null)
-                     .First();
-        }
-
-        private XDocument LoadCSProj(string path)
-        {
-            return XPlatTestUtils.LoadSafe(path);
-        }
-
-        private string GetTargetFrameworkCondition(string targetFramework)
-        {
-            return string.Format("'$(TargetFramework)' == '{0}'", targetFramework);
         }
     }
 }


### PR DESCRIPTION
Fixes NuGet part of : https://github.com/NuGet/Home/issues/4101

This change adds remove package command to NuGet.Xplat.dll

Changes - 
1. Add remove package command, command runner and relevant msbuild methods.
2. Refactor add package test helper methods to allow reuse for remove package command.
3. Add tests for remove package command.
4. Clean up around add package command.

// cc: @emgarten @joelverhagen @rohit21agrawal @jainaashish @zhili1208 @nkolev92 @alpaix @rrelyea 