### PR TITLE
Removing package cahce from nuget.exe locals help and adding temp cache

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -5936,7 +5936,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Clears or lists local NuGet resources such as http requests cache, packages cache or machine-wide global packages folder..
+        ///   Looks up a localized string similar to Clears or lists local NuGet resources such as http requests cache, temp cache or machine-wide global packages folder..
         /// </summary>
         internal static string LocalsCommandDescription {
             get {
@@ -5949,7 +5949,7 @@ namespace NuGet.CommandLine {
         ///
         ///nuget locals http-cache -clear
         ///
-        ///nuget locals packages-cache -list
+        ///nuget locals temp -list
         ///
         ///nuget locals global-packages -list.
         /// </summary>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5292,14 +5292,14 @@ nuget init \\foo\packages \\bar\packages</value>
     <value>If provided, a package added to offline feed is also expanded.</value>
   </data>
   <data name="LocalsCommandDescription" xml:space="preserve">
-    <value>Clears or lists local NuGet resources such as http requests cache, packages cache or machine-wide global packages folder.</value>
+    <value>Clears or lists local NuGet resources such as http requests cache, temp cache or machine-wide global packages folder.</value>
   </data>
   <data name="LocalsCommandExamples" xml:space="preserve">
     <value>nuget locals all -clear
 
 nuget locals http-cache -clear
 
-nuget locals packages-cache -list
+nuget locals temp -list
 
 nuget locals global-packages -list</value>
     <comment>Please don't localize this string</comment>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/3592

We removed package cache support from locals command in https://github.com/NuGet/NuGet.Client/commit/6f3ae2d59140f5ea97eb7573535de1c286d6d336. This PR removes the package cache from `nuget.exe locals -help`

//cc: @joelverhagen @rrelyea @emgarten 