### PR TITLE
Fixing the test for Net Core Cache Update Event

### DIFF
--- a/test/EndToEnd/tests/NetCoreProjectTests.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTests.ps1
@@ -415,12 +415,20 @@ function Test-NetCoreProjectSystemCacheUpdateEvent {
     $projectA = New-NetCoreConsoleApp ConsoleAppA
     Assert-NetCoreProjectCreation $projectA
 
-    # Act 
-    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_AttachHandler()
-    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_InstallPackage("Newtonsoft.Json", "9.0.1")
-    Build-Solution
-    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_DettachHandler()
-    $result = [API.Test.InternalAPITestHook]::CacheUpdateEventCount 
+    # Act
+    Try
+    {
+        [API.Test.InternalAPITestHook]::ProjectCacheEventApi_AttachHandler()
+        [API.Test.InternalAPITestHook]::CacheUpdateEventCount = 0
+        [API.Test.InternalAPITestHook]::ProjectCacheEventApi_InstallPackage("Newtonsoft.Json", "9.0.1")
+        $projectA.Save($projectA.FullName)
+        Build-Solution
+    }
+    Finally 
+    {
+        [API.Test.InternalAPITestHook]::ProjectCacheEventApi_DetachHandler()
+        $result = [API.Test.InternalAPITestHook]::CacheUpdateEventCount 
+    }
 
     # Assert
     Assert-True $result -eq 1

--- a/test/EndToEnd/tests/NetCoreProjectTests.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTests.ps1
@@ -416,7 +416,11 @@ function Test-NetCoreProjectSystemCacheUpdateEvent {
     Assert-NetCoreProjectCreation $projectA
 
     # Act 
-    $result = [API.Test.InternalAPITestHook]::ProjectCacheEventApi("Newtonsoft.Json","9.0.1") 
+    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_AttachHandler()
+    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_InstallPackage("Newtonsoft.Json", "9.0.1")
+    Build-Solution
+    [API.Test.InternalAPITestHook]::ProjectCacheEventApi_DettachHandler()
+    $result = [API.Test.InternalAPITestHook]::CacheUpdateEventCount 
 
     # Assert
     Assert-True $result -eq 1

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -13,6 +13,20 @@ namespace API.Test
 {
     public static class InternalAPITestHook
     {
+        private static int _cacheUpdateEventCount = 0;
+        private static Action<object, NuGetEventArgs<string>> _cacheUpdateEventHandler = delegate (object sender, NuGetEventArgs<string> e)
+        {
+            _cacheUpdateEventCount++;
+        };
+
+        public static int CacheUpdateEventCount
+        {
+            get
+            {
+                return _cacheUpdateEventCount;
+            }
+        }
+
         public static void InstallLatestPackageApi(string id, bool prerelease)
         {
             var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
@@ -138,27 +152,31 @@ namespace API.Test
                    batchStartIds[0].Equals(batchEndIds[0], StringComparison.Ordinal);
         }
 
-        public static int ProjectCacheEventApi(string id, string version)
+        public static void ProjectCacheEventApi_AttachHandler()
+        {
+            var vsSolutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            vsSolutionManager.AfterNuGetCacheUpdated += _cacheUpdateEventHandler.Invoke;
+        }
+
+
+        public static void ProjectCacheEventApi_InstallPackage(string id, string version)
         {
             var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
             var vsSolutionManager = ServiceLocator.GetInstance<ISolutionManager>();
             var installerServices = ServiceLocator.GetInstance<IVsPackageInstaller>();
-            var eventCount = 0;
-            Action<object, NuGetEventArgs<string>> eventHandler = delegate (object sender, NuGetEventArgs<string> e)
-            {
-                eventCount++;
-            };
-
-            vsSolutionManager.AfterNuGetCacheUpdated += eventHandler.Invoke;
+            _cacheUpdateEventCount = 0;
 
             foreach (EnvDTE.Project project in dte.Solution.Projects)
             {
                 installerServices.InstallPackage(null, project, id, version, false);
             }
 
-            vsSolutionManager.AfterNuGetCacheUpdated -= eventHandler.Invoke;
+        }
 
-            return eventCount;
+        public static void ProjectCacheEventApi_DettachHandler()
+        {
+            var vsSolutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            vsSolutionManager.AfterNuGetCacheUpdated -= _cacheUpdateEventHandler.Invoke;
         }
     }
 }

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -25,6 +25,11 @@ namespace API.Test
             {
                 return _cacheUpdateEventCount;
             }
+
+            set
+            {
+                _cacheUpdateEventCount = value;
+            }
         }
 
         public static void InstallLatestPackageApi(string id, bool prerelease)
@@ -164,16 +169,13 @@ namespace API.Test
             var dte = ServiceLocator.GetInstance<EnvDTE.DTE>();
             var vsSolutionManager = ServiceLocator.GetInstance<ISolutionManager>();
             var installerServices = ServiceLocator.GetInstance<IVsPackageInstaller>();
-            _cacheUpdateEventCount = 0;
-
             foreach (EnvDTE.Project project in dte.Solution.Projects)
             {
                 installerServices.InstallPackage(null, project, id, version, false);
             }
-
         }
 
-        public static void ProjectCacheEventApi_DettachHandler()
+        public static void ProjectCacheEventApi_DetachHandler()
         {
             var vsSolutionManager = ServiceLocator.GetInstance<ISolutionManager>();
             vsSolutionManager.AfterNuGetCacheUpdated -= _cacheUpdateEventHandler.Invoke;


### PR DESCRIPTION
The test added as part of  https://github.com/NuGet/NuGet.Client/commit/c5aed1015e2cd3990490c57dc9aaec866ad74d91 is flaky because the install package call does not wait for `CPS nomination -> Restore -> Cache Update`.

To fix that I have split the test into 3 calls such that we build the solution before asserting the `CacheUpdateEventCount` to ensure that restore is executed before assert.

//cc: @emgarten @alpaix @jainaashish @rohit21agrawal 