### PR TITLE
Merge two versions of Install-DotnetCLI cmdlet

### DIFF
--- a/configure.ps1
+++ b/configure.ps1
@@ -49,8 +49,8 @@ Invoke-BuildStep 'Installing .NET CLI' {
     Install-DotnetCLI -Force:$Force
 } -ev +BuildErrors
 
-Invoke-BuildStep 'Installing .NET CLI Test' {
-    Install-DotnetCLI-Test -Force:$Force
+Invoke-BuildStep 'Installing .NET CLI for tests' {
+    Install-DotnetCLI -Test -Force:$Force
 } -ev +BuildErrors
 
 # Restoring tools required for build


### PR DESCRIPTION
Follow-up on NuGet/NuGet.Client#1090.

Merge two cmdlets into one to avoid duplicate code and enforce consistent PS naming convention.

//cc @mishra14 @rohit21agrawal 