### PR TITLE
Improve DownloadTimeoutStream reads

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/HttpSource/HttpSource.cs
@@ -237,14 +237,10 @@ namespace NuGet.Protocol
                 {
                     if (stream == null)
                     {
-                        return Task.FromResult((JObject)null);
+                        return Task.FromResult<JObject>(null);
                     }
 
-                    using (var reader = new StreamReader(stream))
-                    using (var jsonReader = new JsonTextReader(reader))
-                    {
-                        return Task.FromResult(JObject.Load(jsonReader));
-                    }
+                    return stream.AsJObjectAsync();
                 },
                 log: log,
                 token: token);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -78,14 +77,14 @@ namespace NuGet.Protocol
         {
             return await _httpSource.ProcessStreamAsync(
                    new HttpSourceRequest(apiEndpointUri, logger),
-                   stream =>
+                   async stream =>
                    {
-                       using (var reader = new StreamReader(stream))
+                       using (var reader = new StreamReader(await stream.AsSeekableStreamAsync()))
                        using (var jsonReader = new JsonTextReader(reader))
                        {
                            var serializer = JsonSerializer.Create();
                            var json = serializer.Deserialize<string[]>(jsonReader);
-                           return Task.FromResult(json);
+                           return json;
                        }
                    },
                    logger,

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -217,17 +217,17 @@ namespace NuGet.Protocol
                                 EnsureValidContents = stream => HttpStreamValidation.ValidateXml(uri, stream),
                                 MaxTries = 1
                             },
-                            httpSourceResult =>
+                            async httpSourceResult =>
                             {
                                 if (httpSourceResult.Status == HttpSourceResultStatus.NoContent)
                                 {
                                     // Team city returns 204 when no versions of the package exist
                                     // This should result in an empty list and we should not try to
                                     // read the stream as xml.
-                                    return Task.FromResult(false);
+                                    return false;
                                 }
 
-                                var doc = V2FeedParser.LoadXml(httpSourceResult.Stream);
+                                var doc = await V2FeedParser.LoadXmlAsync(httpSourceResult.Stream);
 
                                 var result = doc.Root
                                     .Elements(_xnameEntry)
@@ -242,7 +242,7 @@ namespace NuGet.Protocol
                                 // Stop if there's nothing else to GET
                                 if (string.IsNullOrEmpty(nextUri))
                                 {
-                                    return Task.FromResult(false);
+                                    return false;
                                 }
 
                                 // check for any duplicate url and error out
@@ -257,7 +257,7 @@ namespace NuGet.Protocol
                                 uri = nextUri;
                                 page++;
 
-                                return Task.FromResult(true);
+                                return true;
                             },
                             logger,
                             cancellationToken);

--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/StreamExtensions.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/Utility/StreamExtensions.cs
@@ -4,6 +4,8 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace NuGet.Protocol
 {
@@ -14,6 +16,71 @@ namespace NuGet.Protocol
         public static async Task CopyToAsync(this Stream stream, Stream destination, CancellationToken token)
         {
             await stream.CopyToAsync(destination, BufferSize, token);
+        }
+
+        internal static async Task<JObject> AsJObjectAsync(this Stream stream)
+        {
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using (var reader = new StreamReader(await stream.AsSeekableStreamAsync()))
+            {
+                return JObject.Load(new JsonTextReader(reader));
+            }
+        }
+
+        /// <summary>
+        /// Read a stream into a memory stream if CanSeek is false.
+        /// This method is used to ensure that network streams
+        /// can be read by non-async reads without hanging.
+        /// 
+        /// Closes the original stream by default.
+        /// </summary>
+        internal static Task<Stream> AsSeekableStreamAsync(this Stream stream)
+        {
+            return AsSeekableStreamAsync(stream, leaveStreamOpen: false);
+        }
+
+        /// <summary>
+        /// Read a stream into a memory stream if CanSeek is false.
+        /// This method is used to ensure that network streams
+        /// can be read by non-async reads without hanging.
+        /// </summary>
+        internal static async Task<Stream> AsSeekableStreamAsync(this Stream stream, bool leaveStreamOpen)
+        {
+            if (stream == null)
+            {
+                return null;
+            }
+
+            if (stream.CanSeek)
+            {
+                // Return the same stream if it can seek.
+                // Network streams are not seekable.
+                stream.Position = 0;
+                return stream;
+            }
+
+            var memStream = new MemoryStream();
+
+            try
+            {
+                // Copy the the current stream to a memory stream.
+                // This avoids the sync .Read call.
+                await stream.CopyToAsync(memStream);
+                memStream.Position = 0;
+            }
+            finally
+            {
+                if (!leaveStreamOpen)
+                {
+                    stream.Dispose();
+                }
+            }
+
+            return memStream;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Test.Utility/TestHttpSource.cs
@@ -34,6 +34,12 @@ namespace Test.Utility
         {
         }
 
+        /// <summary>
+        /// Modify or wrap the returned stream.
+        /// By default do nothing.
+        /// </summary>
+        public Func<Stream, Stream> StreamWrapper { get; set; } = (stream) => stream;
+
         public bool DisableCaching { get; set; } = true;
         public int CacheHits { get; private set; }
         public int CacheMisses { get; private set; }
@@ -54,6 +60,11 @@ namespace Test.Utility
             else
             {
                 CacheHits++;
+            }
+
+            if (result != null)
+            {
+                result = StreamWrapper(result);
             }
 
             return result;

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/NoSyncReadStream.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/NoSyncReadStream.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+using Xunit;
+
+namespace NuGet.Protocol.Core.v3.Tests
+{
+    public class NoSyncReadStream : DownloadTimeoutStream
+    {
+        public NoSyncReadStream(Stream stream)
+            : base("nosync", stream, TimeSpan.FromMinutes(1))
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Assert.True(false, "READ should not be called");
+            throw new InvalidOperationException("test failed!! Read should not be called!");
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/RawSearchResourceTests.cs
@@ -12,6 +12,7 @@ using NuGet.Protocol;
 using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
+using NuGet.Protocol.Core.v3.Tests;
 
 namespace NuGet.Protocol.Tests
 {
@@ -43,6 +44,39 @@ namespace NuGet.Protocol.Tests
 
             // Assert
             // Verify that the url matches the one in the response dictionary
+            Assert.True(packagesArray.Length > 0);
+        }
+
+        [Fact]
+        public async Task RawSearchResource_VerifyReadSyncIsNotUsed()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress();
+
+            var responses = new Dictionary<string, string>();
+            responses.Add(serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false&supportedFramework=.NETFramework,Version=v4.5",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.V3Search.json", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+
+            // throw if sync .Read is used
+            httpSource.StreamWrapper = (stream) => new NoSyncReadStream(stream);
+
+            var searchResource = new RawSearchResourceV3(httpSource, new Uri[] { new Uri(serviceAddress) });
+
+            var searchFilter = new SearchFilter(includePrerelease: false)
+            {
+                SupportedFrameworks = new string[] { ".NETFramework,Version=v4.5" }
+            };
+
+            // Act
+            var packages = await searchResource.Search("azure b", searchFilter, 0, 1, NullLogger.Instance, CancellationToken.None);
+            var packagesArray = packages.ToArray();
+
+            // Assert
+            // Verify that the url matches the one in the response dictionary
+            // Verify no failures from Sync Read
             Assert.True(packagesArray.Length > 0);
         }
     }


### PR DESCRIPTION
This change avoids calls to DownloadTimeoutStream.Read by reading streams into MemoryStreams using CopyToStreamAsync which uses DownloadTimeoutStream.ReadAsync instead.

I tried a build with DownloadTimeoutStream.Read set to throw an exception if used and was able to use the UI, install, and restore from v2, v3, and various project types. 

In some scenarios .Read may still be used such as direct download. There could also be edge where this is still needed by the command line so I am going to leave this method as is instead of removing support for it.

Fixes https://github.com/NuGet/Home/issues/4266

//cc @joelverhagen @alpaix @jainaashish @rrelyea
