### PR TITLE
add ability to specify package title in csproj file

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -55,5 +55,6 @@ namespace NuGet.Build.Tasks.Pack
         string[] TargetFrameworks { get; }
         string[] TargetPathsToAssemblies { get; }
         string[] TargetPathsToSymbols { get; }
+        string Title { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -106,6 +106,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               PackageFilesToExclude="@(_PackageFilesToExclude)"
               PackageVersion="$(PackageVersion)"
               PackageId="$(PackageId)"
+              Title="$(Title)"
               Authors="$(Authors)"
               Description="$(Description)"
               Copyright="$(Copyright)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -19,6 +19,7 @@ namespace NuGet.Build.Tasks.Pack
         public string[] PackageTypes { get; set; }
         public string PackageId { get; set; }
         public string PackageVersion { get; set; }
+        public string Title { get; set; }
         public string[] Authors { get; set; }
         public string Description { get; set; }
         public string Copyright { get; set; }
@@ -145,7 +146,8 @@ namespace NuGet.Build.Tasks.Pack
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
                 TargetPathsToAssemblies = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToAssemblies),
-                TargetPathsToSymbols = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToSymbols)
+                TargetPathsToSymbols = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToSymbols),
+                Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title),
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -97,6 +97,7 @@ namespace NuGet.Build.Tasks.Pack
             {
                 Id = request.PackageId,
                 Description = request.Description,
+                Title = request.Title,
                 Copyright = request.Copyright,
                 ReleaseNotes = request.ReleaseNotes,
                 RequireLicenseAcceptance = request.RequireLicenseAcceptance,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -48,5 +48,6 @@ namespace NuGet.Build.Tasks.Pack
         public string[] TargetFrameworks { get; set; }
         public string[] TargetPathsToAssemblies { get; set; }
         public string[] TargetPathsToSymbols { get; set; }
+        public string Title { get; set; }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4150

Brings back the ability to specify "Title" from a csproj file.
Added tests.

CC: @rrelyea @emgarten @alpaix @mishra14 @nkolev92 @zhili1208 @jainaashish 