### PR TITLE
Additional project filtering for nuget.targets

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -143,6 +143,9 @@ namespace NuGet.CommandLine
                 // Add all depenencies as top level restore projects if recursive is set
                 argumentBuilder.Append($" /p:RestoreRecursive={recursive} ");
 
+                // Filter out unknown project types and avoid errors from projects that do not support CustomAfterTargets
+                argumentBuilder.Append($" /p:FilterRestoreProjectsInputs=strict /p:RestoreContinueOnError=WarnAndContinue ");
+
                 // Projects to restore
                 bool isMono = RuntimeEnvironmentHelper.IsMono && !RuntimeEnvironmentHelper.IsWindows;
 

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -225,7 +225,7 @@ namespace NuGet.CommandLine
 
                 DependencyGraphSpec spec = null;
 
-                if (File.Exists(resultsPath))
+                if (File.Exists(resultsPath) && new FileInfo(resultsPath).Length != 0)
                 {
                     spec = DependencyGraphSpec.Load(resultsPath);
                     File.Delete(resultsPath);

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -43,6 +43,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- RuntimeIdentifier compatibility check -->
     <ValidateRuntimeIdentifierCompatibility Condition=" '$(ValidateRuntimeIdentifierCompatibility)' == '' ">false</ValidateRuntimeIdentifierCompatibility>
+    <!-- Error handling while walking projects -->
+    <RestoreContinueOnError Condition=" '$(RestoreContinueOnError)' == '' ">WarnAndContinue</RestoreContinueOnError>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -128,13 +130,14 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreRecursive="$(RestoreRecursive)" />
   </Target>
 
-  <!--
+<!--
     ============================================================
     _LoadRestoreGraphEntryPoints
     Find project entry points and load them into items.
     ============================================================
   -->
-  <Target Name="_LoadRestoreGraphEntryPoints">
+  <Target Name="_LoadRestoreGraphEntryPoints" Returns="@(RestoreGraphProjectInputItems)">
+
     <!-- Allow overriding items with RestoreGraphProjectInput -->
     <ItemGroup Condition=" @(RestoreGraphProjectInputItems) == '' ">
       <RestoreGraphProjectInputItems Include="$(RestoreGraphProjectInput)" />
@@ -157,15 +160,29 @@ Copyright (c) .NET Foundation. All rights reserved.
     Filter out unsupported project entry points.
     ============================================================
   -->
-  <Target Name="_FilterRestoreGraphProjectInputItems" DependsOnTargets="_LoadRestoreGraphEntryPoints">
-    <ItemGroup>
+  <Target Name="_FilterRestoreGraphProjectInputItems" DependsOnTargets="_LoadRestoreGraphEntryPoints"
+    Returns="@(FilteredRestoreGraphProjectInputItems)">
+
+    <!-- Filter to a list of known supported types -->
+    <ItemGroup Condition=" '$(FilterRestoreProjectsInputs)' == 'strict' ">
       <FilteredRestoreGraphProjectInputItems 
        Include="@(RestoreGraphProjectInputItems)"
-       Condition="'%(RestoreGraphProjectInputItems.Extension)' == '.csproj' Or 
-                  '%(RestoreGraphProjectInputItems.Extension)' == '.vbproj' Or
-                  '%(RestoreGraphProjectInputItems.Extension)' == '.fsproj' Or
-                  '%(RestoreGraphProjectInputItems.Extension)' == '.nuproj' Or
-                  '%(RestoreGraphProjectInputItems.Extension)' == '.vcxproj'"/>
+       Condition=" '%(RestoreGraphProjectInputItems.Extension)' == '.csproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.vbproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.fsproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.nuproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.msbuildproj' Or
+                   '%(RestoreGraphProjectInputItems.Extension)' == '.vcxproj' " />
+    </ItemGroup>
+
+    <!-- Filter out disallowed types -->
+    <ItemGroup Condition=" '$(FilterRestoreProjectsInputs)' != 'strict' ">
+      <FilteredRestoreGraphProjectInputItems 
+       Include="@(RestoreGraphProjectInputItems)"
+       Condition=" '%(RestoreGraphProjectInputItems.Extension)' != '.metaproj' 
+                   AND '%(RestoreGraphProjectInputItems.Extension)' != '.shproj'
+                   AND '%(RestoreGraphProjectInputItems.Extension)' != '.vcxitems'
+                   AND '%(RestoreGraphProjectInputItems.Extension)' != '' " />
     </ItemGroup>
   </Target>
 
@@ -175,7 +192,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Entry point for creating the project to project restore graph.
     ============================================================
   -->
-  <Target Name="_GenerateRestoreGraph" DependsOnTargets="_FilterRestoreGraphProjectInputItems">
+<Target Name="_GenerateRestoreGraph" DependsOnTargets="_FilterRestoreGraphProjectInputItems">
     <Message Text="Generating dg file" Importance="low" />
     <Message Text="%(FilteredRestoreGraphProjectInputItems.Identity)" Importance="low" />
 
@@ -183,6 +200,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MsBuild
         Projects="@(FilteredRestoreGraphProjectInputItems)"
         Targets="_GenerateRestoreGraphProjectEntry"
+        ContinueOnError="$(RestoreContinueOnError)"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
                     %(_MSBuildProjectReferenceExistent.SetPlatform);
                     $(_GenerateRestoreGraphProjectEntryInputProperties)"
@@ -439,6 +457,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
       Targets="_GenerateRestoreGraphWalkPerFramework"
+      ContinueOnError="$(RestoreContinueOnError)"
       Properties="TargetFramework=%(_RestoreTargetFrameworksOutputFiltered.Identity);
                   %(_MSBuildProjectReferenceExistent.SetConfiguration);
                   %(_MSBuildProjectReferenceExistent.SetPlatform);
@@ -465,6 +484,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Projects="$(MSBuildProjectFullPath)"
       Targets="_GenerateRestoreProjectReferencePaths"
+      ContinueOnError="$(RestoreContinueOnError)"
       Properties="TargetFramework=%(_RestoreTargetFrameworksOutputFiltered.Identity);
                   %(_MSBuildProjectReferenceExistent.SetConfiguration);
                   %(_MSBuildProjectReferenceExistent.SetPlatform);
@@ -491,6 +511,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Projects="@(RestoreGraphProjectFullPathForOutput)"
       Targets="_GenerateRestoreGraphWalk"
+      ContinueOnError="$(RestoreContinueOnError)"
       Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
                   %(_MSBuildProjectReferenceExistent.SetPlatform);
                   $(_GenerateRestoreGraphProjectEntryInputProperties)"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -153,17 +153,35 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+    _FilterRestoreGraphProjectInputItems"
+    Filter out unsupported project entry points.
+    ============================================================
+  -->
+  <Target Name="_FilterRestoreGraphProjectInputItems" DependsOnTargets="_LoadRestoreGraphEntryPoints">
+    <ItemGroup>
+      <FilteredRestoreGraphProjectInputItems 
+       Include="@(RestoreGraphProjectInputItems)"
+       Condition="'%(RestoreGraphProjectInputItems.Extension)' == '.csproj' Or 
+                  '%(RestoreGraphProjectInputItems.Extension)' == '.vbproj' Or
+                  '%(RestoreGraphProjectInputItems.Extension)' == '.fsproj' Or
+                  '%(RestoreGraphProjectInputItems.Extension)' == '.nuproj' Or
+                  '%(RestoreGraphProjectInputItems.Extension)' == '.vcxproj'"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    ============================================================
     _GenerateRestoreGraph
     Entry point for creating the project to project restore graph.
     ============================================================
   -->
-  <Target Name="_GenerateRestoreGraph" DependsOnTargets="_LoadRestoreGraphEntryPoints">
+  <Target Name="_GenerateRestoreGraph" DependsOnTargets="_FilterRestoreGraphProjectInputItems">
     <Message Text="Generating dg file" Importance="low" />
-    <Message Text="%(RestoreGraphProjectInputItems.Identity)" Importance="low" />
+    <Message Text="%(FilteredRestoreGraphProjectInputItems.Identity)" Importance="low" />
 
     <!-- Walk projects -->
     <MsBuild
-        Projects="@(RestoreGraphProjectInputItems)"
+        Projects="@(FilteredRestoreGraphProjectInputItems)"
         Targets="_GenerateRestoreGraphProjectEntry"
         Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
                     %(_MSBuildProjectReferenceExistent.SetPlatform);

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -838,7 +838,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
-                Assert.True(test1Lock.Exists);
+                Assert.False(test1Lock.Exists);
             }
         }
 
@@ -943,7 +943,7 @@ namespace NuGet.CommandLine.Test
                 var test2Lock = new FileInfo(Path.Combine(projectDir2, "project.lock.json"));
 
                 Assert.True(test1Lock.Exists);
-                Assert.True(test2Lock.Exists);
+                Assert.False(test2Lock.Exists);
             }
         }
 


### PR DESCRIPTION
This adds to https://github.com/NuGet/NuGet.Client/pull/1099

Adding an option to continue on errors. Some projects do not include the common targets required by the restore target. These projects should be ignored so that other valid projects can restore.

Added an option to exclude known invalid projects vs filter to only the allowed list.

//cc @zhili1208 