### PR TITLE
Only hook to solution events when PMC console is opened while executing ps scripts

### DIFF
--- a/test/EndToEnd/Packages/ExecuteInitScriptsOnlyOnce/PackageInitPS1.1.0.0.nuspec
+++ b/test/EndToEnd/Packages/ExecuteInitScriptsOnlyOnce/PackageInitPS1.1.0.0.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <version>1.0.0</version>
+    <authors>daravind</authors>
+    <owners />
+    <id>PackageInitPS1</id>
+    <title />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>My package description.</description>
+  </metadata>
+  <files>
+    <file src="tools\init.ps1" target="tools\init.ps1" />
+  </files>
+</package>

--- a/test/EndToEnd/Packages/ExecuteInitScriptsOnlyOnce/files/PackageInitPS1.1.0.0/tools/init.ps1
+++ b/test/EndToEnd/Packages/ExecuteInitScriptsOnlyOnce/files/PackageInitPS1.1.0.0/tools/init.ps1
@@ -1,0 +1,3 @@
+param($installPath, $toolsPath, $package)
+
+$global:PackageInitPS1Var = $global:PackageInitPS1Var + 1

--- a/test/EndToEnd/Packages/ExecuteInitScriptsPerSolution/PackageInitPS1.1.0.0.nuspec
+++ b/test/EndToEnd/Packages/ExecuteInitScriptsPerSolution/PackageInitPS1.1.0.0.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <version>1.0.0</version>
+    <authors>daravind</authors>
+    <owners />
+    <id>PackageInitPS1</id>
+    <title />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>My package description.</description>
+  </metadata>
+  <files>
+    <file src="tools\init.ps1" target="tools\init.ps1" />
+  </files>
+</package>

--- a/test/EndToEnd/Packages/ExecuteInitScriptsPerSolution/files/PackageInitPS1.1.0.0/tools/init.ps1
+++ b/test/EndToEnd/Packages/ExecuteInitScriptsPerSolution/files/PackageInitPS1.1.0.0/tools/init.ps1
@@ -1,0 +1,3 @@
+param($installPath, $toolsPath, $package)
+
+$global:PackageInitPS1Var = $global:PackageInitPS1Var + 1

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -1,4 +1,4 @@
-function Test-PackageManagerServicesAreAvailableThroughMEF {
+﻿function Test-PackageManagerServicesAreAvailableThroughMEF {
     # Arrange
     $cm = Get-VsComponentModel
 
@@ -701,6 +701,57 @@ function Test-BatchEventsApi
 
     # Assert
     Assert-True $result
+}
+
+function Test-ExecuteInitScriptsPerSolution
+{
+    param($context)
+
+    # Arrange
+    $global:PackageInitPS1Var = 0
+    $p = New-ClassLibrary
+    
+    Install-Package PackageInitPS1 -Project $p.Name -Source $context.RepositoryPath
+    
+    Assert-True ($global:PackageInitPS1Var -eq 1)
+
+    $solutionFile1 = Get-SolutionFullName
+    SaveAs-Solution($solutionFile1)
+	Close-Solution
+
+    $p = New-ClassLibrary
+    $p | Install-Package jquery -Version 1.9
+
+    $solutionFile2 = Get-SolutionFullName
+    SaveAs-Solution($solutionFile2)
+	Close-Solution
+
+    # Act
+    Open-Solution $solutionFile1
+	$p = Get-Project
+    $p | Install-Package jquery -Version 1.9
+
+    # Assert
+    Assert-True ($global:PackageInitPS1Var -eq 1)
+}
+
+function Test-ExecuteInitScriptsOnlyOnce
+{
+    param($context)
+
+    # Arrange
+    $global:PackageInitPS1Var = 0
+    $p = New-ClassLibrary
+    
+    Install-Package PackageInitPS1 -Project $p.Name -Source $context.RepositoryPath
+    
+    Assert-True ($global:PackageInitPS1Var -eq 1)
+
+    # Act
+    $p | Install-Package jquery -Version 1.9
+
+    # Assert
+    Assert-True ($global:PackageInitPS1Var -eq 1)
 }
 
 function Test-CreateVsPathContextWithConfiguration {


### PR DESCRIPTION
This change is to improve our PMC performance with respect to DPL and improve below scenarios:
1. In a VS instance, whenever you install first package, it will make sure to execute init scripts for all existing packages. But it will never execute these init scripts with any solution load/unload until you explicitly open NuGet PMC console. Once the console is open, then it will hook to solution events, and make sure every solution load triggers to execute init scripts for all of it's packages. So eventually it will improve solution load performance with or without DPL when there is no PMC console opened.
2. Currently we hook 2 event handlers for solution load, one when executing any ps script, second when PMC is opened. But these are the same code executed twice. This PR will resolves this as well and make sure only single event handler is hooked.

Fixes https://github.com/NuGet/Home/issues/4258

@rrelyea @emgarten @alpaix @mishra14 @rohit21agrawal 