### PR TITLE
Remove ServiceLocator calls from MEF ctors

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -11,7 +11,7 @@ using NuGet.Protocol.Core.Types;
 namespace NuGet.PackageManagement.VisualStudio
 {
     [Export(typeof(IPackageRestoreManager))]
-    public class VSPackageRestoreManager : PackageRestoreManager
+    internal sealed class VSPackageRestoreManager : PackageRestoreManager
     {
         private ISolutionManager SolutionManager { get; }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/VSSourceControlManagerProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/VSSourceControlManagerProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Linq;
-using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -14,33 +13,27 @@ using NuGet.ProjectManagement;
 namespace NuGet.PackageManagement.VisualStudio
 {
     [Export(typeof(ISourceControlManagerProvider))]
-    public class VSSourceControlManagerProvider : ISourceControlManagerProvider
+    internal sealed class VSSourceControlManagerProvider : ISourceControlManagerProvider
     {
-        private readonly DTE _dte;
-        private readonly IComponentModel _componentModel;
+        private readonly Lazy<EnvDTE.DTE> _dte;
+        private readonly Lazy<IComponentModel> _componentModel;
+
         private const string TfsProviderName = "{4CA58AB2-18FA-4F8D-95D4-32DDF27D184C}";
 
         [ImportingConstructor]
-        public VSSourceControlManagerProvider()
-            : this(ServiceLocator.GetInstance<DTE>(),
-                ServiceLocator.GetGlobalService<SComponentModel, IComponentModel>())
+        public VSSourceControlManagerProvider(
+            [Import(typeof(SVsServiceProvider))]
+            IServiceProvider serviceProvider)
         {
-        }
-
-        public VSSourceControlManagerProvider(DTE dte, IComponentModel componentModel)
-        {
-            if (dte == null)
+            if (serviceProvider == null)
             {
-                throw new ArgumentNullException("dte");
+                throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-            if (componentModel == null)
-            {
-                throw new ArgumentNullException("componentModel");
-            }
-
-            _componentModel = componentModel;
-            _dte = dte;
+            _componentModel = new Lazy<IComponentModel>(
+                () => serviceProvider.GetComponentModel());
+            _dte = new Lazy<EnvDTE.DTE>(
+                () => serviceProvider.GetDTE());
         }
 
         public SourceControlManager GetSourceControlManager()
@@ -49,17 +42,16 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    if (_dte != null
-                        && _dte.SourceControl != null)
+                    if (_dte.Value.SourceControl != null)
                     {
-                        var sourceControl = (SourceControl2)_dte.SourceControl;
+                        var sourceControl = (SourceControl2)_dte.Value.SourceControl;
                         if (sourceControl != null)
                         {
                             SourceControlBindings sourceControlBinding = null;
                             try
                             {
                                 // Get the binding for this solution
-                                sourceControlBinding = sourceControl.GetBindings(_dte.Solution.FullName);
+                                sourceControlBinding = sourceControl.GetBindings(_dte.Value.Solution.FullName);
                             }
                             catch (NotImplementedException)
                             {
@@ -76,7 +68,7 @@ namespace NuGet.PackageManagement.VisualStudio
                                 return null;
                             }
 
-                            var tfsProviders = _componentModel.GetExtensions<ITFSSourceControlManagerProvider>();
+                            var tfsProviders = _componentModel.Value.GetExtensions<ITFSSourceControlManagerProvider>();
                             if (tfsProviders != null
                                 && tfsProviders.Any())
                             {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ServiceLocator.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ServiceLocator.cs
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(GetInstanceAsync<TService>);
         }
 
-        public static async Task<TService> GetInstanceAsync<TService>() where TService : class
+        private static async Task<TService> GetInstanceAsync<TService>() where TService : class
         {
             // VS Threading Rule #1
             // Access to ServiceProvider and a lot of casts are performed in this method,

--- a/src/NuGet.Clients/TeamFoundationServer/TFSSourceControlManagerProvider.cs
+++ b/src/NuGet.Clients/TeamFoundationServer/TFSSourceControlManagerProvider.cs
@@ -16,14 +16,19 @@ using NuGet.ProjectManagement;
 namespace NuGet.TeamFoundationServer
 {
     [Export(typeof(ITFSSourceControlManagerProvider))]
-    public class TFSSourceControlManagerProvider : ITFSSourceControlManagerProvider
+    internal sealed class TFSSourceControlManagerProvider : ITFSSourceControlManagerProvider
     {
         private readonly Configuration.ISettings _settings;
 
         [ImportingConstructor]
-        public TFSSourceControlManagerProvider()
+        public TFSSourceControlManagerProvider(Configuration.ISettings vsSettings)
         {
-            _settings = ServiceLocator.GetInstanceSafe<Configuration.ISettings>();
+            if (vsSettings == null)
+            {
+                throw new ArgumentNullException(nameof(vsSettings));
+            }
+
+            _settings = vsSettings;
         }
 
         public SourceControlManager GetTFSSourceControlManager(SourceControlBindings sourceControlBindings)


### PR DESCRIPTION
Addresses NuGet/Home#4268.
Follow-up on #1120.

Cleanup pass over MEF types to remove all `ServiceLocator` calls from
constructors to avoid switching to UI thread during instantiation.

//cc @emgarten @jainaashish @mishra14 @rohit21agrawal @rrelyea 