### PR TITLE
Resolve VS hang on solution close

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -137,6 +137,9 @@ namespace NuGet.SolutionRestoreManager
                 {
                     await RestoreAsync(request.ForceRestore, request.RestoreSource, token);
                 }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                }
                 catch (Exception e)
                 {
                     // Log the exception to the console and activity log

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -118,6 +118,7 @@ namespace NuGet.SolutionRestoreManager
 
                     var dte = _serviceProvider.GetDTE();
                     _solutionEvents = dte.Events.SolutionEvents;
+                    _solutionEvents.BeforeClosing += SolutionEvents_BeforeClosing;
                     _solutionEvents.AfterClosing += SolutionEvents_AfterClosing;
 #if VS15
                     // these properties are specific to VS15 since they are use to attach to solution events
@@ -149,13 +150,22 @@ namespace NuGet.SolutionRestoreManager
 
         private void Reset(bool isDisposing = false)
         {
-            _workerCts?.Cancel();
+            if (_workerCts?.IsCancellationRequested == false)
+            {
+                _workerCts.Cancel();
+            }
 
             if (_backgroundJobRunner?.IsValueCreated == true)
             {
-                // Do not block VS for more than 5 sec.
-                _joinableFactory.Run(
-                    () => Task.WhenAny(_backgroundJobRunner.Value, Task.Delay(TimeSpan.FromSeconds(5))));
+                // Await completion of the background work
+                _joinableFactory.Run(async () =>
+                {
+                    using (_joinableCollection.Join())
+                    {
+                        // Do not block VS forever
+                        await Task.WhenAny(_backgroundJobRunner.Value, Task.Delay(TimeSpan.FromSeconds(60)));
+                    }
+                });
             }
 
             _pendingRestore?.Dispose();
@@ -184,6 +194,12 @@ namespace NuGet.SolutionRestoreManager
             }
         }
 
+        private void SolutionEvents_BeforeClosing()
+        {
+            // Signal background runner to terminate execution
+            _workerCts?.Cancel();
+        }
+
         private void SolutionEvents_AfterClosing()
         {
             Reset();
@@ -193,6 +209,11 @@ namespace NuGet.SolutionRestoreManager
         public async Task<bool> ScheduleRestoreAsync(
             SolutionRestoreRequest request, CancellationToken token)
         {
+            if (token.IsCancellationRequested)
+            {
+                return false;
+            }
+
             // Initialize if not already done.
             await InitializeAsync();
 
@@ -208,9 +229,14 @@ namespace NuGet.SolutionRestoreManager
             // on-board request onto pending restore operation
             _pendingRequests.Value.TryAdd(request);
 
+            // await completion of the requested restore operation
+            // the caller will be unblocked immediately upon
+            // cancellation request via provided token
+            var tcs = new TaskCompletionSource<bool>();
+            using (token.Register(s => ((TaskCompletionSource<bool>)s).SetResult(false), tcs))
             using (_joinableCollection.Join())
             {
-                return await (Task<bool>)pendingRestore;
+                return await await Task.WhenAny(pendingRestore.Task, tcs.Task);
             }
         }
 
@@ -325,7 +351,7 @@ namespace NuGet.SolutionRestoreManager
 
         private async Task PromoteTaskToActiveAsync(BackgroundRestoreOperation restoreOperation, CancellationToken token)
         {
-            var pendingTask = (Task<bool>)restoreOperation;
+            var pendingTask = restoreOperation.Task;
 
             int attempt = 0;
             for (var retry = true;
@@ -395,11 +421,9 @@ namespace NuGet.SolutionRestoreManager
 
             private TaskCompletionSource<bool> JobTcs { get; } = new TaskCompletionSource<bool>();
 
-            private Task<bool> Task => JobTcs.Task;
+            public Task<bool> Task => JobTcs.Task;
 
             public System.Runtime.CompilerServices.TaskAwaiter<bool> GetAwaiter() => Task.GetAwaiter();
-
-            public static explicit operator Task<bool>(BackgroundRestoreOperation restoreOperation) => restoreOperation.Task;
 
             public void ContinuationAction(Task<bool> targetTask)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -90,7 +90,7 @@ namespace NuGet.PackageManagement
                         dgSpec,
                         userPackagesPath);
 
-                    var restoreSummaries = await RestoreRunner.Run(restoreContext);
+                    var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, token);
 
                     RestoreSummary.Log(log, restoreSummaries);
 
@@ -131,7 +131,7 @@ namespace NuGet.PackageManagement
                         dgSpec,
                         userPackagesPath: null);
 
-                    var restoreSummaries = await RestoreRunner.Run(restoreContext);
+                    var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, token);
 
                     RestoreSummary.Log(log, restoreSummaries);
 
@@ -247,7 +247,7 @@ namespace NuGet.PackageManagement
             token.ThrowIfCancellationRequested();
 
             // Write out the lock file and msbuild files
-            var summary = await RestoreRunner.Commit(result);
+            var summary = await RestoreRunner.CommitAsync(result, token);
 
             RestoreSummary.Log(log, new[] { summary });
 

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2349,7 +2349,7 @@ namespace NuGet.PackageManagement
 
                 originalLockFile = originalRestoreResult.Result.LockFile;
             }
-            
+
             foreach (var action in nuGetProjectActions)
             {
                 if (action.NuGetProjectActionType == NuGetProjectActionType.Uninstall)
@@ -2579,7 +2579,7 @@ namespace NuGet.PackageManagement
                 else
                 {
                     // Write out the lock file
-                    await RestoreRunner.Commit(projectAction.RestoreResultPair);
+                    await RestoreRunner.CommitAsync(projectAction.RestoreResultPair, token);
                 }
 
                 // Write out a message for each action


### PR DESCRIPTION
Resolves NuGet/Home#4257.

This change drastically improves solution close experience when
auto-restore is running in the background.

By implementing following cancellation strategy:
- Unblock the caller (Roslyn) upon cancellation request via provided token
- Cancel background restore operation on solution `BeforeClosing`
- Pass cancellation token via `RestoreRunner` downstream to core
algorithms.

//cc @emgarten @jainaashish @mishra14 @rohit21agrawal @natidea @rrelyea 