### PR TITLE
Fixed UI version list sync

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -31,11 +31,20 @@ namespace NuGet.PackageManagement.UI
 
         public async override Task SetCurrentPackage(
             PackageItemListViewModel searchResultPackage,
-            ItemFilter filter)
+            ItemFilter filter,
+            Func<PackageItemListViewModel> getPackageItemListViewModel)
         {
+            // Set InstalledVersion before fetching versions list.
+            InstalledVersion = searchResultPackage.InstalledVersion;
 
-            await base.SetCurrentPackage(searchResultPackage, filter);
+            await base.SetCurrentPackage(searchResultPackage, filter, getPackageItemListViewModel);
 
+            // SetCurrentPackage can take long time to return, user might changed selected package.
+            // Check selected package.
+            if (getPackageItemListViewModel() != searchResultPackage)
+            {
+                return;
+            }
             InstalledVersion = searchResultPackage.InstalledVersion;
             SelectedVersion.IsCurrentInstalled = InstalledVersion == SelectedVersion.Version;
             OnPropertyChanged(nameof(SelectedVersion));

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/PackageManagerControl.xaml.cs
@@ -669,7 +669,7 @@ namespace NuGet.PackageManagement.UI
                 _packageDetail.Visibility = Visibility.Visible;
                 _packageDetail.DataContext = _detailModel;
 
-                await _detailModel.SetCurrentPackage(selectedPackage, _topPanel.Filter);
+                await _detailModel.SetCurrentPackage(selectedPackage, _topPanel.Filter, ()=>_packageList.SelectedItem);
 
                 _packageDetail.ScrollToHome();
 


### PR DESCRIPTION
fixed https://github.com/NuGet/Home/issues/4198

the issue is
If package source is slow or unavailable. 
1. Open NuGet solution Manager and click installed tab. the installed package version list will be blank even if this package is already installed in one project and available from cache. 
2. switch between packages, package versions list will be out of sync.
nuget will show previous package version information at current package UI.

the root cause is 
1. we don't catch exception when package source throws, VS UI will catch it and nuget will not refresh version list.
2. Even if there is no exception, when user select another package before the fetching versions call return,
UI will update current package version list with previous package version information.

the fix is
1. catch exception if fetching versions call throws.
2. when user select one package, set package version list to installed version first then wait for fetching version list from server. 
3. check current selected package before updating package version list.

@jainaashish @alpaix 