### PR TITLE
Fix for VS hang om install package with onbuild restore

### DIFF
--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26131.1
+VisualStudioVersion = 15.0.26007.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.VisualStudio", "src\NuGet.Clients\PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj", "{306CDDFA-FF0B-4299-930C-9EC6C9308160}"
 EndProject

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -387,19 +387,22 @@ namespace NuGet.SolutionRestoreManager
             await TaskScheduler.Default;
 
             using (var jobCts = CancellationTokenSource.CreateLinkedTokenSource(token))
-            using (var lck = await _lockService.Value.AcquireLockAsync(jobCts.Token))
             {
-                var componentModel = await _componentModel.GetValueAsync(jobCts.Token);
+                return await _lockService.Value.EnterNuGetOperation(async () =>
+                {
+                    var componentModel = await _componentModel.GetValueAsync(jobCts.Token);
 
-                var logger = componentModel.GetService<RestoreOperationLogger>();
-                await logger.StartAsync(
-                    request.RestoreSource,
-                    ErrorListProvider,
-                    _joinableFactory,
-                    jobCts);
+                    var logger = componentModel.GetService<RestoreOperationLogger>();
+                    await logger.StartAsync(
+                        request.RestoreSource,
+                        ErrorListProvider,
+                        _joinableFactory,
+                        jobCts);
 
-                var job = componentModel.GetService<ISolutionRestoreJob>();
-                return await job.ExecuteAsync(request, _restoreJobContext, logger, jobCts.Token);
+                    var job = componentModel.GetService<ISolutionRestoreJob>();
+                    return await job.ExecuteAsync(request, _restoreJobContext, logger, jobCts.Token);
+
+                }, jobCts.Token);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/InstallPackageCommand.cs
@@ -57,25 +57,29 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             // start timer for telemetry event
             TelemetryUtility.StartorResumeTimer();
 
-            using (var lck = _lockService.AcquireLock())
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                Preprocess();
+                await _lockService.EnterNuGetOperation(async () =>
+                {
+                    Preprocess();
 
-                SubscribeToProgressEvents();
-                if (!_readFromPackagesConfig
-                    && !_readFromDirectPackagePath
-                    && _nugetVersion == null)
-                {
-                    Task.Run(InstallPackageByIdAsync);
-                }
-                else
-                {
-                    var identities = GetPackageIdentities();
-                    Task.Run(() => InstallPackagesAsync(identities));
-                }
-                WaitAndLogPackageActions();
-                UnsubscribeFromProgressEvents();
-            }
+                    SubscribeToProgressEvents();
+                    if (!_readFromPackagesConfig
+                        && !_readFromDirectPackagePath
+                        && _nugetVersion == null)
+                    {
+                        await InstallPackageByIdAsync();
+                    }
+                    else
+                    {
+                        var identities = GetPackageIdentities();
+                        await InstallPackagesAsync(identities);
+                    }
+                    WaitAndLogPackageActions();
+                    UnsubscribeFromProgressEvents();
+
+                }, Token);
+            });
 
             // stop timer for telemetry event and create action telemetry event instance
             TelemetryUtility.StopTimer();

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UpdatePackageCommand.cs
@@ -106,14 +106,29 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             // start timer for telemetry event
             TelemetryUtility.StartorResumeTimer();
 
-            using (var lck = _lockService.AcquireLock())
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                Preprocess();
+                await _lockService.EnterNuGetOperation(async () =>
+                {
+                    Preprocess();
 
-                SubscribeToProgressEvents();
-                PerformPackageUpdatesOrReinstalls();
-                UnsubscribeFromProgressEvents();
-            }
+                    SubscribeToProgressEvents();
+
+                    // Update-Package without ID specified
+                    if (!_idSpecified)
+                    {
+                        await UpdateOrReinstallAllPackagesAsync();
+                    }
+                    // Update-Package with Id specified
+                    else
+                    {
+                        await UpdateOrReinstallSinglePackageAsync();
+                    }
+                    WaitAndLogPackageActions();
+
+                    UnsubscribeFromProgressEvents();
+                }, Token);
+            });
 
             // stop timer for telemetry event and create action telemetry event instance
             TelemetryUtility.StopTimer();
@@ -128,24 +143,6 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
 
             // emit telemetry event along with granular level for update operation
             ActionsTelemetryService.Instance.EmitActionEvent(actionTelemetryEvent, TelemetryService.TelemetryEvents);
-        }
-
-        /// <summary>
-        /// Perform package updates or reinstalls
-        /// </summary>
-        private void PerformPackageUpdatesOrReinstalls()
-        {
-            // Update-Package without ID specified
-            if (!_idSpecified)
-            {
-                Task.Run(UpdateOrReinstallAllPackagesAsync);
-            }
-            // Update-Package with Id specified
-            else
-            {
-                Task.Run(UpdateOrReinstallSinglePackageAsync);
-            }
-            WaitAndLogPackageActions();
         }
 
         /// <summary>

--- a/src/NuGet.Clients/PackageManagement.UI/Services/INuGetLockService.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Services/INuGetLockService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.VisualStudio.Threading;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -15,6 +16,10 @@ namespace NuGet.PackageManagement.UI
         /// Gets a value indicating whether any kind of lock is held.
         /// </summary>
         bool IsLockHeld { get; }
+
+        JoinableTask<T> EnterNuGetOperation<T>(Func<System.Threading.Tasks.Task<T>> execute, CancellationToken token);
+
+        JoinableTask EnterNuGetOperation(Func<System.Threading.Tasks.Task> execute, CancellationToken token);
 
         /// <summary>
         /// Obtains a lock, asynchronously awaiting for the lock if it is not immediately awailable.

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/RunspaceManager.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/RunspaceManager.cs
@@ -11,8 +11,8 @@ using System.Reflection;
 using EnvDTE;
 using EnvDTE80;
 using Microsoft.PowerShell;
-using NuGet.Configuration;
 using NuGet.PackageManagement;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 
@@ -53,13 +53,18 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             DTE dte = ServiceLocator.GetInstance<DTE>();
 
             InitialSessionState initialSessionState = InitialSessionState.CreateDefault();
-            initialSessionState.Variables.Add(
+
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                initialSessionState.Variables.Add(
                 new SessionStateVariableEntry(
                     "DTE",
                     (DTE2)dte,
                     "Visual Studio DTE automation object",
                     ScopedItemOptions.AllScope | ScopedItemOptions.Constant)
                 );
+            });
 
             // this is used by the functional tests
             var sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
@@ -75,7 +80,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 };
 
             var runspace = RunspaceFactory.CreateRunspace(host, initialSessionState);
-            runspace.ThreadOptions = PSThreadOptions.Default;
+            runspace.ThreadOptions = PSThreadOptions.UseCurrentThread;
             runspace.Open();
 
             //


### PR DESCRIPTION
This PR synchronize between multiple JTFs across NuGet operations like restore, install/ update/ uninstall through JoinableTaskCollection so that it doesn't hang while NuGet operation is going on, and build gets triggered on UI thread. This implementation is as per the discussion and recommendation from Andrew Arnott.

There will be another part of this where we keep the same behavior for powershell console, I'll either raise a new PR or update this later.

Fixes https://github.com/NuGet/Home/issues/4420

@rrelyea @emgarten @alpaix @AArnott 