### PR TITLE
Allow PCLs to be installed into Xamarin.Mac projects

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
@@ -125,9 +125,10 @@ namespace NuGet.Frameworks
                     var monoandroid = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.MonoAndroid, new Version(0, 0));
                     var monotouch = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.MonoTouch, new Version(0, 0));
                     var xamarinIOs = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.XamarinIOs, new Version(0, 0));
+                    var xamarinMac = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.XamarinMac, new Version(0, 0));
                     var xamarinTVOS = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.XamarinTVOS, new Version(0, 0));
                     var xamarinWatchOS = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.XamarinWatchOS, new Version(0, 0));
-                    var monoFrameworks = new NuGetFramework[] { monoandroid, monotouch, xamarinIOs, xamarinWatchOS, xamarinTVOS };
+                    var monoFrameworks = new NuGetFramework[] { monoandroid, monotouch, xamarinIOs, xamarinMac, xamarinWatchOS, xamarinTVOS };
 
                     profileOptionalFrameworks = new List<KeyValuePair<int, NuGetFramework[]>>();
 

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
@@ -221,6 +221,12 @@ namespace NuGet.Test
         [InlineData("portable-net45+win8", "portable-net45+win8+wp8+monoandroid1+monotouch1")]
         [InlineData("portable-net45+win8+monoandroid+monotouch", "portable-net45+win8+wp8")]
         [InlineData("portable-net45+win8+monoandroid1+monotouch1", "portable-net45+win8+wp8")]
+        [InlineData("monoandroid10", "portable-net45+win8")]
+        [InlineData("monotouch10", "portable-net45+win8")]
+        [InlineData("xamarinios10", "portable-net45+win8")]
+        [InlineData("xamarintvos10", "portable-net45+win8")]
+        [InlineData("xamarinwatchos10", "portable-net45+win8")]
+        [InlineData("xamarinmac20", "portable-net45+win8")]
         public void CompatibilityPCL_Optional(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);


### PR DESCRIPTION
The Xamarin.Mac target framework now supports the portable class
library profiles that the other Xamarin frameworks support.

Fixes NuGet/Home#4454