### PR TITLE
Feature work for package management format selector dialog

### DIFF
--- a/src/NuGet.Clients/Options/GeneralOptionControl.Designer.cs
+++ b/src/NuGet.Clients/Options/GeneralOptionControl.Designer.cs
@@ -36,10 +36,12 @@
             this.BindingRedirectsHeader = new System.Windows.Forms.Label();
             this.localsCommandButton = new System.Windows.Forms.Button();
             this.localsCommandStatusText = new System.Windows.Forms.RichTextBox();
+#if !VS14
             this.PackageManagementHeader = new System.Windows.Forms.Label();
             this.defaultPackageManagementFormatLabel = new System.Windows.Forms.Label();
             this.showPackageManagementChooser = new System.Windows.Forms.CheckBox();
             this.defaultPackageManagementFormatItems = new System.Windows.Forms.ComboBox();
+#endif
             this.SuspendLayout();
             // 
             // skipBindingRedirects
@@ -86,6 +88,12 @@
             this.localsCommandStatusText.ContentsResized += new System.Windows.Forms.ContentsResizedEventHandler(this.localsCommandStatusText_ContentChanged);
             this.localsCommandStatusText.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.localsCommandStatusText_LinkClicked);
             // 
+            // GeneralOptionControl
+            // 
+            resources.ApplyResources(this, "$this");
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+#if !VS14
+            // 
             // PackageManagementHeader
             // 
             resources.ApplyResources(this.PackageManagementHeader, "PackageManagementHeader");
@@ -111,15 +119,17 @@
             resources.GetString("defaultPackageManagementFormatItems.Items1")});
             resources.ApplyResources(this.defaultPackageManagementFormatItems, "defaultPackageManagementFormatItems");
             this.defaultPackageManagementFormatItems.Name = "defaultPackageManagementFormatItems";
-            // 
-            // GeneralOptionControl
-            // 
-            resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+
+            this.Size = new System.Drawing.Size(463, 365);
+            this.skipBindingRedirects.Location = new System.Drawing.Point(19, 118);
+            this.BindingRedirectsHeader.Location = new System.Drawing.Point(2, 92);
+            this.localsCommandButton.Location = new System.Drawing.Point(5, 247);
+            this.localsCommandStatusText.Location = new System.Drawing.Point(5, 276);
             this.Controls.Add(this.defaultPackageManagementFormatItems);
             this.Controls.Add(this.showPackageManagementChooser);
             this.Controls.Add(this.defaultPackageManagementFormatLabel);
             this.Controls.Add(this.PackageManagementHeader);
+#endif
             this.Controls.Add(this.BindingRedirectsHeader);
             this.Controls.Add(this.skipBindingRedirects);
             this.Controls.Add(this.PackageRestoreHeader);
@@ -142,9 +152,11 @@
         private System.Windows.Forms.Label BindingRedirectsHeader;
         private System.Windows.Forms.Button localsCommandButton;
         private System.Windows.Forms.RichTextBox localsCommandStatusText;
+#if !VS14
         private System.Windows.Forms.Label PackageManagementHeader;
         private System.Windows.Forms.Label defaultPackageManagementFormatLabel;
         private System.Windows.Forms.CheckBox showPackageManagementChooser;
         private System.Windows.Forms.ComboBox defaultPackageManagementFormatItems;
+#endif
     }
 }

--- a/src/NuGet.Clients/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/Options/GeneralOptionControl.cs
@@ -53,6 +53,12 @@ namespace NuGet.Options
 
                     var bindingRedirects = new BindingRedirectBehavior(_settings);
                     skipBindingRedirects.Checked = bindingRedirects.IsSkipped;
+#if !VS14
+                    // package management format selection
+                    var packageManagement = new PackageManagementFormat(_settings);
+                    defaultPackageManagementFormatItems.SelectedIndex = packageManagement.SelectedPackageManagementFormat;
+                    showPackageManagementChooser.Checked = packageManagement.IsDisabled;
+#endif
                 }
                 catch (InvalidOperationException)
                 {
@@ -77,6 +83,13 @@ namespace NuGet.Options
 
                 var bindingRedirects = new BindingRedirectBehavior(_settings);
                 bindingRedirects.IsSkipped = skipBindingRedirects.Checked;
+#if !VS14
+                // package management format selection
+                var packageManagement = new PackageManagementFormat(_settings);
+                packageManagement.SelectedPackageManagementFormat = defaultPackageManagementFormatItems.SelectedIndex;
+                packageManagement.IsDisabled = showPackageManagementChooser.Checked;
+                packageManagement.ApplyChanges();
+#endif
             }
             catch (InvalidOperationException)
             {
@@ -169,5 +182,6 @@ namespace NuGet.Options
             localsCommandStatusText.Height = e.NewRectangle.Height + localsCommandStatusText.Margin.Top + localsCommandStatusText.Margin.Bottom;
             localsCommandStatusText.Width = e.NewRectangle.Width + localsCommandStatusText.Margin.Left + localsCommandStatusText.Margin.Right;
         }
+
     }
 }

--- a/src/NuGet.Clients/Options/GeneralOptionControl.resx
+++ b/src/NuGet.Clients/Options/GeneralOptionControl.resx
@@ -123,7 +123,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="skipBindingRedirects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 118</value>
+    <value>19, 138</value>
   </data>
   <data name="skipBindingRedirects.Size" type="System.Drawing.Size, System.Drawing">
     <value>169, 17</value>
@@ -144,7 +144,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;skipBindingRedirects.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>1</value>
   </data>
   <data name="PackageRestoreHeader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -178,7 +178,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;PackageRestoreHeader.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>2</value>
   </data>
   <data name="packageRestoreConsentCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -208,7 +208,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;packageRestoreConsentCheckBox.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>3</value>
   </data>
   <data name="packageRestoreAutomaticCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -238,7 +238,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;packageRestoreAutomaticCheckBox.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>4</value>
   </data>
   <data name="BindingRedirectsHeader.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -250,7 +250,7 @@
     <value>NoControl</value>
   </data>
   <data name="BindingRedirectsHeader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>2, 92</value>
+    <value>2, 112</value>
   </data>
   <data name="BindingRedirectsHeader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -274,13 +274,13 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BindingRedirectsHeader.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>0</value>
   </data>
   <data name="localsCommandButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="localsCommandButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 247</value>
+    <value>5, 194</value>
   </data>
   <data name="localsCommandButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>134, 23</value>
@@ -307,10 +307,7 @@
     <value>True</value>
   </data>
   <data name="localsCommandStatusText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 276</value>
-  </data>
-  <data name="localsCommandStatusText.ScrollBars" type="System.Windows.Forms.RichTextBoxScrollBars, System.Windows.Forms">
-    <value>None</value>
+    <value>5, 220</value>
   </data>
   <data name="localsCommandStatusText.Size" type="System.Drawing.Size, System.Drawing">
     <value>432, 62</value>
@@ -322,9 +319,6 @@
     <value>http://example.com/help/locals</value>
   </data>
   <data name="localsCommandStatusText.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="localsCommandStatusText.WordWrap" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="&gt;&gt;localsCommandStatusText.Name" xml:space="preserve">
@@ -373,7 +367,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;PackageManagementHeader.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="defaultPackageManagementFormatLabel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -400,7 +394,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;defaultPackageManagementFormatLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>6</value>
   </data>
   <data name="showPackageManagementChooser.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -427,7 +421,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;showPackageManagementChooser.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>7</value>
   </data>
   <metadata name="defaultPackageManagementFormatItems.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -457,7 +451,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;defaultPackageManagementFormatItems.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>8</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -469,7 +463,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>460, 365</value>
+    <value>463, 285</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GeneralOptionControl</value>

--- a/src/NuGet.Clients/PackageManagement.UI/Converters/RadioBoolToIntConverter.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Converters/RadioBoolToIntConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class RadioBoolToIntConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            int integer = (int)value;
+            if (integer == int.Parse(parameter.ToString()))
+                return true;
+            else
+                return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return parameter;
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -364,5 +364,13 @@ namespace NuGet.PackageManagement.UI
                 OnPropertyChanged(nameof(Options));
             }
         }
+
+        public IEnumerable<NuGetProject> NuGetProjects
+        {
+            get
+            {
+                return _nugetProjects;
+            }
+        }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageSolutionDetailControlModel.cs
@@ -222,6 +222,7 @@ namespace NuGet.PackageManagement.UI
             _solutionManager = solutionManager;
             _solutionManager.NuGetProjectAdded += SolutionProjectChanged;
             _solutionManager.NuGetProjectRemoved += SolutionProjectChanged;
+            _solutionManager.NuGetProjectUpdated += SolutionProjectChanged;
             _solutionManager.NuGetProjectRenamed += SolutionProjectChanged;
 
             // when the SelectedVersion is changed, we need to update CanInstall
@@ -258,6 +259,7 @@ namespace NuGet.PackageManagement.UI
             _solutionManager.NuGetProjectAdded -= SolutionProjectChanged;
             _solutionManager.NuGetProjectRemoved -= SolutionProjectChanged;
             _solutionManager.NuGetProjectRenamed -= SolutionProjectChanged;
+            _solutionManager.NuGetProjectUpdated -= SolutionProjectChanged;
 
             Options.SelectedChanged -= DependencyBehavior_SelectedChanged;
 

--- a/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Common\NuGetEvent.cs" />
     <Compile Include="Common\NuGetEventTrigger.cs" />
     <Compile Include="Common\OptionsPage.cs" />
+    <Compile Include="Converters\RadioBoolToIntConverter.cs" />
     <Compile Include="Converters\TooltipConverter.cs" />
     <Compile Include="Converters\BooleanToFontWeightConverter.cs" />
     <Compile Include="Converters\CollectionToStringConverter.cs" />
@@ -57,6 +58,7 @@
     <Compile Include="Models\LoadingStatusViewModel.cs" />
     <Compile Include="Models\PackageSearchMetadataCache.cs" />
     <Compile Include="Models\PackageSearchStatus.cs" />
+    <Compile Include="PackageManagementFormat.cs" />
     <Compile Include="Prompts\DotnetDeprecatedPrompt.cs" />
     <Compile Include="Resources\Domain.cs" />
     <Compile Include="Resources\Resources.xaml.cs">
@@ -77,6 +79,9 @@
     <Compile Include="Utility\TelemetryUtility.cs" />
     <Compile Include="Xamls\DeprecatedFrameworkWindow.xaml.cs">
       <DependentUpon>DeprecatedFrameworkWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Xamls\PackageManagementFormatWindow.xaml.cs">
+      <DependentUpon>PackageManagementFormatWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="Xamls\RestartRequestBar.xaml.cs">
       <DependentUpon>RestartRequestBar.xaml</DependentUpon>
@@ -267,6 +272,10 @@
     <Page Include="Xamls\DeprecatedFrameworkWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Xamls\PackageManagementFormatWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Xamls\RestartRequestBar.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/NuGet.Clients/PackageManagement.UI/PackageManagementFormat.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageManagementFormat.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class PackageManagementFormat
+    {
+        private const string PackageManagementSection = "packageManagement";
+        private const string DoNotShowPackageManagementSelectionKey = "disabled";
+        private const string DefaultPackageManagementFormatKey = "format";
+        private const string PackageReferenceDoc = "https://aka.ms/packagereferencesupport";
+
+        private readonly Configuration.ISettings _settings;
+
+        private int SelectedPackageFormat = -1;
+        private bool DoNotShowDialogValue;
+
+        public PackageManagementFormat(Configuration.ISettings settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            _settings = settings;
+
+            PackageRefUri = new Uri(PackageReferenceDoc);
+        }
+
+        public Uri PackageRefUri { get; private set; }
+
+        public List<string> ProjectNames { get; set; }
+
+        public string PackageFormatSelectorLabel
+        {
+            get
+            {
+                if (ProjectNames.Count == 1)
+                {
+                    return string.Format(Resources.Text_PackageFormatSelection, ProjectNames.First());
+                }
+                else
+                {
+                    return string.Format(Resources.Text_PackageFormatSelection_Solution);
+                }
+            }
+        }
+
+        public bool IsSolution
+        {
+            get
+            {
+                return ProjectNames.Count > 1;
+            }
+        }
+
+        public bool IsDisabled
+        {
+            get
+            {
+                if (DoNotShowDialogValue)
+                {
+                    return DoNotShowDialogValue;
+                }
+
+                string settingsValue = _settings.GetValue(PackageManagementSection, DoNotShowPackageManagementSelectionKey) ?? string.Empty;
+                DoNotShowDialogValue = IsSet(settingsValue, false);
+                return DoNotShowDialogValue;
+            }
+
+            set
+            {
+                DoNotShowDialogValue = value;
+            }
+        }
+
+        public int SelectedPackageManagementFormat
+        {
+            get
+            {
+                if (SelectedPackageFormat != -1)
+                {
+                    return SelectedPackageFormat;
+                }
+
+                string settingsValue = _settings.GetValue(PackageManagementSection, DefaultPackageManagementFormatKey) ?? string.Empty;
+                SelectedPackageFormat = IsSet(settingsValue, 0);
+                return SelectedPackageFormat;
+            }
+
+            set
+            {
+                SelectedPackageFormat = value;
+            }
+        }
+
+        public void ApplyChanges()
+        {
+            _settings.SetValue(PackageManagementSection, DefaultPackageManagementFormatKey, SelectedPackageFormat.ToString(CultureInfo.InvariantCulture));
+            _settings.SetValue(PackageManagementSection, DoNotShowPackageManagementSelectionKey, DoNotShowDialogValue.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private static bool IsSet(string value, bool defaultValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue;
+            }
+
+            value = value.Trim();
+
+            bool boolResult;
+            int intResult;
+
+            var result = ((Boolean.TryParse(value, out boolResult) && boolResult) ||
+                          (Int32.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out intResult) && (intResult == 1)));
+
+            return result;
+        }
+
+        private static int IsSet(string value, int defaultValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue;
+            }
+
+            value = value.Trim();
+
+            var result = Int32.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture);
+
+            return result;
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Resources/Resources.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources/Resources.xaml
@@ -47,6 +47,8 @@
     x:Key="ProjectAndSolutionViewMinHeightConverter"/>
   <nuget:IconUrlToImageCacheConverter
     x:Key="IconUrlToImageCacheConverter"/>
+  <nuget:RadioBoolToIntConverter
+    x:Key="RadioBoolToIntConverter" />
 
   <!-- Default styles -->
   <Style

--- a/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/UserInterfaceService/INuGetUI.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
@@ -16,6 +18,10 @@ namespace NuGet.PackageManagement.UI
     /// <remarks>This is not expected to be thread safe.</remarks>
     public interface INuGetUI
     {
+        bool PromptForPackageManagementFormat(PackageManagementFormat selectedFormat);
+
+        Task UpdateNuGetProjectToPackageRef(IEnumerable<NuGetProject> msBuildProjects);
+
         bool WarnAboutDotnetDeprecation(IEnumerable<NuGetProject> projects);
 
         bool PromptForLicenseAcceptance(IEnumerable<PackageLicenseInfo> packages);
@@ -97,5 +103,7 @@ namespace NuGet.PackageManagement.UI
         bool ForceRemove { get; }
 
         DependencyBehavior DependencyBehavior { get; }
+
+        Configuration.ISettings Settings { get; }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml
@@ -1,0 +1,148 @@
+﻿<nuget:VsDialogWindow 
+  x:Class="NuGet.PackageManagement.UI.PackageManagementFormatWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:nuget="clr-namespace:NuGet.PackageManagement.UI"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  Background="{DynamicResource {x:Static nuget:Brushes.HeaderBackground}}"
+  Foreground="{DynamicResource {x:Static nuget:Brushes.UIText}}"
+  mc:Ignorable="d"
+  ResizeMode="NoResize"
+  WindowStartupLocation="CenterOwner"
+  Title="{x:Static nuget:Resources.WindowTitle_PackageFormatSelector}" 
+  Width="525" 
+  SizeToContent="Height">
+  <Window.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <nuget:SharedResources />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Window.Resources>
+  <Window.CommandBindings>
+    <CommandBinding
+      Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}"
+      Executed="ExecuteOpenExternalLink" />
+  </Window.CommandBindings>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+      <RowDefinition Height="auto"/>
+    </Grid.RowDefinitions>
+
+    <TextBlock 
+      Grid.Row="0" 
+      x:Name="textBlock" 
+      Margin="12,12,12,0" 
+      TextWrapping="Wrap"
+      Text="{x:Static nuget:Resources.Text_PackageRefSupport}">
+      <LineBreak /> 
+      <Hyperlink
+        NavigateUri="{Binding Path=PackageRefUri, Mode=OneTime}"
+        Style="{StaticResource HyperlinkStyle}"
+        Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+        <Run Text="{x:Static nuget:Resources.Text_PackageRefSupport_DocumentLink}" />
+      </Hyperlink>
+    </TextBlock>
+
+    <TextBlock
+      Grid.Row="1"
+      Margin="12,12,12,0"
+      TextWrapping="Wrap"
+      Text="{Binding Path=PackageFormatSelectorLabel}" />
+
+    <StackPanel 
+      Grid.Row="2" Margin="12,12,12,0">
+      <RadioButton
+        IsChecked="{Binding Path=SelectedPackageManagementFormat, Converter={StaticResource RadioBoolToIntConverter}, ConverterParameter=0}"
+        Content="{x:Static nuget:Resources.RadioBtn_PackagesConfig}" />
+      <RadioButton
+        Margin="0,6"
+        IsChecked="{Binding Path=SelectedPackageManagementFormat, Converter={StaticResource RadioBoolToIntConverter}, ConverterParameter=1}"
+        Content="{x:Static nuget:Resources.RadioBtn_PackageRef}"/>
+    </StackPanel>
+
+    <TextBlock
+      Grid.Row="3"
+      Margin="12,8,12,0"
+      TextWrapping="Wrap"
+      Text="{x:Static nuget:Resources.Text_PackageFormatApply}"
+      Visibility="{Binding Path=IsSolution, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+    <Border
+      Grid.Row="4"
+      Margin="12,4,12,0"
+      BorderBrush="{DynamicResource {x:Static nuget:Brushes.BorderBrush}}"
+      BorderThickness="1"
+      Width="423"
+      HorizontalAlignment="Left"
+      Visibility="{Binding Path=IsSolution, Converter={StaticResource BooleanToVisibilityConverter}}">
+      <ScrollViewer
+        HorizontalScrollBarVisibility="Auto"
+        VerticalScrollBarVisibility="Visible"
+        CanContentScroll="True"
+        Background="{DynamicResource {x:Static nuget:Brushes.ContentBrushKey}}"
+        IsTabStop="True"
+        Width="423"
+        Height="70"
+        HorizontalAlignment="Left">
+        <ItemsControl
+          Margin="6,6,0,0"
+          ItemsSource="{Binding Path=ProjectNames}"
+          IsTabStop="False" />
+      </ScrollViewer>
+    </Border>
+
+    <CheckBox
+      Grid.Row="5"
+      Margin="12,8,12,0"
+      Content="{x:Static nuget:Resources.CheckBox_DefaultPackageFormat}"
+      IsChecked="{Binding Path=IsDisabled }" />
+
+    <Grid
+      Grid.Row="6"
+      Margin="0,8">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="auto" />
+        <ColumnDefinition />
+        <ColumnDefinition
+          Width="auto" />
+        <ColumnDefinition
+          Width="auto" />
+      </Grid.ColumnDefinitions>
+      <TextBlock
+        Grid.Column="0"
+        Margin="12"
+        Text="{x:Static nuget:Resources.Text_ManageSettings}">
+        <Hyperlink
+          NavigateUri=" "
+          Style="{StaticResource HyperlinkStyle}"
+          Hyperlink.Click="Hyperlink_Click" >
+          <Run Text="{x:Static nuget:Resources.Text_NuGetSettings}" />
+        </Hyperlink>
+      </TextBlock>
+      <Button
+        Grid.Column="2"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="0,12"
+        AutomationProperties.AutomationId="OK"
+        Content="{x:Static nuget:Resources.Button_OK}"
+        Click="OkButtonClicked" />
+      <Button
+        Grid.Column="3"
+        MinWidth="86"
+        MinHeight="24"
+        Margin="6,12,12,12"
+        AutomationProperties.AutomationId="Cancel"
+        Content="{x:Static nuget:Resources.Button_Cancel}"
+        Click="CancelButtonClicked" />
+    </Grid>
+  </Grid>
+</nuget:VsDialogWindow>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagementFormatWindow.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// Interaction logic for PackageManagementFormatWindow.xaml
+    /// </summary>
+    public partial class PackageManagementFormatWindow : VsDialogWindow
+    {
+        private INuGetUIContext _uiContext;
+
+        public PackageManagementFormatWindow(INuGetUIContext uiContext)
+        {
+            _uiContext = uiContext;
+            InitializeComponent();
+        }
+
+        private void CancelButtonClicked(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void OkButtonClicked(object sender, RoutedEventArgs e)
+        {
+            var selectedFormat = DataContext as PackageManagementFormat;
+
+            if (selectedFormat != null && selectedFormat.IsDisabled)
+            {
+                selectedFormat.ApplyChanges();
+            }
+
+            DialogResult = true;
+        }
+
+        private void ExecuteOpenExternalLink(object sender, ExecutedRoutedEventArgs e)
+        {
+            var hyperlink = e.OriginalSource as Hyperlink;
+            if (hyperlink != null
+                && hyperlink.NavigateUri != null)
+            {
+                UIUtility.LaunchExternalLink(hyperlink.NavigateUri);
+                e.Handled = true;
+            }
+        }
+
+        private void Hyperlink_Click(object sender, RoutedEventArgs e)
+        {
+            _uiContext.OptionsPageActivator.ActivatePage(OptionsPage.General, null);
+        }
+
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -53,6 +53,8 @@ namespace NuGet.PackageManagement.UI
 
         public PackageManagerModel Model { get; }
 
+        public Configuration.ISettings Settings { get; }
+
         private PackageSourceMoniker SelectedSource
         {
             get
@@ -81,9 +83,10 @@ namespace NuGet.PackageManagement.UI
             _uiDispatcher = Dispatcher.CurrentDispatcher;
             _uiLogger = uiLogger;
             Model = model;
+            Settings = nugetSettings;
             if (!Model.IsSolution)
             {
-                _detailModel = new PackageDetailControlModel(Model.Context.Projects);
+                _detailModel = new PackageDetailControlModel(Model.Context.SolutionManager, Model.Context.Projects);
             }
             else
             {
@@ -140,6 +143,7 @@ namespace NuGet.PackageManagement.UI
             var solutionManager = Model.Context.SolutionManager;
             solutionManager.NuGetProjectAdded += SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRemoved += SolutionManager_ProjectsChanged;
+            solutionManager.NuGetProjectUpdated += SolutionManager_ProjectsUpdated;
             solutionManager.NuGetProjectRenamed += SolutionManager_ProjectRenamed;
             solutionManager.ActionsExecuted += SolutionManager_ActionsExecuted;
 
@@ -151,6 +155,11 @@ namespace NuGet.PackageManagement.UI
             }
 
             _missingPackageStatus = false;
+        }
+
+        private void SolutionManager_ProjectsUpdated(object sender, NuGetProjectEventArgs e)
+        {
+            Model.Context.Projects = _detailModel.NuGetProjects;
         }
 
         private void SolutionManager_ProjectRenamed(object sender, NuGetProjectEventArgs e)
@@ -911,6 +920,7 @@ namespace NuGet.PackageManagement.UI
             var solutionManager = Model.Context.SolutionManager;
             solutionManager.NuGetProjectAdded -= SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRemoved -= SolutionManager_ProjectsChanged;
+            solutionManager.NuGetProjectUpdated -= SolutionManager_ProjectsChanged;
             solutionManager.NuGetProjectRenamed -= SolutionManager_ProjectRenamed;
             solutionManager.ActionsExecuted -= SolutionManager_ActionsExecuted;
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -305,11 +305,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IEnumerable<LegacyCSProjProjectReference> GetLegacyCSProjProjectReferences(Array desiredMetadata)
         {
-            if (!IsLegacyCSProjPackageReferenceProject)
-            {
-                throw new InvalidOperationException("Project reference call made on a non-legacy CSProj project");
-            }
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             foreach (Reference6 reference in AsVSProject4.References)
@@ -330,11 +325,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IEnumerable<LegacyCSProjPackageReference> GetLegacyCSProjPackageReferences(Array desiredMetadata)
         {
-            if (!IsLegacyCSProjPackageReferenceProject)
-            {
-                throw new InvalidOperationException("Package reference call made on a non-legacy CSProj project");
-            }
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var installedPackages = AsVSProject4.PackageReferences.InstalledPackages;
@@ -362,11 +352,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public void AddOrUpdateLegacyCSProjPackage(string packageName, string packageVersion, string[] metadataElements, string[] metadataValues)
         {
-            if (!IsLegacyCSProjPackageReferenceProject || AsVSProject4 == null)
-            {
-                throw new InvalidOperationException("Cannot add packages to a project which is not a legacy CSProj package reference project");
-            }
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             // Note that API behavior is:
@@ -378,11 +363,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public void RemoveLegacyCSProjPackage(string packageName)
         {
-            if (!IsLegacyCSProjPackageReferenceProject || AsVSProject4 == null)
-            {
-                throw new InvalidOperationException("Cannot remove packages from a project which is not a legacy CSProj package reference project");
-            }
-
             ThreadHelper.ThrowIfNotOnUIThread();
 
             AsVSProject4.PackageReferences.Remove(packageName);

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -292,6 +292,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                             _solutionManager.SolutionClosed += (o, e) => UpdateWorkingDirectory();
                             _solutionManager.NuGetProjectAdded += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
                             _solutionManager.NuGetProjectRenamed += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
+                            _solutionManager.NuGetProjectUpdated += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
                             _solutionManager.NuGetProjectRemoved += (o, e) =>
                                 {
                                     UpdateWorkingDirectoryAndAvailableProjects();

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement
@@ -22,6 +23,8 @@ namespace NuGet.PackageManagement
         event EventHandler<NuGetProjectEventArgs> NuGetProjectRemoved;
 
         event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
+
+        event EventHandler<NuGetProjectEventArgs> NuGetProjectUpdated;
 
         event EventHandler<NuGetProjectEventArgs> AfterNuGetProjectRenamed;
 
@@ -111,6 +114,8 @@ namespace NuGet.PackageManagement
         /// This will only be applicable for VS15 and will do nothing for VS14.
         /// </summary>
         void EnsureSolutionIsLoaded();
+
+        Task<NuGetProject> UpdateNuGetProjectToPackageRef(NuGetProject oldProject);
     }
 
     public class NuGetProjectEventArgs : EventArgs

--- a/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/src/NuGet.Core/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
@@ -164,12 +165,20 @@ namespace Test.Utility
             // do nothing
         }
 
+        public Task<NuGetProject> UpdateNuGetProjectToPackageRef(NuGetProject oldProject)
+        {
+            // do nothing
+            return null;
+        }
+
 #pragma warning disable 0067
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectAdded;
 
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectRemoved;
 
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectRenamed;
+
+        public event EventHandler<NuGetProjectEventArgs> NuGetProjectUpdated;
 
         public event EventHandler<NuGetProjectEventArgs> AfterNuGetProjectRenamed;
 


### PR DESCRIPTION
This PR is to support package management format selector dialog to choose between packages.config vs PackageReference project style when you install your first package.

Spec: https://github.com/NuGet/Home/wiki/Supporting-Package-Reference-in-UWP-WPF-WinForms-and-Classic-Libraries 

Fixes https://github.com/NuGet/Home/issues/3921

@rrelyea @emgarten @rohit21agrawal @mishra14 @zhili1208 @nkolev92 