### PR TITLE
Preemptively move relevant strings for PR #1171

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -61,6 +61,42 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not get the account manager, unable to check the keychain..
+        /// </summary>
+        public static string AccountProvider_FailedToLoadAccountManager {
+            get {
+                return ResourceManager.GetString("AccountProvider_FailedToLoadAccountManager", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not get the account provider, unable to check the keychain..
+        /// </summary>
+        public static string AccountProvider_FailedToLoadVSOAccountProvider {
+            get {
+                return ResourceManager.GetString("AccountProvider_FailedToLoadVSOAccountProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No valid credentials found for VSO account..
+        /// </summary>
+        public static string AccountProvider_NoValidCrededentialsFound {
+            get {
+                return ResourceManager.GetString("AccountProvider_NoValidCrededentialsFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to authenticate without prompting user..
+        /// </summary>
+        public static string AccountProvider_TriedToShowUIOnNonInteractive {
+            get {
+                return ResourceManager.GetString("AccountProvider_TriedToShowUIOnNonInteractive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value must be greater than or equal to {0}..
         /// </summary>
         public static string Argument_Must_Be_GreaterThanOrEqualTo {
@@ -84,6 +120,42 @@ namespace NuGet.PackageManagement.VisualStudio {
         public static string ConfigErrorDialogBoxTitle {
             get {
                 return ResourceManager.GetString("ConfigErrorDialogBoxTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The default credentials credential provider failed to load..
+        /// </summary>
+        public static string CredentialProviderFailed_DefaultCredentialsCredentialProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_DefaultCredentialsCredentialProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load credential provider from assembly {0}..
+        /// </summary>
+        public static string CredentialProviderFailed_ImportedProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_ImportedProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Visual Studio or VSTS account provider failed to load..
+        /// </summary>
+        public static string CredentialProviderFailed_VisualStudioAccountProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_VisualStudioAccountProvider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Visual Studio credential provider failed to load..
+        /// </summary>
+        public static string CredentialProviderFailed_VisualStudioCredentialProvider {
+            get {
+                return ResourceManager.GetString("CredentialProviderFailed_VisualStudioCredentialProvider", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -212,4 +212,28 @@
     <value>Unable to get the project's package installation service for project '{0}'.</value>
     <comment>{0} is the full path to the project.</comment>
   </data>
+  <data name="AccountProvider_FailedToLoadAccountManager" xml:space="preserve">
+    <value>Could not get the account manager, unable to check the keychain.</value>
+  </data>
+  <data name="AccountProvider_FailedToLoadVSOAccountProvider" xml:space="preserve">
+    <value>Could not get the account provider, unable to check the keychain.</value>
+  </data>
+  <data name="AccountProvider_NoValidCrededentialsFound" xml:space="preserve">
+    <value>No valid credentials found for VSO account.</value>
+  </data>
+  <data name="AccountProvider_TriedToShowUIOnNonInteractive" xml:space="preserve">
+    <value>Unable to authenticate without prompting user.</value>
+  </data>
+  <data name="CredentialProviderFailed_VisualStudioCredentialProvider" xml:space="preserve">
+    <value>The Visual Studio credential provider failed to load.</value>
+  </data>
+  <data name="CredentialProviderFailed_VisualStudioAccountProvider" xml:space="preserve">
+    <value>The Visual Studio or VSTS account provider failed to load.</value>
+  </data>
+  <data name="CredentialProviderFailed_DefaultCredentialsCredentialProvider" xml:space="preserve">
+    <value>The default credentials credential provider failed to load.</value>
+  </data>
+  <data name="CredentialProviderFailed_ImportedProvider" xml:space="preserve">
+    <value>Failed to load credential provider from assembly {0}.</value>
+  </data>
 </root>


### PR DESCRIPTION
As part of #1171 we need to move a bunch of strings from NuGet.Tools to PackageManagement.VisualStudio.

We do this early to ease the loc changes

//cc
@mishra14 @rrelyea @emgarten @jainaashish @rohit21agrawal @alpaix  