### PR TITLE
Replace `ServiceLocator` calls with MEF

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -14,20 +14,18 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         private ISolutionManager SolutionManager { get; }
 
-        public VSPackageRestoreManager()
-            : this(
-                ServiceLocator.GetInstance<ISourceRepositoryProvider>(),
-                ServiceLocator.GetInstance<Configuration.ISettings>(),
-                ServiceLocator.GetInstance<ISolutionManager>())
-        {
-        }
-
+        [ImportingConstructor]
         public VSPackageRestoreManager(
             ISourceRepositoryProvider sourceRepositoryProvider,
             Configuration.ISettings settings,
             ISolutionManager solutionManager)
             : base(sourceRepositoryProvider, settings, solutionManager)
         {
+            if (solutionManager == null)
+            {
+                throw new ArgumentNullException(nameof(solutionManager));
+            }
+
             SolutionManager = solutionManager;
             SolutionManager.NuGetProjectAdded += OnNuGetProjectAdded;
             SolutionManager.SolutionOpened += OnSolutionOpenedOrClosed;


### PR DESCRIPTION
Resolves NuGet/Home#4269.

Calling `ServiceLocator.GetInstance` leads to switching to the UI thread when accessing component host.
Instead it should use MEF import mechanism.

//cc @davkean @rrelyea @emgarten @jainaashish @mishra14 @joelverhagen 