### PR TITLE
Remove pre-release labels from assembly version

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/MinClientVersionUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/MinClientVersionUtility.cs
@@ -87,7 +87,12 @@ namespace NuGet.Packaging
                     throw new InvalidOperationException(Strings.UnableToParseClientVersion);
                 }
 
-                _clientVersion = clientVersion;
+                // Remove pre-release info from the version and return a stable version.
+                _clientVersion = new NuGetVersion(
+                    major: clientVersion.Major,
+                    minor: clientVersion.Minor,
+                    patch: clientVersion.Patch,
+                    revision: clientVersion.Revision);
             }
 
             return _clientVersion;

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
@@ -11,6 +11,7 @@ namespace NuGet.Packaging.Test
     {
         [Theory]
         [InlineData("1.0.0", true)]
+        [InlineData("4.0.0", true)]
         [InlineData("9.0.0", false)]
         public void MinClientVersionUtility_CheckCompatible(string version, bool expected)
         {


### PR DESCRIPTION
The current RTM version of NuGet 4.0.0 contains a pre-release label in the assembly information metadata, when used as the current client version it appears lower than the stable ``4.0.0`` version which package authors would expect to use as the MinClientVersion. 

This change removes the pre-release labels from the version read from the assembly metadata. The UserAgent string and current version used for MinClientVersion checks will now use a stable version.

Fixes https://github.com/NuGet/Home/issues/4492

//cc @rrelyea @alpaix @jainaashish @mishra14 @rohit21agrawal @nkolev92 @zhili1208 