### PR TITLE
Moving to latest version of Microsoft.VisualStudio.Workspace.VSIntegration

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/project.json
@@ -1,9 +1,9 @@
-{
+﻿{
   "dependencies": {
     "NuGet.PackageManagement": "4.3.0-*",
     "NuGet.Protocol.VisualStudio": "4.3.0-*",
     "NuGet.Build.Tasks": "4.3.0-*",
-    "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.171-pre"
+    "Microsoft.VisualStudio.Workspace.VSIntegration": "15.0.198-pre"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
Moving NuGet to latest version (15.0.198-pre) of Microsoft.VisualStudio.Workspace.VSIntegration in order to get their fix which will resolve restore issue for PackageReference based projects with LSL (Lightweight Solution Load) enabled.

Fixes https://github.com/NuGet/Home/issues/4241

@rrelyea @emgarten @alpaix @rohit21agrawal @mishra14 @nkolev92 