### PR TITLE
Support v3 versioned services

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Constants.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Constants.cs
@@ -9,13 +9,14 @@ namespace NuGet.Protocol
         public static readonly string Version300beta = "/3.0.0-beta";
         public static readonly string Version300 = "/3.0.0";
         public static readonly string Version340 = "/3.4.0";
+        public static readonly string Versioned = "/Versioned";
 
-        public static readonly string[] SearchQueryService = { "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
-        public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
-        public static readonly string SearchAutocompleteService = "SearchAutocompleteService" + Version300beta;
-        public static readonly string ReportAbuse = "ReportAbuseUriTemplate" + Version300;
-        public static readonly string LegacyGallery = "LegacyGallery" + Version200;
-        public static readonly string PackagePublish = "PackagePublish" + Version200;
-        public static readonly string PackageBaseAddress = "PackageBaseAddress" + Version300;
+        public static readonly string[] SearchQueryService = { "SearchQueryService" + Versioned, "SearchQueryService" + Version340, "SearchQueryService" + Version300beta };
+        public static readonly string[] RegistrationsBaseUrl = { "RegistrationsBaseUrl" + Versioned, "RegistrationsBaseUrl" + Version340, "RegistrationsBaseUrl" + Version300beta };
+        public static readonly string[] SearchAutocompleteService = { "SearchAutocompleteService" + Versioned, "SearchAutocompleteService" + Version300beta };
+        public static readonly string[] ReportAbuse = { "ReportAbuseUriTemplate" + Versioned, "ReportAbuseUriTemplate" + Version300 };
+        public static readonly string[] LegacyGallery = { "LegacyGallery" + Versioned, "LegacyGallery" + Version200 };
+        public static readonly string[] PackagePublish = { "PackagePublish" + Versioned, "PackagePublish" + Version200 };
+        public static readonly string[] PackageBaseAddress = { "PackageBaseAddress" + Versioned, "PackageBaseAddress" + Version300 };
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Model/ServiceIndexEntry.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Model/ServiceIndexEntry.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// index.json entry for v3
+    /// </summary>
+    public class ServiceIndexEntry
+    {
+        /// <summary>
+        /// Service Uri
+        /// </summary>
+        public Uri Uri { get; }
+
+        /// <summary>
+        /// Service Type
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// Client version
+        /// </summary>
+        public SemanticVersion ClientVersion { get; }
+
+        public ServiceIndexEntry(Uri serviceUri, string serviceType, SemanticVersion clientVersion)
+        {
+            if (serviceUri == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            if (clientVersion == null)
+            {
+                throw new ArgumentNullException(nameof(clientVersion));
+            }
+
+            Uri = serviceUri;
+            Type = serviceType;
+            ClientVersion = clientVersion;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/DownloadResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/DownloadResourceV3Provider.cs
@@ -29,7 +29,7 @@ namespace NuGet.Protocol
 
                 // If index.json contains a flat container resource use that to directly
                 // construct package download urls.
-                var packageBaseAddress = serviceIndex[ServiceTypes.PackageBaseAddress].FirstOrDefault()?.AbsoluteUri;
+                var packageBaseAddress = serviceIndex.GetServiceEntryUri(ServiceTypes.PackageBaseAddress)?.AbsoluteUri;
 
                 if (packageBaseAddress != null)
                 {

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ListCommandResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ListCommandResourceV3Provider.cs
@@ -31,7 +31,7 @@ namespace NuGet.Protocol
                 // which may or may not contain a list endpoint.
                 // Returning null here will result in ListCommandResource
                 // getting returned for this very v3 package source as if it was a v2 package source
-                var baseUrl = serviceIndex[ServiceTypes.LegacyGallery].FirstOrDefault();
+                var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.LegacyGallery);
                 listCommandResource = new ListCommandResource(baseUrl?.AbsoluteUri);
             }
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/PackageUpdateResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/PackageUpdateResourceV3Provider.cs
@@ -26,7 +26,7 @@ namespace NuGet.Protocol
 
             if (serviceIndex != null)
             {
-                var baseUrl = serviceIndex[ServiceTypes.PackagePublish].FirstOrDefault();
+                var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.PackagePublish);
 
                 HttpSource httpSource = null;
                 var sourceUri = baseUrl?.AbsoluteUri;

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/RawSearchResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/RawSearchResourceV3Provider.cs
@@ -25,9 +25,9 @@ namespace NuGet.Protocol
 
             if (serviceIndex != null)
             {
-                var endpoints = serviceIndex[ServiceTypes.SearchQueryService].ToArray();
+                var endpoints = serviceIndex.GetServiceEntryUris(ServiceTypes.SearchQueryService);
 
-                if (endpoints.Length > 0)
+                if (endpoints.Count > 0)
                 {
                     var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/RegistrationResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/RegistrationResourceV3Provider.cs
@@ -25,7 +25,7 @@ namespace NuGet.Protocol
 
             if (serviceIndex != null)
             {
-                var baseUrl = serviceIndex[ServiceTypes.RegistrationsBaseUrl].FirstOrDefault();
+                var baseUrl = serviceIndex.GetServiceEntryUri(ServiceTypes.RegistrationsBaseUrl);
 
                 var httpSourceResource = await source.GetResourceAsync<HttpSourceResource>(token);
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ReportAbuseResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Providers/ReportAbuseResourceV3Provider.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol
             var serviceIndex = await source.GetResourceAsync<ServiceIndexResourceV3>(token);
             if (serviceIndex != null)
             {
-                var uriTemplate = serviceIndex[ServiceTypes.ReportAbuse].FirstOrDefault()?.AbsoluteUri;
+                var uriTemplate = serviceIndex.GetServiceEntryUri(ServiceTypes.ReportAbuse)?.AbsoluteUri;
 
                 // construct a new resource
                 resource = new ReportAbuseResourceV3(uriTemplate);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResourceProvider.cs
@@ -10,8 +10,6 @@ namespace NuGet.Protocol
 {
     public class HttpFileSystemBasedFindPackageByIdResourceProvider : ResourceProvider
     {
-        private const string HttpFileSystemIndexType = "PackageBaseAddress/3.0.0";
-
         public HttpFileSystemBasedFindPackageByIdResourceProvider()
             : base(typeof(FindPackageByIdResource),
                 nameof(HttpFileSystemBasedFindPackageByIdResourceProvider),
@@ -23,7 +21,7 @@ namespace NuGet.Protocol
         {
             INuGetResource resource = null;
             var serviceIndexResource = await sourceRepository.GetResourceAsync<ServiceIndexResourceV3>();
-            var packageBaseAddress = serviceIndexResource?[HttpFileSystemIndexType];
+            var packageBaseAddress = serviceIndexResource?.GetServiceEntryUris(ServiceTypes.PackageBaseAddress);
 
             if (packageBaseAddress != null
                 && packageBaseAddress.Count > 0)

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
@@ -34,7 +34,7 @@ namespace NuGet.Protocol
             Common.ILogger log,
             CancellationToken token)
         {
-            var searchUrl = _serviceIndex[ServiceTypes.SearchAutocompleteService].FirstOrDefault();
+            var searchUrl = _serviceIndex.GetServiceEntryUri(ServiceTypes.SearchAutocompleteService);
 
             if (searchUrl == null)
             {


### PR DESCRIPTION
This is a small change that adds support for selecting v3 services based on the client version. The previous model used hardcoded type strings which made it impossible for a server to optimize or support or new feature without breaking older clients unless the client added a new type.

The current behavior will continue to work the same, this feature just allows a new service type to take precedence over the current hardcoded list **if** the index.json file contains the new types.

#### Benefits:
1. nuget.org and 3rd party servers can add support for features for clients that have already shipped
1. servers can control services on a client version level

#### Scenarios:
1. Support for SemVer 2.0.0 on nuget.org in NuGet 4.0.0/CLI 1.0.0
1. Support for compressed flatcontainer json files

The above scenarios work today in 3.5.0 but cannot be enabled without breaking older clients. Having this feature will make it possible to do the server work at a later date instead of when client work begins on a new version.

It would also make it possible for 3rd party servers to support new features instead of being limited to what nuget.org supports.

#### Example service entry
```json
    {
      "@id": "https://api.nuget.org/v3-flatcontainer/",
      "@type": "PackageBaseAddress/3.0.0",
      "comment": "Fallback for older clients"
    },
    {
      "@id": "https://api.nuget.org/updated-flatcontainer/",
      "@type": "PackageBaseAddress/Versioned",
      "comment": "Compressed flatcontainer service that is used for clients 4.0.0 and up",
      "clientVersion": "4.0.0"
    }
```

//cc @rrelyea @joelverhagen @skofman1 @jainaashish @dtivel @alpaix 