### PR TITLE
add more pack tests and improve test infra

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ cli/dotnet-install.sh -i cli -c preview -v 1.0.0-preview2-003121
 
 # Run install.sh fot cli test
 chmod +x cli_test/dotnet-install.sh
-cli_test/dotnet-install.sh -i cli_test -c preview -v 1.0.0-preview5-004275
+cli_test/dotnet-install.sh -i cli_test -c preview -v 1.0.0-rc4-004616
 
 
 # Display current version

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -208,7 +208,7 @@ Function Install-DotnetCLI {
             Root = $CLIRootTest
             DotNetExe = Join-Path $CLIRootTest 'dotnet.exe'
             DotNetInstallUrl = 'https://raw.githubusercontent.com/dotnet/cli/58b0566d9ac399f5fa973315c6827a040b7aae1f/scripts/obtain/dotnet-install.ps1'
-            Version = '1.0.0-preview5-004275'
+            Version = '1.0.0-rc4-004616'
         }
     }
 

--- a/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageReaderBase.cs
@@ -225,6 +225,11 @@ namespace NuGet.Packaging
             return GetFileGroups(PackagingConstants.Folders.Content);
         }
 
+        public IEnumerable<FrameworkSpecificGroup> GetContentItems(string contentFolderName)
+        {
+            return GetFileGroups(contentFolderName);
+        }
+
         public IEnumerable<PackageDependencyGroup> GetPackageDependencies()
         {
             return NuspecReader.GetDependencyGroups();
@@ -233,6 +238,11 @@ namespace NuGet.Packaging
         public IEnumerable<FrameworkSpecificGroup> GetLibItems()
         {
             return GetFileGroups(PackagingConstants.Folders.Lib);
+        }
+
+        public IEnumerable<FrameworkSpecificGroup> GetLibItems(string libFolderName)
+        {
+            return GetFileGroups(libFolderName);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using NuGet.Frameworks;
+
+namespace NuGet.Test.Utility
+{
+    public class ProjectFileUtils
+    {
+        public static void AddProperties(XDocument doc, Dictionary<string, string> properties)
+        {
+            var ns = doc.Root.GetDefaultNamespace();
+
+            var propertyGroup = new XElement(XName.Get("PropertyGroup", ns.NamespaceName));
+            foreach (var pair in properties)
+            {
+                var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
+                propertyGroup.Add(subItem);
+            }
+
+            var lastPropGroup = doc.Root.Elements().Last(e => e.Name.LocalName == "PropertyGroup");
+            lastPropGroup.AddAfterSelf(propertyGroup);
+        }
+
+        public static void AddProperty(XDocument doc, string propertyName, string propertyValue)
+        {
+            var lastPropGroup = doc.Root.Elements().Last(e => e.Name.LocalName == "PropertyGroup");
+            lastPropGroup.Add(new XElement(XName.Get(propertyName), propertyValue));
+        }
+
+        public static void AddItem(XDocument doc,
+            string name,
+            string identity,
+            NuGetFramework framework,
+            Dictionary<string, string> properties,
+            Dictionary<string,string> attributes )
+        {
+            AddItem(doc, name, identity,
+                framework?.IsSpecificFramework == true ? framework.GetShortFolderName() : string.Empty, properties, attributes);
+        }
+
+        public static void AddItem(XDocument doc,
+            string name,
+            string identity,
+            string framework,
+            Dictionary<string, string> properties,
+            Dictionary<string,string> attributes )
+        {
+            var ns = doc.Root.GetDefaultNamespace();
+
+            var itemGroup = new XElement(XName.Get("ItemGroup", ns.NamespaceName));
+            var entry = new XElement(XName.Get(name, ns.NamespaceName));
+            entry.Add(new XAttribute(XName.Get("Include"), identity));
+            itemGroup.Add(entry);
+
+            if (!string.IsNullOrEmpty(framework))
+            {
+                itemGroup.Add(new XAttribute(XName.Get("Condition"), $" '$(TargetFramework)' == '{framework}' "));
+            }
+
+            foreach (var attribute in attributes)
+            {
+                var attr = new XAttribute(XName.Get(attribute.Key), attribute.Value);
+                entry.Add(attr);
+            }
+
+            foreach (var pair in properties)
+            {
+                var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
+                entry.Add(subItem);
+            }
+
+            var lastItemGroup = doc.Root.Elements().LastOrDefault(e => e.Name.LocalName == "ItemGroup");
+            if (lastItemGroup == null)
+            {
+                doc.Root.Elements().Last().AddAfterSelf(itemGroup);
+            }
+            else
+            {
+                lastItemGroup.AddAfterSelf(itemGroup);
+            }
+        }
+
+        public static void SetTargetFrameworkForProject(XDocument doc, string targetFrameworkPropertyName, string targetFrameworkValue)
+        {
+            var existingFrameworkProperty = "TargetFramework";
+            var pgElement = doc.Root.Descendants("PropertyGroup").FirstOrDefault(t => t.Descendants("TargetFramework").Any());
+            if (pgElement == null)
+            {
+                pgElement = doc.Root.Descendants("PropertyGroup").FirstOrDefault(t => t.Descendants("TargetFrameworks").Any());
+                existingFrameworkProperty = "TargetFrameworks";
+            }
+
+            if (pgElement != null)
+            {
+                pgElement.SetElementValue(XName.Get(existingFrameworkProperty), null);
+                pgElement.SetElementValue(XName.Get(targetFrameworkPropertyName), targetFrameworkValue);
+            }
+            else
+            {
+                AddProperty(doc, targetFrameworkPropertyName, targetFrameworkValue);
+            }
+        }
+
+        public static void WriteXmlToFile(XDocument xml, FileStream stream)
+        {
+            var unicodeEncoding = new UTF8Encoding();
+            var xmlString = xml.ToString();
+            stream.SetLength(0);
+            stream.Seek(0, SeekOrigin.Begin);
+            stream.Write(unicodeEncoding.GetBytes(xmlString), 0, unicodeEncoding.GetByteCount(xmlString));
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -8,6 +8,7 @@ using NuGet.XPlat.FuncTest;
 using NuGet.Test.Utility;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
+using Xunit;
 
 namespace Dotnet.Integration.Test
 {
@@ -32,7 +33,8 @@ namespace Dotnet.Integration.Test
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"new {args}",
-                waitForExit: true);
+                waitForExit: true,
+                timeOutInMilliseconds: 300000);
         }
 
         internal void RestoreProject(string workingDirectory, string projectName, string args)
@@ -41,6 +43,8 @@ namespace Dotnet.Integration.Test
                 workingDirectory,
                 $"restore {projectName}.csproj {args}",
                 waitForExit: true);
+            Assert.True(result.Item1 == 0, $"Restore failed with following log information :\n {result.Item2}");
+            Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.Item3}");
         }
 
         internal void PackProject(string workingDirectory, string projectName, string args)
@@ -49,14 +53,18 @@ namespace Dotnet.Integration.Test
                 workingDirectory,
                 $"pack {projectName}.csproj {args}",
                 waitForExit: true);
+            Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.Item2}");
+            Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.Item3}");
         }
 
-        internal CommandRunnerResult BuildProject(string workingDirectory, string projectName, string args)
+        internal void BuildProject(string workingDirectory, string projectName, string args)
         {
-            return CommandRunner.Run(TestDotnetCli,
+            var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
                 $"msbuild {projectName}.csproj {args}",
                 waitForExit: true);
+            Assert.True(result.Item1 == 0, $"Build failed with following log information :\n {result.Item2}");
+            Assert.True(result.Item3 == "", $"Build failed with following message in error stream :\n {result.Item3}");
         }
 
         private string CopyLatestCliForPack()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
@@ -60,7 +61,7 @@ namespace Dotnet.Integration.Test
                     var packages = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
-                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.0")), packages[0].VersionRange);
+                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
                     Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
@@ -81,33 +82,39 @@ namespace Dotnet.Integration.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectFileContents =
-                    @"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-
-  <ItemGroup Condition=""'$(TargetFramework)' == 'netcoreapp1.0'"">
-    <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
-  </ItemGroup>
-  <ItemGroup Condition=""'$(TargetFramework)' == 'net45'"">
-    <PackageReference Include=""Newtonsoft.Json"" Version=""9.0.1"" />
-  </ItemGroup>
-
-</Project>";
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netcoreapp1.0;net45");
+                    ProjectFileUtils.AddProperty(xml, "RuntimeIdentifier", "win7-x64");
+
+                    var attributes = new Dictionary<string,string>();
+
+                    attributes["Version"] = "1.0.1";
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "PackageReference",
+                            "Microsoft.NETCore.App",
+                            "netcoreapp1.0",
+                            new Dictionary<string, string>(),
+                            attributes);
+
+                    attributes["Version"] = "9.0.1";
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "PackageReference",
+                            "Newtonsoft.Json",
+                            "net45",
+                            new Dictionary<string, string>(),
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
 
                 // This is a hack to make restore work with <TargetFrameworks> . Once we update the CLI_TEST in our repo, we can remove this.
                 msbuildFixture.RestoreProject(workingDirectory, projectName, "/p:RestoreProjectStyle=PackageReference");
@@ -189,36 +196,44 @@ namespace Dotnet.Integration.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectFileContents1 =
-                    @"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net45</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include=""Newtonsoft.Json"" Version=""9.0.1"">";
-
-                var projectFileContents2 = (!string.IsNullOrEmpty(includeAssets) ? $"<IncludeAssets>{includeAssets}</IncludeAssets>\n" : string.Empty)
-                    + (!string.IsNullOrEmpty(excludeAssets) ? $"<ExcludeAssets>{excludeAssets}</ExcludeAssets>\n" : string.Empty) 
-                    + (!string.IsNullOrEmpty(privateAssets) ? $"<PrivateAssets>{privateAssets}</PrivateAssets>\n" : string.Empty);
-            var projectFileContents3 = @"
-    </PackageReference>
-  </ItemGroup>
-
-</Project>";
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllLines(Path.Combine(workingDirectory, $"{projectName}.csproj"), new string[] {projectFileContents1, projectFileContents2, projectFileContents3});
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "net45");
+
+                    var attributes = new Dictionary<string, string>();
+                    attributes["Version"] = "9.0.1";
+
+                    var properties = new Dictionary<string, string>();
+                    if (!string.IsNullOrEmpty(includeAssets))
+                    {
+                        properties["IncludeAssets"] = includeAssets;
+                    }
+                    if (!string.IsNullOrEmpty(excludeAssets))
+                    {
+                        properties["ExcludeAssets"] = excludeAssets;
+                    }
+                    if (!string.IsNullOrEmpty(privateAssets))
+                    {
+                        properties["PrivateAssets"] = privateAssets;
+                    }
+
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "PackageReference",
+                            "Newtonsoft.Json",
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
                 // Act
@@ -260,33 +275,33 @@ namespace Dotnet.Integration.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectFileContents =
-                    @"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard1.4</TargetFrameworks>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include=""..\ClassLibrary2\ClassLibrary2.csproj"" />
-  </ItemGroup>
-
-</Project>";
                 var projectName = "ClassLibrary1";
                 var referencedProject = "ClassLibrary2";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, referencedProject, "-t lib");
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    var attributes = new Dictionary<string, string>();
+                    
+                    var properties = new Dictionary<string, string>();
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "ProjectReference",
+                            @"..\ClassLibrary2\ClassLibrary2.csproj",
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
                 // Act
@@ -317,7 +332,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(2,
                                     packagesA.Count);
                     Assert.Equal("NETStandard.Library", packagesA[1].Id);
-                    Assert.Equal(new VersionRange(new NuGetVersion("1.6")), packagesA[1].VersionRange);
+                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packagesA[1].VersionRange);
                     Assert.Equal(new List<string> { "Analyzers", "Build" }, packagesA[1].Exclude);
                     Assert.Empty(packagesA[1].Include);
                     
@@ -559,45 +574,37 @@ namespace Dotnet.Integration.Test
                 {
                     sourcePath = sourcePath.Replace("##", workingDirectory);
                 }
-                var projectFileContents = packagePath != null ? 
-                                    $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-                  <PropertyGroup>
-                    <TargetFrameworks>netstandard1.4</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Compile Include=""**\*.cs"" />
-                    <EmbeddedResource Include=""**\*.resx"" />
-                    <Content Include=""{sourcePath}"">
-                      <PackagePath>{packagePath}</PackagePath>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-                  </ItemGroup>
-                </Project>" 
-
-                : $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-                  <PropertyGroup>
-                    <TargetFrameworks>netstandard1.4</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Compile Include=""**\*.cs"" />
-                    <EmbeddedResource Include=""**\*.resx"" />
-                    <Content Include=""{sourcePath}""/>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-                  </ItemGroup>
-                </Project>";
 
                 // Create the subdirectory structure for testing possible source paths for the content file
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA"));
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA", "folderB"));
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    var attributes = new Dictionary<string, string>();
+
+                    var properties = new Dictionary<string, string>();
+                    if (packagePath != null)
+                    {
+                        properties["PackagePath"] = packagePath;
+                    }
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "Content",
+                            sourcePath,
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 var pathToContent = Path.Combine(workingDirectory, sourcePath);
                 if (Path.IsPathRooted(sourcePath))
                 {
@@ -643,26 +650,20 @@ namespace Dotnet.Integration.Test
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                var projectFileContents =
-                    $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-  <PropertyGroup>
-    <TargetFrameworks>netstandard1.4</TargetFrameworks>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-  </ItemGroup>
-
-</Project>";
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " -t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+                    
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
                 var args = "" + 
@@ -751,51 +752,44 @@ namespace Dotnet.Integration.Test
                 {
                     sourcePath = sourcePath.Replace("##", workingDirectory);
                 }
-                var projectFileContents = packagePath != null ?
-                                    $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-                  <PropertyGroup>
-                    <TargetFramework>netstandard1.4</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Compile Include=""**\*.cs"" />
-                    <EmbeddedResource Include=""**\*.resx"" />
-                    <Content Include=""{sourcePath}"">
-                      <PackagePath>{packagePath}</PackagePath>
-                    </Content>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-                  </ItemGroup>
-                </Project>"
-
-                : $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-                  <PropertyGroup>
-                    <TargetFramework>netstandard1.4</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Compile Include=""**\*.cs"" />
-                    <EmbeddedResource Include=""**\*.resx"" />
-                    <Content Include=""{sourcePath}""/>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-                  </ItemGroup>
-                </Project>";
 
                 // Create the subdirectory structure for testing possible source paths for the content file
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA"));
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA", "folderB"));
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
                 var pathToContent = Path.Combine(workingDirectory, sourcePath);
                 if (Path.IsPathRooted(sourcePath))
                 {
                     pathToContent = sourcePath;
                 }
                 File.WriteAllText(pathToContent, "this is sample text in the content file");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    var attributes = new Dictionary<string, string>();
+
+                    var properties = new Dictionary<string, string>();
+                    if (packagePath != null)
+                    {
+                        properties["PackagePath"] = packagePath;
+                    }
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "Content",
+                            sourcePath,
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
@@ -853,33 +847,40 @@ namespace Dotnet.Integration.Test
                 {
                     sourcePath = sourcePath.Replace("##", workingDirectory);
                 }
-                var projectFileContents = $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
-
-                  <PropertyGroup>
-                    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <Compile Include=""**\*.cs"" />
-                    <EmbeddedResource Include=""**\*.resx"" />
-                    <Content Include=""{sourcePath}""/>
-                  </ItemGroup>
-                  <ItemGroup>
-                    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-                  </ItemGroup>
-                </Project>";
 
                 // Create the subdirectory structure for testing possible source paths for the content file
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA"));
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA", "folderB"));
 
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName);
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
                 var pathToContent = Path.Combine(workingDirectory, sourcePath);
                 if (Path.IsPathRooted(sourcePath))
                 {
                     pathToContent = sourcePath;
                 }
                 File.WriteAllText(pathToContent, "this is sample text in the content file");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "net45;netstandard1.3");
+
+                    var attributes = new Dictionary<string, string>();
+                    var properties = new Dictionary<string, string>();
+
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "Content",
+                            sourcePath,
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
@@ -925,34 +926,24 @@ namespace Dotnet.Integration.Test
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFileContents =
-                    $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-  <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-  </ItemGroup>
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " -t lib");
 
-</Project>";
-                // Act
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+                    ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                var result = msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+                msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
                 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-
-                // Assert Exit code was 0, and there was nothing in the error stream
-                Assert.Equal(result.Item1, 0);
-                Assert.Equal(result.Item3, "");
 
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
@@ -975,7 +966,7 @@ namespace Dotnet.Integration.Test
                     var packages = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
-                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.0")), packages[0].VersionRange);
+                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
                     Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
@@ -1000,34 +991,24 @@ namespace Dotnet.Integration.Test
             {
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
-                var projectFileContents =
-                    $@"<Project Sdk=""Microsoft.NET.Sdk"" ToolsVersion=""15.0"">
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
 
-  <PropertyGroup>
-    <TargetFrameworks>{frameworks}</TargetFrameworks>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""**\*.cs"" />
-    <EmbeddedResource Include=""**\*.resx"" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
-  </ItemGroup>
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " -t lib");
 
-</Project>";
-                // Act
-                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
-                File.WriteAllText(Path.Combine(workingDirectory, $"{projectName}.csproj"), projectFileContents);
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", frameworks);
+                    ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                var result = msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+                msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
-
-                // Assert Exit code was 0, and there was nothing in the error stream
-                Assert.Equal(result.Item1, 0);
-                Assert.Equal(result.Item3, "");
 
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
@@ -1058,6 +1039,243 @@ namespace Dotnet.Integration.Test
                     foreach (var framework in frameworksArray)
                     {
                         Assert.Contains($"lib/{framework}/ClassLibrary1.dll", libItems);
+                    }
+                }
+            }
+        }
+
+        // This test checks to see that when IncludeBuildOutput=false, the generated nupkg does not contain lib folder
+        [Platform(Platform.Windows)]
+        [Fact]
+        public void PackCommand_PackNewDefaultProject_IncludeBuildOutputDoesNotCreateLibFolder()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:IncludeBuildOutput=false");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+
+                    // Validate the output .nuspec.
+                    Assert.Equal("ClassLibrary1", nuspecReader.GetId());
+                    Assert.Equal("1.0.0", nuspecReader.GetVersion().ToFullString());
+                    Assert.Equal("ClassLibrary1", nuspecReader.GetAuthors());
+                    Assert.Equal("ClassLibrary1", nuspecReader.GetOwners());
+                    Assert.Equal("Package Description", nuspecReader.GetDescription());
+                    Assert.False(nuspecReader.GetRequireLicenseAcceptance());
+
+                    var dependencyGroups = nuspecReader.GetDependencyGroups().ToList();
+                    Assert.Equal(1, dependencyGroups.Count);
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, dependencyGroups[0].TargetFramework);
+                    var packages = dependencyGroups[0].Packages.ToList();
+                    Assert.Equal(1, packages.Count);
+                    Assert.Equal("NETStandard.Library", packages[0].Id);
+                    Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
+                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Empty(packages[0].Include);
+
+                    // Validate the assets.
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(0, libItems.Count);
+                }
+            }
+        }
+
+        // This test checks to see that when BuildOutputTargetFolder is specified, the generated nupkg has the DLLs in the specified output folder
+        // instead of the default lib folder.
+        [Platform(Platform.Windows)]
+        [Fact]
+        public void PackCommand_PackNewDefaultProject_BuildOutputTargetFolderOutputsLibsToRightFolder()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var buildOutputTargetFolder = "build";
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:BuildOutputTargetFolder={buildOutputTargetFolder}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    // Validate the assets.
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(0, libItems.Count);
+                    libItems = nupkgReader.GetLibItems(buildOutputTargetFolder).ToList();
+                    Assert.Equal(1, libItems.Count);
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
+                    Assert.Equal(new[] { $"{buildOutputTargetFolder}/netstandard1.4/ClassLibrary1.dll" }, libItems[0].Items);
+                }
+            }
+        }
+
+        // This test checks to see that when GeneratePackageOnBuild is set to true, the generated nupkg and the intermediate
+        // nuspec is deleted when the clean target is invoked.
+        [Platform(Platform.Windows)]
+        [Fact]
+        public void PackCommand_PackNewProject_CleanDeletesNupkgAndNuspec()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " -t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(xml, "GeneratePackageOnBuild", "true");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory} ");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                // Run the clean target
+                msbuildFixture.BuildProject(workingDirectory, projectName, $"/t:Clean /p:PackageOutputPath={workingDirectory}\\");
+
+                Assert.True(!File.Exists(nupkgPath), "The output .nupkg was not deleted by the Clean target");
+                Assert.True(!File.Exists(nuspecPath), "The intermediate nuspec file was not deleted by the Clean target");
+            }
+        }
+
+        // All commented out tests are because of the bug : https://github.com/NuGet/Home/issues/4407
+        // TODO : Uncomment all the test cases once the above bug is fixed.
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("abc.txt",                  null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("folderA/abc.txt",          null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt",  null,                                       "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        //[InlineData("abc.txt",                  "folderA/",                                 "folderA/abc.txt")]
+        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        //[InlineData("abc.txt",                  "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
+        //[InlineData("folderA/abc.txt",          "folderA/",                                 "folderA/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;folderB",                          "folderA/folderA/abc.txt;folderB/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles",                     "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles\\",                   "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        //[InlineData("folderA/abc.txt",          "folderA;contentFiles/",                    "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles/folderA",             "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA/xyz.txt",                          "folderA/xyz.txt/folderA/abc.txt")]
+        //[InlineData("C:/abc.txt",               "folderA/",                                 "folderA/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        //[InlineData("C:/abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        //[InlineData("../abc.txt",               "folderA/",                                 "folderA/abc.txt")]
+        [InlineData("../abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        //[InlineData("../abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        // ## is a special syntax specifically for this test which means that ## should be replaced by the absolute path to the project directory.
+        [InlineData("##/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/folderA/abc.txt",       null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("##/../abc.txt",            null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/abc.txt",               "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/folderA/abc.txt",       "folderX;folderY",                          "folderX/folderA/abc.txt;folderY/folderA/abc.txt")]
+        [InlineData("##/../abc.txt",            "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
+        
+        public void PackCommand_PackProject_ContentTargetFoldersPacksContentCorrectly(string sourcePath, string contentTargetFolders, string expectedTargetPaths)
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+
+                if (sourcePath.StartsWith("##"))
+                {
+                    sourcePath = sourcePath.Replace("##", workingDirectory);
+                }
+
+                // Create the subdirectory structure for testing possible source paths for the content file
+                Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA"));
+                Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA", "folderB"));
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, "-t lib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+                    ProjectFileUtils.AddProperty(xml, "ContentTargetFolders", contentTargetFolders);
+
+                    var attributes = new Dictionary<string, string>();
+
+                    var properties = new Dictionary<string, string>();
+                    ProjectFileUtils.AddItem(
+                            xml,
+                            "Content",
+                            sourcePath,
+                            string.Empty,
+                            properties,
+                            attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                var pathToContent = Path.Combine(workingDirectory, sourcePath);
+                if (Path.IsPathRooted(sourcePath))
+                {
+                    pathToContent = sourcePath;
+                }
+                File.WriteAllText(pathToContent, "this is sample text in the content file");
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                // Assert
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var items = new HashSet<string>(nupkgReader.GetFiles());
+                    var expectedPaths = expectedTargetPaths.Split(';');
+                    foreach (var path in expectedPaths)
+                    {
+                        Assert.Contains(path, items);
                     }
                 }
             }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4414

1) added new test cases for Pack, namely, testing the Clean target, IncludeBuildOutput flag, BuildOutputTargetFolder property, ContentTargetFolders property.

2) Instead of hard-coding project files in Pack tests, project template is now obtained via ```dotnet new``` , and ProjectFileUtils class is used to parse XML and add properties and items as needed.

3) Update the cli_test to the latest version of CLI as of today.

CC: @alpaix @emgarten @mishra14 @nkolev92 @jainaashish @zhili1208 @rrelyea 