### PR TITLE
Add missing package for new E2E test

### DIFF
--- a/test/EndToEnd/Packages/NetCoreWebAppExecuteInitScriptsOnlyOnce/PackageInitPS1.1.0.0.nuspec
+++ b/test/EndToEnd/Packages/NetCoreWebAppExecuteInitScriptsOnlyOnce/PackageInitPS1.1.0.0.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <version>1.0.0</version>
+    <authors>daravind</authors>
+    <owners />
+    <id>PackageInitPS1</id>
+    <title />
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>My package description.</description>
+  </metadata>
+  <files>
+    <file src="tools\init.ps1" target="tools\init.ps1" />
+  </files>
+</package>

--- a/test/EndToEnd/Packages/NetCoreWebAppExecuteInitScriptsOnlyOnce/files/PackageInitPS1.1.0.0/tools/init.ps1
+++ b/test/EndToEnd/Packages/NetCoreWebAppExecuteInitScriptsOnlyOnce/files/PackageInitPS1.1.0.0/tools/init.ps1
@@ -1,0 +1,3 @@
+param($installPath, $toolsPath, $package)
+
+$global:PackageInitPS1Var = $global:PackageInitPS1Var + 1


### PR DESCRIPTION
I added an end-to-end test in https://github.com/NuGet/NuGet.Client/pull/1166 but forgot to include the package it requires. For posterity, you must `git add -f` the package under the `test/EndToEnd/Packages` directory otherwise Git will ignore it.