### PR TITLE
Fixing a bug in the CPS detection logic

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -68,12 +68,12 @@ namespace NuGet.PackageManagement.VisualStudio
             var hasTargetFramework = context
                 .MSBuildProperties
                 .TryGetValue(ProjectSystemProviderContext.TargetFramework, out targetFramework)
-                && !string.IsNullOrEmpty(restoreProjectStyle);
+                && !string.IsNullOrEmpty(targetFramework);
 
             var hasTargetFrameworks = context
                 .MSBuildProperties
                 .TryGetValue(ProjectSystemProviderContext.TargetFrameworks, out targetFrameworks)
-                && !string.IsNullOrEmpty(restoreProjectStyle);
+                && !string.IsNullOrEmpty(targetFrameworks);
 
             // check for RestoreProjectStyle property is set and if set to PackageReference then return false
             if (hasRestoreProjectStyle && !restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixing a bug in https://github.com/NuGet/NuGet.Client/commit/4102576776ec65d9a5b79ed05ef7d7b5c2d0bfdc that caused .NetCore restore regression

//cc: @jainaashish @emgarten @alpaix @rrelyea 