### PR TITLE
PackageSpec version for legacy csproj projects

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -98,6 +98,28 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
+        public string Version
+        {
+            get
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                var packageVersion = GetMSBuildProperty(AsIVsBuildPropertyStorage, "PackageVersion");
+
+                if (string.IsNullOrEmpty(packageVersion))
+                {
+                    packageVersion = GetMSBuildProperty(AsIVsBuildPropertyStorage, "Version");
+
+                    if (string.IsNullOrEmpty(packageVersion))
+                    {
+                        packageVersion = "1.0.0";
+                    }
+                }
+
+                return packageVersion;
+            }
+        }
+
         public string BaseIntermediateOutputPath
         {
             get

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IEnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IEnvDTEProjectAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -26,6 +26,11 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Project Name
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Version
+        /// </summary>
+        string Version { get; }
 
         /// <summary>
         /// Unique project name

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -284,7 +284,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return new PackageSpec(tfis)
             {
                 Name = _projectName ?? _projectUniqueName,
-                Version = new NuGetVersion(1, 0, 0, 0, (string)null, string.Empty),
+                Version = new NuGetVersion(_project.Version),
                 Authors = new string[] { },
                 Owners = new string[] { },
                 Tags = new string[] { },


### PR DESCRIPTION
This sets packageSpec version for legacy csproj projects to matches it with pack and NuGet.targets behavior for determining a package version.

Fixes https://github.com/NuGet/Home/issues/3902

@rrelyea @alpaix @emgarten @rohit21agrawal 