### PR TITLE
Do NOT open output window during auto-restore

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -276,7 +276,6 @@ namespace NuGet.SolutionRestoreManager
                     switch (_operationSource)
                     {
                         case RestoreOperationSource.Implicit:
-                            _outputConsole.Activate();
                             WriteLine(VerbosityLevel.Quiet, Resources.RestoringPackages);
                             break;
                         case RestoreOperationSource.OnBuild:


### PR DESCRIPTION
Resolves NuGet/Home#4274.

Current behavior for auto-restore was to activate output console on
first message, e.g. on header line "Restoring NuGet packages...".
So to stop annoying the user with popping output window the `Activate`
method call was removed from this scenario. The ouput window itself
will be created and log messages will be logged after this change. In
order to see them user will have to locate the output pane titled
"Package Manager" and make it visible.

Other scenarios, including on-build and explicit solution restore, will
NOT be affected.

//cc @emgarten @mishra14 @nkolev92 @jainaashish @rohit21agrawal @zhili1208 @rrelyea 