### PR TITLE
Added check for VSProject4 before showing format selector dialog

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -340,7 +340,12 @@ namespace NuGet.PackageManagement.UI
             return await Task.FromResult(true);
 #else
             var newProjectNames = new List<string>();
-            var msBuildProjects = uiService.Projects.Where(project => project is MSBuildNuGetProject);
+
+            // check if project is packages.config and it's dte project instance can also be converted to VSProject4.
+            // otherwise don't show format selector dialog for this project
+            var msBuildProjects = uiService.Projects.Where(project =>
+                project is MSBuildNuGetProject &&
+                (project as MSBuildNuGetProject).MSBuildNuGetProjectSystem.VSProject4 != null);
 
             // get all packages.config based projects with no installed packages
             foreach (var project in msBuildProjects)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -16,6 +16,7 @@ using NuGet.Frameworks;
 using NuGet.PackageManagement.UI;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
+using VSLangProj150;
 using Constants = NuGet.ProjectManagement.Constants;
 using EnvDTEProject = EnvDTE.Project;
 using EnvDTEProjectItems = EnvDTE.ProjectItems;
@@ -176,6 +177,18 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
 
                 return _targetFramework;
+            }
+        }
+
+        public dynamic VSProject4
+        {
+            get
+            {
+                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    return EnvDTEProject.Object as VSProject4;
+                });
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
@@ -23,6 +23,8 @@ namespace NuGet.ProjectManagement
         void RemoveFile(string path);
         bool FileExistsInProject(string path);
 
+        dynamic VSProject4 { get; }
+
         /// <summary>
         /// Method called when adding an assembly reference to the project.
         /// </summary>

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -99,6 +99,8 @@ namespace Test.Utility
             }
         }
 
+        public dynamic VSProject4 { get; }
+
         public string ProjectFullPath { get; }
 
         public string ProjectFileFullPath { get; }


### PR DESCRIPTION
Before showing package management format selector dialog for any new project (which doesn't have any package installed yet), we will check if we can actually convert that dte project to VSProject4 or not. Because in order to support PackageRef, we need VSProject4 instance to manage package references. So if we can't get VSProject4 then don't show this dialog at all for such projects.

Fixes https://github.com/NuGet/Home/issues/4378

@rrelyea @emgarten @alpaix