### PR TITLE
fix the path for picking up NuGet.exe for E2E tests

### DIFF
--- a/scripts/e2etests/Bootstrap.ps1
+++ b/scripts/e2etests/Bootstrap.ps1
@@ -28,7 +28,7 @@ function ExtractEndToEndZip
 
     $endToEndZipSrc = Join-Path $NuGetDropPath 'EndToEnd.zip'
     $endToEndZip = Join-Path $FuncTestRoot 'EndToEnd.zip'
-    $artifactsNuGetExe = Join-Path $FuncTestRoot 'NuGet.exe'
+    $artifactsNuGetExe = Join-Path $NuGetDropPath 'NuGet.exe'
     $endToEndNuGetExe = Join-Path $NuGetTestPath 'NuGet.exe'
 
     Copy-Item $endToEndZipSrc $endToEndZip -Force


### PR DESCRIPTION
Fixing the path to picking up NuGet.exe for E2E tests, which was wrong in https://github.com/NuGet/NuGet.Client/commit/3187dc2135b015bcc0bb6817e4a9fdd9b0ef8efd

//cc: @alpaix @emgarten @rohit21agrawal @jainaashish 