### PR TITLE
AutoReferenced support

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -341,7 +341,9 @@ namespace NuGet.SolutionRestoreManager
                 LibraryRange = new LibraryRange(
                     name: item.Name,
                     versionRange: GetVersionRange(item),
-                    typeConstraint: LibraryDependencyTarget.Package)
+                    typeConstraint: LibraryDependencyTarget.Package),
+
+                AutoReferenced = GetPropertyBoolOrDefault(item, "AutoReferenced")
             };
 
             MSBuildRestoreUtility.ApplyIncludeFlags(
@@ -385,6 +387,23 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return VersionRange.All;
+        }
+
+        private static bool GetPropertyBoolOrDefault(
+                IVsReferenceItem item, string propertyName)
+        {
+            try
+            {
+                return MSBuildStringUtility.IsTrue(item.Properties?.Item(propertyName)?.Value);
+            }
+            catch (ArgumentException)
+            {
+            }
+            catch (KeyNotFoundException)
+            {
+            }
+
+            return false;
         }
 
         private static string GetPropertyValueOrNull(

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -344,7 +344,7 @@ namespace NuGet.SolutionRestoreManager
                     typeConstraint: LibraryDependencyTarget.Package),
 
                 // Mark packages coming from the SDK as AutoReferenced
-                AutoReferenced = GetPropertyBoolOrDefault(item, "IsImplicitlyDefined")
+                AutoReferenced = GetPropertyBoolOrFalse(item, "IsImplicitlyDefined")
             };
 
             MSBuildRestoreUtility.ApplyIncludeFlags(
@@ -390,7 +390,7 @@ namespace NuGet.SolutionRestoreManager
             return VersionRange.All;
         }
 
-        private static bool GetPropertyBoolOrDefault(
+        private static bool GetPropertyBoolOrFalse(
                 IVsReferenceItem item, string propertyName)
         {
             try

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -343,7 +343,8 @@ namespace NuGet.SolutionRestoreManager
                     versionRange: GetVersionRange(item),
                     typeConstraint: LibraryDependencyTarget.Package),
 
-                AutoReferenced = GetPropertyBoolOrDefault(item, "AutoReferenced")
+                // Mark packages coming from the SDK as AutoReferenced
+                AutoReferenced = GetPropertyBoolOrDefault(item, "IsImplicitlyDefined")
             };
 
             MSBuildRestoreUtility.ApplyIncludeFlags(

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/GetPackageCommand.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Host;
 using NuGet.PackageManagement.UI;
+using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -193,6 +194,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
         private async Task WriteUpdatePackagesFromRemoteSourceAsync(NuGetProject project)
         {
             var installedPackages = await project.GetInstalledPackagesAsync(Token);
+            installedPackages = installedPackages.Where(p => !IsAutoReferenced(p));
 
             VersionType versionType;
             if (CollapseVersions)
@@ -358,6 +360,11 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             // Add a line after
             WriteLine();
             return choice;
+        }
+
+        private static bool IsAutoReferenced(PackageReference reference)
+        {
+            return (reference as BuildIntegratedPackageReference)?.Dependency?.AutoReferenced == true;
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollection.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollection.cs
@@ -13,40 +13,41 @@ namespace NuGet.PackageManagement.UI
     /// <summary>
     /// Wrapper class consolidating common queries against a collection of packages
     /// </summary>
-    internal class PackageCollection : IEnumerable<PackageIdentity>
+    internal class PackageCollection : IEnumerable<PackageCollectionItem>
     {
-        private readonly PackageIdentity[] _packages;
+        private readonly PackageCollectionItem[] _packages;
         private readonly ISet<string> _uniqueIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        public PackageCollection(PackageIdentity[] packages)
+        public PackageCollection(PackageCollectionItem[] packages)
         {
             _packages = packages;
             _uniqueIds.UnionWith(_packages.Select(p => p.Id));
         }
 
-        public IEnumerator<PackageIdentity> GetEnumerator()
+        public IEnumerator<PackageCollectionItem> GetEnumerator()
         {
-            return ((IEnumerable<PackageIdentity>)_packages).GetEnumerator();
+            return ((IEnumerable<PackageCollectionItem>)_packages).GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<PackageIdentity>)_packages).GetEnumerator();
+            return ((IEnumerable<PackageCollectionItem>)_packages).GetEnumerator();
         }
 
         public bool ContainsId(string packageId) => _uniqueIds.Contains(packageId);
 
         public static async Task<PackageCollection> FromProjectsAsync(IEnumerable<NuGetProject> projects, CancellationToken cancellationToken)
         {
+            // Read package references from all projects.
             var tasks = projects
                 .Select(project => project.GetInstalledPackagesAsync(cancellationToken));
             var packageReferences = await Task.WhenAll(tasks);
+
+            // Group all package references for an id/version into a single item.
             var packages = packageReferences
-                .SelectMany(p => p)
-                .Where(p => p != null)
-                .Select(p => p.PackageIdentity)
-                .Distinct(PackageIdentity.Comparer)
-                .ToArray();
+                    .SelectMany(e => e)
+                    .GroupBy(e => e.PackageIdentity, (key, group) => new PackageCollectionItem(key.Id, key.Version, group))
+                    .ToArray();
 
             return new PackageCollection(packages);
         }
@@ -85,6 +86,25 @@ namespace NuGet.PackageManagement.UI
                 .GroupById()
                 .Select(g => new PackageIdentity(g.Key, g.MinOrDefault()))
                 .ToArray();
+        }
+
+        /// <summary>
+        /// True if any package reference is AutoReferenced=true.
+        /// </summary>
+        public static bool IsAutoReferenced(this IEnumerable<PackageCollectionItem> packages, string id)
+        {
+            return packages.Where(e => StringComparer.OrdinalIgnoreCase.Equals(id, e.Id))
+                .Any(e => e.IsAutoReferenced());
+        }
+    }
+
+    internal static class PackageCollectionItemExtensions
+    {
+        public static bool IsAutoReferenced(this PackageCollectionItem package)
+        {
+            return package.PackageReferences
+                .Select(e => e as BuildIntegratedPackageReference)
+                .Any(e => e?.Dependency?.AutoReferenced == true);
         }
     }
 

--- a/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollectionItem.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollectionItem.cs
@@ -1,0 +1,25 @@
+﻿using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGet.PackageManagement.UI
+{
+    /// <summary>
+    /// id, version, original PackageReference if available.
+    /// </summary>
+    public class PackageCollectionItem : PackageIdentity
+    {
+        /// <summary>
+        /// Installed package references.
+        /// </summary>
+        public List<PackageReference> PackageReferences { get; }
+
+        public PackageCollectionItem(string id, NuGetVersion version, IEnumerable<PackageReference> installedReferences)
+            : base(id, version)
+        {
+            PackageReferences = installedReferences?.ToList() ?? new List<PackageReference>();
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollectionItem.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Common/PackageCollectionItem.cs
@@ -1,8 +1,11 @@
-﻿using NuGet.Packaging;
-using NuGet.Packaging.Core;
-using NuGet.Versioning;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
 
 namespace NuGet.PackageManagement.UI
 {

--- a/src/NuGet.Clients/PackageManagement.UI/DisplayVersion.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/DisplayVersion.cs
@@ -18,17 +18,18 @@ namespace NuGet.PackageManagement.UI
             NuGetVersion version,
             string additionalInfo,
             bool isValidVersion = true,
-            bool isCurrentInstalled = false)
-            : this(GetRange(version), additionalInfo, isValidVersion, isCurrentInstalled)
+            bool isCurrentInstalled = false,
+            bool autoReferenced = false)
+            : this(GetRange(version), additionalInfo, isValidVersion, isCurrentInstalled, autoReferenced)
         {
-
         }
 
         public DisplayVersion(
             VersionRange range,
             string additionalInfo,
             bool isValidVersion = true,
-            bool isCurrentInstalled = false)
+            bool isCurrentInstalled = false,
+            bool autoReferenced = false)
         {
             Range = range;
             _additionalInfo = additionalInfo;
@@ -37,6 +38,7 @@ namespace NuGet.PackageManagement.UI
 
             Version = range.MinVersion;
             IsCurrentInstalled = isCurrentInstalled;
+            AutoReferenced = autoReferenced;
 
             // Display a single version if the range is locked
             if (range.HasLowerAndUpperBounds && range.MinVersion == range.MaxVersion)
@@ -61,6 +63,8 @@ namespace NuGet.PackageManagement.UI
         public VersionRange Range { get; }
 
         public bool IsValidVersion { get; set; }
+
+        public bool AutoReferenced { get; set; }
 
         public override string ToString()
         {

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/ConsolidatePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/ConsolidatePackageFeed.cs
@@ -16,12 +16,12 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     internal class ConsolidatePackageFeed : PlainPackageFeedBase
     {
-        private readonly IEnumerable<PackageIdentity> _installedPackages;
+        private readonly IEnumerable<PackageCollectionItem> _installedPackages;
         private readonly IPackageMetadataProvider _metadataProvider;
         private readonly Common.ILogger _logger;
 
         public ConsolidatePackageFeed(
-            IEnumerable<PackageIdentity> installedPackages,
+            IEnumerable<PackageCollectionItem> installedPackages,
             IPackageMetadataProvider metadataProvider,
             Common.ILogger logger)
         {

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/InstalledPackageFeed.cs
@@ -16,12 +16,12 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     internal class InstalledPackageFeed : PlainPackageFeedBase
     {
-        private readonly IEnumerable<PackageIdentity> _installedPackages;
+        private readonly IEnumerable<PackageCollectionItem> _installedPackages;
         private readonly IPackageMetadataProvider _metadataProvider;
         private readonly Common.ILogger _logger;
 
         public InstalledPackageFeed(
-            IEnumerable<PackageIdentity> installedPackages,
+            IEnumerable<PackageCollectionItem> installedPackages,
             IPackageMetadataProvider metadataProvider,
             Common.ILogger logger)
         {

--- a/src/NuGet.Clients/PackageManagement.UI/Feeds/UpdatePackageFeed.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Feeds/UpdatePackageFeed.cs
@@ -18,14 +18,14 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     internal class UpdatePackageFeed : PlainPackageFeedBase
     {
-        private readonly IEnumerable<PackageIdentity> _installedPackages;
+        private readonly IEnumerable<PackageCollectionItem> _installedPackages;
         private readonly IPackageMetadataProvider _metadataProvider;
         private readonly PackageSearchMetadataCache _cachedUpdates;
         private readonly Common.ILogger _logger;
         private readonly NuGetProject[] _projects;
 
         public UpdatePackageFeed(
-            IEnumerable<PackageIdentity> installedPackages,
+            IEnumerable<PackageCollectionItem> installedPackages,
             IPackageMetadataProvider metadataProvider,
             NuGetProject[] projects,
             PackageSearchMetadataCache optionalCachedUpdates,
@@ -101,6 +101,7 @@ namespace NuGet.PackageManagement.UI
         public async Task<IEnumerable<IPackageSearchMetadata>> GetPackagesWithUpdatesAsync(string searchText, SearchFilter searchFilter, CancellationToken cancellationToken)
         {
             var packages = _installedPackages
+                .Where(p => !p.IsAutoReferenced())
                 .GetEarliest()
                 .Where(p => p.Id.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) != -1)
                 .OrderBy(p => p.Id);

--- a/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/DetailControlModel.cs
@@ -34,7 +34,8 @@ namespace NuGet.PackageManagement.UI
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields")]
         protected ItemFilter _filter;
 
-        protected Dictionary<string, VersionRange> _projectVersionRangeDict;
+        // Project constraints on the allowed package versions.
+        protected List<ProjectVersionConstraint> _projectVersionConstraints;
 
         private Dictionary<NuGetVersion, DetailedPackageMetadata> _metadataDict;
 
@@ -77,18 +78,64 @@ namespace NuGet.PackageManagement.UI
 
             var getVersionsTask = searchResultPackage.GetVersionsAsync();
 
-            _projectVersionRangeDict = new Dictionary<string, VersionRange>(StringComparer.OrdinalIgnoreCase);
+            var cacheContext = new DependencyGraphCacheContext();
+            _projectVersionConstraints = new List<ProjectVersionConstraint>();
 
-            // filter project.json based projects since allowedVersion is only applicable to packages.config
-            var packagesConfigProjects = _nugetProjects.Where(project => !(project is INuGetIntegratedProject));
+            // Filter out projects that are not managed by NuGet.
+            var projects = _nugetProjects.Where(project => !(project is ProjectKNuGetProjectBase)).ToArray();
 
-            foreach (var project in packagesConfigProjects)
+            foreach (var project in projects)
             {
-                // cache allowed version range for each nuget project for current selected package
-                var packageReference = (await project.GetInstalledPackagesAsync(CancellationToken.None))
-                    .FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.PackageIdentity.Id, searchResultPackage.Id));
+                if (project is MSBuildNuGetProject)
+                {
+                    // cache allowed version range for each nuget project for current selected package
+                    var packageReference = (await project.GetInstalledPackagesAsync(CancellationToken.None))
+                        .FirstOrDefault(r => StringComparer.OrdinalIgnoreCase.Equals(r.PackageIdentity.Id, searchResultPackage.Id));
 
-                _projectVersionRangeDict.Add(project.GetMetadata<string>(NuGetProjectMetadataKeys.Name), packageReference?.AllowedVersions);
+                    var range = packageReference?.AllowedVersions;
+
+                    if (range != null && !VersionRange.All.Equals(range))
+                    {
+                        var constaint = new ProjectVersionConstraint()
+                        {
+                            ProjectName = project.GetMetadata<string>(NuGetProjectMetadataKeys.Name),
+                            VersionRange = range,
+                            IsPackagesConfig = true,
+                        };
+
+                        _projectVersionConstraints.Add(constaint);
+                    }
+                }
+                else if (project is BuildIntegratedNuGetProject)
+                {
+                    var packageReferences = await project.GetInstalledPackagesAsync(CancellationToken.None);
+
+                    // First the lowest auto referenced version of this package.
+                    var autoReferenced = packageReferences.Where(e => StringComparer.OrdinalIgnoreCase.Equals(searchResultPackage.Id, e.PackageIdentity.Id)
+                                                                      && e.PackageIdentity.Version != null)
+                                                        .Select(e => e as BuildIntegratedPackageReference)
+                                                        .Where(e => e?.Dependency?.AutoReferenced == true)
+                                                        .OrderBy(e => e.PackageIdentity.Version)
+                                                        .FirstOrDefault();
+
+                    if (autoReferenced != null)
+                    {
+                        // Add constraint for auto referenced package.
+                        var constaint = new ProjectVersionConstraint()
+                        {
+                            ProjectName = project.GetMetadata<string>(NuGetProjectMetadataKeys.Name),
+                            VersionRange = new VersionRange(
+                                minVersion: autoReferenced.PackageIdentity.Version,
+                                includeMinVersion: true,
+                                maxVersion: autoReferenced.PackageIdentity.Version,
+                                includeMaxVersion: true),
+
+                            IsAutoReferenced = true,
+                        };
+
+                        _projectVersionConstraints.Add(constaint);
+                    }
+                }
             }
 
             // Add Current package version to package versions list.
@@ -368,6 +415,39 @@ namespace NuGet.PackageManagement.UI
 
         public abstract bool IsSolution { get; }
 
+        private string _optionsBlockedMessage;
+
+        public virtual string OptionsBlockedMessage
+        {
+            get
+            {
+                return _optionsBlockedMessage;
+            }
+
+            set
+            {
+                _optionsBlockedMessage = value;
+                OnPropertyChanged(nameof(OptionsBlockedMessage));
+            }
+        }
+
+        private Uri _optionsBlockedUrl;
+
+        public virtual Uri OptionsBlockedUrl
+        {
+            get
+            {
+                return _optionsBlockedUrl;
+            }
+
+            set
+            {
+                _optionsBlockedUrl = value;
+                OnPropertyChanged(nameof(OptionsBlockedUrl));
+                OnPropertyChanged(nameof(OptionsBlockedMessage));
+            }
+        }
+
         private Options _options;
 
         public Options Options
@@ -385,6 +465,66 @@ namespace NuGet.PackageManagement.UI
             get
             {
                 return _nugetProjects;
+            }
+        }
+
+        protected void AddBlockedVersions(NuGetVersion[] blockedVersions)
+        {
+            // add a separator
+            if (blockedVersions.Length > 0)
+            {
+                if (_versions.Count > 0)
+                {
+                    _versions.Add(null);
+                }
+
+                var blockedMessage = Resources.Version_Blocked_Generic;
+
+                if (_projectVersionConstraints.All(e => e.IsPackagesConfig))
+                {
+                    // Use the packages.config specific message.
+                    blockedMessage = Resources.Version_Blocked;
+                }
+
+                _versions.Add(new DisplayVersion(new VersionRange(new NuGetVersion(0, 0, 0)), blockedMessage, isValidVersion: false));
+            }
+
+            // add all the versions blocked to disable the update button
+            foreach (var version in blockedVersions)
+            {
+                _versions.Add(new DisplayVersion(version, string.Empty, isValidVersion: false));
+            }
+        }
+
+        protected void SetAutoReferencedCheck(NuGetVersion installedVersion)
+        {
+            var autoReferenced = installedVersion != null
+                    && _projectVersionConstraints.Any(e => e.IsAutoReferenced);
+
+            SetAutoReferencedCheck(autoReferenced);
+        }
+
+        protected void SetAutoReferencedCheck(bool autoReferenced)
+        {
+            if (autoReferenced)
+            {
+                OptionsBlockedUrl = new Uri("https://go.microsoft.com/fwlink/?linkid=841238");
+                OptionsBlockedMessage = "AutoReferenced";
+
+                if (_searchResultPackage != null)
+                {
+                    _searchResultPackage.AutoReferenced = true;
+                }
+            }
+            else
+            {
+                OptionsBlockedUrl = null;
+                OptionsBlockedMessage = null;
+
+                if (_searchResultPackage != null)
+                {
+                    _searchResultPackage.AutoReferenced = false;
+                }
             }
         }
     }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -118,7 +118,7 @@ namespace NuGet.PackageManagement.UI
             }
 
             // null, if no version constraint defined in package.config
-            var allowedVersions = _projectVersionRangeDict.Select(kvp => kvp.Value).FirstOrDefault() ?? VersionRange.All;
+            var allowedVersions = _projectVersionConstraints.Select(e => e.VersionRange).FirstOrDefault() ?? VersionRange.All;
             var allVersionsAllowed = allVersions.Where(v => allowedVersions.Satisfies(v)).ToArray();
 
             // null, if all versions are allowed to be install or update
@@ -151,27 +151,23 @@ namespace NuGet.PackageManagement.UI
             // first add all the available versions to be updated
             foreach (var version in allVersionsAllowed)
             {
-                _versions.Add(new DisplayVersion(version, string.Empty, isCurrentInstalled: version.Equals(installedVersion)));
-            }
+                var installed = version.Equals(installedVersion);
+                var autoReferenced = false;
 
-            // add a separator
-            if (blockedVersions.Any())
-            {
-                if (_versions.Count > 0)
+                if (installed && _projectVersionConstraints.Any(e => e.IsAutoReferenced && e.VersionRange?.Satisfies(version) == true))
                 {
-                    _versions.Add(null);
+                    // do not allow auto referenced packatges
+                    autoReferenced = true;
                 }
 
-                _versions.Add(new DisplayVersion(new VersionRange(new NuGetVersion("0.0.0")), Resources.Version_Blocked, false));
+                _versions.Add(new DisplayVersion(version, string.Empty, isCurrentInstalled: installed, autoReferenced: autoReferenced));
             }
 
-            // add all the versions blocked because of version constraint in package.config
-            bool isBlockedVersionEnabled = Options.SelectedDependencyBehavior.Behavior == DependencyBehavior.Ignore;
+            // Disable controls if this is an auto referenced package.
+            SetAutoReferencedCheck(InstalledVersion);
 
-            foreach (var version in blockedVersions)
-            {
-                _versions.Add(new DisplayVersion(version, string.Empty, isBlockedVersionEnabled));
-            }
+            // Add disabled versions
+            AddBlockedVersions(blockedVersions);
 
             SelectVersion();
 

--- a/src/NuGet.Clients/PackageManagement.UI/Models/PackageStatus.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/PackageStatus.cs
@@ -10,6 +10,9 @@ namespace NuGet.PackageManagement.UI
         // the latest applicable version is installed.
         Installed,
         
-        UpdateAvailable
+        UpdateAvailable,
+
+        // The package is installed but may not be managed.
+        AutoReferenced
     }
 }

--- a/src/NuGet.Clients/PackageManagement.UI/Models/ProjectVersionConstraint.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Models/ProjectVersionConstraint.cs
@@ -1,0 +1,35 @@
+﻿using NuGet.Versioning;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// An additional dependency constraint on a package id specified by a project.
+    /// </summary>
+    public class ProjectVersionConstraint
+    {
+        /// <summary>
+        /// Parent project
+        /// </summary>
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// Range
+        /// </summary>
+        public VersionRange VersionRange { get; set; } = VersionRange.All;
+
+        /// <summary>
+        /// packags.config allowedVersions value.
+        /// </summary>
+        public bool IsPackagesConfig { get; set; }
+
+        /// <summary>
+        /// PackageReference AutoReferenced value.
+        /// </summary>
+        public bool IsAutoReferenced { get; set; }
+
+        public override string ToString()
+        {
+            return $"{ProjectName} {VersionRange.ToNormalizedString()}";
+        }
+    }
+}

--- a/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Common\NuGetEvent.cs" />
     <Compile Include="Common\NuGetEventTrigger.cs" />
     <Compile Include="Common\OptionsPage.cs" />
+    <Compile Include="Common\PackageCollectionItem.cs" />
     <Compile Include="Converters\RadioBoolToIntConverter.cs" />
     <Compile Include="Converters\TooltipConverter.cs" />
     <Compile Include="Converters\BooleanToFontWeightConverter.cs" />
@@ -58,6 +59,7 @@
     <Compile Include="Models\LoadingStatusViewModel.cs" />
     <Compile Include="Models\PackageSearchMetadataCache.cs" />
     <Compile Include="Models\PackageSearchStatus.cs" />
+    <Compile Include="Models\ProjectVersionConstraint.cs" />
     <Compile Include="PackageManagementFormat.cs" />
     <Compile Include="Prompts\DotnetDeprecatedPrompt.cs" />
     <Compile Include="Resources\Domain.cs" />

--- a/src/NuGet.Clients/PackageManagement.UI/PackageInstallationInfo.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/PackageInstallationInfo.cs
@@ -29,6 +29,18 @@ namespace NuGet.PackageManagement.UI
             }
         }
 
+        private bool _autoReferenced;
+
+        public bool AutoReferenced
+        {
+            get { return _autoReferenced; }
+            set
+            {
+                _autoReferenced = value;
+                OnPropertyChanged(nameof(AutoReferenced));
+            }
+        }
+
         public event EventHandler SelectedChanged;
 
         private bool _isSelected;

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.Designer.cs
@@ -1350,7 +1350,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Following versions are unavailable due to allowedVersions constraint in package.config.
+        ///   Looks up a localized string similar to Following versions are unavailable due to additional constraints in the project or packages.config.
         /// </summary>
         public static string ToolTip_BlockedVersion {
             get {
@@ -1445,6 +1445,15 @@ namespace NuGet.PackageManagement.UI {
         public static string Version_Blocked {
             get {
                 return ResourceManager.GetString("Version_Blocked", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Blocked by project.
+        /// </summary>
+        public static string Version_Blocked_Generic {
+            get {
+                return ResourceManager.GetString("Version_Blocked_Generic", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/PackageManagement.UI/Resources.resx
@@ -558,7 +558,7 @@ Packages installed into Website projects will not be restored during build. Cons
     <value>Blocked by package.config</value>
   </data>
   <data name="ToolTip_BlockedVersion" xml:space="preserve">
-    <value>Following versions are unavailable due to allowedVersions constraint in package.config</value>
+    <value>Following versions are unavailable due to additional constraints in the project or packages.config</value>
   </data>
   <data name="Warning_ProjectJson" xml:space="preserve">
     <value>These options are not applicable to projects managing their dependencies through project.json.</value>
@@ -616,6 +616,9 @@ Packages installed into Website projects will not be restored during build. Cons
   </data>
   <data name="Text_PackageFormatApply" xml:space="preserve">
     <value>The package manager format will apply to the following projects in this Solution</value>
+  </data>
+  <data name="Version_Blocked_Generic" xml:space="preserve">
+    <value>Blocked by project</value>
   </data>
   <data name="CheckBox_SelectProject_HelpText" xml:space="preserve">
     <value>Select this checkbox to install the NuGet Package to the project '{0}'</value>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/DetailControl.xaml
@@ -94,14 +94,29 @@
         Margin="0,11,0,0"
         BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
         BorderThickness="0,1,0,1">
-        <nuget:OptionsControl
-          x:Name="_optionsControl"
-          Margin="0,12,0,16"
-          DataContext="{Binding}" />
+        <Grid>
+          <TextBlock
+            x:Name="_optionsBlockedTextBox"
+            Margin="0,12,0,16"
+            Visibility="{Binding Path=OptionsBlockedMessage,Converter={StaticResource NullToVisibilityConverter}}">
+            <Run Text="{Binding OptionsBlockedMessage}"/>
+            <Hyperlink
+              NavigateUri="{Binding Path=OptionsBlockedUrl}"
+              Style="{StaticResource HyperlinkStyle}"
+              Command="{x:Static nuget:PackageManagerControlCommands.OpenExternalLink}">
+              <Run Text="{Binding Path=OptionsBlockedUrl}" />
+            </Hyperlink>
+          </TextBlock>
+          <nuget:OptionsControl
+            x:Name="_optionsControl"
+            Margin="0,12,0,16"
+            DataContext="{Binding}"
+            Visibility="{Binding Path=OptionsBlockedMessage,Converter={StaticResource InverseNullToVisibilityConverter}}" />
+        </Grid>
       </Border>
-
+      
       <nuget:PackageMetadataControl
-        Grid.Row="4"
+        Grid.Row="5"
         Margin="0,12,0,0"
         DataContext="{Binding PackageMetadata}" />
     </Grid>

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/InfiniteScrollList.xaml.cs
@@ -13,11 +13,10 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
-using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using Mvs = Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
 using Resx = NuGet.PackageManagement.UI;
 
 namespace NuGet.PackageManagement.UI
@@ -113,7 +112,7 @@ namespace NuGet.PackageManagement.UI
             {
                 _itemsLock.Release();
             }
-            
+
 
             _selectedCount = 0;
 
@@ -404,7 +403,7 @@ namespace NuGet.PackageManagement.UI
             _loadingStatusBar.ItemsLoaded = 0;
         }
 
-        public void UpdatePackageStatus(PackageIdentity[] installedPackages)
+        public void UpdatePackageStatus(PackageCollectionItem[] installedPackages)
         {
             // in this case, we only need to update PackageStatus of
             // existing items in the package list

--- a/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/PackageManagement.UI/Xamls/ProjectView.xaml
@@ -79,6 +79,7 @@
       AutomationProperties.AutomationId="Project_Button_Uninstall"
       HorizontalAlignment="Left"
       Visibility="{Binding InstalledVersion, Converter={StaticResource NullToVisibilityConverter}, Mode=OneWay}"
+      IsEnabled="{Binding SelectedVersion.AutoReferenced,Converter={StaticResource NotNullOrTrueToBooleanConverter}}"
       Click="UninstallButton_Clicked"
       Content="{x:Static local:Resources.Button_Uninstall}" />
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
@@ -197,16 +197,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             return libraries
                 .Where(l => l.LibraryRange.TypeConstraint == LibraryDependencyTarget.Package)
-                .Select(l => ToPackageReference(l, targetFramework));
-        }
-
-        private static PackageReference ToPackageReference(LibraryDependency library, NuGetFramework targetFramework)
-        {
-            var identity = new PackageIdentity(
-                library.LibraryRange.Name,
-                library.LibraryRange.VersionRange.MinVersion);
-
-            return new PackageReference(identity, targetFramework);
+                .Select(l => new BuildIntegratedPackageReference(l, targetFramework));
         }
 
         public override async Task<bool> InstallPackageAsync(

--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependency.cs
@@ -22,6 +22,11 @@ namespace NuGet.LibraryModel
             get { return LibraryRange.Name; }
         }
 
+        /// <summary>
+        /// True if the PackageReference is added by the SDK and not the user.
+        /// </summary>
+        public bool AutoReferenced { get; set; }
+
         public override string ToString()
         {
             var sb = new StringBuilder();
@@ -49,6 +54,7 @@ namespace NuGet.LibraryModel
             hashCode.AddObject(Type);
             hashCode.AddObject(IncludeType);
             hashCode.AddObject(SuppressParent);
+            hashCode.AddObject(AutoReferenced);
 
             return hashCode.CombinedHash;
         }
@@ -70,7 +76,8 @@ namespace NuGet.LibraryModel
                 return true;
             }
 
-            return EqualityUtility.EqualsWithNullCheck(LibraryRange, other.LibraryRange) &&
+            return AutoReferenced == other.AutoReferenced &&
+                   EqualityUtility.EqualsWithNullCheck(LibraryRange, other.LibraryRange) &&
                    EqualityUtility.EqualsWithNullCheck(Type, other.Type) &&
                    IncludeType == other.IncludeType &&
                    SuppressParent == other.SuppressParent;
@@ -88,7 +95,8 @@ namespace NuGet.LibraryModel
                     VersionRange = LibraryRange.VersionRange
                 },
                 SuppressParent = SuppressParent,
-                Type = Type
+                Type = Type,
+                AutoReferenced = AutoReferenced
             };
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectManagement/BuildIntegratedPackageReference.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/BuildIntegratedPackageReference.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.ProjectManagement
+{
+    /// <summary>
+    /// Extends PackageReference to include the original LibraryDependency data.
+    /// </summary>
+    public class BuildIntegratedPackageReference : PackageReference
+    {
+        /// <summary>
+        /// LibraryDependency from the project.
+        /// </summary>
+        public LibraryDependency Dependency { get; }
+
+        /// <summary>
+        /// Create a PackageReference based on a LibraryDependency.
+        /// </summary>
+        /// <param name="dependency">Full PackageReference metadata.</param>
+        public BuildIntegratedPackageReference(LibraryDependency dependency, NuGetFramework projectFramework)
+            : base(GetIdentity(dependency),
+                  targetFramework: projectFramework,
+                  userInstalled: true,
+                  developmentDependency: dependency?.SuppressParent == LibraryIncludeFlags.All,
+                  requireReinstallation: false,
+                  allowedVersions: GetAllowedVersions(dependency))
+        {
+            if (dependency == null)
+            {
+                throw new ArgumentNullException(nameof(dependency));
+            }
+
+            Dependency = dependency;
+        }
+
+        /// <summary>
+        /// Convert range to a PackageIdentity
+        /// </summary>
+        private static PackageIdentity GetIdentity(LibraryDependency dependency)
+        {
+            if (dependency == null)
+            {
+                throw new ArgumentNullException(nameof(dependency));
+            }
+
+            // MinVersion may not exist for ranges such as ( , 2.0.0];
+            var version = dependency.LibraryRange?.VersionRange?.MinVersion ?? new NuGetVersion(0, 0, 0);
+
+            return new PackageIdentity(dependency.Name, version);
+        }
+
+        /// <summary>
+        /// Get allowed version range.
+        /// </summary>
+        private static VersionRange GetAllowedVersions(LibraryDependency dependency)
+        {
+            if (dependency == null)
+            {
+                throw new ArgumentNullException(nameof(dependency));
+            }
+
+            var minVersion = GetMinVersion(dependency);
+
+            if (dependency.AutoReferenced)
+            {
+                return new VersionRange(
+                    minVersion: minVersion,
+                    includeMinVersion: true,
+                    maxVersion: minVersion,
+                    includeMaxVersion: true);
+            }
+
+            // Return null if no range existed
+            return dependency.LibraryRange?.VersionRange;
+        }
+
+        private static NuGetVersion GetMinVersion(LibraryDependency dependency)
+        {
+            // MinVersion may not exist for ranges such as ( , 2.0.0];
+            return dependency.LibraryRange?.VersionRange?.MinVersion ?? new NuGetVersion(0, 0, 0);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/HashObjectWriter.cs
@@ -100,6 +100,19 @@ namespace NuGet.ProjectModel
             _writer.WriteValue(value);
         }
 
+        public void WriteNameValue(string name, bool value)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            ThrowIfReadOnly();
+
+            _writer.WritePropertyName(name);
+            _writer.WriteValue(value);
+        }
+
         public void WriteNameValue(string name, string value)
         {
             if (name == null)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -123,34 +123,22 @@ namespace NuGet.ProjectModel
                 SetValue(writer, "projectStyle", msbuildMetadata.ProjectStyle.ToString());
             }
 
-            if (msbuildMetadata.CrossTargeting)
-            {
-                SetValue(writer, "crossTargeting", msbuildMetadata.CrossTargeting.ToString());
-            }
+            SetValueIfTrue(writer, "crossTargeting", msbuildMetadata.CrossTargeting);
 
-            if (msbuildMetadata.LegacyPackagesDirectory)
-            {
-                SetValue(
+            SetValueIfTrue(
                     writer,
                     "legacyPackagesDirectory",
-                    msbuildMetadata.LegacyPackagesDirectory.ToString());
-            }
+                    msbuildMetadata.LegacyPackagesDirectory);
 
-            if (msbuildMetadata.ValidateRuntimeAssets)
-            {
-                SetValue(
+            SetValueIfTrue(
                     writer,
                     "validateRuntimeAssets",
-                    msbuildMetadata.ValidateRuntimeAssets.ToString());
-            }
+                    msbuildMetadata.ValidateRuntimeAssets);
 
-            if (msbuildMetadata.SkipContentFileWrite)
-            {
-                SetValue(
+            SetValueIfTrue(
                     writer,
                     "skipContentFileWrite",
-                    msbuildMetadata.SkipContentFileWrite.ToString());
-            }
+                    msbuildMetadata.SkipContentFileWrite);
 
             SetArrayValue(writer, "fallbackFolders", msbuildMetadata.FallbackFolders);
             SetArrayValue(writer, "originalTargetFrameworks", msbuildMetadata.OriginalTargetFrameworks);
@@ -262,10 +250,7 @@ namespace NuGet.ProjectModel
             SetValue(writer, "releaseNotes", packageSpec.ReleaseNotes);
             SetValue(writer, "licenseUrl", packageSpec.LicenseUrl);
 
-            if (packageSpec.RequireLicenseAcceptance)
-            {
-                SetValue(writer, "requireLicenseAcceptance", packageSpec.RequireLicenseAcceptance.ToString());
-            }
+            SetValueIfTrue(writer, "requireLicenseAcceptance", packageSpec.RequireLicenseAcceptance);
 
             if (packOptions.PackageType != null)
             {
@@ -303,6 +288,7 @@ namespace NuGet.ProjectModel
                 var expandedMode = dependency.IncludeType != LibraryIncludeFlags.All
                     || dependency.SuppressParent != LibraryIncludeFlagUtils.DefaultSuppressParent
                     || dependency.Type != LibraryDependencyType.Default
+                    || dependency.AutoReferenced
                     || (dependency.LibraryRange.TypeConstraint != LibraryDependencyTarget.Reference
                         && dependency.LibraryRange.TypeConstraint != (LibraryDependencyTarget.All & ~LibraryDependencyTarget.Reference));
 
@@ -351,6 +337,8 @@ namespace NuGet.ProjectModel
                         SetValue(writer, "version", versionString);
                     }
 
+                    SetValueIfTrue(writer, "autoReferenced", dependency.AutoReferenced);
+
                     writer.WriteObjectEnd();
                 }
                 else
@@ -389,6 +377,14 @@ namespace NuGet.ProjectModel
                 }
 
                 writer.WriteObjectEnd();
+            }
+        }
+
+        private static void SetValueIfTrue(IObjectWriter writer, string name, bool value)
+        {
+            if (value)
+            {
+                writer.WriteNameValue(name, value);
             }
         }
 

--- a/src/NuGet.Core/NuGet.RuntimeModel/IObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/IObjectWriter.cs
@@ -44,6 +44,13 @@ namespace NuGet.RuntimeModel
         /// </summary>
         /// <param name="name">The name of the datum.  Throws if <c>null</c>.</param>
         /// <param name="value">The datum.</param>
+        void WriteNameValue(string name, bool value);
+
+        /// <summary>
+        /// Writes a name-value pair.
+        /// </summary>
+        /// <param name="name">The name of the datum.  Throws if <c>null</c>.</param>
+        /// <param name="value">The datum.</param>
         void WriteNameValue(string name, string value);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.RuntimeModel/JsonObjectWriter.cs
+++ b/src/NuGet.Core/NuGet.RuntimeModel/JsonObjectWriter.cs
@@ -69,6 +69,18 @@ namespace NuGet.RuntimeModel
             _currentContainer[name] = value;
         }
 
+        public void WriteNameValue(string name, bool value)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            ThrowIfReadOnly();
+
+            _currentContainer[name] = value;
+        }
+
         public void WriteNameValue(string name, string value)
         {
             if (name == null)

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/UpdatePackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Feeds/UpdatePackageFeedTests.cs
@@ -52,7 +52,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithAllVersions_RetrievesSingleUpdate()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
 
             var projectA = SetupProject("FakePackage", "1.0.0");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithAllowedVersions_RetrievesSingleUpdate()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
 
             var projectA = SetupProject("FakePackage", "1.0.0", "[1,2)");
             SetupRemotePackageMetadata("FakePackage", "0.0.1", "1.0.0", "2.0.1", "2.0.0", "1.0.1");
@@ -106,7 +106,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate1()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", new NuGetVersion("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", new NuGetVersion("1.0.0"), null);
 
             // Both projects need to be updated to different versions
             // projectA: 1.0.0 => 2.0.1
@@ -138,7 +138,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate2()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
 
             // Only one project needs to be updated
             // projectA: 2.0.0 => 2.0.1
@@ -170,7 +170,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesSingleUpdate3()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
 
             // Only one project needs to be updated
             // projectA: 2.0.1 => None
@@ -202,7 +202,7 @@ namespace NuGet.PackageManagement.UI.Test
         public async Task GetPackagesWithUpdatesAsync_WithMultipleProjects_RetrievesNoUpdates()
         {
             // Arrange
-            var testPackageIdentity = new PackageIdentity("FakePackage", NuGetVersion.Parse("1.0.0"));
+            var testPackageIdentity = new PackageCollectionItem("FakePackage", NuGetVersion.Parse("1.0.0"), null);
 
             var projectA = SetupProject("FakePackage", "2.0.1");
             var projectB = SetupProject("FakePackage", "1.0.1", "[1,2)");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/HashObjectWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/HashObjectWriterTests.cs
@@ -97,6 +97,31 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void WriteNameValue_WithBoolValue_ThrowsForNullName()
+        {
+            Assert.Throws<ArgumentNullException>(() => _writer.WriteNameValue(name: null, value: true));
+        }
+
+        [Fact]
+        public void WriteNameValue_WithBoolValue_ThrowsIfReadOnly()
+        {
+            MakeReadOnly();
+
+            Assert.Throws<InvalidOperationException>(() => _writer.WriteNameValue("a", value: true));
+        }
+
+        [Fact]
+        public void WriteNameValue_WithBoolValue_SupportsEmptyName()
+        {
+            _writer.WriteNameValue(name: "", value: true);
+
+            const string expectedHash = "h+DBc/HiHXmYua4cJFF3KTsac/iwr0KN4TQNtXZdHgZA05PwtMldoPNkXQ/H+8bGw3OCxzDolEdgCkLF4F559A==";
+            var actualHash = _writer.GetHash();
+
+            Assert.Equal(expectedHash, actualHash);
+        }
+
+        [Fact]
         public void WriteNameValue_WithIntValue_ThrowsForNullName()
         {
             Assert.Throws<ArgumentNullException>(() => _writer.WriteNameValue(name: null, value: 0));

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -19,6 +19,33 @@ namespace NuGet.ProjectModel.Test
         private static readonly PackageSpec _emptyPackageSpec = JsonPackageSpecReader.GetPackageSpec(new JObject());
 
         [Fact]
+        public void RoundTripAutoReferencedProperty()
+        {
+            // Arrange
+            var json = @"{
+                    ""dependencies"": {
+                        ""b"": {
+                            ""version"": ""1.0.0"",
+                            ""autoReferenced"": true
+                        }
+                    },
+                  ""frameworks"": {
+                    ""net46"": {
+                        ""dependencies"": {
+                            ""a"": {
+                                ""version"": ""1.0.0"",
+                                ""autoReferenced"": true
+                            }
+                        }
+                    }
+                  }
+                }";
+
+            // Act & Assert
+            VerifyJsonPackageSpecRoundTrip(json);
+        }
+
+        [Fact]
         public void Write_ThrowsForNullPackageSpec()
         {
             var writer = new JsonObjectWriter();
@@ -260,8 +287,10 @@ namespace NuGet.ProjectModel.Test
 
             var actualResult = writer.GetJson();
 
+            var expected = JObject.Parse(json).ToString();
+
             // Assert
-            Assert.Equal(json, actualResult);
+            Assert.Equal(expected, actualResult);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
@@ -35,7 +35,7 @@
     "summary": "summary",
     "releaseNotes": "releaseNotes",
     "licenseUrl": "licenseUrl",
-    "requireLicenseAcceptance": "True"
+    "requireLicenseAcceptance": true
   },
   "restore": {
     "projectUniqueName": "projectUniqueName",
@@ -45,7 +45,7 @@
     "packagesPath": "packagesPath",
     "outputPath": "outputPath",
     "projectStyle": "PackageReference",
-    "crossTargeting": "True",
+    "crossTargeting": true,
     "fallbackFolders": [
       "b",
       "a",

--- a/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/JsonObjectWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.RuntimeModel.Test/JsonObjectWriterTests.cs
@@ -143,6 +143,20 @@ namespace NuGet.RuntimeModel.Test
         }
 
         [Fact]
+        public void WriteNameValue_WithBoolValue_ThrowsForNullName()
+        {
+            Assert.Throws<ArgumentNullException>(() => _writer.WriteNameValue(name: null, value: true));
+        }
+
+        [Fact]
+        public void WriteNameValue_WithBoolValue_ThrowsIfReadOnly()
+        {
+            MakeReadOnly();
+
+            Assert.Throws<InvalidOperationException>(() => _writer.WriteNameValue("a", true));
+        }
+
+        [Fact]
         public void WriteNameValue_WithIntValue_SupportsEmptyName()
         {
             _writer.WriteNameValue(name: "", value: 3);


### PR DESCRIPTION
Add UI/PMC support for AutoReferenced package references.

References with this metadata set will be ignored during Update-Package. The UI will display all other versions as blocked and disallow changes.

I've manually gone through the UI project, UI solution, and powershell console scenarios. Testing the integration of the CPS project system with the UI and powershell is not possible to automate currently without rewriting much of it in test code.

https://github.com/NuGet/Home/issues/4044

//cc @rrelyea @rohit21agrawal @alpaix @jainaashish @mishra14 @zhili1208 @nkolev92 