### PR TITLE
Removing packing of NuGet.exe in EndToEnd.zip

### DIFF
--- a/scripts/cibuild/CreateEndToEndTestPackage.ps1
+++ b/scripts/cibuild/CreateEndToEndTestPackage.ps1
@@ -61,10 +61,6 @@ try {
     Write-Verbose "Copying test extension from '$TestExtension' to '$WorkingDirectory'"
     Copy-Item $TestExtension $WorkingDirectory
 
-    $NuGetExe = Join-Path $NuGetRoot "artifacts\VS14\NuGet.exe" -Resolve
-    Write-Verbose "Copying nuget.exe from '$NuGetExe' to '$WorkingDirectory'"
-    Copy-Item $NuGetExe $WorkingDirectory
-
     $ScriptsDirectory = Join-Path $WorkingDirectory scripts
     New-Item -ItemType Directory -Force -Path $ScriptsDirectory | Out-Null
 

--- a/scripts/e2etests/Bootstrap.ps1
+++ b/scripts/e2etests/Bootstrap.ps1
@@ -28,8 +28,8 @@ function ExtractEndToEndZip
 
     $endToEndZipSrc = Join-Path $NuGetDropPath 'EndToEnd.zip'
     $endToEndZip = Join-Path $FuncTestRoot 'EndToEnd.zip'
-	$artifactsNuGetExe = Join-Path $FuncTestRoot 'NuGet.exe'
-	$endToEndNuGetExe = Join-Path $NuGetTestPath 'NuGet.exe'
+    $artifactsNuGetExe = Join-Path $FuncTestRoot 'NuGet.exe'
+    $endToEndNuGetExe = Join-Path $NuGetTestPath 'NuGet.exe'
 
     Copy-Item $endToEndZipSrc $endToEndZip -Force
 
@@ -37,12 +37,14 @@ function ExtractEndToEndZip
     mkdir $NuGetTestPath
 
     ExtractZip $endToEndZip $NuGetTestPath
-	
-	if(Test-Path $artifactsNuGetExe){
-	
-		Write-Host 'Copying ' $artifactsNuGetExe ' to ' $endToEndNuGetExe
-		Copy-Item $artifactsNuGetExe $endToEndNuGetExe -Force
-	}
+
+    if(Test-Path $artifactsNuGetExe){
+        Write-Host 'Copying ' $artifactsNuGetExe ' to ' $endToEndNuGetExe
+        Copy-Item $artifactsNuGetExe $endToEndNuGetExe -Force
+    }
+    else {
+        Write-Host 'NuGet.Exe not found at ' $artifactsNuGetExe
+    }
 }
 
 function CleanPaths($NuGetTestPath)

--- a/scripts/e2etests/Bootstrap.ps1
+++ b/scripts/e2etests/Bootstrap.ps1
@@ -28,6 +28,8 @@ function ExtractEndToEndZip
 
     $endToEndZipSrc = Join-Path $NuGetDropPath 'EndToEnd.zip'
     $endToEndZip = Join-Path $FuncTestRoot 'EndToEnd.zip'
+	$artifactsNuGetExe = Join-Path $FuncTestRoot 'NuGet.exe'
+	$endToEndNuGetExe = Join-Path $NuGetTestPath 'NuGet.exe'
 
     Copy-Item $endToEndZipSrc $endToEndZip -Force
 
@@ -35,6 +37,12 @@ function ExtractEndToEndZip
     mkdir $NuGetTestPath
 
     ExtractZip $endToEndZip $NuGetTestPath
+	
+	if(Test-Path $artifactsNuGetExe){
+	
+		Write-Host 'Copying ' $artifactsNuGetExe ' to ' $endToEndNuGetExe
+		Copy-Item $artifactsNuGetExe $endToEndNuGetExe -Force
+	}
 }
 
 function CleanPaths($NuGetTestPath)


### PR DESCRIPTION
This removes the packing of artifacts/VS14/NuGet.exe into EndToEnd.zip.

In place of that I have added a TeamCity dependency that moves the signed NuGet.exe into the artifacts folder of End to end machines. Then the Bootstrap.ps1 adds it into the unzipped EndToEnd folder.

//cc: @zhili1208 @emgarten @alpaix 