### PR TITLE
Correctly update NuGet projects for Manager UI at project level

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -339,7 +339,7 @@ namespace NuGet.PackageManagement.UI
             // don't show this dialog for VS 2015
             return await Task.FromResult(true);
 #else
-            var newProjectNames = new List<string>();
+            var potentialProjects = new List<NuGetProject>();
 
             // check if project is packages.config and it's dte project instance can also be converted to VSProject4.
             // otherwise don't show format selector dialog for this project
@@ -352,12 +352,12 @@ namespace NuGet.PackageManagement.UI
             {
                 if (!(await project.GetInstalledPackagesAsync(token)).Any())
                 {
-                    newProjectNames.Add(project.GetMetadata<string>(NuGetProjectMetadataKeys.Name));
+                    potentialProjects.Add(project);
                 }
             }
-
+            
             // only show this dialog if there are any new project(s) with no installed packages.
-            if (newProjectNames.Count > 0)
+            if (potentialProjects.Count > 0)
             {
                 var packageManagementFormat = new PackageManagementFormat(uiService.Settings);
                 if (!packageManagementFormat.Enabled)
@@ -366,13 +366,15 @@ namespace NuGet.PackageManagement.UI
                     // now check for default package format, if its set to PackageReference then update the project.
                     if (packageManagementFormat.SelectedPackageManagementFormat == 1)
                     {
-                        await uiService.UpdateNuGetProjectToPackageRef(msBuildProjects);
+                        await uiService.UpdateNuGetProjectToPackageRef(potentialProjects);
                     }
 
                     return true;
                 }
 
-                packageManagementFormat.ProjectNames = newProjectNames.OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToList();
+                packageManagementFormat.ProjectNames = potentialProjects
+                    .Select(project => project.GetMetadata<string>(NuGetProjectMetadataKeys.Name))
+                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase).ToList();
 
                 // show dialog for package format selector
                 var result = uiService.PromptForPackageManagementFormat(packageManagementFormat);
@@ -380,7 +382,7 @@ namespace NuGet.PackageManagement.UI
                 // update nuget projects if user selected PackageReference option
                 if (result && packageManagementFormat.SelectedPackageManagementFormat == 1)
                 {
-                    await uiService.UpdateNuGetProjectToPackageRef(msBuildProjects);
+                    await uiService.UpdateNuGetProjectToPackageRef(potentialProjects);
                 }
                 return result;
             }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -57,7 +57,7 @@ namespace NuGet.PackageManagement.UI
 
         private void NuGetProjectChanged(object sender, NuGetProjectEventArgs e)
         {
-            _nugetProjects = _solutionManager.GetNuGetProjects();
+            _nugetProjects = new List<NuGetProject> { e.NuGetProject };
             UpdateInstalledVersion();
         }
 


### PR DESCRIPTION
It fixes two things:
1. Instead of updating all the projects for manager ui at project level, it will now update only the current project. so that it doesn't add all the projects from solution in current model context.
2. Only update projects from Packages.config to PackageRef which doesn't have any package installed. Currently It tries to update all the packages.config based projects if user choose to select PackageRef.

Fixes https://github.com/NuGet/Home/issues/4433

@rrelyea @emgarten @alpaix @rohit21agrawal @zhili1208 