### PR TITLE
Skip on-build restore for pure .NET Core solutions

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio;
@@ -46,6 +47,8 @@ namespace NuGet.SolutionRestoreManager
 
         private readonly JoinableTaskCollection _joinableCollection;
         private readonly JoinableTaskFactory _joinableFactory;
+
+        private IVsSolutionManager SolutionManager => _solutionManager.Value;
 
         private ErrorListProvider ErrorListProvider => NuGetUIThreadHelper.JoinableTaskFactory.Run(_errorListProvider.GetValueAsync);
 
@@ -217,7 +220,7 @@ namespace NuGet.SolutionRestoreManager
             // Initialize if not already done.
             await InitializeAsync();
 
-            if (_solutionManager.Value.IsSolutionFullyLoaded)
+            if (SolutionManager.IsSolutionFullyLoaded)
             {
                 // start background runner if not yet started
                 // ignore the value
@@ -251,6 +254,18 @@ namespace NuGet.SolutionRestoreManager
                         // Initialize if not already done.
                         await InitializeAsync();
 
+#if VS15
+                        if (request.RestoreSource == RestoreOperationSource.OnBuild)
+                        {
+                            if (!await SolutionManager.SolutionHasDeferredProjectsAsync()
+                                && SolutionManager.GetNuGetProjects().All(p => p is CpsPackageReferenceProject))
+                            {
+                                // Do nothing if all projects are .NET Core projects (Roslyn project system)
+                                // in that case on-build restore is not needed
+                                return true;
+                            }
+                        }
+#endif
                         using (var restoreOperation = new BackgroundRestoreOperation())
                         {
                             await PromoteTaskToActiveAsync(restoreOperation, _workerCts.Token);


### PR DESCRIPTION
Addresses NuGet/Home#4225.

Determine if a solution contains .NET Core projects only (Roslyn project
system) and no LSL enabled. In this case skip on-buld restore as
redundant. Auto-restore should be sufficient for this scenario.

//cc @rrelyea @lifengl