### PR TITLE
Display restore progress dialog

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -50,6 +50,7 @@
     <Compile Include="VerbosityLevel.cs" />
     <Compile Include="VsSolutionRestoreService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WaitDialogProgress.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj">

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -89,7 +89,7 @@ namespace NuGet.SolutionRestoreManager
             _externalCts.Token.Register(() => _cancelled = true);
 
 #if VS14
-            _progressFactory = t => WaitDialogProgress.StartAsync(_serviceProvider, _taskFactory, t);
+            _progressFactory = t => WaitDialogProgress.StartAsync(_serviceProvider, _taskFactory, isCancelable: true, token: t);
 #else
             _progressFactory = t => StatusBarProgress.StartAsync(_serviceProvider, _taskFactory, t);
 #endif
@@ -426,75 +426,6 @@ namespace NuGet.SolutionRestoreManager
                 return (int)value;
             }
             return 0;
-        }
-
-        private class WaitDialogProgress : RestoreOperationProgressUI
-        {
-            private readonly ThreadedWaitDialogHelper.Session _session;
-            private readonly JoinableTaskFactory _taskFactory;
-
-            private WaitDialogProgress(
-                ThreadedWaitDialogHelper.Session session,
-                JoinableTaskFactory taskFactory)
-            {
-                _session = session;
-                _taskFactory = taskFactory;
-                UserCancellationToken = _session.UserCancellationToken;
-            }
-
-            public static async Task<RestoreOperationProgressUI> StartAsync(
-                IServiceProvider serviceProvider,
-                JoinableTaskFactory jtf,
-                CancellationToken token)
-            {
-                return await jtf.RunAsync(async () =>
-                {
-                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                    var waitDialogFactory = serviceProvider.GetService<
-                        SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>();
-
-                    var session = waitDialogFactory.StartWaitDialog(
-                        waitCaption: Resources.DialogTitle,
-                        initialProgress: new ThreadedWaitDialogProgressData(
-                            Resources.RestoringPackages,
-                            progressText: string.Empty,
-                            statusBarText: string.Empty,
-                            isCancelable: true,
-                            currentStep: 0,
-                            totalSteps: 0));
-
-                    return new WaitDialogProgress(session, jtf);
-                });
-            }
-
-            public override void Dispose()
-            {
-                _taskFactory.Run(async () =>
-                {
-                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                    _session.Dispose();
-                });
-            }
-
-            public override void ReportProgress(
-                string progressMessage,
-                uint currentStep,
-                uint totalSteps)
-            {
-                ThreadHelper.ThrowIfNotOnUIThread();
-
-                // When both currentStep and totalSteps are 0, we get a marquee on the dialog
-                var progressData = new ThreadedWaitDialogProgressData(
-                    progressMessage,
-                    progressText: string.Empty,
-                    statusBarText: string.Empty,
-                    isCancelable: true,
-                    currentStep: (int)currentStep,
-                    totalSteps: (int)totalSteps);
-
-                _session.Progress.Report(progressData);
-            }
         }
 
         private class StatusBarProgress : RestoreOperationProgressUI

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/WaitDialogProgress.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/WaitDialogProgress.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using NuGet.PackageManagement.UI;
+using NuGet.PackageManagement.VisualStudio;
+
+namespace NuGet.SolutionRestoreManager
+{
+    internal sealed class WaitDialogProgress : RestoreOperationProgressUI
+    {
+        private readonly ThreadedWaitDialogHelper.Session _session;
+        private readonly JoinableTaskFactory _taskFactory;
+
+        private WaitDialogProgress(
+            ThreadedWaitDialogHelper.Session session,
+            JoinableTaskFactory taskFactory)
+        {
+            _session = session;
+            _taskFactory = taskFactory;
+            UserCancellationToken = _session.UserCancellationToken;
+        }
+
+        public static async Task<RestoreOperationProgressUI> StartAsync(
+            IServiceProvider serviceProvider,
+            JoinableTaskFactory jtf,
+            bool isCancelable,
+            CancellationToken token)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (jtf == null)
+            {
+                throw new ArgumentNullException(nameof(jtf));
+            }
+
+            return await jtf.RunAsync(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                var waitDialogFactory = serviceProvider.GetService<
+                    SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>();
+
+                var session = waitDialogFactory.StartWaitDialog(
+                    waitCaption: Resources.DialogTitle,
+                    initialProgress: new ThreadedWaitDialogProgressData(
+                        Resources.RestoringPackages,
+                        progressText: string.Empty,
+                        statusBarText: string.Empty,
+                        isCancelable: isCancelable,
+                        currentStep: 0,
+                        totalSteps: 0));
+
+                return new WaitDialogProgress(session, jtf);
+            });
+        }
+
+        public override void Dispose()
+        {
+            _taskFactory.Run(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                _session.Dispose();
+            });
+        }
+
+        public override void ReportProgress(
+            string progressMessage,
+            uint currentStep,
+            uint totalSteps)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // When both currentStep and totalSteps are 0, we get a marquee on the dialog
+            var progressData = new ThreadedWaitDialogProgressData(
+                progressMessage,
+                progressText: string.Empty,
+                statusBarText: string.Empty,
+                isCancelable: true,
+                currentStep: (int)currentStep,
+                totalSteps: (int)totalSteps);
+
+            _session.Progress.Report(progressData);
+        }
+    }
+}


### PR DESCRIPTION
Addresses NuGet/Home#4225.

This change utilizes pre-existing `WaitDialogProgress` in
order to display on-build restore progress dialog when an auto-restore is
in progress.

This is to improve user experience when building hybrid solutions
containing both .NET Core and non-.NET Core projects.

//cc @rrelyea 