### PR TITLE
Compare parsed versions when validating $(PackageVersion)

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -232,22 +232,27 @@ namespace NuGet.SolutionRestoreManager
         private static NuGetVersion GetPackageVersion(IVsTargetFrameworks tfms)
         {
             // $(PackageVersion) property if set overrides the $(Version)
-            var versionPropertyValue = 
-                GetNonEvaluatedPropertyOrNull(tfms, PackageVersion) 
-                ?? GetNonEvaluatedPropertyOrNull(tfms, Version);
+            var versionPropertyValue =
+                GetNonEvaluatedPropertyOrNull(tfms, PackageVersion, NuGetVersion.Parse)
+                ?? GetNonEvaluatedPropertyOrNull(tfms, Version, NuGetVersion.Parse);
 
-            return versionPropertyValue != null
-                ? NuGetVersion.Parse(versionPropertyValue)
-                : PackageSpec.DefaultVersion;
+            return versionPropertyValue ?? PackageSpec.DefaultVersion;
         }
 
         // Trying to fetch a property value from tfm property bags.
         // If defined the property should have identical values in all of the occurances.
-        private static string GetNonEvaluatedPropertyOrNull(IVsTargetFrameworks tfms, string propertyName)
+        private static TValue GetNonEvaluatedPropertyOrNull<TValue>(
+            IVsTargetFrameworks tfms,
+            string propertyName,
+            Func<string, TValue> valueFactory)
         {
             return tfms
                 .Cast<IVsTargetFrameworkInfo>()
-                .Select(tfm => GetPropertyValueOrNull(tfm.Properties, propertyName))
+                .Select(tfm =>
+                {
+                    var val = GetPropertyValueOrNull(tfm.Properties, propertyName);
+                    return val != null ? valueFactory(val) : default(TValue);
+                })
                 .Distinct()
                 .SingleOrDefault();
         }


### PR DESCRIPTION
Resolves NuGet/Home#4419.

This change enhances the validation method of global non-evaluated properties that must not differ between different TFMs.

`VsSolutionRestoreService` will attempt to parse property values of `$(PackageVersion)` and `$(Version)` before eliminating duplicates in a list of properties retrieved for each TFM.

//cc @emgarten @jainaashish @rohit21agrawal @mishra14 @rrelyea 