### PR TITLE
Add semVerLevel to client HTTP requests (this is NuGet SemVer 2.0.0 protocol)

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -44,7 +44,7 @@ namespace NuGet.Protocol
         {
             var apiEndpointUri = new UriBuilder(new Uri(_baseUri, @"package-ids"))
             {
-                Query = $"partialId={packageIdPrefix}&includePrerelease={includePrerelease.ToString()}"
+                Query = $"partialId={packageIdPrefix}&includePrerelease={includePrerelease}&semVerLevel=2.0.0"
             };
 
             return await GetResults(apiEndpointUri.Uri, log, token);
@@ -59,12 +59,13 @@ namespace NuGet.Protocol
         {
             var apiEndpointUri = new UriBuilder(new Uri(_baseUri, @"package-versions/" + packageId))
             {
-                Query = $"includePrerelease={includePrerelease.ToString()}"
+                Query = $"includePrerelease={includePrerelease}&semVerLevel=2.0.0"
             };
 
             var results = await GetResults(apiEndpointUri.Uri, log, token);
             var versions = results.ToList();
-            versions = versions.Where(item => item.StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase))
+            versions = versions
+                .Where(item => item.StartsWith(versionPrefix, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
             return versions.Select(item => NuGetVersion.Parse(item));

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedQueryBuilder.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedQueryBuilder.cs
@@ -23,16 +23,17 @@ namespace NuGet.Protocol
         private const string IsLatestVersionFilterFlag = "IsLatestVersion";
         private const string IsAbsoluteLatestVersionFilterFlag = "IsAbsoluteLatestVersion";
         private const string IdProperty = "Id";
+        private const string SemVerLevel = "semVerLevel=2.0.0";
 
         // constants for /Packages(ID,VERSION) endpoint
         private const string GetSpecificPackageFormat = "/Packages(Id='{0}',Version='{1}')";
 
         // constants for /Search() endpoint
-        private const string SearchEndpointFormat = "/Search()?{0}{1}searchTerm='{2}'&targetFramework='{3}'&includePrerelease={4}&$skip={5}&$top={6}";
+        private const string SearchEndpointFormat = "/Search()?{0}{1}searchTerm='{2}'&targetFramework='{3}'&includePrerelease={4}&$skip={5}&$top={6}&" + SemVerLevel;
         private const string QueryDelimiter = "&";
 
         // constants for /FindPackagesById() endpoint
-        private const string FindPackagesByIdFormat = "/FindPackagesById()?id='{0}'";
+        private const string FindPackagesByIdFormat = "/FindPackagesById()?id='{0}'&" + SemVerLevel;
 
         // constants for /Packages() endpoint
         private const string GetPackagesFormat = "/Packages{0}";
@@ -177,6 +178,11 @@ namespace NuGet.Protocol
                     topParameter);
                 hasParameters = true;
             }
+
+            builder.AppendFormat(
+                hasParameters ? ParameterFormat : FirstParameterFormat,
+                SemVerLevel);
+            hasParameters = true;
 
             return builder.ToString();
         }

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/AutoCompleteResourceV3.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -44,7 +43,9 @@ namespace NuGet.Protocol
             // Construct the query
             var queryUrl = new UriBuilder(searchUrl.AbsoluteUri);
             var queryString =
-                "q=" + WebUtility.UrlEncode(packageIdPrefix) + "&includePrerelease=" + includePrerelease.ToString().ToLowerInvariant();
+                "q=" + WebUtility.UrlEncode(packageIdPrefix) +
+                "&includePrerelease=" + includePrerelease.ToString().ToLowerInvariant() +
+                "&semVerLevel=2.0.0";
 
             queryUrl.Query = queryString;
 

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Resources/RawSearchResourceV3.cs
@@ -50,6 +50,7 @@ namespace NuGet.Protocol
                     "&skip=" + skip.ToString() +
                     "&take=" + take.ToString() +
                     "&prerelease=" + filters.IncludePrerelease.ToString().ToLowerInvariant();
+
                 if (filters.IncludeDelisted)
                 {
                     queryString += "&includeDelisted=true";
@@ -73,6 +74,8 @@ namespace NuGet.Protocol
                             s => "packageTypeFilter=" + s));
                     queryString += "&" + types;
                 }
+
+                queryString += "&semVerLevel=2.0.0";
 
                 queryUrl.Query = queryString;
 

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -62,7 +62,7 @@ function Test-InstallPackageWithInvalidHttpSourceVerbose {
     $project = New-ConsoleApplication
     $source = "http://example.com"
     $escapedSource = [regex]::Escape($source)
-    $escapedUrl = [regex]::Escape($source+"/FindPackagesById()?id='$package'")
+    $escapedUrl = [regex]::Escape($source+"/FindPackagesById()?id='$package'&semVerLevel=2.0.0")
     $message = "\ \ GET\ $escapedUrl\ \ \ NotFound\ $escapedUrl\ [\w]+\ An\ error\ occurred\ while\ retrieving\ package\ metadata\ for\ '$package'\ from\ source\ '$escapedSource'\.\r\n\ \ The\ V2\ feed\ at\ '$escapedUrl'\ returned\ an\ unexpected\ status\ code\ '404\ Not\ Found'\.\ Unable\ to\ find\ package\ '$package'\ at\ source\ '$escapedSource'\."
 
     # Act

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -19,7 +19,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "package-ids?partialId=Azure&includePrerelease=False",
+            responses.Add(serviceAddress + "package-ids?partialId=Azure&includePrerelease=False&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureAutoComplete.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -41,7 +41,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "package-versions/xunit?includePrerelease=False",
+            responses.Add(serviceAddress + "package-versions/xunit?includePrerelease=False&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitVersionAutoComplete.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "package-versions/azure?includePrerelease=False", "[]");
+            responses.Add(serviceAddress + "package-versions/azure?includePrerelease=False&semVerLevel=2.0.0", "[]");
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -107,7 +107,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -142,7 +142,7 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -167,7 +167,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/DownloadResourceV2FeedTests.cs
@@ -24,7 +24,7 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LegacyFeed/V2FeedQueryBuilderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/LegacyFeed/V2FeedQueryBuilderTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Tests
                 take: null);
 
             // Assert
-            Assert.Equal("/Packages", actual);
+            Assert.Equal("/Packages?semVerLevel=2.0.0", actual);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace NuGet.Protocol.Tests
                 take: null);
 
             // Assert
-            Assert.Equal("/Packages?$skip=100", actual);
+            Assert.Equal("/Packages?$skip=100&semVerLevel=2.0.0", actual);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace NuGet.Protocol.Tests
                 take: 30);
 
             // Assert
-            Assert.Equal("/Packages()?$orderby=Id&$skip=0&$top=30", actual);
+            Assert.Equal("/Packages()?$orderby=Id&$skip=0&$top=30&semVerLevel=2.0.0", actual);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace NuGet.Protocol.Tests
                 take: 30);
 
             // Assert
-            Assert.Equal("/Packages()?$filter=IsAbsoluteLatestVersion&$orderby=Id&$skip=0&$top=30", actual);
+            Assert.Equal("/Packages()?$filter=IsAbsoluteLatestVersion&$orderby=Id&$skip=0&$top=30&semVerLevel=2.0.0", actual);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace NuGet.Protocol.Tests
                 take: 30);
 
             // Assert
-            Assert.Equal("/Packages()?$filter=IsLatestVersion&$orderby=Id&$skip=0&$top=30", actual);
+            Assert.Equal("/Packages()?$filter=IsLatestVersion&$orderby=Id&$skip=0&$top=30&semVerLevel=2.0.0", actual);
         }
 
         /// <summary>
@@ -140,8 +140,8 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.Equal(
                 "/Packages()?$filter=(((Id%20ne%20null)%20and%20substringof('nuget',tolower(Id)))%20or%20" +
-                "((Description%20ne%20null)%20and%20substringof('nuget',tolower(Description))))%20or%20" + 
-                "((Tags%20ne%20null)%20and%20substringof('%20nuget%20',tolower(Tags)))",
+                "((Description%20ne%20null)%20and%20substringof('nuget',tolower(Description))))%20or%20" +
+                "((Tags%20ne%20null)%20and%20substringof('%20nuget%20',tolower(Tags)))&semVerLevel=2.0.0",
                 actual);
         }
 
@@ -168,8 +168,8 @@ namespace NuGet.Protocol.Tests
             Assert.Equal(
                 "/Packages()?$filter=((((Id%20ne%20null)%20and%20substringof('nuget',tolower(Id)))%20or%20" +
                 "((Description%20ne%20null)%20and%20substringof('nuget',tolower(Description))))%20or%20" + 
-                "((Tags%20ne%20null)%20and%20substringof('%20nuget%20',tolower(Tags))))%20and%20" + 
-                "IsAbsoluteLatestVersion&$orderby=Id&$skip=0&$top=30",
+                "((Tags%20ne%20null)%20and%20substringof('%20nuget%20',tolower(Tags))))%20and%20" +
+                "IsAbsoluteLatestVersion&$orderby=Id&$skip=0&$top=30&semVerLevel=2.0.0",
                 actual);
         }
 
@@ -199,7 +199,7 @@ namespace NuGet.Protocol.Tests
                 "substringof('%20bar%20',tolower(Tags))))%20or%20((Id%20ne%20null)%20and%20" +
                 "substringof('baz',tolower(Id))))%20or%20((Description%20ne%20null)%20and%20" + 
                 "substringof('baz',tolower(Description))))%20or%20((Tags%20ne%20null)%20and%20" +
-                "substringof('%20baz%20',tolower(Tags)))",
+                "substringof('%20baz%20',tolower(Tags)))&semVerLevel=2.0.0",
                 actual);
         }
 
@@ -213,7 +213,7 @@ namespace NuGet.Protocol.Tests
             var actual = target.BuildFindPackagesByIdUri("Newtonsoft.Json");
 
             // Assert
-            Assert.Equal("/FindPackagesById()?id='Newtonsoft.Json'", actual);
+            Assert.Equal("/FindPackagesById()?id='Newtonsoft.Json'&semVerLevel=2.0.0", actual);
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace NuGet.Protocol.Tests
             var actual = target.BuildFindPackagesByIdUri("foo! bar/ baz?");
 
             // Assert
-            Assert.Equal("/FindPackagesById()?id='foo%21%20bar%2F%20baz%3F'", actual);
+            Assert.Equal("/FindPackagesById()?id='foo%21%20bar%2F%20baz%3F'&semVerLevel=2.0.0", actual);
         }
 
         [Fact]
@@ -290,7 +290,7 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.Equal(
                 "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='foo%21%20bar%2F%20baz%3F'&" +
-                "targetFramework='net45%7Cnetcoreapp1.0'&includePrerelease=true&$skip=0&$top=30",
+                "targetFramework='net45%7Cnetcoreapp1.0'&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
                 actual);
         }
 
@@ -310,7 +310,7 @@ namespace NuGet.Protocol.Tests
             // Assert
             Assert.Equal(
                 "/Search()?searchTerm='foo%21%20bar%2F%20baz%3F'&targetFramework=''" +
-                "&includePrerelease=true&$skip=0&$top=30",
+                "&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
                 actual);
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/MetadataResourceV2FeedTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -43,7 +43,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -65,7 +65,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -87,7 +87,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -109,7 +109,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -131,8 +131,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+            responses.Add(
+                serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -155,9 +156,11 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -184,7 +187,8 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -206,7 +210,8 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -228,7 +233,8 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -253,7 +259,8 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -62,7 +62,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -109,7 +109,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='0.0.0')",
                  TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/PackageSearchResourceV2FeedTests.cs
@@ -19,7 +19,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -62,8 +64,10 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
-     TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=100&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
@@ -1,15 +1,14 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
-using NuGet.Protocol;
-using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 using NuGet.Protocol.Core.v3.Tests;
@@ -25,7 +24,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false&supportedFramework=.NETFramework,Version=v4.5",
+            responses.Add(
+                serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false" +
+                "&supportedFramework=.NETFramework,Version=v4.5&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.V3Search.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
@@ -119,9 +119,13 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'&targetFramework=''&includePrerelease=false&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NewtonSearch30Entries.xml", GetType()));
-            responses.Add(serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'&targetFramework=''&includePrerelease=false&$skip=30&$top=30",
+            responses.Add(
+                serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
+                "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NewtonSearch30Entries.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
+                "&targetFramework=''&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NewtonSearch3Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
@@ -166,8 +170,10 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='NuGet.Exe'&targetFramework=''&includePrerelease=true&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='NuGet.Exe'" +
+                "&targetFramework=''&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.MetadataTT.xml", GetType()));
@@ -211,9 +217,13 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=true&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
-            responses.Add(serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=true&$skip=30&$top=30",
+            responses.Add(
+                serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'" +
+                "&targetFramework=''&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'" +
+                "&targetFramework=''&includePrerelease=true&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
@@ -259,8 +269,10 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$orderby=Id&searchTerm='NuGet.Exe'&targetFramework=''&includePrerelease=true&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$orderby=Id&searchTerm='NuGet.Exe'&targetFramework=''" +
+                "&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.MetadataTT.xml", GetType()));
@@ -304,9 +316,13 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=true&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
-            responses.Add(serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=true&$skip=30&$top=30",
+            responses.Add(
+                serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
+                "&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
+                "&includePrerelease=true&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
@@ -352,9 +368,13 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
 
-            responses.Add(serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=false&$skip=0&$top=30",
-               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
-            responses.Add(serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''&includePrerelease=false&$skip=30&$top=30",
+            responses.Add(
+                serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
+                "&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+            responses.Add(
+                serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
+                "&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedParserTests.cs
@@ -28,7 +28,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -53,7 +53,8 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='ravendb.client'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='ravendb.client'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.RavendbFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','1.2.2067-Unstable'",
@@ -79,7 +80,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -152,7 +153,8 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -184,7 +186,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -229,7 +233,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$orderby=Id&searchTerm=''&targetFramework=''&includePrerelease=false&$skip=0&$top=5",
+            responses.Add(
+                serviceAddress + "Search()?$orderby=Id&searchTerm=''&targetFramework=''&includePrerelease=false" +
+                "&$skip=0&$top=5&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.SearchOrderById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -264,7 +270,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'&targetFramework='portable-net45%2Bwin8'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'" + 
+                "&targetFramework='portable-net45%2Bwin8'&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -291,9 +299,14 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=100",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=100&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch100.xml", GetType()));
-            responses.Add("https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$filter=IsLatestVersion&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
+            responses.Add(
+                "https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$filter=IsLatestVersion" +
+                "&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearchNext100.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -318,7 +331,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
                 string.Empty);
             responses.Add(serviceAddress, string.Empty);
 
@@ -340,7 +355,8 @@ namespace NuGet.Protocol.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'" +
+                "&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -352,7 +368,9 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
+                "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
                 null);
             responses.Add(serviceAddress, string.Empty);
 
@@ -374,7 +392,8 @@ namespace NuGet.Protocol.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1' " +
+                "The V2 feed at '" + serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'" +
+                "&targetFramework='net40-client'&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }
@@ -427,7 +446,7 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -451,7 +470,7 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -493,7 +512,7 @@ namespace NuGet.Protocol.Tests
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0", string.Empty);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
@@ -510,7 +529,7 @@ namespace NuGet.Protocol.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -549,7 +568,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", string.Empty);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0", string.Empty);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
@@ -564,7 +583,7 @@ namespace NuGet.Protocol.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0' " +
                 "returned an unexpected status code '404 Not Found'.",
                 exception.Message);
         }
@@ -576,7 +595,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'", null);
+            responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0", null);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
@@ -591,7 +610,7 @@ namespace NuGet.Protocol.Tests
                 CancellationToken.None));
 
             Assert.Equal(
-                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'' " +
+                "The V2 feed at '" + serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0' " +
                 "returned an unexpected status code '500 Internal Server Error'.",
                 exception.Message);
         }
@@ -603,7 +622,8 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='PackageA'",
+            responses.Add(
+                serviceAddress + "FindPackagesById()?id='PackageA'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.NexusFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -638,7 +658,7 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "FindPackagesById()?id='ravendb.client'",
+            responses.Add(serviceAddress + "FindPackagesById()?id='ravendb.client'&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.CyclicDependency.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(dupUrl,
@@ -674,7 +694,10 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'&targetFramework='portable45-net45%2Bwin8%2Bwpa81%7Cwpa81%7Cmonoandroid60'&includePrerelease=false&$skip=0&$top=1",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'" +
+                "&targetFramework='portable45-net45%2Bwin8%2Bwpa81%7Cwpa81%7Cmonoandroid60'&includePrerelease=false" +
+                "&$skip=0&$top=1&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -707,9 +730,13 @@ namespace NuGet.Protocol.Tests
             var serviceAddress = TestUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'&targetFramework=''&includePrerelease=false&$skip=0&$top=30",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'" +
+                "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
-            responses.Add(serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'&targetFramework=''&includePrerelease=false&$skip=30&$top=30",
+            responses.Add(
+                serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'" +
+                "&targetFramework=''&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
@@ -740,12 +767,12 @@ namespace NuGet.Protocol.Tests
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages()?$filter=((((Id%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Id)))"+
                 "%20or%20((Description%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Description))))%20or%20((Tags%20ne%20null)"+
-                "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=0&$top=30",
+                "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=0&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
 
             responses.Add(serviceAddress +"Packages()?$filter=((((Id%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Id)))" +
                 "%20or%20((Description%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Description))))%20or%20((Tags%20ne%20null)" +
-                "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=30&$top=30",
+                "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=30&$top=30&semVerLevel=2.0.0",
                 TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/JsonData.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.VisualStudio.Tests/JsonData.cs
@@ -1,19 +1,44 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Protocol.VisualStudio.Tests
 {
     public static class JsonData
     {
-        #region PSAutoCompleteV2Example
-        public const string PSAutoCompleteV2Example = @"[""elm.TypeScript.DefinitelyTyped"",""elmah"",""Elmah.AzureTableStorage"",""Elmah.BlogEngine.Net"",""Elmah.Contrib.EntityFramework"",""Elmah.Contrib.Mvc"",""Elmah.Contrib.WebApi"",""elmah.corelibrary"",""elmah.corelibrary.ews"",""Elmah.ElasticSearch"",""Elmah.Everywhere"",""elmah.ews"",""Elmah.FallbackErrorLog"",""elmah.filtering.sample"",""elmah.io"",""elmah.io.client"",""elmah.io.core"",""elmah.io.log4net"",""elmah.io.umbraco"",""elmah.mongodb"",""elmah.msaccess"",""Elmah.MVC"",""Elmah.MVC.ews"",""Elmah.MVC.XMLLight"",""elmah.mysql"",""elmah.oracle"",""elmah.postgresql"",""Elmah.RavenDB"",""Elmah.RavenDB.3"",""Elmah.RavenDB-4.5""]";
-        #endregion PSAutoCompleteV2Example
-
-
-        #region PSAutoCompleteV3Example
-        public const string PsAutoCompleteV3Example = @"{
+        public const string AutoCompleteV2Example = @"[
+    ""elm.TypeScript.DefinitelyTyped"",
+    ""elmah"",
+    ""Elmah.AzureTableStorage"",
+    ""Elmah.BlogEngine.Net"",
+    ""Elmah.Contrib.EntityFramework"",
+    ""Elmah.Contrib.Mvc"",
+    ""Elmah.Contrib.WebApi"",
+    ""elmah.corelibrary"",
+    ""elmah.corelibrary.ews"",
+    ""Elmah.ElasticSearch"",
+    ""Elmah.Everywhere"",
+    ""elmah.ews"",
+    ""Elmah.FallbackErrorLog"",
+    ""elmah.filtering.sample"",
+    ""elmah.io"",
+    ""elmah.io.client"",
+    ""elmah.io.core"",
+    ""elmah.io.log4net"",
+    ""elmah.io.umbraco"",
+    ""elmah.mongodb"",
+    ""elmah.msaccess"",
+    ""Elmah.MVC"",
+    ""Elmah.MVC.ews"",
+    ""Elmah.MVC.XMLLight"",
+    ""elmah.mysql"",
+    ""elmah.oracle"",
+    ""elmah.postgresql"",
+    ""Elmah.RavenDB"",
+    ""Elmah.RavenDB.3"",
+    ""Elmah.RavenDB-4.5""
+]";
+        
+        public const string AutoCompleteV3Example = @"{
               ""@context"": {
                 ""@vocab"": ""http://schema.nuget.org/schema#""
               },
@@ -42,9 +67,168 @@ namespace NuGet.Protocol.VisualStudio.Tests
                 ""Logary.Targets.ElmahIO""
               ]
             }";
-        #endregion PSAutoCompleteV3Example
 
-        #region index.json
+        public const string VersionAutocompleteRegistrationExample = @"{
+    ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json"",
+    ""@type"": [
+        ""catalog:CatalogRoot"",
+        ""PackageRegistration"",
+        ""catalog:Permalink""
+    ],
+    ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+    ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+    ""count"": 1,
+    ""items"": [
+        {
+            ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json#page/0.1.0-alpha/4.0.0-rc2"",
+            ""@type"": ""catalog:CatalogPage"",
+            ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+            ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+            ""count"": 4,
+            ""items"": [
+                {
+                    ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/3.5.0-rc1-final.json"",
+                    ""@type"": ""Package"",
+                    ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+                    ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+                    ""catalogEntry"": {
+                        ""@id"": ""https://api.nuget.org/v3/catalog0/data/2016.08.11.22.28.34/nuget.versioning.3.5.0-rc1-final.json"",
+                        ""@type"": ""PackageDetails"",
+                        ""authors"": ""NuGet"",
+                        ""dependencyGroups"": [],
+                        ""description"": ""NuGet's implementation of Semantic Versioning."",
+                        ""iconUrl"": """",
+                        ""id"": ""NuGet.Versioning"",
+                        ""language"": """",
+                        ""licenseUrl"": ""https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"",
+                        ""listed"": true,
+                        ""minClientVersion"": """",
+                        ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.3.5.0-rc1-final.nupkg"",
+                        ""projectUrl"": ""https://github.com/NuGet/NuGet.Client"",
+                        ""published"": ""2016-08-11T18:10:12.513+00:00"",
+                        ""requireLicenseAcceptance"": false,
+                        ""summary"": """",
+                        ""tags"": [],
+                        ""title"": """",
+                        ""version"": ""3.5.0-rc1-final""
+                    },
+                    ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.3.5.0-rc1-final.nupkg"",
+                    ""registration"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json""
+                },
+                {
+                    ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/3.5.0.json"",
+                    ""@type"": ""Package"",
+                    ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+                    ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+                    ""catalogEntry"": {
+                        ""@id"": ""https://api.nuget.org/v3/catalog0/data/2016.12.14.23.48.30/nuget.versioning.3.5.0.json"",
+                        ""@type"": ""PackageDetails"",
+                        ""authors"": ""NuGet"",
+                        ""dependencyGroups"": [],
+                        ""description"": ""NuGet's implementation of Semantic Versioning."",
+                        ""iconUrl"": """",
+                        ""id"": ""NuGet.Versioning"",
+                        ""language"": """",
+                        ""licenseUrl"": ""https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"",
+                        ""listed"": true,
+                        ""minClientVersion"": """",
+                        ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.3.5.0.nupkg"",
+                        ""projectUrl"": ""https://github.com/NuGet/NuGet.Client"",
+                        ""published"": ""2016-12-14T23:48:25.08+00:00"",
+                        ""requireLicenseAcceptance"": false,
+                        ""summary"": """",
+                        ""tags"": [
+                            ""semver"",
+                            ""semantic"",
+                            ""versioning""
+                        ],
+                        ""title"": """",
+                        ""version"": ""3.5.0""
+                    },
+                    ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.3.5.0.nupkg"",
+                    ""registration"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json""
+                },
+                {
+                    ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/4.0.0-rc-2048.json"",
+                    ""@type"": ""Package"",
+                    ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+                    ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+                    ""catalogEntry"": {
+                        ""@id"": ""https://api.nuget.org/v3/catalog0/data/2016.11.16.18.59.35/nuget.versioning.4.0.0-rc-2048.json"",
+                        ""@type"": ""PackageDetails"",
+                        ""authors"": ""NuGet"",
+                        ""dependencyGroups"": [],
+                        ""description"": ""NuGet's implementation of Semantic Versioning."",
+                        ""iconUrl"": """",
+                        ""id"": ""NuGet.Versioning"",
+                        ""language"": """",
+                        ""licenseUrl"": ""https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"",
+                        ""listed"": true,
+                        ""minClientVersion"": """",
+                        ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.4.0.0-rc-2048.nupkg"",
+                        ""projectUrl"": ""https://github.com/NuGet/NuGet.Client"",
+                        ""published"": ""2016-11-16T18:59:24.227+00:00"",
+                        ""requireLicenseAcceptance"": false,
+                        ""summary"": """",
+                        ""tags"": [
+                            ""semantic"",
+                            ""versioning"",
+                            ""semver""
+                        ],
+                        ""title"": """",
+                        ""version"": ""4.0.0-rc-2048""
+                    },
+                    ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.4.0.0-rc-2048.nupkg"",
+                    ""registration"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json""
+                },
+                {
+                    ""@id"": ""https://api.nuget.org/v3/registration0/nuget.versioning/4.0.0-rc2.json"",
+                    ""@type"": ""Package"",
+                    ""commitId"": ""02aed777-4081-43c1-8959-28892d2f3230"",
+                    ""commitTimeStamp"": ""2016-12-14T23:51:22.0976604Z"",
+                    ""catalogEntry"": {
+                        ""@id"": ""https://api.nuget.org/v3/catalog0/data/2016.12.14.00.55.36/nuget.versioning.4.0.0-rc2.json"",
+                        ""@type"": ""PackageDetails"",
+                        ""authors"": ""NuGet"",
+                        ""dependencyGroups"": [],
+                        ""description"": ""NuGet's implementation of Semantic Versioning."",
+                        ""iconUrl"": """",
+                        ""id"": ""NuGet.Versioning"",
+                        ""language"": """",
+                        ""licenseUrl"": ""https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt"",
+                        ""listed"": true,
+                        ""minClientVersion"": """",
+                        ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.4.0.0-rc2.nupkg"",
+                        ""projectUrl"": ""https://github.com/NuGet/NuGet.Client"",
+                        ""published"": ""2016-12-14T00:55:27.807+00:00"",
+                        ""requireLicenseAcceptance"": false,
+                        ""summary"": """",
+                        ""tags"": [
+                            ""semver"",
+                            ""semantic"",
+                            ""versioning""
+                        ],
+                        ""title"": """",
+                        ""version"": ""4.0.0-rc2""
+                    },
+                    ""packageContent"": ""https://api.nuget.org/packages/nuget.versioning.4.0.0-rc2.nupkg"",
+                    ""registration"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json""
+                }
+            ],
+            ""parent"": ""https://api.nuget.org/v3/registration0/nuget.versioning/index.json"",
+            ""lower"": ""0.1.0-alpha"",
+            ""upper"": ""4.0.0-rc2""
+        }
+    ]
+}";
+
+        public const string VersionAutoCompleteV2Example = @"[
+                ""3.5.0"",
+                ""3.5.0-rc1-final"",
+                ""4.0.0-rc2"",
+                ""4.0.0-rc-2048""
+            ]";
+        
         public const string IndexJson = @"{
  ""version"": ""3.0.0-beta.1"",
  ""resources"": [
@@ -161,8 +345,5 @@ namespace NuGet.Protocol.VisualStudio.Tests
   ""@vocab"": ""https://schema.nuget.org/services#""
  }
 }";
-
-        #endregion
-
     }
 }


### PR DESCRIPTION
This implements [SemVer 2.0.0 Protocol](https://github.com/NuGet/Home/wiki/Semver-2.0.0-Protocol) in the client. In addition to the reviewed endpoints, I've added the autocomplete endpoints, which were overlooked in the initial design.

Registration blob SemVer 2.0.0 protocol support is already implemented by PR https://github.com/NuGet/NuGet.Client/pull/1094.

The basis of the design is that clients must opt-in to see SemVer 2.0.0 packages.

/cc @emgarten @alpaix @dtivel @skofman1 @rrelyea 