### PR TITLE
Fix RPS issue for ManagedLangs_CS_DDRIT.0300.Rebuild Solution

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -203,17 +203,12 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 var settings = ServiceLocator.GetInstance<ISettings>();
 
-                var msBuildProperties = new Dictionary<string, string> {
-                    { ProjectSystemProviderContext.RestoreProjectStyle, ProjectStyle.PackageReference.ToString() }
-                };
-                   
                 var context = new ProjectSystemProviderContext(
                     EmptyNuGetProjectContext,
-                    () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings),
-                    msBuildProperties);
+                    () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings));
 
                 return new LegacyCSProjPackageReferenceProject(
-                    new EnvDTEProjectAdapter(dteProject, context),
+                    new EnvDTEProjectAdapter(dteProject),
                     VsHierarchyUtility.GetProjectId(dteProject));
             });
 
@@ -915,28 +910,10 @@ namespace NuGet.PackageManagement.VisualStudio
         private NuGetProject CreateNuGetProject(Project envDTEProject, INuGetProjectContext projectContext = null)
         {
             var settings = ServiceLocator.GetInstance<ISettings>();
-            var vsHierarchy = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
-            // read MSBuild property RestoreProjectStyle which can be set to any NuGet project sytle
-            // and pass it on to NugetFactory which can pass it to each NuGet project provider to consume.
-            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
-                ProjectSystemProviderContext.RestoreProjectStyle);
-
-            var targetFramework = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
-                ProjectSystemProviderContext.TargetFramework);
-
-            var targetFrameworks = VsHierarchyUtility.GetMSBuildProperty(vsHierarchy, 
-                ProjectSystemProviderContext.TargetFrameworks);
-
-            var msBuildProperties = new Dictionary<string, string> {
-                {ProjectSystemProviderContext.RestoreProjectStyle, restoreProjectStyle },
-                {ProjectSystemProviderContext.TargetFramework, targetFramework},
-                {ProjectSystemProviderContext.TargetFrameworks, targetFrameworks }
-            };
 
             var context = new ProjectSystemProviderContext(
                 projectContext ?? EmptyNuGetProjectContext,
-                () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings),
-                msBuildProperties);
+                () => PackagesFolderPathUtility.GetPackagesFolderPath(this, settings));
 
             NuGetProject result;
             if (_projectSystemFactory.TryCreateNuGetProject(envDTEProject, context, out result))

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -22,9 +22,9 @@ namespace NuGet.PackageManagement.VisualStudio
     [Microsoft.VisualStudio.Utilities.Order(After = nameof(ProjectKNuGetProjectProvider))]
     public class CpsPackageReferenceProjectProvider : IProjectSystemProvider
     {
-        private readonly string RestoreProjectStyle = "RestoreProjectStyle";
-        private readonly string TargetFramework = "TargetFramework";
-        private readonly string TargetFrameworks = "TargetFrameworks";
+        private const string RestoreProjectStyle = "RestoreProjectStyle";
+        private const string TargetFramework = "TargetFramework";
+        private const string TargetFrameworks = "TargetFrameworks";
 
         private readonly IProjectSystemCache _projectSystemCache;
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProjectProvider.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Utilities;
 using NuGet.PackageManagement.UI;
 using NuGet.ProjectManagement;
@@ -21,6 +22,10 @@ namespace NuGet.PackageManagement.VisualStudio
     [Microsoft.VisualStudio.Utilities.Order(After = nameof(ProjectKNuGetProjectProvider))]
     public class CpsPackageReferenceProjectProvider : IProjectSystemProvider
     {
+        private readonly string RestoreProjectStyle = "RestoreProjectStyle";
+        private readonly string TargetFramework = "TargetFramework";
+        private readonly string TargetFrameworks = "TargetFrameworks";
+
         private readonly IProjectSystemCache _projectSystemCache;
 
         // Reason it's lazy<object> is because we don't want to load any CPS assemblies untill
@@ -62,32 +67,30 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return false;
             }
-            var restoreProjectStyle = string.Empty;
-            var targetFramework = string.Empty;
-            var targetFrameworks = string.Empty;
 
-            var hasRestoreProjectStyle = context
-                .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.RestoreProjectStyle, out restoreProjectStyle) 
-                && !string.IsNullOrEmpty(restoreProjectStyle);
-
-            var hasTargetFramework = context
-                .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.TargetFramework, out targetFramework)
-                && !string.IsNullOrEmpty(targetFramework);
-
-            var hasTargetFrameworks = context
-                .MSBuildProperties
-                .TryGetValue(ProjectSystemProviderContext.TargetFrameworks, out targetFrameworks)
-                && !string.IsNullOrEmpty(targetFrameworks);
-
-            // check for RestoreProjectStyle property is set and if set to PackageReference then return false
-            if (hasRestoreProjectStyle && !restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase))
+            // Check if the project is not CPS capable or if it is CPS capable then it does not have TargetFramework(s), if so then return false
+            if (!hierarchy.IsCapabilityMatch("CPS"))
             {
                 return false;
             }
-            // Check if the project is not CPS capable or if it is CPS capable then it does not have TargetFramework(s), if so then return false
-            else if (!(hierarchy.IsCapabilityMatch("CPS") && (hasTargetFramework || hasTargetFrameworks)))
+
+            var buildPropertyStorage = hierarchy as IVsBuildPropertyStorage;
+
+            // read MSBuild property RestoreProjectStyle, TargetFramework, and TargetFrameworks
+            var restoreProjectStyle = VsHierarchyUtility.GetMSBuildProperty(buildPropertyStorage, RestoreProjectStyle);
+
+            var targetFramework = VsHierarchyUtility.GetMSBuildProperty(buildPropertyStorage, TargetFramework);
+
+            var targetFrameworks = VsHierarchyUtility.GetMSBuildProperty(buildPropertyStorage, TargetFrameworks);
+
+            // check for RestoreProjectStyle property is set and if not set to PackageReference then return false
+            if (!(string.IsNullOrEmpty(restoreProjectStyle) || 
+                restoreProjectStyle.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+            // check whether TargetFramework or TargetFrameworks property is set, else return false
+            else if (string.IsNullOrEmpty(targetFramework) && string.IsNullOrEmpty(targetFrameworks))
             {
                 return false;
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProjectProvider.cs
@@ -51,7 +51,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             result = null;
 
-            var project = new EnvDTEProjectAdapter(dteProject, context);
+            var project = new EnvDTEProjectAdapter(dteProject);
             if (!project.IsLegacyCSProjPackageReferenceProject)
             {
                 return false;

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/ProjectSystemProviderContext.cs
@@ -13,20 +13,13 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public class ProjectSystemProviderContext
     {
-        public static readonly string RestoreProjectStyle = "RestoreProjectStyle";
-        public static readonly string TargetFramework = "TargetFramework";
-        public static readonly string TargetFrameworks = "TargetFrameworks";
-
         public INuGetProjectContext ProjectContext { get; }
 
         public Func<string> PackagesPathFactory { get; }
 
-        public Dictionary<string, string> MSBuildProperties{ get; }
-
         public ProjectSystemProviderContext(
             INuGetProjectContext projectContext,
-            Func<string> packagesPathFactory,
-            Dictionary<string, string> msBuildProperties)
+            Func<string> packagesPathFactory)
         {
             if (projectContext == null)
             {
@@ -40,7 +33,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ProjectContext = projectContext;
             PackagesPathFactory = packagesPathFactory;
-            MSBuildProperties = msBuildProperties;
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -43,6 +43,14 @@ namespace NuGet.PackageManagement.VisualStudio
             ThreadHelper.ThrowIfNotOnUIThread();
 
             var buildPropertyStorage = pHierarchy as IVsBuildPropertyStorage;
+
+            return GetMSBuildProperty(buildPropertyStorage, name);
+        }
+
+        public static string GetMSBuildProperty(IVsBuildPropertyStorage buildPropertyStorage, string name)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             string output = null;
 
             if (buildPropertyStorage != null)


### PR DESCRIPTION
Avoid reading MSBuild property `RestoreProjectStyle ``TargetFramework ``TargetFrameworks `by default before creating any NuGet project, rather read these properties only for CPS based .net core project system since these properties are only applicable for .net core projects for now. 

Although we were thinking to support `RestoreProjectStyle `for legacy csproj project system as well to support `PackageReference `but currently nobody is using it and it's unnecessary adding perf regression for normal scenario since we always try to create legacy csproj project system before project.json or packages.config. Anyways `PackageReference `will become default package management format going forward so we might not need this property for this project system.

Fixes https://github.com/NuGet/Home/issues/4441

@rrelyea @emgarten @alpaix @mishra14 