### PR TITLE
Added inner exception to error in case of MsBuild solution file parse failure

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -330,11 +330,14 @@ namespace NuGet.CommandLine
             }
             catch (Exception ex)
             {
+                var exMessage = ex.Message;
+                if (ex.InnerException != null)
+                    exMessage += "  " + ex.InnerException.Message;
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     LocalizedResourceManager.GetString("Error_SolutionFileParseError"),
                     solutionFile,
-                    ex.Message);
+                    exMessage);
 
                 throw new CommandLineException(message);
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1363,6 +1363,7 @@ EndProject";
                 Assert.NotEqual(0, r.Item1);
                 var error = r.Item3;
                 Assert.True(error.Contains("Error parsing solution file"));
+                Assert.True(error.Contains("Error parsing a project section"));
             }
         }
 


### PR DESCRIPTION
Fixes NuGet/Home#4411