### PR TITLE
PackageVersion property for .NET Core projects

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/ProjectRestoreInfoBuilder.cs
@@ -13,18 +13,24 @@ namespace NuGet.SolutionRestoreManager.Test
     /// Helper class providing a method of building <see cref="IVsProjectRestoreInfo"/>
     /// out of <see cref="PackageSpec"/>.
     /// </summary>
-    internal static class ProjectRestoreInfoBuilder
+    internal class ProjectRestoreInfoBuilder
     {
+        private readonly VsProjectRestoreInfo _pri;
+
+        private ProjectRestoreInfoBuilder(VsProjectRestoreInfo pri)
+        {
+            _pri = pri;
+        }
+
         /// <summary>
         /// Creates project restore info object to be consumed by <see cref="IVsSolutionRestoreService"/>.
         /// </summary>
         /// <param name="packageSpec">Source project restore object</param>
         /// <returns>Desired project restore object</returns>
-        public static VsProjectRestoreInfo Build(
+        public static ProjectRestoreInfoBuilder FromPackageSpec(
             PackageSpec packageSpec,
             string baseIntermediatePath,
-            bool crossTargeting,
-            IEnumerable<LibraryRange> tools)
+            bool crossTargeting)
         {
             if (packageSpec == null)
             {
@@ -36,18 +42,24 @@ namespace NuGet.SolutionRestoreManager.Test
                 return null;
             }
 
+            var projectProperties = new VsProjectProperties { };
+
+            if (packageSpec.Version != null)
+            {
+                projectProperties = new VsProjectProperties
+                {
+                    { "PackageVersion", packageSpec.Version.ToString() }
+                };
+            }
+
             var targetFrameworks = new VsTargetFrameworks(
                 packageSpec
                     .TargetFrameworks
-                    .Select(ToTargetFrameworkInfo));
+                    .Select(tfm => ToTargetFrameworkInfo(tfm, projectProperties)));
 
             var pri = new VsProjectRestoreInfo(
                 baseIntermediatePath,
-                targetFrameworks)
-            {
-                ToolReferences = new VsReferenceItems(
-                    (tools ?? Enumerable.Empty<LibraryRange>()).Select(ToToolReference))
-            };
+                targetFrameworks);
 
             if (crossTargeting)
             {
@@ -57,32 +69,61 @@ namespace NuGet.SolutionRestoreManager.Test
                         .Select(tfm => tfm.FrameworkName.GetShortFolderName()));
             }
 
-            return pri;
+            return new ProjectRestoreInfoBuilder(pri);
         }
 
-        private static VsTargetFrameworkInfo ToTargetFrameworkInfo(TargetFrameworkInformation tfm)
+        public ProjectRestoreInfoBuilder WithTool(string name, string version)
         {
-            var packageReferences = new VsReferenceItems(
-                tfm.Dependencies
-                    .Where(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package)
-                    .Select(ToPackageReference));
+            var properties = new VsReferenceProperties
+            {
+                { "Version", version }
+            };
 
-            var projectReferences = new VsReferenceItems(
-                tfm.Dependencies
-                    .Where(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.ExternalProject)
-                    .Select(ToProjectReference));
+            _pri.ToolReferences = new VsReferenceItems
+            {
+                new VsReferenceItem(name, properties)
+            };
 
-            var projectProperties = new VsProjectProperties(
-                new VsProjectProperty(
+            return this;
+        }
+
+        public ProjectRestoreInfoBuilder WithTargetFrameworkInfo(
+            IVsTargetFrameworkInfo tfi)
+        {
+            (_pri.TargetFrameworks as VsTargetFrameworks).Add(tfi);
+
+            return this;
+        }
+
+        public VsProjectRestoreInfo Build() => _pri;
+
+        private static VsTargetFrameworkInfo ToTargetFrameworkInfo(
+            TargetFrameworkInformation tfm, 
+            IEnumerable<IVsProjectProperty> globalProperties)
+        {
+            var packageReferences = tfm
+                .Dependencies
+                .Where(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package)
+                .Select(ToPackageReference);
+
+            var projectReferences = tfm
+                .Dependencies
+                .Where(d => d.LibraryRange.TypeConstraint == LibraryDependencyTarget.ExternalProject)
+                .Select(ToProjectReference);
+
+            var projectProperties = new VsProjectProperties
+            {
+                {
                     "PackageTargetFallback",
-                    string.Join(";", tfm.Imports.Select(x => x.GetShortFolderName())))
-            );
+                    string.Join(";", tfm.Imports.Select(x => x.GetShortFolderName()))
+                }
+            };
 
             return new VsTargetFrameworkInfo(
                 tfm.FrameworkName.ToString(),
                 packageReferences,
                 projectReferences,
-                projectProperties);
+                projectProperties.Concat(globalProperties));
         }
 
         private static IVsReferenceItem ToPackageReference(LibraryDependency library)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectProperties.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectProperties.cs
@@ -15,5 +15,10 @@ namespace NuGet.SolutionRestoreManager.Test
         public VsProjectProperties(params IVsProjectProperty[] collection) : base(collection) { }
 
         protected override string GetKeyForItem(IVsProjectProperty value) => value.Name;
+
+        public void Add(string propertyName, string propertyValue)
+        {
+            Add(new VsProjectProperty(propertyName, propertyValue));
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsProjectRestoreInfo.cs
@@ -12,7 +12,7 @@ namespace NuGet.SolutionRestoreManager.Test
     /// </summary>
     internal class VsProjectRestoreInfo : IVsProjectRestoreInfo
     {
-        public String BaseIntermediatePath { get; }
+        public string BaseIntermediatePath { get; }
 
         public string OriginalTargetFrameworks { get; set; }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperties.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsReferenceProperties.cs
@@ -13,5 +13,10 @@ namespace NuGet.SolutionRestoreManager.Test
         public VsReferenceProperties(IEnumerable<IVsReferenceProperty> collection) : base(collection) { }
 
         protected override String GetKeyForItem(IVsReferenceProperty value) => value.Name;
+
+        public void Add(string propertyName, string propertyValue)
+        {
+            Add(new VsReferenceProperty(propertyName, propertyValue));
+        }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsTargetFrameworkInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace NuGet.SolutionRestoreManager.Test
 {
@@ -13,13 +14,13 @@ namespace NuGet.SolutionRestoreManager.Test
 
         public IVsProjectProperties Properties { get; }
 
-        public String TargetFrameworkMoniker { get; }
+        public string TargetFrameworkMoniker { get; }
 
         public VsTargetFrameworkInfo(
             string targetFrameworkMoniker,
-            IVsReferenceItems packageReferences,
-            IVsReferenceItems projectReferences,
-            IVsProjectProperties projectProperties)
+            IEnumerable<IVsReferenceItem> packageReferences,
+            IEnumerable<IVsReferenceItem> projectReferences,
+            IEnumerable<IVsProjectProperty> projectProperties)
         {
             if (string.IsNullOrEmpty(targetFrameworkMoniker))
             {
@@ -42,9 +43,9 @@ namespace NuGet.SolutionRestoreManager.Test
             }
 
             TargetFrameworkMoniker = targetFrameworkMoniker;
-            PackageReferences = packageReferences;
-            ProjectReferences = projectReferences;
-            Properties = projectProperties;
+            PackageReferences = new VsReferenceItems(packageReferences);
+            ProjectReferences = new VsReferenceItems(projectReferences);
+            Properties = new VsProjectProperties(projectProperties);
         }
     }
 }


### PR DESCRIPTION
Resolves NuGet/Home#3901.

Acquire package version property for a .NET Core project from the
`IVsProjectRestoreInfo` as provided via the Nominate API call.

Although the `$(PackageVersion)` property shouldn't differ between
different TFMs current API design assumes all project properties will be
evaluated per each TFM.

As a result `SolutionRestoreService` expects to get the
same value of package version defined in each TFM property bag.
Otherwise `InvalidOperationException` will be thrown.

//cc @emgarten @jainaashish @mishra14 @rohit21agrawal @natidea @rrelyea 