### PR TITLE
Fix VS perf regression

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 using System.Linq;
 using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.PackageManagement;
@@ -27,25 +28,29 @@ namespace NuGet.SolutionRestoreManager
         private const int CommandId = PkgCmdIDList.cmdidRestorePackages;
         private static readonly Guid CommandSet = GuidList.guidNuGetDialogCmdSet;
 
-        [Import]
-        private Lazy<INuGetUILogger> Logger { get; set; }
+        private Lazy<INuGetUILogger> _logger;
+        private Lazy<ISolutionRestoreWorker> _solutionRestoreWorker;
+        private Lazy<ISolutionManager> _solutionManager;
+        private Lazy<IConsoleStatus> _consoleStatus;
 
-        [Import]
-        private Lazy<ISolutionRestoreWorker> SolutionRestoreWorker { get; set; }
-
-        [Import]
-        private Lazy<ISolutionManager> SolutionManager { get; set; }
-
-        [Import]
-        private Lazy<IConsoleStatus> ConsoleStatus { get; set; }
+        private INuGetUILogger Logger => _logger.Value;
+        private ISolutionRestoreWorker SolutionRestoreWorker => _solutionRestoreWorker.Value;
+        private ISolutionManager SolutionManager => _solutionManager.Value;
+        private IConsoleStatus ConsoleStatus => _consoleStatus.Value;
 
         private readonly IVsMonitorSelection _vsMonitorSelection;
         private uint _solutionNotBuildingAndNotDebuggingContextCookie;
 
         private SolutionRestoreCommand(
             IMenuCommandService commandService,
-            IVsMonitorSelection vsMonitorSelection)
+            IVsMonitorSelection vsMonitorSelection,
+            IComponentModel componentModel)
         {
+            if (componentModel == null)
+            {
+                throw new ArgumentNullException(nameof(componentModel));
+            }
+
             var menuCommandId = new CommandID(CommandSet, CommandId);
             var menuItem = new OleMenuCommand(
                 OnRestorePackages, null, BeforeQueryStatusForPackageRestore, menuCommandId);
@@ -56,6 +61,18 @@ namespace NuGet.SolutionRestoreManager
             // get the solution not building and not debugging cookie
             var guid = VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid;
             _vsMonitorSelection.GetCmdUIContextCookie(ref guid, out _solutionNotBuildingAndNotDebuggingContextCookie);
+
+            _logger = new Lazy<INuGetUILogger>(
+                () => componentModel.GetService<INuGetUILogger>());
+
+            _solutionRestoreWorker = new Lazy<ISolutionRestoreWorker>(
+                () => componentModel.GetService<ISolutionRestoreWorker>());
+
+            _solutionManager = new Lazy<ISolutionManager>(
+                () => componentModel.GetService<ISolutionManager>());
+
+            _consoleStatus = new Lazy<IConsoleStatus>(
+                () => componentModel.GetService<IConsoleStatus>());
         }
 
         /// <summary>
@@ -69,12 +86,11 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(package));
             }
 
-            var commandService = await package.GetServiceAsync<IMenuCommandService>();
-            var vsMonitorSelection = await package.GetServiceAsync<IVsMonitorSelection>();
-
-            _instance = new SolutionRestoreCommand(commandService, vsMonitorSelection);
-
+            var commandService = await package.GetServiceAsync(typeof(IMenuCommandService)) as IMenuCommandService;
+            var vsMonitorSelection = await package.GetServiceAsync(typeof(IVsMonitorSelection)) as IVsMonitorSelection;
             var componentModel = await package.GetComponentModelAsync();
+
+            _instance = new SolutionRestoreCommand(commandService, vsMonitorSelection, componentModel);
             componentModel.DefaultCompositionService.SatisfyImportsOnce(_instance);
         }
 
@@ -87,15 +103,15 @@ namespace NuGet.SolutionRestoreManager
         /// <param name="e">Event args.</param>
         private void OnRestorePackages(object sender, EventArgs args)
         {
-            if (!SolutionRestoreWorker.Value.IsBusy)
+            if (!SolutionRestoreWorker.IsBusy)
             {
-                SolutionRestoreWorker.Value.Restore(SolutionRestoreRequest.ByMenu());
+                SolutionRestoreWorker.Restore(SolutionRestoreRequest.ByMenu());
             }
             else
             {
                 // QueryStatus should disable the context menu in most of the cases.
                 // Except when NuGetPackage was not loaded before VS won't send QueryStatus.
-                Logger.Value.Log(MessageLevel.Info, Resources.SolutionRestoreFailed_RestoreWorkerIsBusy);
+                Logger.Log(MessageLevel.Info, Resources.SolutionRestoreFailed_RestoreWorkerIsBusy);
             }
         }
 
@@ -114,10 +130,10 @@ namespace NuGet.SolutionRestoreManager
                 // - if the solution is DPL enabled or there are NuGetProjects. This means that there loaded, supported projects
                 // Checking for DPL more is a temporary code until we've the capability to get nuget projects
                 // even in DPL mode. See https://github.com/NuGet/Home/issues/3711
-                command.Enabled = !ConsoleStatus.Value.IsBusy &&
-                    !SolutionRestoreWorker.Value.IsBusy &&
+                command.Enabled = !ConsoleStatus.IsBusy &&
+                    !SolutionRestoreWorker.IsBusy &&
                     IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
-                    (SolutionManager.Value.IsSolutionDPLEnabled || Enumerable.Any<NuGetProject>(SolutionManager.Value.GetNuGetProjects()));
+                    (SolutionManager.IsSolutionDPLEnabled || Enumerable.Any<NuGetProject>(SolutionManager.GetNuGetProjects()));
             });
         }
 


### PR DESCRIPTION
MEF lazy load isn't fully lazy since it atleast load these assemblies/classes and resolves their types which add some perf regression cpu time to load/new solution. So right fix it to make it real lazy.

Fixes https://github.com/NuGet/Home/issues/4261

@rrelyea @emgarten @alpaix @mishra14 @rohit21agrawal 