### PR TITLE
Add RootPath and IsLowerCase properties to VersionFolderPathResolver

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -1,38 +1,54 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
-using NuGet.Common;
 using NuGet.Versioning;
 
 namespace NuGet.Packaging
 {
     public class VersionFolderPathResolver
     {
-        private readonly string _path;
-        private readonly bool _isLowercase;
+        /// <summary>
+        /// Packages directory root folder.
+        /// </summary>
+        public string RootPath { get; }
 
-        public VersionFolderPathResolver(string path) : this(path, isLowercase: true)
+        /// <summary>
+        /// True if package id and versions are made lowercase.
+        /// </summary>
+        public bool IsLowerCase { get; }
+
+        /// <summary>
+        /// VersionFolderPathResolver
+        /// </summary>
+        /// <param name="rootPath">Packages directory root folder.</param>
+        public VersionFolderPathResolver(string rootPath) : this(rootPath, isLowercase: true)
         {
         }
 
-        public VersionFolderPathResolver(string path, bool isLowercase)
+        /// <summary>
+        /// VersionFolderPathResolver
+        /// </summary>
+        /// <param name="rootPath">Packages directory root folder.</param>
+        /// <param name="isLowercase">True if package id and versions are made lowercase.</param>
+        public VersionFolderPathResolver(string rootPath, bool isLowercase)
         {
-            _path = path;
-            _isLowercase = isLowercase;
+            RootPath = rootPath;
+            IsLowerCase = isLowercase;
         }
 
         public string GetInstallPath(string packageId, NuGetVersion version)
         {
             return Path.Combine(
-                _path,
+                RootPath,
                 GetPackageDirectory(packageId, version));
         }
 
         public string GetVersionListPath(string packageId)
         {
             return Path.Combine(
-                _path,
+                RootPath,
                 GetVersionListDirectory(packageId));
         }
 
@@ -89,7 +105,7 @@ namespace NuGet.Packaging
         {
             var versionString = version.ToNormalizedString();
 
-            if (_isLowercase)
+            if (IsLowerCase)
             {
                 versionString = versionString.ToLowerInvariant();
             }
@@ -99,7 +115,7 @@ namespace NuGet.Packaging
 
         private string Normalize(string packageId)
         {
-            if (_isLowercase)
+            if (IsLowerCase)
             {
                 packageId = packageId.ToLowerInvariant();
             }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
@@ -9,6 +9,17 @@ namespace NuGet.Packaging.Test
 {
     public class VersionFolderPathResolverTests
     {
+        [Fact]
+        public void VersionFolderPathResolver_GetRoot()
+        {
+            // Arrange && Act
+            var resolver = new VersionFolderPathResolver("/tmp/test", isLowercase: false);
+
+            // Assert
+            Assert.Equal("/tmp/test", resolver.RootPath);
+            Assert.False(resolver.IsLowerCase);
+        }
+
         [Theory]
         [InlineData("nuget.packaging", "3.4.3-beta", true)]
         [InlineData("NuGet.Packaging", "3.4.3-Beta", false)]


### PR DESCRIPTION
Normally the caller creates VersionFolderPathResolver and has access to the inputs, however with FallbackPackagePathResolver it constructs VersionFolderPathResolvers internally and return one for the first match. This change exposes those input properties.

Fixes https://github.com/NuGet/Home/issues/4174

//cc @joelverhagen @alpaix @zhili1208 @nkolev92 @mishra14 @rohit21agrawal @jainaashish 