### PR TITLE
Remove directoryexists check for the obj folder - resolves #4528

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -188,7 +188,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var baseIntermediatePath = _project.BaseIntermediateOutputPath;
 
-            if (string.IsNullOrEmpty(baseIntermediatePath) || !Directory.Exists(baseIntermediatePath))
+            if (string.IsNullOrEmpty(baseIntermediatePath))
             {
                 throw new InvalidDataException(nameof(_project.BaseIntermediateOutputPath));
             }


### PR DESCRIPTION
This closes NuGet/Home#4528

The directory exists check in the obj folder is redundant as when we commit the restore result we create the directory. 
https://github.com/NuGet/NuGet.Client/blob/d56985eedd20135fa645c9182bd63e83a1402a1e/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs#L177