### PR TITLE
Remove ContentFiles for UWP PackageReference

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -400,7 +400,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(TargetFrameworks)' != '' ">
       <_RestoreCrossTargeting>true</_RestoreCrossTargeting>
     </PropertyGroup>
-
+    
+    <!-- Determine if ContentFiles should be written by NuGet -->
+    <PropertyGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' AND '$(_RestoreSkipContentFileWrite)' == '' ">
+      <_RestoreSkipContentFileWrite Condition=" '$(TargetFrameworks)' == '' AND '$(TargetFramework)' == '' ">true</_RestoreSkipContentFileWrite>
+    </PropertyGroup>
+    
     <!-- Write properties for the top level entry point -->
     <ItemGroup Condition=" '$(RestoreProjectStyle)' == 'PackageReference' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
@@ -420,6 +425,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <CrossTargeting>$(_RestoreCrossTargeting)</CrossTargeting>
         <RestoreLegacyPackagesDirectory>$(RestoreLegacyPackagesDirectory)</RestoreLegacyPackagesDirectory>
         <ValidateRuntimeAssets>$(ValidateRuntimeIdentifierCompatibility)</ValidateRuntimeAssets>
+        <SkipContentFileWrite>$(_RestoreSkipContentFileWrite)</SkipContentFileWrite>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -517,9 +517,9 @@ namespace NuGet.Commands
                     props.AddRange(GenerateGroupsWithConditions(buildCrossPropsGroup, isMultiTargeting, CrossTargetingCondition));
                 }
 
-                // ContentFiles are read by the build task, not by NuGet
-                // for UAP with project.json.
-                if (request.ProjectStyle != ProjectStyle.ProjectJson)
+                // Write out contentFiles only for XPlat PackageReference projects.
+                if (request.ProjectStyle != ProjectStyle.ProjectJson
+                    && request.Project.RestoreMetadata?.SkipContentFileWrite != true)
                 {
                     // Create a group for every package, with the nearest from each of allLanguages
                     props.AddRange(sortedPackages.Select(pkg =>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -208,6 +208,9 @@ namespace NuGet.Commands
 
                     // ValidateRuntimeAssets compat check
                     result.RestoreMetadata.ValidateRuntimeAssets = IsPropertyTrue(specItem, "ValidateRuntimeAssets");
+
+                    // True for .NETCore projects.
+                    result.RestoreMetadata.SkipContentFileWrite = IsPropertyTrue(specItem, "SkipContentFileWrite");
                 }
 
                 if (restoreType == ProjectStyle.ProjectJson)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -211,6 +211,7 @@ namespace NuGet.ProjectModel
             msbuildMetadata.CrossTargeting = rawMSBuildMetadata.GetValue<bool>("crossTargeting");
             msbuildMetadata.LegacyPackagesDirectory = rawMSBuildMetadata.GetValue<bool>("legacyPackagesDirectory");
             msbuildMetadata.ValidateRuntimeAssets = rawMSBuildMetadata.GetValue<bool>("validateRuntimeAssets");
+            msbuildMetadata.SkipContentFileWrite = rawMSBuildMetadata.GetValue<bool>("skipContentFileWrite");
 
             msbuildMetadata.Sources = new List<PackageSource>();
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -144,6 +144,14 @@ namespace NuGet.ProjectModel
                     msbuildMetadata.ValidateRuntimeAssets.ToString());
             }
 
+            if (msbuildMetadata.SkipContentFileWrite)
+            {
+                SetValue(
+                    writer,
+                    "skipContentFileWrite",
+                    msbuildMetadata.SkipContentFileWrite.ToString());
+            }
+
             SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
             SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks);
 

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -89,6 +89,11 @@ namespace NuGet.ProjectModel
         /// </summary>
         public bool ValidateRuntimeAssets { get; set; }
 
+        /// <summary>
+        /// True if this is an XPlat PackageReference project.
+        /// </summary>
+        public bool SkipContentFileWrite { get; set; }
+
         public override int GetHashCode()
         {
             var hashCode = new HashCodeCombiner();
@@ -108,6 +113,7 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(LegacyPackagesDirectory);
             hashCode.AddObject(Files);
             hashCode.AddObject(ValidateRuntimeAssets);
+            hashCode.AddObject(SkipContentFileWrite);
 
             return hashCode.CombinedHash;
         }
@@ -143,6 +149,7 @@ namespace NuGet.ProjectModel
                    CrossTargeting == other.CrossTargeting &&
                    LegacyPackagesDirectory == other.LegacyPackagesDirectory &&
                    ValidateRuntimeAssets == other.ValidateRuntimeAssets &&
+                   SkipContentFileWrite == other.SkipContentFileWrite &&
                    EqualityUtility.SequenceEqualWithNullCheck(Files, other.Files);
         }
     }


### PR DESCRIPTION
This adds an additional flag to the PackageSpec which allows enabling/disabling the write of contentFiles.

XPlat PackageReference needs to write contentFiles to .props. UAP PackageReference should not since it will conflict.

Fixes https://github.com/NuGet/Home/issues/4226

//cc @zhili1208 @jainaashish @alpaix @nkolev92 @rrelyea @rohit21agrawal 