### PR TITLE
Added `Credentials` to the equality comparer for `PackageSource`

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSource.cs
@@ -152,7 +152,8 @@ namespace NuGet.Configuration
             }
 
             return Name.Equals(other.Name, StringComparison.CurrentCultureIgnoreCase) &&
-                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase);
+                   Source.Equals(other.Source, StringComparison.OrdinalIgnoreCase) &&
+                   Equals(Credentials, other.Credentials);
         }
 
         public override bool Equals(object obj)

--- a/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
+++ b/src/NuGet.Core/NuGet.Configuration/PackageSource/PackageSourceCredential.cs
@@ -9,8 +9,10 @@ namespace NuGet.Configuration
     /// <summary>
     /// Represents credentials required to authenticate user within package source web requests.
     /// </summary>
-    public class PackageSourceCredential
+    public class PackageSourceCredential : IEquatable<PackageSourceCredential>
     {
+        private readonly int _hashCode;
+
         /// <summary>
         /// User name
         /// </summary>
@@ -86,6 +88,14 @@ namespace NuGet.Configuration
             Username = username;
             PasswordText = passwordText;
             IsPasswordClearText = isPasswordClearText;
+
+            unchecked
+            {
+                _hashCode = username.GetHashCode();
+                _hashCode = (_hashCode * 397) ^ (passwordText?.GetHashCode() ?? 0);
+                _hashCode = (_hashCode * 397) ^ IsPasswordClearText.GetHashCode();
+                _hashCode = (_hashCode * 397) ^ source.GetHashCode();
+            }
         }
 
         /// <summary>
@@ -124,5 +134,22 @@ namespace NuGet.Configuration
                     string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedEncryptPassword, source), e);
             }
         }
+
+        public bool Equals(PackageSourceCredential other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Username, other.Username) && string.Equals(PasswordText, other.PasswordText) && IsPasswordClearText == other.IsPasswordClearText && string.Equals(Source, other.Source);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((PackageSourceCredential) obj);
+        }
+
+        public override int GetHashCode() => _hashCode;
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceCredentialTests.cs
@@ -90,5 +90,31 @@ namespace NuGet.Configuration.Test
 
             Assert.False(credentials.IsValid());
         }
+
+        [Fact]
+        public void Equals_WithDifferentPasswords_AreNotEqual()
+        {
+            var a = new PackageSourceCredential("source", "user", "Password", isPasswordClearText: false);
+            var b = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+
+            Assert.NotEqual(a,b);
+        }
+
+        [Fact]
+        public void Equals_WithUsernames_AreNotEqual()
+        {
+            var a = new PackageSourceCredential("source", "user1", "password", isPasswordClearText: false);
+            var b = new PackageSourceCredential("source", "user2", "password", isPasswordClearText: false);
+
+            Assert.NotEqual(a, b);
+        }
+
+        [Fact]
+        public void Equals_WithTheSameValues_AreEqual()
+        {
+            var a = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+            var b = new PackageSourceCredential("source", "user", "password", isPasswordClearText: false);
+            Assert.Equal(a,b);
+        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Configuration.Test/PackageSourceTests.cs
@@ -11,12 +11,7 @@ namespace NuGet.Configuration
         public void Clone_CopiesAllPropertyValuesFromSource()
         {
             // Arrange
-            var credentials = new PackageSourceCredential("SourceName", "username", "password", isPasswordClearText: false);
-            var source = new PackageSource("Source", "SourceName", isEnabled: false)
-                {
-                    Credentials = credentials,
-                    ProtocolVersion = 43
-                };
+            var source = Create("password");
 
             // Act
             var result = source.Clone();
@@ -28,5 +23,36 @@ namespace NuGet.Configuration
             Assert.Equal(source.ProtocolVersion, result.ProtocolVersion);
             Assert.Same(source.Credentials, result.Credentials);
         }
+
+        [Fact]
+        public void Equals_WithDifferentCredentials_AreNotEqual()
+        {
+            var a = Create("Foo");
+            var b = Create("Bar");
+
+            Assert.NotEqual(a,b);
+        }
+
+        [Fact]
+        public void Equals_WithSameCredentials_AreEqual()
+        {
+            var a = Create("Foo");
+            var b = Create("Foo");
+
+            Assert.Equal(a,b);
+        }
+
+
+        private static PackageSource Create(string password)
+        {
+            var credentials = new PackageSourceCredential("SourceName", "username", password, isPasswordClearText: false);
+            var source = new PackageSource("Source", "SourceName", isEnabled: false)
+            {
+                Credentials = credentials,
+                ProtocolVersion = 43
+            };
+            return source;
+        }
+
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Core.v3.Tests/HttpSource/HttpSourceResourceProviderTests.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class HttpSourceResourceProviderTests
+    {
+        private const string FakeSource = "https://fake.server/users.json";
+
+        [Fact]
+        public void TryCreate_WithDifferentSourceRepositoryCredentials_ReturnsDifferentHttpSourceResources()
+        {
+            var provider = new HttpSourceResourceProvider();
+            var a = provider.TryCreate(CreateSourceRepository("Foo"), CancellationToken.None);
+            var b = provider.TryCreate(CreateSourceRepository("Bar"), CancellationToken.None);
+
+            Assert.NotSame(a.Result.Item2, b.Result.Item2);
+        }
+
+        [Fact]
+        public void TryCreate_WithTheSameSourceRepositoryCredentials_ReturnsTheSameHttpSourceResource()
+        {
+            var provider = new HttpSourceResourceProvider();
+            var a = provider.TryCreate(CreateSourceRepository("Foo"), CancellationToken.None);
+            var b = provider.TryCreate(CreateSourceRepository("Foo"), CancellationToken.None);
+
+            Assert.Same(a.Result.Item2, b.Result.Item2);
+        }
+
+        private static SourceRepository CreateSourceRepository(string password)
+        {
+            return new SourceRepository(
+                new PackageSource(FakeSource) { Credentials = new PackageSourceCredential(FakeSource, "user", password, true)},
+                new[]
+                {
+                    new HttpSourceResourceProvider()
+                }
+            );
+        }
+    }
+}


### PR DESCRIPTION
So that when `HttpSourceResourceProvider` caches `HttpClient`s, it creates a new client when the credentials change. Previously it was returning the same `HttpClient` (which already has credentials set) regardles of the `PackageSource.Credentails` value.

Fixes https://github.com/NuGet/Home/issues/4427