### PR TITLE
Moving from Shell JTF to NuGetUIThreadHelper

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -68,9 +68,9 @@ namespace NuGet.SolutionRestoreManager
             // Lazy load the CPS enabled JoinableTaskFactory for the UI.
             NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(componentModel);
 
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var dte = (EnvDTE.DTE)await GetServiceAsync(typeof(SDTE));
                 _buildEvents = dte.Events.BuildEvents;
                 _buildEvents.OnBuildBegin += BuildEvents_OnBuildBegin;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -85,9 +85,9 @@ namespace NuGet.SolutionRestoreManager
             _progressFactory = t => StatusBarProgress.StartAsync(_serviceProvider, t);
 #endif
 
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 OutputVerbosity = GetMSBuildOutputVerbositySetting();
 
@@ -352,9 +352,9 @@ namespace NuGet.SolutionRestoreManager
             // capture current progress from the current execution context
             var progress = RestoreOperationProgressUI.Current;
 
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 action(this, progress);
             });
         }
@@ -368,9 +368,9 @@ namespace NuGet.SolutionRestoreManager
             // capture current progress from the current execution context
             var progress = RestoreOperationProgressUI.Current;
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 action(this, progress);
             });
         }
@@ -432,9 +432,9 @@ namespace NuGet.SolutionRestoreManager
 
             public static async Task<RestoreOperationProgressUI> StartAsync(IServiceProvider serviceProvider, CancellationToken token)
             {
-                return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var waitDialogFactory = serviceProvider.GetService<
                         SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>();
@@ -455,9 +455,9 @@ namespace NuGet.SolutionRestoreManager
 
             public override void Dispose()
             {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     _session.Dispose();
                 });
             }
@@ -497,9 +497,9 @@ namespace NuGet.SolutionRestoreManager
                 IServiceProvider serviceProvider,
                 CancellationToken token)
             {
-                return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+                return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var statusBar = serviceProvider.GetService<SVsStatusbar, IVsStatusbar>();
 
@@ -523,9 +523,9 @@ namespace NuGet.SolutionRestoreManager
 
             public override void Dispose()
             {
-                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     StatusBar.Animation(0, ref icon);
                     StatusBar.Progress(ref cookie, 0, "", 0, 0);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -117,9 +117,9 @@ namespace NuGet.SolutionRestoreManager
 
         private void BeforeQueryStatusForPackageRestore(object sender, EventArgs args)
         {
-            ThreadHelper.JoinableTaskFactory.Run((Func<Task>)async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run((Func<Task>)async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 OleMenuCommand command = (OleMenuCommand)sender;
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -549,9 +549,9 @@ namespace NuGet.SolutionRestoreManager
 
         private async Task<bool> CheckPackagesConfigAsync()
         {
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var dte = _serviceProvider.GetDTE();
                 var projects = dte.Solution.Projects;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -47,7 +47,7 @@ namespace NuGet.SolutionRestoreManager
         private readonly JoinableTaskCollection _joinableCollection;
         private readonly JoinableTaskFactory _joinableFactory;
 
-        private ErrorListProvider ErrorListProvider => ThreadHelper.JoinableTaskFactory.Run(_errorListProvider.GetValueAsync);
+        private ErrorListProvider ErrorListProvider => NuGetUIThreadHelper.JoinableTaskFactory.Run(_errorListProvider.GetValueAsync);
 
         public Task<bool> CurrentRestoreOperation => _activeRestoreTask;
 
@@ -93,14 +93,14 @@ namespace NuGet.SolutionRestoreManager
 
             _errorListProvider = new AsyncLazy<ErrorListProvider>(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return new ErrorListProvider(serviceProvider);
                 },
                 _joinableFactory);
 
             _componentModel = new AsyncLazy<IComponentModel>(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return serviceProvider.GetService<SComponentModel, IComponentModel>();
                 },
                 _joinableFactory);
@@ -114,7 +114,7 @@ namespace NuGet.SolutionRestoreManager
             {
                 await _joinableFactory.RunAsync(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var dte = _serviceProvider.GetDTE();
                     _solutionEvents = dte.Events.SolutionEvents;
@@ -134,7 +134,7 @@ namespace NuGet.SolutionRestoreManager
 
             _joinableFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _solutionEvents.AfterClosing -= SolutionEvents_AfterClosing;
 #if VS15

--- a/src/NuGet.Clients/NuGet.Tools/Handlers/ProjectRetargetingHandler.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Handlers/ProjectRetargetingHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.PackageManagement;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 
@@ -96,9 +97,9 @@ namespace NuGetVSExtension
 
         private void SolutionEvents_AfterClosing()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _errorListProvider.Tasks.Clear();
             });
@@ -109,9 +110,9 @@ namespace NuGetVSExtension
             // Clear the error list upon the first build action
             // Note that the retargeting error message is shown on the errorlistprovider this class creates
             // Hence, explicit clearing of the error list is required
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _errorListProvider.Tasks.Clear();
 
@@ -154,9 +155,9 @@ namespace NuGetVSExtension
         #region IVsTrackProjectRetargetingEvents
         int IVsTrackProjectRetargetingEvents.OnRetargetingAfterChange(string projRef, IVsHierarchy pAfterChangeHier, string fromTargetFramework, string toTargetFramework)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _errorListProvider.Tasks.Clear();
                 var project = VsHierarchyUtility.GetProjectFromHierarchy(pAfterChangeHier);
@@ -202,9 +203,9 @@ namespace NuGetVSExtension
         #region IVsTrackBatchRetargetingEvents
         int IVsTrackBatchRetargetingEvents.OnBatchRetargetingBegin()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var project = EnvDTEProjectUtility.GetActiveProject(_vsMonitorSelection);
 
@@ -224,9 +225,9 @@ namespace NuGetVSExtension
 
         int IVsTrackBatchRetargetingEvents.OnBatchRetargetingEnd()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _errorListProvider.Tasks.Clear();
                 if (_platformRetargetingProject != null)

--- a/src/NuGet.Clients/NuGet.Tools/Handlers/ProjectUpgradeHandler.cs
+++ b/src/NuGet.Clients/NuGet.Tools/Handlers/ProjectUpgradeHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.PackageManagement;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging.Core;
 
@@ -57,9 +58,9 @@ namespace NuGetVSExtension
         #region IVsSolutionEventsProjectUpgrade
         int IVsSolutionEventsProjectUpgrade.OnAfterUpgradeProject(IVsHierarchy pHierarchy, uint fUpgradeFlag, string bstrCopyLocation, SYSTEMTIME stUpgradeTime, IVsUpgradeLogger pLogger)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 Debug.Assert(pHierarchy != null);
 

--- a/src/NuGet.Clients/NuGet.Tools/InteractiveLoginProvider.cs
+++ b/src/NuGet.Clients/NuGet.Tools/InteractiveLoginProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Services.Client.AccountManagement;
 using Microsoft.VisualStudio.Services.DelegatedAuthorization.Client;
 using Microsoft.VisualStudio.Services.WebApi;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 
 namespace NuGetVSExtension
@@ -48,9 +49,9 @@ namespace NuGetVSExtension
             }
             Account account = null;
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var parent = IntPtr.Zero;
                 if (_dte != null)
                 {
@@ -88,9 +89,9 @@ namespace NuGetVSExtension
             // need to reverse the flag
             var shouldPrompt = !nonInteractive;
             AuthenticationResult result = null;
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var parent = IntPtr.Zero;
                 if (_dte != null)

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -571,7 +571,7 @@ namespace NuGetVSExtension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 string parameterString = null;
                 OleMenuCmdEventArgs args = e as OleMenuCmdEventArgs;
@@ -763,7 +763,7 @@ namespace NuGetVSExtension
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 var windowFrame = await FindExistingSolutionWindowFrameAsync();
                 if (windowFrame == null)
@@ -817,9 +817,9 @@ namespace NuGetVSExtension
 
         private void BeforeQueryStatusForAddPackageDialog(object sender, EventArgs args)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 OleMenuCommand command = (OleMenuCommand)sender;
 
@@ -840,9 +840,9 @@ namespace NuGetVSExtension
 
         private void BeforeQueryStatusForAddPackageForSolutionDialog(object sender, EventArgs args)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 OleMenuCommand command = (OleMenuCommand)sender;
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetSearchTask.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetSearchTask.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.PackageManagement.UI;
 
 namespace NuGetVSExtension
 {
@@ -61,9 +62,9 @@ namespace NuGetVSExtension
 
         public void Start()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 SetStatus(VsSearchTaskStatus.Started);
 

--- a/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
+++ b/src/NuGet.Clients/NuGet.Tools/OutputConsoleLogger.cs
@@ -51,9 +51,9 @@ namespace NuGetVSExtension
                 throw new ArgumentNullException(nameof(consoleProvider));
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 ErrorListProvider = new ErrorListProvider(serviceProvider);
 
@@ -71,9 +71,9 @@ namespace NuGetVSExtension
 
         public void Dispose()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 ErrorListProvider.Dispose();
             });
@@ -81,9 +81,9 @@ namespace NuGetVSExtension
 
         public void End()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 OutputConsole.WriteLine(Resources.Finished);
                 OutputConsole.WriteLine(string.Empty);
@@ -126,9 +126,9 @@ namespace NuGetVSExtension
 
         public void Start()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _verbosityLevel = GetMSBuildVerbosityLevel();
                 ErrorListProvider.Tasks.Clear();
@@ -163,9 +163,9 @@ namespace NuGetVSExtension
             else
             {
                 // Run in JTF
-                ThreadHelper.JoinableTaskFactory.Run(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     action();
                 });

--- a/src/NuGet.Clients/NuGet.Tools/VisualStudioCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Tools/VisualStudioCredentialProvider.cs
@@ -5,10 +5,10 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Configuration;
 using NuGet.Credentials;
+using NuGet.PackageManagement.UI;
 using WebProxy = System.Net.WebProxy;
 
 namespace NuGetVSExtension
@@ -24,7 +24,7 @@ namespace NuGetVSExtension
                 throw new ArgumentNullException(nameof(webProxyService));
             }
             _webProxyService = webProxyService;
-            Id = $"{typeof (VisualStudioCredentialProvider).Name}_{Guid.NewGuid()}";
+            Id = $"{typeof(VisualStudioCredentialProvider).Name}_{Guid.NewGuid()}";
         }
 
         /// <summary>
@@ -112,9 +112,9 @@ namespace NuGetVSExtension
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
                 result = _webProxyService.PrepareWebProxy(uri.OriginalString,
                     (uint)oldState,

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/DeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/DeferredProjectWorkspaceService.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Workspace;
 using Microsoft.VisualStudio.Workspace.Extensions.MSBuild;
 using Microsoft.VisualStudio.Workspace.Indexing;
 using Microsoft.VisualStudio.Workspace.VSIntegration;
+using NuGet.PackageManagement.UI;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -21,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         private readonly AsyncLazy<IVsSolutionWorkspaceService> _solutionWorkspaceService;
 
-        private IVsSolutionWorkspaceService SolutionWorkspaceService => ThreadHelper.JoinableTaskFactory.Run(_solutionWorkspaceService.GetValueAsync);
+        private IVsSolutionWorkspaceService SolutionWorkspaceService => NuGetUIThreadHelper.JoinableTaskFactory.Run(_solutionWorkspaceService.GetValueAsync);
 
         [ImportingConstructor]
         public DeferredProjectWorkspaceService(
@@ -35,7 +36,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _solutionWorkspaceService = new AsyncLazy<IVsSolutionWorkspaceService>(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 return (IVsSolutionWorkspaceService)serviceProvider.GetService(typeof(SVsSolutionWorkspaceService));
             });
         }
@@ -58,9 +59,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public async Task<IMSBuildProjectDataService> GetMSBuildProjectDataService(string projectFilePath, string targetFramework = "")
         {
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var factory = SolutionWorkspaceService.GetService(typeof(IVsSolutionMSBuildProjectServiceFactory)) as IVsSolutionMSBuildProjectServiceFactory;
 
                 if (factory == null)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -37,7 +38,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // This is a solution event. Should be on the UI thread
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
                     // is showing and the user closes the solution; in that case, we want to hide the Update bar.
@@ -51,7 +52,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // This is a solution event. Should be on the UI thread
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     var solutionDirectory = SolutionManager.SolutionDirectory;
                     await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -129,9 +129,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private async Task InitializeAsync()
         {
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _vsSolution = _serviceProvider.GetService<SVsSolution, IVsSolution>();
                 _vsMonitorSelection = _serviceProvider.GetService<SVsShellMonitorSelection, IVsMonitorSelection>();
@@ -192,9 +192,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
             RemoveEnvDTEProjectFromCache(projectName);
 
-            var nuGetProject = await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            var nuGetProject = await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var settings = ServiceLocator.GetInstance<ISettings>();
 
@@ -290,9 +290,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public void SaveProject(NuGetProject nuGetProject)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var safeName = GetNuGetProjectSafeName(nuGetProject);
                 EnvDTEProjectUtility.Save(GetDTEProject(safeName));
             });
@@ -317,9 +317,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var dte = _serviceProvider.GetDTE();
                     return dte != null &&
@@ -333,9 +333,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     if (!IsSolutionOpen)
                     {
@@ -376,9 +376,9 @@ namespace NuGet.PackageManagement.VisualStudio
             // Not applicable for Dev14 so always return empty list.
             return await Task.FromResult(Enumerable.Empty<string>());
 #else
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var projectPaths = new List<string>();
                 IEnumHierarchies enumHierarchies;
@@ -416,9 +416,9 @@ namespace NuGet.PackageManagement.VisualStudio
             // for Dev14 always return false since DPL not exists there.
             return await Task.FromResult(false);
 #else
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // check if solution is DPL enabled or not. 
                 if (!IsSolutionDPLEnabled)
@@ -441,9 +441,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 // for Dev14 always return false since DPL not exists there.
                 return false;
 #else
-                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     EnsureInitialize();
                     var vsSolution7 = _vsSolution as IVsSolution7;
@@ -463,9 +463,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             get
             {
-                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     EnsureInitialize();
                     var value = GetVSSolutionProperty((int)(__VSPROPID4.VSPROPID_IsSolutionFullyLoaded));
@@ -476,9 +476,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public void EnsureSolutionIsLoaded()
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 EnsureInitialize();
                 var vsSolution4 = _vsSolution as IVsSolution4;
@@ -500,7 +500,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     return null;
                 }
 
-                return ThreadHelper.JoinableTaskFactory.Run(async delegate
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     string solutionFilePath = await GetSolutionFilePathAsync();
 
@@ -515,7 +515,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private async Task<string> GetSolutionFilePathAsync()
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // Use .Properties.Item("Path") instead of .FullName because .FullName might not be
             // available if the solution is just being created
@@ -644,9 +644,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 OnBeforeClosing();
 
-                ThreadHelper.JoinableTaskFactory.Run(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     OnSolutionExistsAndFullyLoaded();
                 });
             }
@@ -871,9 +871,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     _initialized = true;
 
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                         await InitializeAsync();
 
@@ -891,9 +891,9 @@ namespace NuGet.PackageManagement.VisualStudio
                     // the solution was not saved and/or there were no projects in the solution
                     if (!_cacheInitialized && _solutionOpenedRaised)
                     {
-                        ThreadHelper.JoinableTaskFactory.Run(async delegate
+                        NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
-                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                             EnsureNuGetAndEnvDTEProjectCache();
                         });
                     }
@@ -967,7 +967,7 @@ namespace NuGet.PackageManagement.VisualStudio
             // if A has a project reference to B (A -> B) the this will return B -> A
             // We need to run this on the ui thread so that it doesn't freeze for websites. Since there might be a
             // large number of references.
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             EnsureInitialize();
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VsCommonOperations.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VsCommonOperations.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.IO;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -34,9 +35,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(fullPath));
             }
 
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     if (_dte.ItemOperations != null
                         && File.Exists(fullPath))
@@ -56,9 +57,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(solutionManager));
             }
 
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _expandedNodes = await VsHierarchyUtility.GetAllExpandedNodesAsync(solutionManager);
 
@@ -73,9 +74,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(solutionManager));
             }
 
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 await VsHierarchyUtility.CollapseAllNodesAsync(solutionManager, _expandedNodes);
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsProjectSystem.cs
@@ -4,11 +4,10 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using EnvDTEProject = EnvDTE.Project;
-using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
 using ProjectSystem = NuGet.VisualStudio.Facade.ProjectSystem;
-using NuGet.PackageManagement.UI;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -34,7 +33,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var root = EnvDTEProjectUtility.GetFullPath(EnvDTEProject);
                     string relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(root), targetFullPath);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/FSharpProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/FSharpProjectSystem.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using VSLangProj;
 using EnvDTEProject = EnvDTE.Project;
@@ -50,9 +51,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override bool FileExistsInProject(string path)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     EnvDTEProjectItem projectItem = await EnvDTEProjectUtility.GetProjectItemAsync(EnvDTEProject, path);
                     return (projectItem != null);
@@ -68,9 +69,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="name"></param>
         public override void RemoveReference(string name)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     RemoveReferenceCore(name, EnvDTEProjectUtility.GetReferences(EnvDTEProject));
                 });

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/JsProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/JsProjectSystem.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using EnvDTEProject = EnvDTE.Project;
 using EnvDTEProjectItems = EnvDTE.ProjectItems;
@@ -28,9 +29,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (String.IsNullOrEmpty(_projectName))
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
-                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                             _projectName = EnvDTEProjectUtility.GetName(EnvDTEProject);
                         });
@@ -47,9 +48,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     await EnvDTEProjectUtility.GetProjectItemsAsync(EnvDTEProject, Path.GetDirectoryName(path), createIfNotExists: true);
                     base.AddFile(path, stream);
@@ -64,9 +65,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     await EnvDTEProjectUtility.GetProjectItemsAsync(EnvDTEProject, Path.GetDirectoryName(path), createIfNotExists: true);
                     base.AddFile(path, writeToStream);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio.Shell;
 using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.PackageManagement.UI;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -142,9 +143,9 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var success = false;
 
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // We don't adjust package reference metadata from UI
                 _project.AddOrUpdateLegacyCSProjPackage(
@@ -162,9 +163,9 @@ namespace NuGet.PackageManagement.VisualStudio
         public override async Task<Boolean> UninstallPackageAsync(PackageIdentity packageIdentity, INuGetProjectContext nuGetProjectContext, CancellationToken token)
         {
             var success = false;
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 _project.RemoveLegacyCSProjPackage(packageIdentity.Id);
 
@@ -409,9 +410,9 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             T result = default(T);
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async delegate
+            await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 result = uiThreadFunction();
             });

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/NativeProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/NativeProjectSystem.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.IO;
-using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using EnvDTEProject = EnvDTE.Project;
 using Task = System.Threading.Tasks.Task;
@@ -29,11 +29,10 @@ namespace NuGet.PackageManagement.VisualStudio
                 return;
             }
 
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             // Get the project items for the folder path
             string folderPath = Path.GetDirectoryName(path);
             string fullPath = FileSystemUtility.GetFullPath(ProjectFullPath, path);
-            ;
 
             VCProjectHelper.AddFileToProject(EnvDTEProject.Object, fullPath, folderPath);
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.UI;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using Constants = NuGet.ProjectManagement.Constants;
@@ -88,9 +89,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (string.IsNullOrEmpty(_projectFullPath))
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         _projectFullPath = EnvDTEProjectUtility.GetFullPath(EnvDTEProject);
                     });
                 }
@@ -110,9 +111,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (string.IsNullOrEmpty(_projectFileFullPath))
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                         _projectFileFullPath = EnvDTEProjectUtility.GetFullProjectPath(EnvDTEProject);
                     });
@@ -130,9 +131,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (String.IsNullOrEmpty(_projectName))
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                     {
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                         _projectName = EnvDTEProject.Name;
                     });
                 }
@@ -148,9 +149,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (String.IsNullOrEmpty(_projectCustomUniqueName))
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
-                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                             _projectCustomUniqueName = EnvDTEProjectUtility.GetCustomUniqueName(EnvDTEProject);
                         });
                 }
@@ -167,9 +168,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 if (_targetFramework == null)
                 {
-                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                         {
-                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                             _targetFramework = EnvDTEProjectUtility.GetTargetNuGetFramework(EnvDTEProject);
                         });
                 }
@@ -185,9 +186,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual void AddFile(string path, Stream stream)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 await AddFileCoreAsync(path, () => FileSystemUtility.AddFile(ProjectFullPath, path, stream, NuGetProjectContext));
             });
@@ -195,9 +196,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual void AddFile(string path, Action<Stream> writeToStream)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 await AddFileCoreAsync(path, () => FileSystemUtility.AddFile(ProjectFullPath, path, writeToStream, NuGetProjectContext));
             });
@@ -251,9 +252,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(String.Format(CultureInfo.CurrentCulture, Strings.PathToExistingFileNotPresent, fullPath, ProjectName));
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 await AddFileCoreAsync(path, () => { });
             });
@@ -306,9 +307,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public void AddFrameworkReference(string name, string packageId)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 try
                 {
@@ -351,9 +352,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, "targetPath");
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 string relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(ProjectFullPath), targetFullPath);
                 EnvDTEProjectUtility.AddImportStatement(EnvDTEProject, relativeTargetPath, location);
@@ -383,9 +384,9 @@ namespace NuGet.PackageManagement.VisualStudio
             try
             {
                 // Perform all DTE operations on the UI thread
-                ThreadHelper.JoinableTaskFactory.Run(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     // Read DTE properties from the UI thread
                     projectFullPath = ProjectFullPath;
@@ -452,9 +453,9 @@ namespace NuGet.PackageManagement.VisualStudio
                             FileSystemUtility.MakeWritable(dteProjectFullName);
 
                             // Change to the UI thread to save
-                            ThreadHelper.JoinableTaskFactory.Run(async delegate
+                            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                             {
-                                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                                 // Save the project after we've modified it.
                                 EnvDTEProject.Save();
@@ -483,7 +484,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             NuGetProjectContext.Log(
                 ProjectManagement.MessageLevel.Debug,
-                $"Added reference '{name}' to project:'{projectName}'. Was the Reference Resolved To Package (resolvedToPackage):'{resolvedToPackage}', "+
+                $"Added reference '{name}' to project:'{projectName}'. Was the Reference Resolved To Package (resolvedToPackage):'{resolvedToPackage}', " +
                 "where Reference Path from DTE(dteOriginalPath):'{dteOriginalPath}' and Reference Path from package reference(assemblyFullPath):'{assemblyFullPath}'.");
         }
 
@@ -522,9 +523,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual void RemoveFile(string path)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var deleteProjectItem = await EnvDTEProjectUtility.DeleteProjectItemAsync(EnvDTEProject, path);
                 if (deleteProjectItem)
@@ -544,9 +545,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual bool ReferenceExists(string name)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 try
                 {
@@ -573,9 +574,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(CommonResources.Argument_Cannot_Be_Null_Or_Empty, "targetPath");
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 string relativeTargetPath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(ProjectFullPath), targetFullPath);
                 EnvDTEProjectUtility.RemoveImportStatement(EnvDTEProject, relativeTargetPath);
@@ -589,9 +590,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual void RemoveReference(string name)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 try
                 {
@@ -696,9 +697,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual bool FileExistsInProject(string path)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var containsFile = await EnvDTEProjectUtility.ContainsFile(EnvDTEProject, path);
                     return containsFile;
@@ -707,9 +708,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual dynamic GetPropertyValue(string propertyName)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 try
                 {
@@ -803,11 +804,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
             if (!behavior.IsSkipped)
             {
-                ThreadHelper.JoinableTaskFactory.Run(async delegate
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     try
                     {
-                        await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                         InitForBindingRedirects();
                         if (IsBindingRedirectSupported && VSSolutionManager != null)
@@ -891,9 +892,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 return;
             }
 
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // Workaround for TFS update issue. If we're bound to TFS, do not try and delete directories.
                 if (SourceControlUtility.GetSourceControlManager(NuGetProjectContext) == null)
@@ -914,9 +915,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new NotSupportedException();
             }
 
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var childItems = await EnvDTEProjectUtility.GetChildItems(EnvDTEProject, path, filter, NuGetVSConstants.VsProjectItemKindPhysicalFile);
                 // Get all physical files
@@ -934,9 +935,9 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <returns>The list of full paths.</returns>
         public IEnumerable<string> GetFullPaths(string fileName)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var paths = new List<string>();
                 var projectItemsQueue = new Queue<EnvDTEProjectItems>();
@@ -966,9 +967,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public virtual IEnumerable<string> GetDirectories(string path)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var childItems = await EnvDTEProjectUtility.GetChildItems(EnvDTEProject, path, "*.*", NuGetVSConstants.VsProjectItemKindPhysicalFolder);
                 // Get all physical folders

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using VsWebSite;
 using EnvDTEProject = EnvDTE.Project;
@@ -33,9 +34,9 @@ namespace NuGet.PackageManagement.VisualStudio
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to catch all exceptions")]
         public override void AddReference(string referencePath)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     string name = Path.GetFileNameWithoutExtension(referencePath);
                     try
@@ -64,9 +65,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public override void RemoveReference(string name)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     // Remove the reference via DTE.
                     RemoveDTEReference(name);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/VSSourceControlManagerProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/VSSourceControlManagerProvider.cs
@@ -8,6 +8,7 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -44,9 +45,9 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public SourceControlManager GetSourceControlManager()
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     if (_dte != null
                         && _dte.SourceControl != null)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -21,6 +21,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using VSLangProj;
 using VSLangProj80;
@@ -503,12 +504,12 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </remarks>
         public static string GetCustomUniqueName(EnvDTEProject envDTEProject)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate { return await GetCustomUniqueNameAsync(envDTEProject); });
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate { return await GetCustomUniqueNameAsync(envDTEProject); });
         }
 
         public static async Task<string> GetCustomUniqueNameAsync(EnvDTEProject envDTEProject)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             if (IsWebSite(envDTEProject))
             {
@@ -800,7 +801,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static async Task<bool> IncludeExistingFolderToProjectAsync(EnvDTEProject envDTEProject, string folderRelativePath)
         {
             // Execute command to include the existing folder into project. Must do this on UI thread.
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             IVsUIHierarchy projectHierarchy = (IVsUIHierarchy)VsHierarchyUtility.ToVsHierarchy(envDTEProject);
 
@@ -1339,9 +1340,9 @@ namespace NuGet.PackageManagement.VisualStudio
                 throw new ArgumentNullException(nameof(project));
             }
 
-            return ThreadHelper.JoinableTaskFactory.Run(async () =>
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // Get the vs solution
                 IVsSolution solution = ServiceLocator.GetInstance<IVsSolution>();

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -18,7 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// </summary>
         public static IEnumerable<EnvDTE.Project> GetAllEnvDTEProjects(EnvDTE.DTE dte)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     var result = await GetAllEnvDTEProjectsAsync(dte);
                     return result;
@@ -27,7 +28,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public static async Task<IEnumerable<EnvDTE.Project>> GetAllEnvDTEProjectsAsync(EnvDTE.DTE dte)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var envDTESolution = dte.Solution;
             if (envDTESolution == null

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RuntimeHelpers.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RuntimeHelpers.cs
@@ -13,6 +13,7 @@ using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using EnvDTEProject = EnvDTE.Project;
 using Task = System.Threading.Tasks.Task;
@@ -32,7 +33,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             try
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // Keep track of visited projects
                 if (EnvDTEProjectUtility.SupportsBindingRedirects(envDTEProject))
@@ -114,7 +115,7 @@ namespace NuGet.PackageManagement.VisualStudio
             INuGetProjectContext nuGetProjectContext)
         {
             // Run this on the UI thread since it enumerates all references
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var redirects = Enumerable.Empty<AssemblyBinding>();
             var msBuildNuGetProjectSystem = GetMSBuildNuGetProjectSystem(solutionManager, envDTEProject);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSProjectRestoreReferenceUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VSProjectRestoreReferenceUtility.cs
@@ -5,13 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Common;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectModel;
 using VSLangProj;
 using VSLangProj80;
@@ -29,10 +28,10 @@ namespace NuGet.PackageManagement.VisualStudio
             IEnumerable<string> resolvedProjects,
             ILogger log)
         {
-            return await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            return await NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 // DTE calls need to be done from the main thread
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var results = new List<ProjectRestoreReference>();
 
@@ -51,7 +50,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                         // check if deferred projects resolved this reference, which means this is still not loaded so simply continue
                         // We'll get this reference from deferred projects later
-                        if (reference3 != null && 
+                        if (reference3 != null &&
                         resolvedProjects.Contains(reference3.Name, StringComparer.OrdinalIgnoreCase))
                         {
                             continue;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -9,6 +9,7 @@ using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 using TaskExpandedNodes = System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, System.Collections.Generic.ISet<NuGet.PackageManagement.VisualStudio.VsHierarchyItem>>>;
 
@@ -61,7 +62,7 @@ namespace NuGet.PackageManagement.VisualStudio
             return output;
         }
 
-public static VsHierarchyItem GetHierarchyItemForProject(Project project)
+        public static VsHierarchyItem GetHierarchyItemForProject(Project project)
         {
             Debug.Assert(ThreadHelper.CheckAccess());
 
@@ -133,7 +134,7 @@ public static VsHierarchyItem GetHierarchyItemForProject(Project project)
         public static async TaskExpandedNodes GetAllExpandedNodesAsync(ISolutionManager solutionManager)
         {
             // this operation needs to execute on UI thread
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dte = ServiceLocator.GetInstance<DTE>();
             var projects = dte.Solution.Projects;
@@ -154,7 +155,7 @@ public static VsHierarchyItem GetHierarchyItemForProject(Project project)
         public static async Task CollapseAllNodesAsync(ISolutionManager solutionManager, IDictionary<string, ISet<VsHierarchyItem>> ignoreNodes)
         {
             // this operation needs to execute on UI thread
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var dte = ServiceLocator.GetInstance<DTE>();
             var projects = dte.Solution.Projects;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/VSMachineWideSettings.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/VSMachineWideSettings.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.UI;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
@@ -27,7 +28,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _settings = new AsyncLazy<Configuration.Settings[]>(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                     var baseDirectory = Common.NuGetEnvironment.GetFolderPath(
                         Common.NuGetFolderPath.MachineWideConfigDirectory);
@@ -43,6 +44,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 ThreadHelper.JoinableTaskFactory);
         }
 
-        public IEnumerable<Configuration.Settings> Settings => ThreadHelper.JoinableTaskFactory.Run(_settings.GetValueAsync);
+        public IEnumerable<Configuration.Settings> Settings => NuGetUIThreadHelper.JoinableTaskFactory.Run(_settings.GetValueAsync);
     }
 }

--- a/src/NuGet.Clients/VsConsole/Console/Console/ConsoleDispatcher.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Console/ConsoleDispatcher.cs
@@ -13,6 +13,7 @@ using System.Windows.Media;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using NuGet.Common;
+using NuGet.PackageManagement.UI;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole.Implementation.Console
@@ -140,9 +141,9 @@ namespace NuGetConsole.Implementation.Console
 
         private void RaiseEventSafe(EventHandler handler)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     if (handler != null)
                     {
                         handler(this, EventArgs.Empty);
@@ -195,9 +196,9 @@ namespace NuGetConsole.Implementation.Console
                         ).ContinueWith(
                             task =>
                                 {
-                                    ThreadHelper.JoinableTaskFactory.Run(async delegate
+                                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                                         {
-                                            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                                            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                                             if (task.IsFaulted)
                                             {

--- a/src/NuGet.Clients/VsConsole/Console/NuGet.Console.csproj
+++ b/src/NuGet.Clients/VsConsole/Console/NuGet.Console.csproj
@@ -117,6 +117,10 @@
       <Project>{306cddfa-ff0b-4299-930c-9ec6c9308160}</Project>
       <Name>NuGet.PackageManagement.VisualStudio</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\VisualStudio.Facade\NuGet.VisualStudio.Facade.csproj">
+      <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
+      <Name>NuGet.VisualStudio.Facade</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Console.Types\NuGet.Console.Types.csproj">
       <Project>{6FD11460-39A3-4A10-BA63-7541B0A7D053}</Project>
       <Name>NuGet.Console.Types</Name>

--- a/src/NuGet.Clients/VsConsole/Console/OutputConsole/OutputConsoleProvider.cs
+++ b/src/NuGet.Clients/VsConsole/Console/OutputConsole/OutputConsoleProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 
 namespace NuGetConsole
@@ -20,9 +21,9 @@ namespace NuGetConsole
         private readonly AsyncLazy<IVsUIShell> _vsUIShell;
         private readonly Lazy<IConsole> _cachedOutputConsole;
 
-        private IVsOutputWindow VsOutputWindow => ThreadHelper.JoinableTaskFactory.Run(_vsOutputWindow.GetValueAsync);
+        private IVsOutputWindow VsOutputWindow => NuGetUIThreadHelper.JoinableTaskFactory.Run(_vsOutputWindow.GetValueAsync);
 
-        private IVsUIShell VsUIShell => ThreadHelper.JoinableTaskFactory.Run(_vsUIShell.GetValueAsync);
+        private IVsUIShell VsUIShell => NuGetUIThreadHelper.JoinableTaskFactory.Run(_vsUIShell.GetValueAsync);
 
         [ImportingConstructor]
         OutputConsoleProvider(
@@ -45,13 +46,13 @@ namespace NuGetConsole
 
             _vsOutputWindow = new AsyncLazy<IVsOutputWindow>(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return serviceProvider.GetService<SVsOutputWindow, IVsOutputWindow>();
                 });
 
             _vsUIShell = new AsyncLazy<IVsUIShell>(async () =>
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return serviceProvider.GetService<SVsUIShell, IVsUIShell>();
                 });
 

--- a/src/NuGet.Clients/VsConsole/Console/ScriptExecutor.cs
+++ b/src/NuGet.Clients/VsConsole/Console/ScriptExecutor.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Threading;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.PowerShellCmdlets;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -180,7 +181,7 @@ namespace NuGetConsole
         private async Task<IHost> GetHostAsync()
         {
             // Since we are creating the output console and the output window pane, switch to the main thread
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             // create the console and instantiate the PS host on demand
             var console = OutputConsoleProvider.CreatePowerShellConsole();

--- a/src/NuGet.Clients/VsConsole/Console/Utils/Marshaler.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Utils/Marshaler.cs
@@ -1,8 +1,8 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.Shell;
+using NuGet.PackageManagement.UI;
 
 namespace NuGetConsole
 {
@@ -20,9 +20,9 @@ namespace NuGetConsole
         /// </summary>
         protected static void Invoke(Action action)
         {
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     action();
                 });
         }
@@ -32,9 +32,9 @@ namespace NuGetConsole
         /// </summary>
         protected static TResult Invoke<TResult>(Func<TResult> func)
         {
-            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
-                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                     return func();
                 });
         }

--- a/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.Win32;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using ActivityLog = Microsoft.VisualStudio.Shell.ActivityLog;
 using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
@@ -355,7 +356,7 @@ namespace NuGetConsole.Implementation.Console
                                 }
                                 else
                                 {
-                                    ThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); });
+                                    NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async delegate { await TriggerCompletionAsync(); });
                                 }
                             }
                             hr = VSConstants.S_OK;


### PR DESCRIPTION
This change replaces the shell JTF with NuGetUIThreadHelper in the majority of the code. The previous change only replaced it where it would be installing into CPS projects.

This should fix a hang caused by both an auto restore and an on build restore running at the same time. The auto restore is already using the CPS JTF and from the dump file it appeared that the shell JTF was blocked and unable to get the UI thread when it needed to read with DTE.

This change is primarily a find/replace. There is no new logic here.

I did some manual testing with this build and did not hit any hangs when trying to both edit the project and do an on build restore. Migration also went fine.

Fixes https://github.com/NuGet/Home/issues/4298

//cc @alpaix @jainaashish @rrelyea 