### PR TITLE
Read RestoreProjectStyle MSBuild property once for all the NuGet project providers

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -778,9 +778,14 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var settings = ServiceLocator.GetInstance<ISettings>();
 
+            // read MSBuild property RestoreProjectStyle which can be set to any NuGet project sytle
+            // and pass it on to NugetFactory which can pass it to each NuGet project provider to consume.
+            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), "RestoreProjectStyle");
+
             var context = new ProjectSystemProviderContext(
                 projectContext ?? EmptyNuGetProjectContext,
-                () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings));
+                () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings),
+                restoreProjectStyle);
 
             NuGetProject result;
             if (_projectSystemFactory.TryCreateNuGetProject(envDTEProject, context, out result))

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.ProjectManagement;
+using NuGet.ProjectModel;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -56,8 +57,14 @@ namespace NuGet.PackageManagement.VisualStudio
                 return false;
             }
 
-            if (!hierarchy.IsCapabilityMatch("CPS") ||
-                !hierarchy.IsCapabilityMatch("PackageReferences"))
+            // check for RestoreProjectStyle property and if set to PackageReference and project also has CPS 
+            // capability then only mark it as CPS based project.
+            if (!string.IsNullOrEmpty(context.NuGetProjectStyle) &&
+                !context.NuGetProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            else if (!hierarchy.IsCapabilityMatch("CPS"))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             result = null;
 
-            var project = new EnvDTEProjectAdapter(dteProject);
+            var project = new EnvDTEProjectAdapter(dteProject, context);
             if (!project.IsLegacyCSProjPackageReferenceProject)
             {
                 return false;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
@@ -15,9 +15,12 @@ namespace NuGet.PackageManagement.VisualStudio
         public INuGetProjectContext ProjectContext { get; }
         public Func<string> PackagesPathFactory { get; }
 
+        public string NuGetProjectStyle { get; }
+
         public ProjectSystemProviderContext(
             INuGetProjectContext projectContext,
-            Func<string> packagesPathFactory)
+            Func<string> packagesPathFactory,
+            string nuGetProjectStyle)
         {
             if (projectContext == null)
             {
@@ -31,6 +34,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ProjectContext = projectContext;
             PackagesPathFactory = packagesPathFactory;
+            NuGetProjectStyle = nuGetProjectStyle;
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -37,7 +37,31 @@ namespace NuGet.PackageManagement.VisualStudio
             return hierarchy;
         }
 
-        public static VsHierarchyItem GetHierarchyItemForProject(Project project)
+        public static string GetMSBuildProperty(IVsHierarchy pHierarchy, string name)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            var buildPropertyStorage = pHierarchy as IVsBuildPropertyStorage;
+            string output = null;
+
+            if (buildPropertyStorage != null)
+            {
+                var result = buildPropertyStorage.GetPropertyValue(
+                    name,
+                    string.Empty,
+                    (uint)_PersistStorageType.PST_PROJECT_FILE,
+                    out output);
+
+                if (result != NuGetVSConstants.S_OK || string.IsNullOrWhiteSpace(output))
+                {
+                    return null;
+                }
+            }
+
+            return output;
+        }
+
+public static VsHierarchyItem GetHierarchyItemForProject(Project project)
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 


### PR DESCRIPTION
This PR targets reading MSBuild property RestoreProjectStyle which can be set to any project style in order to set that NuGet project style. So NuGet should also respect this property and create NuGet project accordingly. To have better VS performance, we read this property only once and pass to all the nuget project providers to consume.

Fixes https://github.com/NuGet/Home/issues/4134 

@rrelyea @emgarten @alpaix @zhili1208 @rohit21agrawal @mishra14 