### PR TITLE
Execute init.ps1 at PMC command execute time if a restore has happened

### DIFF
--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26020.0
+VisualStudioVersion = 15.0.26131.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Guids.cs" />
     <Compile Include="ISolutionRestoreJob.cs" />
     <Compile Include="PkgCmdID.cs" />
+    <Compile Include="RestoreEventPublisher.cs" />
     <Compile Include="RestoreManagerPackage.cs" />
     <Compile Include="RestoreOperationLogger.cs" />
     <Compile Include="RestoreOperationProgressUI.cs" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreEventPublisher.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreEventPublisher.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.PackageManagement.UI;
+using NuGet.VisualStudio.Facade;
+
+namespace NuGet.SolutionRestoreManager
+{
+    [Export(typeof(IRestoreEventsPublisher))]
+    [Export(typeof(IRestoreEvents))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public sealed class RestoreEventPublisher : IRestoreEventsPublisher, IRestoreEvents
+    {
+        private readonly Lazy<ILogger> _logger;
+
+        public event SolutionRestoreCompletedEventHandler SolutionRestoreCompleted;
+        
+        [ImportingConstructor]
+        public RestoreEventPublisher(
+            [Import(typeof(VisualStudioActivityLogger))]
+            Lazy<ILogger> logger)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            _logger = logger;
+        }
+
+        public void OnSolutionRestoreCompleted(SolutionRestoredEventArgs args)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    SolutionRestoreCompleted?.Invoke(args);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Value.LogError(ex.ToString());
+                }
+            });
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -15,7 +15,6 @@ using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using Task = System.Threading.Tasks.Task;
-using NuGet.PackageManagement.UI;
 
 namespace NuGet.SolutionRestoreManager
 {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -21,6 +21,7 @@ using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
 using NuGet.Protocol.Core.Types;
+using NuGet.VisualStudio.Facade;
 using Strings = NuGet.PackageManagement.VisualStudio.Strings;
 using Task = System.Threading.Tasks.Task;
 
@@ -40,6 +41,7 @@ namespace NuGet.SolutionRestoreManager
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
         private readonly ISettings _settings;
         private readonly IDeferredProjectWorkspaceService _deferredWorkspaceService;
+        private readonly IRestoreEventsPublisher _restoreEventsPublisher;
 
         private RestoreOperationLogger _logger;
         private string _dependencyGraphProjectCacheHash;
@@ -59,6 +61,7 @@ namespace NuGet.SolutionRestoreManager
             IPackageRestoreManager packageRestoreManager,
             IVsSolutionManager solutionManager,
             ISourceRepositoryProvider sourceRepositoryProvider,
+            IRestoreEventsPublisher restoreEventsPublisher,
 #if !VS14
             IDeferredProjectWorkspaceService deferredWorkspaceService,
 #endif
@@ -84,6 +87,11 @@ namespace NuGet.SolutionRestoreManager
                 throw new ArgumentNullException(nameof(sourceRepositoryProvider));
             }
 
+            if (restoreEventsPublisher == null)
+            {
+                throw new ArgumentNullException(nameof(restoreEventsPublisher));
+            }
+
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
@@ -93,6 +101,7 @@ namespace NuGet.SolutionRestoreManager
             _packageRestoreManager = packageRestoreManager;
             _solutionManager = solutionManager;
             _sourceRepositoryProvider = sourceRepositoryProvider;
+            _restoreEventsPublisher = restoreEventsPublisher;
             _settings = settings;
 #if VS14
             _deferredWorkspaceService = null;
@@ -209,6 +218,21 @@ namespace NuGet.SolutionRestoreManager
                     isSolutionAvailable,
                     deferredProjectsData.PackageSpecs,
                     token);
+
+                // TODO: To limit risk, we only publish the event when there is a cross-platform PackageReference
+                // project in the solution. Extending this behavior to all solutions is tracked here:
+                // https://github.com/NuGet/Home/issues/4478
+#if !VS14
+                if (projects.OfType<CpsPackageReferenceProject>().Any() &&
+                    !string.IsNullOrEmpty(_dependencyGraphProjectCacheHash))
+                {
+                    // A no-op restore is considered successful. A cancellation is considered unsuccessful.
+                    var args = new SolutionRestoredEventArgs(
+                        isSuccess: _status == NuGetOperationStatus.Succeeded || _status == NuGetOperationStatus.NoOp,
+                        solutionSpecHash: _dependencyGraphProjectCacheHash);
+                    _restoreEventsPublisher.OnSolutionRestoreCompleted(args);
+                }
+#endif
             }
             finally
             {

--- a/src/NuGet.Clients/VisualStudio.Facade/Events/IRestoreEvents.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Events/IRestoreEvents.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Facade
+{
+    public delegate void SolutionRestoreCompletedEventHandler(SolutionRestoredEventArgs args);
+
+    /// <summary>
+    /// The interface for listening to events concerning restore operations.
+    /// </summary>
+    public interface IRestoreEvents
+    {
+        event SolutionRestoreCompletedEventHandler SolutionRestoreCompleted;
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/Events/IRestoreEventsPublisher.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Events/IRestoreEventsPublisher.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.VisualStudio.Facade
+{
+    /// <summary>
+    /// The interface for publishing restore-related events. The event consumers use <see cref="IRestoreEvents"/> to
+    /// listen to events.
+    /// </summary>
+    public interface IRestoreEventsPublisher
+    {
+        /// <summary>
+        /// Publishes the <see cref="IRestoreEvents.SolutionRestoreCompleted" /> asynchronously such that the caller
+        /// need not be concerned about slow consumers.
+        /// </summary>
+        void OnSolutionRestoreCompleted(SolutionRestoredEventArgs args);
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/Events/SolutionRestoredEventArgs.cs
+++ b/src/NuGet.Clients/VisualStudio.Facade/Events/SolutionRestoredEventArgs.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace NuGet.VisualStudio.Facade
+{
+    /// <summary>
+    /// The data available when the <see cref="IRestoreEvents.SolutionRestoreCompleted"/> event is raised.
+    /// </summary>
+    public class SolutionRestoredEventArgs : EventArgs
+    {
+        public SolutionRestoredEventArgs(bool isSuccess, string solutionSpecHash)
+        {
+            if (string.IsNullOrEmpty(solutionSpecHash))
+            {
+                throw new ArgumentNullException(nameof(solutionSpecHash));
+            }
+
+            IsSuccess = isSuccess;
+            SolutionSpecHash = solutionSpecHash;
+        }
+
+        public bool IsSuccess { get; }
+
+        public string SolutionSpecHash { get; }
+    }
+}

--- a/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
+++ b/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
@@ -23,6 +23,9 @@
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Events\IRestoreEvents.cs" />
+    <Compile Include="Events\IRestoreEventsPublisher.cs" />
+    <Compile Include="Events\SolutionRestoredEventArgs.cs" />
     <Compile Include="NuGetUIThreadHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProjectSystem\ProjectHelper.cs" />

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/AsyncPowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/AsyncPowerShellHost.cs
@@ -8,6 +8,7 @@ using System.Management.Automation.Runspaces;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio.Facade;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
 {
@@ -15,8 +16,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
     {
         public event EventHandler ExecuteEnd;
 
-        public AsyncPowerShellHost(string name, IRunspaceManager runspaceManager)
-            : base(name, runspaceManager)
+        public AsyncPowerShellHost(string name, IRestoreEvents restoreEvents, IRunspaceManager runspaceManager)
+            : base(name, restoreEvents, runspaceManager)
         {
         }
 

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHostService.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHostService.cs
@@ -1,7 +1,8 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using NuGet.VisualStudio.Facade;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
 {
@@ -13,16 +14,16 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             "Microsoft.Reliability",
             "CA2000:Dispose objects before losing scope",
             Justification = "Can't dispose an object if we want to return it.")]
-        public static IHost CreateHost(string name, bool isAsync)
+        public static IHost CreateHost(string name, IRestoreEvents restoreEvents, bool isAsync)
         {
             IHost host;
             if (isAsync)
             {
-                host = new AsyncPowerShellHost(name, _runspaceManager);
+                host = new AsyncPowerShellHost(name, restoreEvents, _runspaceManager);
             }
             else
             {
-                host = new SyncPowerShellHost(name, _runspaceManager);
+                host = new SyncPowerShellHost(name, restoreEvents, _runspaceManager);
             }
 
             return host;

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/SyncPowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/SyncPowerShellHost.cs
@@ -6,13 +6,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.VisualStudio.Facade;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
 {
     internal class SyncPowerShellHost : PowerShellHost
     {
-        public SyncPowerShellHost(string name, IRunspaceManager runspaceManager)
-            : base(name, runspaceManager)
+        public SyncPowerShellHost(string name, IRestoreEvents restoreEvents, IRunspaceManager runspaceManager)
+            : base(name, restoreEvents, runspaceManager)
         {
         }
 

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/NuGetConsole.Host.PowerShellProvider.csproj
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/NuGetConsole.Host.PowerShellProvider.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\Build\Common.props" Condition="Exists('..\..\..\..\Build\Common.props')" />
   <PropertyGroup>
@@ -49,6 +49,10 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\VisualStudio.Facade\NuGet.VisualStudio.Facade.csproj">
+      <Project>{eea49a74-6efc-410e-9745-bad367ac151d}</Project>
+      <Name>NuGet.VisualStudio.Facade</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Console.Types\NuGet.Console.Types.csproj">
       <Project>{6FD11460-39A3-4A10-BA63-7541B0A7D053}</Project>
       <Name>NuGet.Console.Types</Name>

--- a/src/NuGet.Clients/VsConsole/PowerShellHostProvider/PowerShellHostProvider.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHostProvider/PowerShellHostProvider.cs
@@ -1,9 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.ComponentModel.Composition;
 using System.Runtime.CompilerServices;
+using NuGet.VisualStudio.Facade;
 using NuGetConsole.Host.PowerShell.Implementation;
 
 namespace NuGetConsole.Host.PowerShellProvider
@@ -25,6 +26,19 @@ namespace NuGetConsole.Host.PowerShellProvider
         /// </summary>
         public const string PowerConsoleHostName = "Package Manager Host";
 
+        private readonly IRestoreEvents _restoreEvents;
+        
+        [ImportingConstructor]
+        public PowerShellHostProvider(IRestoreEvents restoreEvents)
+        {
+            if (restoreEvents == null)
+            {
+                throw new ArgumentNullException(nameof(restoreEvents));
+            }
+
+            _restoreEvents = restoreEvents;
+        }
+
         public IHost CreateHost(bool @async)
         {
             bool isPowerShell2Installed = RegistryHelper.CheckIfPowerShell2OrAboveInstalled();
@@ -36,7 +50,7 @@ namespace NuGetConsole.Host.PowerShellProvider
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static IHost CreatePowerShellHost(bool @async)
+        private IHost CreatePowerShellHost(bool @async)
         {
             // backdoor: allow turning off async mode by setting enviroment variable NuGetSyncMode=1
             string syncModeFlag = Environment.GetEnvironmentVariable("NuGetSyncMode", EnvironmentVariableTarget.User);
@@ -45,7 +59,7 @@ namespace NuGetConsole.Host.PowerShellProvider
                 @async = false;
             }
 
-            return PowerShellHostService.CreateHost(PowerConsoleHostName, @async);
+            return PowerShellHostService.CreateHost(PowerConsoleHostName, _restoreEvents, @async);
         }
     }
 }

--- a/test/EndToEnd/tests/NetCoreProjectTests.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTests.ps1
@@ -408,6 +408,24 @@ function Test-NetCoreWebApp10ProjectReference {
     Assert-NetCoreProjectReference $projectA $projectB
 }
 
+function Test-NetCoreWebAppExecuteInitScriptsOnlyOnce
+{
+    param($context)
+
+    # Arrange
+    $global:PackageInitPS1Var = 0
+    $p = New-NetCoreWebApp10 WebApp
+    
+    # Act & Assert
+    Install-Package PackageInitPS1 -Project $p.Name -Source $context.RepositoryPath
+    Build-Solution    
+    Assert-True ($global:PackageInitPS1Var -eq 1)
+
+    $p | Install-Package jquery -Version 1.9
+    Build-Solution
+    Assert-True ($global:PackageInitPS1Var -eq 1)
+}
+
 # VSSolutionManager and ProjectSystemCache event test for .net core
 function Test-NetCoreProjectSystemCacheUpdateEvent {
     


### PR DESCRIPTION
This fix addresses https://github.com/NuGet/Home/issues/4308 and https://github.com/NuGet/Home/issues/4426. I will be working with the customers to give them a private build of the VSIX so I can verify the fix more confidently.

General idea:

1. When a restore completes, an event is raised containing the solution spec hash.
1. PowerShell host listens to this event and keeps track of the last spec hash it saw.
1. Right before a user's PMC command is executed and if the hash has changed, execute init.ps1.

Alternatively, we could have had some smarts to execute init.ps1 at the end of restore. However this would impact restore performance. The benefit of this approach is that it only impacts users that actually typing things in their PMC (which is what init.ps1 is supposed to add behavior to).

There is still a problem where user's cannot execute PMC commands before auto-restore has completed. However, this is an existing issue with the rest of the IDE, such as Intellisense.

Although there are external asks for restore events, I chose not to over-design the event mechanism due to the short time frame and the need for more clear requirements ("what do partner teams or the community *actually* need?").

Per @rrelyea's request, we reduced the risk of this change by limiting the new event to solutions that have at least one xplat PackageReference project. The future work of extending this is tracked here:
https://github.com/NuGet/Home/issues/4478