### PR TITLE
remove circular dependency of pack and build

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -31,6 +31,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
     <PackDependsOn>GenerateNuspec; $(PackDependsOn)</PackDependsOn>
+    <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
+    <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -52,7 +54,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <Target Name="_PackAsBuildAfterTarget"
           AfterTargets="Build" 
-          Condition="'$(GeneratePackageOnBuild)' == 'true'"
+          Condition="'$(GeneratePackageOnBuild)' == 'true' AND '$(IsInnerBuild)' != 'true'"
           DependsOnTargets="Pack">
   </Target>
 

--- a/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/CommandRunners/PackCommandRunner.cs
@@ -131,7 +131,6 @@ namespace NuGet.Commands
                 PrintVerbose(outputPath, builder);
             }
 
-            WriteLine(String.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath));
             _packArgs.Logger.LogMinimal(String.Format(CultureInfo.CurrentCulture, Strings.Log_PackageCommandSuccess, outputPath));
             return new PackageArchiveReader(outputPath);
         }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -51,6 +51,14 @@ namespace Dotnet.Integration.Test
                 waitForExit: true);
         }
 
+        internal CommandRunnerResult BuildProject(string workingDirectory, string projectName, string args)
+        {
+            return CommandRunner.Run(TestDotnetCli,
+                workingDirectory,
+                $"msbuild {projectName}.csproj {args}",
+                waitForExit: true);
+        }
+
         private string CopyLatestCliForPack()
         {
             var cliDirectory = TestDirectory.Create();


### PR DESCRIPTION
Fixes the following issues : https://github.com/NuGet/Home/issues/4381
https://github.com/NuGet/Home/issues/4380
https://github.com/NuGet/Home/issues/4397
https://github.com/NuGet/Home/issues/4289

This PR does the following:

1) Evaluates a condition ```$(IsInnerBuild)``` to determine if the running build is the TFM specific build or the outer build. ```_PackAsAfterBuildTarget``` then uses this condition to kick off the ```Pack``` target only after the Outer Build has completed if ```$(GenereatePackageOnBuild)``` property is set.

2) If ```$(GeneratePackageOnBuild)``` is set to true (via the VS UI or editing the csproj file), the targets coerce the value of ```$(NoBuild)``` to ```true``` - which means that **running Pack would not build the project**. This is needed to solve the circular target dependency problem.

3) Adds tests for those scenarios.

4) Removes double logging of the Package successfully created message at High verbosity. Now we only output one message - at default verbosity.

CC: @rrelyea @emgarten @alpaix @jainaashish @zhili1208 @mishra14 @nkolev92 