### PR TITLE
Fix project style detection logic to prevent false detection for CPS+Package.Config

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -146,8 +146,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
                     var hasRestoreProjectStyle = _context
                         .MSBuildProperties
-                        .TryGetValue(ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, out restoreProjectStyle)
+                        .TryGetValue(ProjectSystemProviderContext.RestoreProjectStyle, out restoreProjectStyle)
                         && !string.IsNullOrEmpty(restoreProjectStyle);
+
                     if (!hasRestoreProjectStyle)
                     {
                         // A legacy CSProj can't be CPS, must cast to VSProject4 and *must* have at least one package
@@ -167,7 +168,8 @@ namespace NuGet.PackageManagement.VisualStudio
                             _isLegacyCSProjPackageReferenceProject = true;
                         }
                     }
-                    else if (restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+                    else if (restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), 
+                        StringComparison.OrdinalIgnoreCase))
                     {
                         // if RestoreProjectStyle MSBuild property is set to PackageReference then set this project as 
                         // Legacy csproj

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -142,7 +142,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 if (!_isLegacyCSProjPackageReferenceProject.HasValue)
                 {
-                    if (string.IsNullOrEmpty(_context.NuGetProjectStyle))
+                    var restoreProjectStyle = string.Empty;
+
+                    var hasRestoreProjectStyle = _context
+                        .MSBuildProperties
+                        .TryGetValue(ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, out restoreProjectStyle)
+                        && !string.IsNullOrEmpty(restoreProjectStyle);
+                    if (!hasRestoreProjectStyle)
                     {
                         // A legacy CSProj can't be CPS, must cast to VSProject4 and *must* have at least one package
                         // reference already in the CSProj. In the future this logic may change. For now a user must
@@ -161,7 +167,7 @@ namespace NuGet.PackageManagement.VisualStudio
                             _isLegacyCSProjPackageReferenceProject = true;
                         }
                     }
-                    else if (_context.NuGetProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+                    else if (restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         // if RestoreProjectStyle MSBuild property is set to PackageReference then set this project as 
                         // Legacy csproj

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -198,10 +198,14 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 var settings = ServiceLocator.GetInstance<ISettings>();
 
+                var msBuildProperties = new Dictionary<string, string> {
+                    { ProjectSystemProviderContext.RestoreProjectStyle, ProjectStyle.PackageReference.ToString() }
+                };
+                   
                 var context = new ProjectSystemProviderContext(
                     EmptyNuGetProjectContext,
                     () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings),
-                    ProjectStyle.PackageReference.ToString());
+                    msBuildProperties);
 
                 return new LegacyCSProjPackageReferenceProject(
                     new EnvDTEProjectAdapter(dteProject, context),
@@ -906,22 +910,22 @@ namespace NuGet.PackageManagement.VisualStudio
         private NuGetProject CreateNuGetProject(Project envDTEProject, INuGetProjectContext projectContext = null)
         {
             var settings = ServiceLocator.GetInstance<ISettings>();
-
+            var vsHierarchy = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
             // read MSBuild property RestoreProjectStyle which can be set to any NuGet project sytle
             // and pass it on to NugetFactory which can pass it to each NuGet project provider to consume.
-            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
-                ProjectSystemProviderContext.RESTORE_PROJECT_STYLE);
+            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
+                ProjectSystemProviderContext.RestoreProjectStyle);
 
-            var targetFramework = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
-                ProjectSystemProviderContext.TARGET_FRAMEWORK);
+            var targetFramework = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
+                ProjectSystemProviderContext.TargetFramework);
 
-            var targetFrameworks = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
-                ProjectSystemProviderContext.TARGET_FRAMEWORKS);
+            var targetFrameworks = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
+                ProjectSystemProviderContext.TargetFrameworks);
 
             var msBuildProperties = new Dictionary<string, string> {
-                {ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, restoreProjectStyle },
-                {ProjectSystemProviderContext.TARGET_FRAMEWORK, targetFramework},
-                {ProjectSystemProviderContext.TARGET_FRAMEWORKS, targetFrameworks }
+                {ProjectSystemProviderContext.RestoreProjectStyle, restoreProjectStyle },
+                {ProjectSystemProviderContext.TargetFramework, targetFramework},
+                {ProjectSystemProviderContext.TargetFrameworks, targetFrameworks }
             };
 
             var context = new ProjectSystemProviderContext(

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -909,12 +909,25 @@ namespace NuGet.PackageManagement.VisualStudio
 
             // read MSBuild property RestoreProjectStyle which can be set to any NuGet project sytle
             // and pass it on to NugetFactory which can pass it to each NuGet project provider to consume.
-            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), "RestoreProjectStyle");
+            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
+                ProjectSystemProviderContext.RESTORE_PROJECT_STYLE);
+
+            var targetFramework = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
+                ProjectSystemProviderContext.TARGET_FRAMEWORK);
+
+            var targetFrameworks = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), 
+                ProjectSystemProviderContext.TARGET_FRAMEWORKS);
+
+            var msBuildProperties = new Dictionary<string, string> {
+                {ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, restoreProjectStyle },
+                {ProjectSystemProviderContext.TARGET_FRAMEWORK, targetFramework},
+                {ProjectSystemProviderContext.TARGET_FRAMEWORKS, targetFrameworks }
+            };
 
             var context = new ProjectSystemProviderContext(
                 projectContext ?? EmptyNuGetProjectContext,
                 () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings),
-                restoreProjectStyle);
+                msBuildProperties);
 
             NuGetProject result;
             if (_projectSystemFactory.TryCreateNuGetProject(envDTEProject, context, out result))

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -62,17 +62,17 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var hasRestoreProjectStyle = context
                 .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, out restoreProjectStyle) 
+                .TryGetValue(ProjectSystemProviderContext.RestoreProjectStyle, out restoreProjectStyle) 
                 && !string.IsNullOrEmpty(restoreProjectStyle);
 
             var hasTargetFramework = context
                 .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.TARGET_FRAMEWORK, out targetFramework)
+                .TryGetValue(ProjectSystemProviderContext.TargetFramework, out targetFramework)
                 && !string.IsNullOrEmpty(restoreProjectStyle);
 
             var hasTargetFrameworks = context
                 .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.TARGET_FRAMEWORKS, out targetFrameworks)
+                .TryGetValue(ProjectSystemProviderContext.TargetFrameworks, out targetFrameworks)
                 && !string.IsNullOrEmpty(restoreProjectStyle);
 
             // check for RestoreProjectStyle property is set and if set to PackageReference then return false
@@ -81,7 +81,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return false;
             }
             // Check if the project is not CPS capable or if it is CPS capable then it does not have TargetFramework(s), if so then return false
-            else if (!hierarchy.IsCapabilityMatch("CPS") || !(hasTargetFramework || hasTargetFrameworks))
+            else if (!(hierarchy.IsCapabilityMatch("CPS") && (hasTargetFramework || hasTargetFrameworks)))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -56,15 +56,32 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
+            var restoreProjectStyle = string.Empty;
+            var targetFramework = string.Empty;
+            var targetFrameworks = string.Empty;
 
-            // check for RestoreProjectStyle property and if set to PackageReference and project also has CPS 
-            // capability then only mark it as CPS based project.
-            if (!string.IsNullOrEmpty(context.NuGetProjectStyle) &&
-                !context.NuGetProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+            var hasRestoreProjectStyle = context
+                .MSBuildProperties
+                .TryGetValue(ProjectSystemProviderContext.RESTORE_PROJECT_STYLE, out restoreProjectStyle) 
+                && !string.IsNullOrEmpty(restoreProjectStyle);
+
+            var hasTargetFramework = context
+                .MSBuildProperties
+                .TryGetValue(ProjectSystemProviderContext.TARGET_FRAMEWORK, out targetFramework)
+                && !string.IsNullOrEmpty(restoreProjectStyle);
+
+            var hasTargetFrameworks = context
+                .MSBuildProperties
+                .TryGetValue(ProjectSystemProviderContext.TARGET_FRAMEWORKS, out targetFrameworks)
+                && !string.IsNullOrEmpty(restoreProjectStyle);
+
+            // check for RestoreProjectStyle property is set and if set to PackageReference then return false
+            if (hasRestoreProjectStyle && !restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
-            else if (!hierarchy.IsCapabilityMatch("CPS"))
+            // Check if the project is not CPS capable or if it is CPS capable then it does not have TargetFramework(s), if so then return false
+            else if (!hierarchy.IsCapabilityMatch("CPS") || !(hasTargetFramework || hasTargetFrameworks))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
@@ -13,36 +13,15 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public class ProjectSystemProviderContext
     {
-        public const string RESTORE_PROJECT_STYLE = "RestoreProjectStyle";
-        public const string TARGET_FRAMEWORK = "TargetFramework";
-        public const string TARGET_FRAMEWORKS = "TargetFrameworks";
+        public static readonly string RestoreProjectStyle = "RestoreProjectStyle";
+        public static readonly string TargetFramework = "TargetFramework";
+        public static readonly string TargetFrameworks = "TargetFrameworks";
 
         public INuGetProjectContext ProjectContext { get; }
 
         public Func<string> PackagesPathFactory { get; }
 
         public Dictionary<string, string> MSBuildProperties{ get; }
-
-        public ProjectSystemProviderContext(
-            INuGetProjectContext projectContext,
-            Func<string> packagesPathFactory,
-            string restoreProjectStyle)
-        {
-            if (projectContext == null)
-            {
-                throw new ArgumentNullException(nameof(projectContext));
-            }
-
-            if (packagesPathFactory == null)
-            {
-                throw new ArgumentNullException(nameof(packagesPathFactory));
-            }
-
-            ProjectContext = projectContext;
-            PackagesPathFactory = packagesPathFactory;
-            MSBuildProperties.Add(RESTORE_PROJECT_STYLE, restoreProjectStyle);
-        }
-
 
         public ProjectSystemProviderContext(
             INuGetProjectContext projectContext,

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -12,15 +13,20 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public class ProjectSystemProviderContext
     {
+        public const string RESTORE_PROJECT_STYLE = "RestoreProjectStyle";
+        public const string TARGET_FRAMEWORK = "TargetFramework";
+        public const string TARGET_FRAMEWORKS = "TargetFrameworks";
+
         public INuGetProjectContext ProjectContext { get; }
+
         public Func<string> PackagesPathFactory { get; }
 
-        public string NuGetProjectStyle { get; }
+        public Dictionary<string, string> MSBuildProperties{ get; }
 
         public ProjectSystemProviderContext(
             INuGetProjectContext projectContext,
             Func<string> packagesPathFactory,
-            string nuGetProjectStyle)
+            string restoreProjectStyle)
         {
             if (projectContext == null)
             {
@@ -34,7 +40,28 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ProjectContext = projectContext;
             PackagesPathFactory = packagesPathFactory;
-            NuGetProjectStyle = nuGetProjectStyle;
+            MSBuildProperties.Add(RESTORE_PROJECT_STYLE, restoreProjectStyle);
+        }
+
+
+        public ProjectSystemProviderContext(
+            INuGetProjectContext projectContext,
+            Func<string> packagesPathFactory,
+            Dictionary<string, string> msBuildProperties)
+        {
+            if (projectContext == null)
+            {
+                throw new ArgumentNullException(nameof(projectContext));
+            }
+
+            if (packagesPathFactory == null)
+            {
+                throw new ArgumentNullException(nameof(packagesPathFactory));
+            }
+
+            ProjectContext = projectContext;
+            PackagesPathFactory = packagesPathFactory;
+            MSBuildProperties = msBuildProperties;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -308,8 +308,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     Returns="$(RestoreProjectStyle)">
     <!-- This may be overridden by setting RestoreProjectStyle in the project. -->
     <PropertyGroup>
-      <!-- .NETCore cross platform projects contain the TargetFrameworks property and must be treated as PackageReference. -->
-      <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND '$(TargetFrameworks)' != '' ">PackageReference</RestoreProjectStyle>
       <!-- If any PackageReferences exist treat it as PackageReference. This has priority over project.json. -->
       <RestoreProjectStyle Condition=" '$(RestoreProjectStyle)' == '' AND @(PackageReference) != '' ">PackageReference</RestoreProjectStyle>
       <!-- If this is not a PackageReference project check if project.json or projectName.project.json exists. -->

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -309,6 +309,7 @@ namespace NuGet.Test.Utility
         {
             var context = new SimpleTestProjectContext(projectName, ProjectStyle.PackageReference, solutionRoot);
             context.Frameworks.AddRange(frameworks.Select(e => new SimpleTestProjectFrameworkContext(e)));
+            context.Properties.Add("RestoreProjectStyle", "PackageReference");
             return context;
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -19,6 +19,52 @@ namespace NuGet.CommandLine.Test
     public class RestoreNetCoreTest
     {
         [Fact]
+        public async Task RestoreNetCore_VerifyPackageReference_WithoutRestoreProjectStyle()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.Properties.Clear();
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var propsXML = XDocument.Load(projectA.PropsOutput);
+                var styleNode = propsXML.Root.Elements().First().Elements(XName.Get("NuGetProjectStyle", "http://schemas.microsoft.com/developer/msbuild/2003")).FirstOrDefault();
+
+                // Assert
+                Assert.Equal(ProjectStyle.PackageReference, dgSpec.Projects.Single().RestoreMetadata.ProjectStyle);
+                Assert.Equal("PackageReference", styleNode.Value);
+            }
+        }
+
+        [Fact]
         public async Task RestoreNetCore_SetProjectStyleWithProperty_PackageReference()
         {
             // Arrange
@@ -50,6 +96,7 @@ namespace NuGet.CommandLine.Test
                                                }");
 
                 projectA.AddPackageToAllFrameworks(packageX);
+                projectA.Properties.Clear();
                 projectA.Properties.Add("RestoreProjectStyle", "PackageReference");
 
                 solution.Projects.Add(projectA);
@@ -102,6 +149,7 @@ namespace NuGet.CommandLine.Test
                                                   }");
 
                 // Force this project to ProjectJson
+                projectA.Properties.Clear();
                 projectA.Properties.Add("RestoreProjectStyle", "ProjectJson");
 
                 solution.Projects.Add(projectA);
@@ -2189,7 +2237,7 @@ namespace NuGet.CommandLine.Test
                 projectD.Version = "1.4.9-child.project";
 
                 // Override with PackageVersion
-                projectC.Properties.Add("PackageVersion", "2.4.5-alpha.7+use.this");                
+                projectC.Properties.Add("PackageVersion", "2.4.5-alpha.7+use.this");
 
                 solution.Projects.Add(projectA);
                 solution.Projects.Add(projectB);


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4253 and  internal bugs: 366059 and 366159

In the commit: https://github.com/NuGet/NuGet.Client/commit/27cb686e81a435ff3b8ead309656eb4da90c7a63, we added a check for property `RestoreProjectStyle `and if that was not present we checked if the project was CPS or not. This broke scenarios for CPS projects of type Packages.Config.

Now, we first check the property `RestoreProjectStyle`. if it is not present then we check if the project is CPS  and it has `TargetFramework`/`TargetFrameworks` property to determine if the project is of type PackageReference_XPlat.

//cc: @emgarten @jainaashish @rrelyea @alpaix @rohit21agrawal @nkolev92 @zhili1208 