### PR TITLE
Remove duplicate mutli-targeting imports

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -415,6 +415,10 @@ namespace NuGet.Commands
             var props = new List<MSBuildRestoreItemGroup>();
             var targets = new List<MSBuildRestoreItemGroup>();
 
+            // MultiTargeting imports are shared between TFMs, to avoid
+            // duplicate import warnings only add each once.
+            var multiTargetingImportsAdded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
             // Skip runtime graphs, msbuild targets may not come from RID specific packages.
             var ridlessTargets = assetsFile.Targets
                 .Where(e => string.IsNullOrEmpty(e.RuntimeIdentifier));
@@ -497,6 +501,7 @@ namespace NuGet.Commands
                         pkg.Key.BuildMultiTargeting.WithExtension(TargetsExtension)
                             .Where(e => pkg.Value.Exists())
                             .Select(e => pkg.Value.GetAbsolutePath(e)))
+                            .Where(path => multiTargetingImportsAdded.Add(path))
                             .Select(path => GetPathWithMacros(path, repositoryRoot))
                             .Select(GenerateImport));
 
@@ -511,6 +516,7 @@ namespace NuGet.Commands
                         pkg.Key.BuildMultiTargeting.WithExtension(PropsExtension)
                             .Where(e => pkg.Value.Exists())
                             .Select(e => pkg.Value.GetAbsolutePath(e)))
+                            .Where(path => multiTargetingImportsAdded.Add(path))
                             .Select(path => GetPathWithMacros(path, repositoryRoot))
                             .Select(GenerateImport));
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1197,6 +1197,56 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task RestoreNetCore_VerifyBuildCrossTargeting_VerifyNoDuplicateImports()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"),
+                    NuGetFramework.Parse("net46"));
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                packageX.AddFile("buildCrossTargeting/x.targets");
+                packageX.AddFile("lib/net45/test.dll");
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                // Assert
+                Assert.True(File.Exists(projectA.TargetsOutput), r.Item2);
+
+                var targetsXML = XDocument.Parse(File.ReadAllText(projectA.TargetsOutput));
+                var targetItemGroups = targetsXML.Root.Elements().Where(e => e.Name.LocalName == "ImportGroup").ToList();
+
+                Assert.Equal(1, targetItemGroups.Count);
+                Assert.Equal("'$(TargetFramework)' == '' AND '$(ExcludeRestorePackageImports)' != 'true'", targetItemGroups[0].Attribute(XName.Get("Condition")).Value.Trim());
+                Assert.Equal(1, targetItemGroups[0].Elements().Count());
+                Assert.EndsWith("x.targets", targetItemGroups[0].Elements().ToList()[0].Attribute(XName.Get("Project")).Value);
+            }
+        }
+
+        [Fact]
         public async Task RestoreNetCore_VerifyBuildCrossTargeting_VerifyImportIsNotAddedForUAP()
         {
             // Arrange


### PR DESCRIPTION
Multi targeting imports are outside of the framework condition and should only be added once to the targets/props files.

Fixes https://github.com/NuGet/Home/issues/4283

//cc @alpaix @jainaashish @mishra14 @rohit21agrawal @zhili1208 @rrelyea @nkolev92 