### PR TITLE
Fix RPS regression for VM_ImagesInMemory_Total_devenv

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -77,9 +77,6 @@ namespace NuGet.SolutionRestoreManager
                     new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
             });
 
-            // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(componentModel);
-
             await SolutionRestoreCommand.InitializeAsync(this);
 
             await base.InitializeAsync(cancellationToken, progress);

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -158,9 +158,6 @@ namespace NuGetVSExtension
             _dteEvents = _dte.Events.DTEEvents;
             _dteEvents.OnBeginShutdown += OnBeginShutDown;
 
-            // Set the JoinableTaskFactory for the current version of visual studio.
-            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(componentModel);
-
             SetDefaultCredentialProvider();
 
             if (SolutionManager.NuGetProjectContext == null)

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
 
@@ -21,6 +22,9 @@ namespace NuGet.PackageManagement.VisualStudio
     public class CpsPackageReferenceProjectProvider : IProjectSystemProvider
     {
         private readonly IProjectSystemCache _projectSystemCache;
+
+        [Import]
+        private Lazy<IProjectServiceAccessor> ProjectServiceAccessor { get; set; }
 
         [ImportingConstructor]
         public CpsPackageReferenceProjectProvider(IProjectSystemCache projectSystemCache)
@@ -85,6 +89,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
+
+            // Lazy load the CPS enabled JoinableTaskFactory for the UI.
+            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value);
 
             var projectNames = ProjectNames.FromDTEProject(dteProject);
             var fullProjectPath = EnvDTEProjectUtility.GetFullProjectPath(dteProject);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
@@ -6,8 +6,8 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Utilities;
+using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
-using VSLangProj150;
 using ProjectSystem = Microsoft.VisualStudio.ProjectSystem;
 
 namespace NuGet.PackageManagement.VisualStudio
@@ -18,6 +18,9 @@ namespace NuGet.PackageManagement.VisualStudio
     public class LegacyCSProjPackageReferenceProjectProvider : IProjectSystemProvider
     {
         private readonly IProjectSystemCache _projectSystemCache;
+
+        [Import]
+        private Lazy<ProjectSystem.IProjectServiceAccessor> ProjectServiceAccessor { get; set; }
 
         [ImportingConstructor]
         public LegacyCSProjPackageReferenceProjectProvider(IProjectSystemCache projectSystemCache)
@@ -51,6 +54,9 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
+
+            // Lazy load the CPS enabled JoinableTaskFactory for the UI.
+            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value);
 
             result = new LegacyCSProjPackageReferenceProject(
                 project,

--- a/src/NuGet.Clients/VisualStudio.Facade/NuGetUIThreadHelper.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/NuGetUIThreadHelper.cs
@@ -33,28 +33,29 @@ namespace NuGet.PackageManagement.UI
         /// Retrieve the CPS enabled JoinableTaskFactory for the current version of Visual Studio.
         /// This overrides the default VsTaskLibraryHelper.ServiceInstance JTF.
         /// </summary>
-        public static void SetJoinableTaskFactoryFromService(IComponentModel componentModel)
+        public static void SetJoinableTaskFactoryFromService(IProjectServiceAccessor projectServiceAccessor)
         {
-            if (componentModel == null)
+            if (projectServiceAccessor == null)
             {
-                throw new ArgumentNullException(nameof(componentModel));
+                throw new ArgumentNullException(nameof(projectServiceAccessor));
             }
 
-            _joinableTaskFactory = new Lazy<JoinableTaskFactory>(() =>
+            if (_joinableTaskFactory == null)
             {
-                var projectServiceAccessor = componentModel.GetService<IProjectServiceAccessor>();
-
+                _joinableTaskFactory = new Lazy<JoinableTaskFactory>(() =>
+                {
 #if VS14
-                // Use IThreadHandling.AsyncPump for Visual Studio 2015
-                ProjectService projectService = projectServiceAccessor.GetProjectService();
-                IThreadHandling threadHandling = projectService.Services.ThreadingPolicy;
-                return threadHandling.AsyncPump;
+                    // Use IThreadHandling.AsyncPump for Visual Studio 2015
+                    ProjectService projectService = projectServiceAccessor.GetProjectService();
+                    IThreadHandling threadHandling = projectService.Services.ThreadingPolicy;
+                    return threadHandling.AsyncPump;
 #else
-                // Use IProjectService for Visual Studio 2017
-                IProjectService projectService = projectServiceAccessor.GetProjectService();
-                return projectService.Services.ThreadingPolicy.JoinableTaskFactory;
+                    // Use IProjectService for Visual Studio 2017
+                    IProjectService projectService = projectServiceAccessor.GetProjectService();
+                    return projectService.Services.ThreadingPolicy.JoinableTaskFactory;
 #endif
-            });
+                });
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes couple of RPS regression for VM_ImagesInMemory_Total_devenv and VM_FileBytes_Total_devenv perf counters for WebForms_DDRIT 1200.Close Solution and ManagedLangs_CS_DDRIT 0800.Close Solution test scenarios.

Regression was due to the fact that we moved to CPS JTF for all our projects which caused CPS assemblies to loaded by NuGet even though there is no project which uses CPS. So the solution is by default we always use Shell JTF, until there is some CPS based NuGet projects to be created and then we fault into CPS JTF and start using that for all the actions.

Fixes https://github.com/NuGet/Home/issues/4408

@emgarten @rrelyea @alpaix

