### PR TITLE
allow pack task to get properties for token substitution while packing from nuspec

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -32,7 +32,9 @@ namespace NuGet.Build.Tasks.Pack
         ILogger Logger { get; }
         string MinClientVersion { get; }
         bool NoPackageAnalysis { get; }
+        string NuspecBasePath { get; }
         string NuspecFile { get; }
+        string[] NuspecProperties { get; }
         string NuspecOutputPath { get; }
         TItem[] PackageFiles { get; }
         TItem[] PackageFilesToExclude { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -123,7 +123,9 @@ Copyright (c) .NET Foundation. All rights reserved.
               BuildOutputFolder="$(BuildOutputTargetFolder)"
               ContentTargetFolders="$(ContentTargetFolders)"
               RestoreOutputPath="$(RestoreOutputAbsolutePath)"
-              NuspecFile="$(NuspecFileAbsolutePath)"/>
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
   </Target>
   <!--
     ============================================================

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -35,6 +35,8 @@ namespace NuGet.Build.Tasks.Pack
         public string PackageVersion { get; set; }
         public IMSBuildItem PackItem { get; set; }
         public string ProjectUrl { get; set; }
+        public string NuspecBasePath { get; set; }
+        public string[] NuspecProperties { get; set; }
         public string ReleaseNotes { get; set; }
         public string RepositoryType { get; set; }
         public string RepositoryUrl { get; set; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.Designer.cs
@@ -87,6 +87,15 @@ namespace NuGet.Build.Tasks.Pack {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to NuspecProperties should be in the form of &quot;key1=value1;key2=value2&quot;..
+        /// </summary>
+        public static string InvalidNuspecProperties {
+            get {
+                return ResourceManager.GetString("InvalidNuspecProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to PackageReference {0} needs to have a valid version..
         /// </summary>
         public static string InvalidPackageReferenceVersion {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.resx
@@ -129,6 +129,9 @@
     <value>MinClientVersion string specified '{0}' is invalid.</value>
     <comment>{0} is the version.</comment>
   </data>
+  <data name="InvalidNuspecProperties" xml:space="preserve">
+    <value>NuspecProperties should be in the form of "key1=value1;key2=value2".</value>
+  </data>
   <data name="InvalidPackageReferenceVersion" xml:space="preserve">
     <value>PackageReference {0} needs to have a valid version.</value>
     <comment>{0} is the ID of the PackageReference.</comment>

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -284,6 +284,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 MinClientVersion = "MinClientVersion",
                 NoPackageAnalysis = true,
                 NuspecOutputPath = "NuspecOutputPath",
+                NuspecProperties = new string[0],
                 PackItem = null, // This is asserted by other tests. It does not serialize well.
                 PackageFiles = new ITaskItem[0],
                 PackageFilesToExclude = new ITaskItem[0],


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4250

This introduces new msbuild properties- 

a) NuspecProperties : This is a semicolon separated list of property value pairs , for eg: /p:NuspecProperties=\"authors=rohit;id=abcd\"

b) NuspecBasePath : This sets the base path for the input nuspec

This changeset also removes the requirement of having an assets file if you are packing using a nuspec file, i.e, if /p:NuspecFile is not an empty string.

CC: @rrelyea @rrelyea @emgarten @mishra14 @nkolev92 @alpaix 

**Note : I will update this PR with tests once https://github.com/NuGet/NuGet.Client/pull/1116 is checked in**
