### PR TITLE
add pri files to the build outputs for pack in uwp related projects

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -157,6 +157,15 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_TargetPathsToAssemblies" />
     </MSBuild>
+    
+    <!--Projects with target framework like UWP, Win8, wpa81 produce a Pri file
+    in their bin dir. This Pri file is not included in the BuiltProjectGroupOutput, and
+    has to be added manually here.-->
+    <ItemGroup Condition="'$(IncludeProjectPriFile)' == 'true'">
+      <_TargetPathsToAssemblies Include="$(ProjectPriFullPath)">
+        <FinalOutputPath>$(ProjectPriFullPath)</FinalOutputPath>
+      </_TargetPathsToAssemblies>
+    </ItemGroup>
 
     <MSBuild
       Condition="'$(IncludeSymbols)' == 'true' OR '$(IncludeSource)' == 'true'"

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -31,7 +31,8 @@ namespace NuGet.Commands
             ".exe",
             ".xml",
             ".json",
-            ".winmd"
+            ".winmd",
+            ".pri"
         };
 
         // List of extensions to allow in the output path if IncludeSymbols is set
@@ -43,6 +44,7 @@ namespace NuGet.Commands
             ".xml",
             ".winmd",
             ".json",
+            ".pri",
             ".pdb",
             ".mdb"
         };


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4136

Adds the Pri file that is generated in projects targeting uap10.0 / win8 etc. We figure out the existence of this file using the msbuild property $(IncludeProjectPriFile) and then add it to our item group using the $(ProjectPriFullPath) property.

Also added .pri to the list of extensions that can be included in the lib folder.

CC: @emgarten @alpaix @rrelyea @mishra14 @nkolev92 @jainaashish @zhili1208 