### PR TITLE
enabled developmentDependencySet test and use nuget.exe from current build

### DIFF
--- a/scripts/cibuild/CreateEndToEndTestPackage.ps1
+++ b/scripts/cibuild/CreateEndToEndTestPackage.ps1
@@ -61,6 +61,10 @@ try {
     Write-Verbose "Copying test extension from '$TestExtension' to '$WorkingDirectory'"
     Copy-Item $TestExtension $WorkingDirectory
 
+    $NuGetExe = Join-Path $NuGetRoot "artifacts\VS14\NuGet.exe" -Resolve
+    Write-Verbose "Copying nuget.exe from '$NuGetExe' to '$WorkingDirectory'"
+    Copy-Item $NuGetExe $WorkingDirectory
+
     $ScriptsDirectory = Join-Path $WorkingDirectory scripts
     New-Item -ItemType Directory -Force -Path $ScriptsDirectory | Out-Null
 

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -16,19 +16,7 @@ $testRepositoryPath = Join-Path $currentPath Packages
 
 $nugetRoot = Join-Path $currentPath "..\.."
 
-$dotNuGetFolder = Join-Path $nugetRoot ".nuget"
-
-$nugetExePath = [string]$null
-
-if ((Test-Path $dotNuGetFolder) -eq $True)
-{
-    $nugetExePath = Join-Path $dotNuGetFolder "nuget.exe"
-}
-else
-{
-    # Since there is no .nuget folder, assume that nuget.exe should be present alongside this module script
-    $nugetExePath = Join-Path $currentPath "nuget.exe"
-}
+$nugetExePath = Join-Path $currentPath "nuget.exe"
 
 if ((Test-Path $nugetExePath) -eq $False)
 {

--- a/test/EndToEnd/tests/PackTest.ps1
+++ b/test/EndToEnd/tests/PackTest.ps1
@@ -32,15 +32,6 @@ function Test-PackFromProjectWithDevelopmentDependencySet {
         $context
     )
 
-    # An MSBuild 15 dependency on an MSBuild 14 DLL is breaking this test. Leave it enabled for MSBuild 14 
-    # and remove this skip when issue addressed. Re-enabling tracked here: https://github.com/NuGet/Home/issues/3272
-    if ((Get-VSVersion) -eq "15.0") {
-        Write-Host "Skipping PackFromProjectWithDevelopmentDependencySet for VS15"
-        return
-    }
-
-    # This test is for bug 3378: Undue circular dependency detected when developmentDependency = "true"
-
     # Arrange 
 
     $p = New-WebApplication


### PR DESCRIPTION
Fixed https://github.com/NuGet/Home/issues/3272
Copy nuget.exe to endtoend.zip