### PR TITLE
Improve E2E script to prevent failure if VSIX not installed

### DIFF
--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -11,9 +11,9 @@
     {
         $ProgramFilesPath = ${env:ProgramFiles(x86)}
     }
-	
+
     $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)
-	
+
     return $VSFolderPath
 }
 
@@ -137,8 +137,17 @@ function UninstallVSIX
 
     if ($p.ExitCode -ne 0)
     {
-        Write-Error "Error uninstalling the VSIX! Exit code: " $p.ExitCode
-        return $false
+        if($p.ExitCode -eq 1002)
+        {
+            Write-Error "VSIX already uninstalled. Moving on to installing the VSIX! Exit code: " $p.ExitCode 
+            return $true
+        }
+        else 
+        {
+            Write-Error "Error uninstalling the VSIX! Exit code: " $p.ExitCode
+            return $false
+        }
+
     }
 
     start-sleep -Seconds $VSIXInstallerWaitTimeInSecs

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -139,12 +139,12 @@ function UninstallVSIX
     {
         if($p.ExitCode -eq 1002)
         {
-            Write-Error "VSIX already uninstalled. Moving on to installing the VSIX! Exit code: " $p.ExitCode 
+            Write-Host "VSIX already uninstalled. Moving on to installing the VSIX! Exit code: $($p.ExitCode)" 
             return $true
         }
         else 
         {
-            Write-Error "Error uninstalling the VSIX! Exit code: " $p.ExitCode
+            Write-Error "Error uninstalling the VSIX! Exit code: $($p.ExitCode)"
             return $false
         }
 


### PR DESCRIPTION
Currently, if our VSIX is not installed on the E2E box, the whole process fails out. I have added a check to prevent that by looking at the uninstall error and not fail if the error was because VSIX was not already installed.

//ccL @emgarten @alpaix @rohit21agrawal @joelverhagen 