### PR TITLE
Nuget.exe list delisted option is not propagated correctly in certain cases for V2Feeds, closes #4334

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedListResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol.Core.v3/LegacyFeed/V2FeedListResource.cs
@@ -64,7 +64,10 @@ namespace NuGet.Protocol
                     {
                         filter = new SearchFilter(includePrerelease: false,
                             filter: SearchFilterType.IsLatestVersion)
-                        { OrderBy = SearchOrderBy.Id };
+                        {
+                            OrderBy = SearchOrderBy.Id,
+                            IncludeDelisted = includeDelisted
+                        };
                     }
                 }
             }
@@ -95,7 +98,10 @@ namespace NuGet.Protocol
                     {
                         filter = new SearchFilter(includePrerelease: false,
                             filter: SearchFilterType.IsLatestVersion)
-                        { OrderBy = SearchOrderBy.Id };
+                        {
+                            OrderBy = SearchOrderBy.Id,
+                            IncludeDelisted = includeDelisted
+                        };
                     }
                 }
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
@@ -20,6 +20,97 @@ namespace NuGet.Protocol.Tests
 {
     public class V2FeedListResourceTests
     {
+
+        [Fact]
+        public async Task TestListDelistedNoPrereleaseNotAllVersionsDelistedOnlyResponse()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+
+            var responses = new Dictionary<string, string>();
+
+            responses.Add(serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'&targetFramework=''&includePrerelease=false&$skip=0&$top=30",
+               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+            responses.Add(serviceAddress + "/$metadata",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.MetadataTT.xml", GetType()));
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+
+            var parser = new V2FeedParser(httpSource, serviceAddress);
+            var legacyResource = new LegacyFeedCapabilityResourceV2Feed(parser, serviceAddress);
+            var resource = new V2FeedListResource(parser, legacyResource, serviceAddress);
+
+
+            var enumerable = await resource.ListAsync(searchTerm: "newton",
+                prerelease: false, allVersions: false, includeDelisted: true, logger: NullLogger.Instance, token: CancellationToken.None);
+
+            int ExpectedCount = 6;
+            int ActualCount = 0;
+            var enumerator = enumerable.GetEnumeratorAsync();
+
+
+            while (await enumerator.MoveNextAsync())
+            {
+                if (enumerator.Current != null)
+                {
+                    ActualCount++;
+                    Assert.True(ExpectedCount >= ActualCount, "Too many results");
+                }
+                else
+                {
+                    Assert.False(false, "Null Value, this shouldn't happen.");
+                }
+            }
+
+            Assert.True(ExpectedCount == ActualCount, "Expected was " + ExpectedCount + " but actual was " + ActualCount);
+        }
+
+        [Fact]
+        public async Task TestListNoDelistedNoPrereleaseNotAllVersionsDelistedOnlyResponse()
+        {
+            // Arrange
+            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+
+            var responses = new Dictionary<string, string>();
+
+            responses.Add(serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'&targetFramework=''&includePrerelease=false&$skip=0&$top=30",
+               TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
+            responses.Add(serviceAddress, string.Empty);
+            responses.Add(serviceAddress + "/$metadata",
+                TestUtility.GetResource("NuGet.Protocol.Core.v3.Tests.compiler.resources.MetadataTT.xml", GetType()));
+
+            var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
+
+            var parser = new V2FeedParser(httpSource, serviceAddress);
+            var legacyResource = new LegacyFeedCapabilityResourceV2Feed(parser, serviceAddress);
+            var resource = new V2FeedListResource(parser, legacyResource, serviceAddress);
+
+
+            var enumerable = await resource.ListAsync(searchTerm: "newton",
+                prerelease: false, allVersions: false, includeDelisted: false, logger: NullLogger.Instance, token: CancellationToken.None);
+
+            int ExpectedCount = 0;
+            int ActualCount = 0;
+            var enumerator = enumerable.GetEnumeratorAsync();
+
+
+            while (await enumerator.MoveNextAsync())
+            {
+                if (enumerator.Current != null)
+                {
+                    ActualCount++;
+                    Assert.True(ExpectedCount >= ActualCount, "Too many results");
+                }
+                else
+                {
+                    Assert.False(false, "Null Value, this shouldn't happen.");
+                }
+            }
+
+            Assert.True(ExpectedCount == ActualCount, "Expected was " + ExpectedCount + " but actual was " + ActualCount);
+        }
+
         [Fact]
         public async Task TestListNoDelistedNoPrereleaseNotAllVersions()
         {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/V2FeedListResourceTests.cs
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expected was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expected was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
 
@@ -293,7 +293,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -341,7 +341,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
         [Fact]
@@ -388,7 +388,7 @@ namespace NuGet.Protocol.Tests
                 }
             }
 
-            Assert.True(ExpectedCount == ActualCount, "Expect was " + ExpectedCount + " but actual was " + ActualCount);
+            Assert.Equal(ExpectedCount, ActualCount);
         }
 
     }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/6DelistedEntries.xml
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/compiler/resources/6DelistedEntries.xml
@@ -1,0 +1,253 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<feed xml:base="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
+  <id>http://schemas.datacontract.org/2004/07/</id>
+  <title />
+  <updated>2017-01-18T21:15:38Z</updated>
+  <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages" />
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package10',Version='2.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package10',Version='2.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package10',Version='2.0.0')" />
+    <title type="text">V40RC3_V2Package10</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3_v2package10&amp;version=2.0.0" />
+    <m:properties>
+      <d:Id>V40RC3_V2Package10</d:Id>
+      <d:Version>2.0.0</d:Version>
+      <d:NormalizedVersion>2.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package20',Version='1.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package20',Version='1.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package20',Version='1.0.0')" />
+    <title type="text">V40RC3_V2Package20</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3_v2package20&amp;version=1.0.0" />
+    <m:properties>
+      <d:Id>V40RC3_V2Package20</d:Id>
+      <d:Version>1.0.0</d:Version>
+      <d:NormalizedVersion>1.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package30',Version='1.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package30',Version='1.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3_V2Package30',Version='1.0.0')" />
+    <title type="text">V40RC3_V2Package30</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3_v2package30&amp;version=1.0.0" />
+    <m:properties>
+      <d:Id>V40RC3_V2Package30</d:Id>
+      <d:Version>1.0.0</d:Version>
+      <d:NormalizedVersion>1.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package10',Version='2.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package10',Version='2.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package10',Version='2.0.0')" />
+    <title type="text">V40RC3Package10</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3package10&amp;version=2.0.0" />
+    <m:properties>
+      <d:Id>V40RC3Package10</d:Id>
+      <d:Version>2.0.0</d:Version>
+      <d:NormalizedVersion>2.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package20',Version='1.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package20',Version='1.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package20',Version='1.0.0')" />
+    <title type="text">V40RC3Package20</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3package20&amp;version=1.0.0" />
+    <m:properties>
+      <d:Id>V40RC3Package20</d:Id>
+      <d:Version>1.0.0</d:Version>
+      <d:NormalizedVersion>1.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+  <entry>
+    <id>https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package30',Version='1.0.0')</id>
+    <category term="Microsoft.VisualStudio.Services.NuGet.Server.Controllers.V2.ServerV2FeedPackage" scheme="http://schemas.microsoft.com/ado/2007/08/dataservices/scheme" />
+    <link rel="edit" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package30',Version='1.0.0')" />
+    <link rel="self" href="https://_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2/Packages(Id='V40RC3Package30',Version='1.0.0')" />
+    <title type="text">V40RC3Package30</title>
+    <updated>0001-01-02T00:00:00Z</updated>
+    <author>
+      <name />
+    </author>
+    <content type="application/zip" src="https://codesharing-su1.pkgs.visualstudio.com/_packaging/224e3f52-6a96-4fef-a1c9-cb56acee9375/nuget/v2?id=v40rc3package30&amp;version=1.0.0" />
+    <m:properties>
+      <d:Id>V40RC3Package30</d:Id>
+      <d:Version>1.0.0</d:Version>
+      <d:NormalizedVersion>1.0.0</d:NormalizedVersion>
+      <d:Authors m:null="true" />
+      <d:Copyright m:null="true" />
+      <d:Created m:type="Edm.DateTime">0001-01-02T00:00:00</d:Created>
+      <d:Dependencies m:null="true" />
+      <d:Description>testdesc</d:Description>
+      <d:DownloadCount m:type="Edm.Int32">0</d:DownloadCount>
+      <d:IconUrl m:null="true" />
+      <d:IsLatestVersion m:type="Edm.Boolean">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type="Edm.Boolean">true</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type="Edm.Boolean">false</d:IsPrerelease>
+      <d:Language m:null="true" />
+      <d:LastUpdated m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastUpdated>
+      <d:Published m:type="Edm.DateTime">0001-01-02T00:00:00</d:Published>
+      <d:PackageSize m:type="Edm.Int64">0</d:PackageSize>
+      <d:ProjectUrl m:null="true" />
+      <d:ReleaseNotes m:null="true" />
+      <d:RequireLicenseAcceptance m:type="Edm.Boolean">false</d:RequireLicenseAcceptance>
+      <d:Summary m:null="true" />
+      <d:Tags m:null="true" />
+      <d:Title m:null="true" />
+      <d:MinClientVersion m:null="true" />
+      <d:LastEdited m:type="Edm.DateTime">0001-01-02T00:00:00</d:LastEdited>
+      <d:LicenseUrl m:null="true" />
+      <d:Listed m:type="Edm.Boolean">true</d:Listed>
+    </m:properties>
+  </entry>
+</feed>


### PR DESCRIPTION
This closes NuGet/Home#4334
In some cases the "IncludeDelisted" option is not propagated fully.

When we call nuget.exe list -source SomeSource -IncludeDelisted
The IncludeDelisted option value is not included in the filter construction, which means it'll default to false.

I have fixed this and added some extra tests for this scenario.

\\cc
@mishra14 @rohit21agrawal @alpaix @emgarten @zhili1208 @jainaashish 