### PR TITLE
Removing RID specific assets from compile

### DIFF
--- a/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
+++ b/src/NuGet.Core/NuGet.Client/ManagedCodeConventions.cs
@@ -37,6 +37,10 @@ namespace NuGet.Client
             PropertyNames.CodeLanguage,
             parser: CodeLanguage_Parser);
 
+        private static readonly Dictionary<string, object> NetTFMTable = new Dictionary<string, object>
+        {
+            { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
+        };
 
         private static readonly Dictionary<string, object> DefaultTfmAny = new Dictionary<string, object>
         {
@@ -344,9 +348,14 @@ namespace NuGet.Client
             public PatternSet RuntimeAssemblies { get; }
 
             /// <summary>
-            /// Pattern used to locate all files designed for using as managed code references at compile-time
+            /// Pattern used to locate ref assemblies for compile.
             /// </summary>
-            public PatternSet CompileAssemblies { get; }
+            public PatternSet CompileRefAssemblies { get; }
+
+            /// <summary>
+            /// Pattern used to locate lib assemblies for compile.
+            /// </summary>
+            public PatternSet CompileLibAssemblies { get; }
 
             /// <summary>
             /// Pattern used to locate all files designed for loading as native code libraries at run-time
@@ -394,23 +403,16 @@ namespace NuGet.Client
                     {
                         new PatternDefinition("runtimes/{rid}/lib/{tfm}/{any?}", table: DotnetAnyTable),
                         new PatternDefinition("lib/{tfm}/{any?}", table: DotnetAnyTable),
-                        new PatternDefinition("lib/{assembly?}", table: DotnetAnyTable,
-                            defaults: new Dictionary<string, object>
-                            {
-                                { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
-                            })
+                        new PatternDefinition("lib/{assembly?}", table: DotnetAnyTable, defaults: NetTFMTable)
                     },
                     pathPatterns: new PatternDefinition[]
                     {
                         new PatternDefinition("runtimes/{rid}/lib/{tfm}/{assembly}", table: DotnetAnyTable),
                         new PatternDefinition("lib/{tfm}/{assembly}", table: DotnetAnyTable),
-                        new PatternDefinition("lib/{assembly}", table: DotnetAnyTable, defaults: new Dictionary<string, object>
-                            {
-                                { "tfm", new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Net, FrameworkConstants.EmptyVersion) }
-                            })
+                        new PatternDefinition("lib/{assembly}", table: DotnetAnyTable, defaults: NetTFMTable)
                     });
 
-                CompileAssemblies = new PatternSet(
+                CompileRefAssemblies = new PatternSet(
                     conventions.Properties,
                     groupPatterns: new PatternDefinition[]
                         {
@@ -419,6 +421,19 @@ namespace NuGet.Client
                     pathPatterns: new PatternDefinition[]
                         {
                             new PatternDefinition("ref/{tfm}/{assembly}", table: DotnetAnyTable),
+                        });
+
+                CompileLibAssemblies = new PatternSet(
+                    conventions.Properties,
+                    groupPatterns: new PatternDefinition[]
+                        {
+                            new PatternDefinition("lib/{tfm}/{any?}", table: DotnetAnyTable),
+                            new PatternDefinition("lib/{assembly?}", table: DotnetAnyTable, defaults: NetTFMTable)
+                        },
+                    pathPatterns: new PatternDefinition[]
+                        {
+                            new PatternDefinition("lib/{tfm}/{assembly}", table: DotnetAnyTable),
+                            new PatternDefinition("lib/{assembly}", table: DotnetAnyTable, defaults: NetTFMTable)
                         });
 
                 NativeLibraries = new PatternSet(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -222,7 +222,7 @@ namespace NuGet.Commands
             var patterns = new[]
             {
                 graph.Conventions.Patterns.ResourceAssemblies,
-                graph.Conventions.Patterns.CompileAssemblies,
+                graph.Conventions.Patterns.CompileRefAssemblies,
                 graph.Conventions.Patterns.RuntimeAssemblies,
                 graph.Conventions.Patterns.ContentFiles
             };

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -144,11 +144,12 @@ namespace NuGet.Commands
             var orderedCriteria = CreateCriteria(targetGraph, framework);
 
             // Compile
+            // ref takes precedence over lib
             var compileGroup = GetLockFileItems(
                 orderedCriteria,
                 contentItems,
-                targetGraph.Conventions.Patterns.CompileAssemblies,
-                targetGraph.Conventions.Patterns.RuntimeAssemblies);
+                targetGraph.Conventions.Patterns.CompileRefAssemblies,
+                targetGraph.Conventions.Patterns.CompileLibAssemblies);
 
             lockFileLib.CompileTimeAssemblies.AddRange(compileGroup);
 
@@ -365,11 +366,12 @@ namespace NuGet.Commands
                     var orderedCriteria = CreateCriteria(targetGraph, targetGraph.Framework);
 
                     // Compile
+                    // ref takes precedence over lib
                     var compileGroup = GetLockFileItems(
                         orderedCriteria,
                         contentItems,
-                        targetGraph.Conventions.Patterns.CompileAssemblies,
-                        targetGraph.Conventions.Patterns.RuntimeAssemblies);
+                        targetGraph.Conventions.Patterns.CompileRefAssemblies,
+                        targetGraph.Conventions.Patterns.CompileLibAssemblies);
 
                     projectLib.CompileTimeAssemblies.AddRange(
                         ConvertToProjectPaths(fileLookup, projectDir, compileGroup));

--- a/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Client.Test/ContentModelTests.cs
@@ -48,7 +48,7 @@ namespace NuGet.Client.Test
             });
 
             // Act
-            var groups = collection.FindItemGroups(conventions.Patterns.CompileAssemblies)
+            var groups = collection.FindItemGroups(conventions.Patterns.CompileRefAssemblies)
                 .OrderBy(group => ((NuGetFramework)group.Properties["tfm"]).GetShortFolderName())
                 .ToList();
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -23,6 +23,215 @@ namespace NuGet.Commands.Test
 {
     public class RestoreCommandTests
     {
+        [Fact]
+        public async Task RestoreCommand_VerifyRuntimeSpecificAssetsAreNotIncludedForCompile_RuntimeOnly()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              },
+              ""runtimes"": {
+                ""win7-x64"": {}
+              }
+            }";
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("runtimes/win7-x64/lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), "win7-x64")
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(0, targetLib.CompileTimeAssemblies.Count);
+                Assert.Equal("runtimes/win7-x64/lib/netstandard1.5/a.dll", targetLib.RuntimeAssemblies.Single());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_VerifyRuntimeSpecificAssetsAreNotIncludedForCompile_RuntimeAndRef()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              },
+              ""runtimes"": {
+                ""win7-x64"": {}
+              }
+            }";
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("ref/netstandard1.5/a.dll");
+                packageAContext.AddFile("runtimes/win7-x64/lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), "win7-x64")
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal("ref/netstandard1.5/a.dll", targetLib.CompileTimeAssemblies.Single());
+                Assert.Equal("runtimes/win7-x64/lib/netstandard1.5/a.dll", targetLib.RuntimeAssemblies.Single());
+            }
+        }
+
+        [Fact]
+        public async Task RestoreCommand_CompileAssetsWithBothRefAndLib_VerifyRefWins()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.5"": {
+                    ""dependencies"": {
+                        ""packageA"": ""1.0.0""
+                    }
+                }
+              },
+              ""runtimes"": {
+                ""win7-x64"": {}
+              }
+            }";
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageAContext = new SimpleTestPackageContext("packageA");
+                packageAContext.AddFile("ref/netstandard1.5/a.dll");
+                packageAContext.AddFile("lib/netstandard1.5/a.dll");
+
+                SimpleTestPackageUtility.CreateFullPackage(packageSource.FullName, packageAContext);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                var lockFile = result.LockFile;
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                var targetLib = lockFile.GetTarget(NuGetFramework.Parse("netstandard1.5"), "win7-x64")
+                    .Libraries
+                    .Single(library => library.Name == "packageA");
+
+                var compile = targetLib.CompileTimeAssemblies.OrderBy(s => s).ToArray();
+
+                // Assert
+                Assert.True(result.Success);
+                Assert.Equal(1, compile.Length);
+                Assert.Equal("ref/netstandard1.5/a.dll", compile[0]);
+                Assert.Equal("lib/netstandard1.5/a.dll", targetLib.RuntimeAssemblies.Single());
+            }
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
This change removes RID specific assets in the ``runtimes/`` folder from the ``compile`` section of the assets file.

When referencing a package that contained only ``runtimes/`` assets it was possible to fallback to using these assets under ``compile``.

#### Previous behavior:
1. Select compile assets from ``ref/``
1. If no ``ref/`` assets exist try ``lib/`` and ``runtimes/`` assets.

#### Fixed behavior:
1. Select compile assets from ``ref/``
1. If no ``ref/`` assets exist try ``lib/`` assets.

#### Risk
Users depending directly on runtime only packages and not the ref package could see build breaks when the compile assets are missing. In this scenario it seems like users should just fix their references.

Fixes https://github.com/NuGet/Home/issues/4207

//cc @ericstj @alpaix @rrelyea 