### PR TITLE
remove version suffix and add tests for package version

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -55,6 +55,5 @@ namespace NuGet.Build.Tasks.Pack
         string[] TargetFrameworks { get; }
         string[] TargetPathsToAssemblies { get; }
         string[] TargetPathsToSymbols { get; }
-        string VersionSuffix { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -118,7 +118,6 @@ Copyright (c) .NET Foundation. All rights reserved.
               NoPackageAnalysis="$(NoPackageAnalysis)"
               MinClientVersion="$(MinClientVersion)"
               Serviceable="$(Serviceable)"
-              VersionSuffix= "$(VersionSuffix)"
               AssemblyReferences="@(_References)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
               NuspecOutputPath="$(BaseIntermediateOutputPath)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -43,7 +43,6 @@ namespace NuGet.Build.Tasks.Pack
         public string NuspecFile { get; set; }
         public string MinClientVersion { get; set; }
         public bool Serviceable { get; set; }
-        public string VersionSuffix { get; set; }
         public ITaskItem[] AssemblyReferences { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string NuspecOutputPath { get; set; }
@@ -146,8 +145,7 @@ namespace NuGet.Build.Tasks.Pack
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
                 TargetPathsToAssemblies = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToAssemblies),
-                TargetPathsToSymbols = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToSymbols),
-                VersionSuffix = MSBuildStringUtility.TrimAndGetNullForEmpty(VersionSuffix)
+                TargetPathsToSymbols = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToSymbols)
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -26,7 +26,6 @@ namespace NuGet.Build.Tasks.Pack
                 Logger = request.Logger,
                 OutputDirectory = request.PackageOutputPath,
                 Serviceable = request.Serviceable,
-                Suffix = request.VersionSuffix,
                 Tool = request.IsTool,
                 Symbols = request.IncludeSymbols,
                 BasePath = request.NuspecBasePath,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -48,6 +48,5 @@ namespace NuGet.Build.Tasks.Pack
         public string[] TargetFrameworks { get; set; }
         public string[] TargetPathsToAssemblies { get; set; }
         public string[] TargetPathsToSymbols { get; set; }
-        public string VersionSuffix { get; set; }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -73,8 +73,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 ProjectUrl = " ProjectUrl \t ",
                 ReleaseNotes = " ReleaseNotes \t ",
                 RepositoryType = " RepositoryType \t ",
-                RepositoryUrl = " RepositoryUrl \t ",
-                VersionSuffix = " VersionSuffix \t "
+                RepositoryUrl = " RepositoryUrl \t "
             };
 
             // Act
@@ -96,7 +95,6 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Equal("ReleaseNotes", actual.ReleaseNotes);
             Assert.Equal("RepositoryType", actual.RepositoryType);
             Assert.Equal("RepositoryUrl", actual.RepositoryUrl);
-            Assert.Equal("VersionSuffix", actual.VersionSuffix);
         }
 
         [Fact]
@@ -120,7 +118,6 @@ namespace NuGet.Build.Tasks.Pack.Test
                 ReleaseNotes = " \t ",
                 RepositoryType = " \t ",
                 RepositoryUrl = " \t ",
-                VersionSuffix = " \t ",
             };
 
             // Act
@@ -142,7 +139,6 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Null(actual.ReleaseNotes);
             Assert.Null(actual.RepositoryType);
             Assert.Null(actual.RepositoryUrl);
-            Assert.Null(actual.VersionSuffix);
         }
 
         [Fact]
@@ -302,8 +298,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Tags = new string[0],
                 TargetFrameworks = new string[0],
                 TargetPathsToAssemblies = new string[0],
-                TargetPathsToSymbols = new string[0],
-                VersionSuffix = "VersionSuffix"
+                TargetPathsToSymbols = new string[0]
             };
 
             var settings = new JsonSerializerSettings


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4324

$(PackageVersion) defaults to $(Version) which is composed of $(VersionPrefix) and $(VersionSuffix). Until now, pack was taking the $(PackageVersion) and appending the $(VersionSuffix) to it if provided.

We should let MSBuild append the $(VersionSuffix) to the $(VersionPrefix) and compose the $(Version) property, and if $(PackageVersion) is provided by the user, treat $(PackageVersion) as the final version, else use $(Version) as the default value

CC: @rrelyea @emgarten @alpaix @mishra14 @nkolev92 @zhili1208 @jainaashish 

Tagging @natemcmaster to inspect the test matrix : https://github.com/NuGet/NuGet.Client/compare/dev-ragrawal-versionfix?expand=1#diff-0a8ea4346824f4b1f738f32446ce80caR631