### PR TITLE
ValidateRuntimeIdentifierCompatibility option support

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -41,6 +41,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Recurse by default -->
     <RestoreRecursive Condition=" '$(RestoreRecursive)' == '' ">true</RestoreRecursive>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <!-- RuntimeIdentifier compatibility check -->
+    <ValidateRuntimeIdentifierCompatibility Condition=" '$(ValidateRuntimeIdentifierCompatibility)' == '' ">false</ValidateRuntimeIdentifierCompatibility>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -371,6 +373,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <RuntimeSupports>$(RuntimeSupports)</RuntimeSupports>
         <CrossTargeting>$(_RestoreCrossTargeting)</CrossTargeting>
         <RestoreLegacyPackagesDirectory>$(RestoreLegacyPackagesDirectory)</RestoreLegacyPackagesDirectory>
+        <ValidateRuntimeAssets>$(ValidateRuntimeIdentifierCompatibility)</ValidateRuntimeAssets>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -21,12 +21,14 @@ namespace NuGet.Commands
         private readonly IReadOnlyList<NuGetv3LocalRepository> _localRepositories;
         private readonly LockFile _lockFile;
         private readonly ILogger _log;
+        private readonly bool _validateRuntimeAssets;
 
-        public CompatibilityChecker(IReadOnlyList<NuGetv3LocalRepository> localRepositories, LockFile lockFile, ILogger log)
+        public CompatibilityChecker(IReadOnlyList<NuGetv3LocalRepository> localRepositories, LockFile lockFile, bool validateRuntimeAssets, ILogger log)
         {
             _localRepositories = localRepositories;
             _lockFile = lockFile;
             _log = log;
+            _validateRuntimeAssets = validateRuntimeAssets;
         }
 
         internal CompatibilityCheckResult Check(
@@ -58,6 +60,8 @@ namespace NuGet.Commands
             var runtimeAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var compileAssemblies = new Dictionary<string, LibraryIdentity>(StringComparer.OrdinalIgnoreCase);
             var issues = new List<CompatibilityIssue>();
+
+            // Verify framework assets also as part of runtime assets validation.
             foreach (var node in graph.Flattened)
             {
                 _log.LogDebug(string.Format(CultureInfo.CurrentCulture, Strings.Log_CheckingPackageCompatibility, node.Key.Name, node.Key.Version, graph.Name));
@@ -131,7 +135,7 @@ namespace NuGet.Commands
 
                 // Check for matching ref/libs if we're checking a runtime-specific graph
                 var targetLibrary = compatibilityData.TargetLibrary;
-                if (!string.IsNullOrEmpty(graph.RuntimeIdentifier))
+                if (_validateRuntimeAssets  && !string.IsNullOrEmpty(graph.RuntimeIdentifier))
                 {
                     // Skip runtime checks for packages that have runtime references excluded,
                     // this allows compile only packages that do not have runtimes for the 
@@ -188,7 +192,7 @@ namespace NuGet.Commands
             }
 
             // Generate errors for un-matched reference assemblies, if we're checking a runtime-specific graph
-            if (!string.IsNullOrEmpty(graph.RuntimeIdentifier))
+            if (_validateRuntimeAssets && !string.IsNullOrEmpty(graph.RuntimeIdentifier))
             {
                 foreach (var compile in compileAssemblies)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -60,6 +60,8 @@ namespace NuGet.Commands
 
         public int? LockFileVersion { get; set; }
 
+        public bool? ValidateRuntimeAssets { get; set; }
+
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
             = new ConcurrentDictionary<string, ISettings>(StringComparer.Ordinal);
@@ -190,6 +192,24 @@ namespace NuGet.Commands
             if (LockFileVersion.HasValue && LockFileVersion.Value > 0)
             {
                 request.LockFileVersion = LockFileVersion.Value;
+            }
+
+            // Run runtime asset checks for project.json, and for other types if enabled.
+            if (ValidateRuntimeAssets == null)
+            {
+                if (request.ProjectStyle == ProjectStyle.ProjectJson
+                    || request.Project.RestoreMetadata == null)
+                {
+                    request.ValidateRuntimeAssets = request.ProjectStyle == ProjectStyle.ProjectJson;
+                }
+                else
+                {
+                    request.ValidateRuntimeAssets = request.Project.RestoreMetadata.ValidateRuntimeAssets;
+                }
+            }
+            else
+            {
+                request.ValidateRuntimeAssets = ValidateRuntimeAssets.Value;
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -96,6 +96,7 @@ namespace NuGet.Commands
                 localRepositories,
                 assetsFile,
                 graphs,
+                _request.ValidateRuntimeAssets,
                 _logger);
 
             if (checkResults.Any(r => !r.Success))
@@ -288,13 +289,14 @@ namespace NuGet.Commands
             IReadOnlyList<NuGetv3LocalRepository> localRepositories,
             LockFile lockFile,
             IEnumerable<RestoreTargetGraph> graphs,
+            bool validateRuntimeAssets,
             ILogger logger)
         {
             // Scan every graph for compatibility, as long as there were no unresolved packages
             var checkResults = new List<CompatibilityCheckResult>();
             if (graphs.All(g => !g.Unresolved.Any()))
             {
-                var checker = new CompatibilityChecker(localRepositories, lockFile, logger);
+                var checker = new CompatibilityChecker(localRepositories, lockFile, validateRuntimeAssets, logger);
                 foreach (var graph in graphs)
                 {
                     logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_CheckingCompatibility, graph.Name));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -155,5 +155,9 @@ namespace NuGet.Commands
         /// </summary>
         public string RestoreOutputPath { get; set; }
 
+        /// <summary>
+        /// Compatibility options
+        /// </summary>
+        public bool ValidateRuntimeAssets { get; set; } = true;
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -205,6 +205,15 @@ namespace NuGet.Commands
                     result.RestoreMetadata.LegacyPackagesDirectory = IsPropertyTrue(
                         specItem,
                         "RestoreLegacyPackagesDirectory");
+
+                    // ValidateRuntimeAssets compat check
+                    result.RestoreMetadata.ValidateRuntimeAssets = IsPropertyTrue(specItem, "ValidateRuntimeAssets");
+                }
+
+                if (restoreType == ProjectStyle.ProjectJson)
+                {
+                    // Check runtime assets by default for project.json
+                    result.RestoreMetadata.ValidateRuntimeAssets = true;
                 }
 
                 // File assets

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -210,6 +210,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.ProjectPath = rawMSBuildMetadata.GetValue<string>("projectPath");
             msbuildMetadata.CrossTargeting = rawMSBuildMetadata.GetValue<bool>("crossTargeting");
             msbuildMetadata.LegacyPackagesDirectory = rawMSBuildMetadata.GetValue<bool>("legacyPackagesDirectory");
+            msbuildMetadata.ValidateRuntimeAssets = rawMSBuildMetadata.GetValue<bool>("validateRuntimeAssets");
 
             msbuildMetadata.Sources = new List<PackageSource>();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -136,6 +136,14 @@ namespace NuGet.ProjectModel
                     msbuildMetadata.LegacyPackagesDirectory.ToString());
             }
 
+            if (msbuildMetadata.ValidateRuntimeAssets)
+            {
+                SetValue(
+                    writer,
+                    "validateRuntimeAssets",
+                    msbuildMetadata.ValidateRuntimeAssets.ToString());
+            }
+
             SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
             SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -84,6 +84,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public IList<ProjectRestoreMetadataFile> Files { get; set; } = new List<ProjectRestoreMetadataFile>();
 
+        /// <summary>
+        /// Compatibility check for runtime framework assets.
+        /// </summary>
+        public bool ValidateRuntimeAssets { get; set; }
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -102,6 +107,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(CrossTargeting);
             hashCode.AddObject(LegacyPackagesDirectory);
             hashCode.AddObject(Files);
+            hashCode.AddObject(ValidateRuntimeAssets);
 
             return hashCode.CombinedHash;
         }
@@ -136,6 +142,7 @@ namespace NuGet.ProjectModel
                    EqualityUtility.SequenceEqualWithNullCheck(OriginalTargetFrameworks, other.OriginalTargetFrameworks) &&
                    CrossTargeting == other.CrossTargeting &&
                    LegacyPackagesDirectory == other.LegacyPackagesDirectory &&
+                   ValidateRuntimeAssets == other.ValidateRuntimeAssets &&
                    EqualityUtility.SequenceEqualWithNullCheck(Files, other.Files);
         }
     }


### PR DESCRIPTION
Adding support for ``ValidateRuntimeIdentifierCompatibility`` to control RID compatibility checks for restore. By default this will be disabled for PackageReference projects.

Project.json projects will keep the old behavior.

Fixes https://github.com/NuGet/Home/issues/3768

//cc @rohit21agrawal @alpaix @rrelyea @zhili1208 @jainaashish @nkolev92 @mishra14 