### PR TITLE
Changing AddPackage command to add version as attribute

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -223,14 +223,10 @@ namespace NuGet.CommandLine.XPlat
         {
             var packageVersion = packageDependency.VersionRange.OriginalString ??
                 packageDependency.VersionRange.MinVersion.ToString();
-            var packageMetadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            { { VERSION_TAG, packageVersion } };
 
-            // Currently metadata is added as a metadata. As opposed to an attribute
-            // Due to https://github.com/Microsoft/msbuild/issues/1393
+            var item = itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, packageDependency.Id);
+            item.AddMetadata(VERSION_TAG, packageVersion, expressAsAttribute: true);
 
-            itemGroup.AddItem(PACKAGE_REFERENCE_TYPE_TAG, packageDependency.Id, packageMetadata);
-            itemGroup.ContainingProject.Save();
             Logger.LogInformation(string.Format(CultureInfo.CurrentCulture,
                 Strings.Info_AddPkgAdded,
                 packageDependency.Id,

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -35,7 +36,7 @@ namespace NuGet.Test.Utility
             string identity,
             NuGetFramework framework,
             Dictionary<string, string> properties,
-            Dictionary<string,string> attributes )
+            Dictionary<string, string> attributes)
         {
             AddItem(doc, name, identity,
                 framework?.IsSpecificFramework == true ? framework.GetShortFolderName() : string.Empty, properties, attributes);
@@ -46,7 +47,7 @@ namespace NuGet.Test.Utility
             string identity,
             string framework,
             Dictionary<string, string> properties,
-            Dictionary<string,string> attributes )
+            Dictionary<string, string> attributes)
         {
             var ns = doc.Root.GetDefaultNamespace();
 
@@ -68,8 +69,15 @@ namespace NuGet.Test.Utility
 
             foreach (var pair in properties)
             {
-                var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
-                entry.Add(subItem);
+                if (pair.Key.Equals("version", StringComparison.OrdinalIgnoreCase))
+                {
+                    entry.Add(new XAttribute(XName.Get("Version"), pair.Value));
+                }
+                else
+                {
+                    var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
+                    entry.Add(subItem);
+                }
             }
 
             var lastItemGroup = doc.Root.Elements().LastOrDefault(e => e.Name.LocalName == "ItemGroup");

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -69,15 +69,8 @@ namespace NuGet.Test.Utility
 
             foreach (var pair in properties)
             {
-                if (pair.Key.Equals("version", StringComparison.OrdinalIgnoreCase))
-                {
-                    entry.Add(new XAttribute(XName.Get("Version"), pair.Value));
-                }
-                else
-                {
-                    var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
-                    entry.Add(subItem);
-                }
+                var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
+                entry.Add(subItem);
             }
 
             var lastItemGroup = doc.Root.Elements().LastOrDefault(e => e.Name.LocalName == "ItemGroup");

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -416,8 +416,16 @@ namespace NuGet.Test.Utility
                         }
 
                         var props = new Dictionary<string, string>();
+                        var attributes = new Dictionary<string, string>();
 
-                        props.Add("Version", package.Version.ToString());
+                        if (ToolingVersion15)
+                        {
+                            attributes.Add("Version", package.Version.ToString());
+                        }
+                        else
+                        {
+                            props.Add("Version", package.Version.ToString());
+                        }
 
                         if (!string.IsNullOrEmpty(package.Include))
                         {
@@ -440,7 +448,7 @@ namespace NuGet.Test.Utility
                             package.Id,
                             referenceFramework,
                             props,
-                            new Dictionary<string, string>());
+                            attributes);
                     }
 
                     foreach (var project in frameworkInfo.ProjectReferences)

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -394,7 +394,8 @@ namespace NuGet.Test.Utility
                     });
                 }
 
-                var addedToAll = new HashSet<SimpleTestProjectContext>();
+                var addedToAllProjectReferences = new HashSet<SimpleTestProjectContext>();
+                var addedToAllPackageReferences = new HashSet<SimpleTestPackageContext>();
 
                 foreach (var frameworkInfo in Frameworks)
                 {
@@ -406,6 +407,12 @@ namespace NuGet.Test.Utility
                         if (Frameworks.All(f => f.PackageReferences.Contains(package)))
                         {
                             referenceFramework = NuGetFramework.AnyFramework;
+
+                            if (!addedToAllPackageReferences.Add(package))
+                            {
+                                // Skip since this was already added
+                                continue;
+                            }
                         }
 
                         var props = new Dictionary<string, string>();
@@ -445,7 +452,7 @@ namespace NuGet.Test.Utility
                         {
                             referenceFramework = NuGetFramework.AnyFramework;
 
-                            if (!addedToAll.Add(project))
+                            if (!addedToAllProjectReferences.Add(project))
                             {
                                 // Skip since this was already added
                                 continue;
@@ -531,56 +538,6 @@ namespace NuGet.Test.Utility
             }
 
             return xml;
-        }
-
-        private static void AddProperties(XDocument doc, Dictionary<string, string> properties)
-        {
-            var ns = doc.Root.GetDefaultNamespace();
-
-            var propertyGroup = new XElement(XName.Get("PropertyGroup", ns.NamespaceName));
-            foreach (var pair in properties)
-            {
-                var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
-                propertyGroup.Add(subItem);
-            }
-
-            var lastPropGroup = doc.Root.Elements().Where(e => e.Name.LocalName == "PropertyGroup").Last();
-            lastPropGroup.AddAfterSelf(propertyGroup);
-        }
-
-        private static void AddItem(XDocument doc,
-            string name,
-            string identity,
-            NuGetFramework framework,
-            Dictionary<string, string> properties)
-        {
-            var ns = doc.Root.GetDefaultNamespace();
-
-            var itemGroup = new XElement(XName.Get("ItemGroup", ns.NamespaceName));
-            var entry = new XElement(XName.Get(name, ns.NamespaceName));
-            entry.Add(new XAttribute(XName.Get("Include"), identity));
-            itemGroup.Add(entry);
-
-            if (framework?.IsSpecificFramework == true)
-            {
-                itemGroup.Add(new XAttribute(XName.Get("Condition"), $" '$(TargetFramework)' == '{framework.GetShortFolderName()}' "));
-            }
-
-            foreach (var pair in properties)
-            {
-                if (pair.Key.Equals("version", StringComparison.OrdinalIgnoreCase))
-                {
-                    entry.Add(new XAttribute(XName.Get("Version"), pair.Value));
-                }
-                else
-                {
-                    var subItem = new XElement(XName.Get(pair.Key, ns.NamespaceName), pair.Value);
-                    entry.Add(subItem);
-                }
-            }
-
-            var lastItemGroup = doc.Root.Elements().Where(e => e.Name.LocalName == "ItemGroup").Last();
-            lastItemGroup.AddAfterSelf(itemGroup);
         }
 
         public override bool Equals(object obj)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -241,12 +241,12 @@ namespace NuGet.XPlat.FuncTest
                 return false;
             }
 
-            var versions = packageReferences
+            var versionAttribute = packageReferences
                 .First()
-                .Descendants("Version");
+                .Attribute("Version");
 
-            if (versions.Count() != 1 ||
-                !versions.First().Value.Equals(version, StringComparison.OrdinalIgnoreCase))
+            if (versionAttribute == null ||
+                !versionAttribute.Value.Equals(version, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4325

Current :
We add version as a child element to the package reference.
 
```xml
  <ItemGroup>
    <PackageReference Include="Newtonsoft.Json">
      <Version>9.0.1</Version>
    </PackageReference>
  </ItemGroup>
```

After Fix: 
We will add version as an attribute.

```xml
  <ItemGroup>
    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
  </ItemGroup>
```