### PR TITLE
Handle Solution Event UpdateSolution_QueryDelayFirstUpdateAction to delay build

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
@@ -12,6 +13,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Configuration;
 using NuGet.PackageManagement;
+using NuGet.PackageManagement.UI;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using Task = System.Threading.Tasks.Task;
@@ -44,9 +46,13 @@ namespace NuGet.SolutionRestoreManager
         private ISettings Settings => _settings.Value;
         private IVsSolutionManager SolutionManager => _solutionManager.Value;
 
+        private IVsSolutionBuildManager5 _solutionBuildManager;
+
         // keeps a reference to BuildEvents so that our event handler
         // won't get disconnected.
         private EnvDTE.BuildEvents _buildEvents;
+
+        private uint _updateSolutionEventsCookie4;
 
         protected override async Task InitializeAsync(
             CancellationToken cancellationToken,
@@ -64,6 +70,11 @@ namespace NuGet.SolutionRestoreManager
             _solutionManager = new Lazy<IVsSolutionManager>(
                 () => componentModel.GetService<IVsSolutionManager>());
 
+            var lockService = new Lazy<INuGetLockService>(
+                () => componentModel.GetService<INuGetLockService>());
+
+            var updateSolutionEvent = new VsUpdateSolutionEvent(lockService);
+
             // Don't use CPS thread helper because of RPS perf regression
             await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -74,11 +85,26 @@ namespace NuGet.SolutionRestoreManager
 
                 UserAgent.SetUserAgentString(
                     new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
+
+                _solutionBuildManager = (IVsSolutionBuildManager5)await GetServiceAsync(typeof(SVsSolutionBuildManager));
+                Assumes.Present(_solutionBuildManager);
+
+                _solutionBuildManager.AdviseUpdateSolutionEvents4(updateSolutionEvent, out _updateSolutionEventsCookie4);
             });
 
             await SolutionRestoreCommand.InitializeAsync(this);
 
             await base.InitializeAsync(cancellationToken, progress);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_updateSolutionEventsCookie4 != 0)
+            {
+                _solutionBuildManager?.UnadviseUpdateSolutionEvents4(_updateSolutionEventsCookie4);
+            }
         }
 
         private void BuildEvents_OnBuildBegin(
@@ -113,6 +139,43 @@ namespace NuGet.SolutionRestoreManager
                 var packageRestoreConsent = new PackageRestoreConsent(Settings);
                 return packageRestoreConsent.IsAutomatic;
             }
+        }
+
+        private sealed class VsUpdateSolutionEvent : IVsUpdateSolutionEvents4
+        {
+            private Lazy<INuGetLockService> _lockService;
+
+            public VsUpdateSolutionEvent(Lazy<INuGetLockService> lockService)
+            {
+                _lockService = lockService;
+            }
+
+            public void UpdateSolution_QueryDelayFirstUpdateAction(out int pfDelay)
+            {
+                // check if NuGet lock is already acquired by some other NuGet operation
+                if (_lockService.Value.IsLockHeld)
+                {
+                    // delay build by setting pfDelay to non-zero
+                    pfDelay = 1;
+                }
+                else
+                {
+                    // Set delay to 0 which means don't delay build
+                    pfDelay = 0;
+                }
+            }
+
+            public void UpdateSolution_BeginFirstUpdateAction() { }
+
+            public void UpdateSolution_EndLastUpdateAction() { }
+
+            public void UpdateSolution_BeginUpdateAction(uint dwAction) { }
+
+            public void UpdateSolution_EndUpdateAction(uint dwAction) { }
+
+            public void OnActiveProjectCfgChangeBatchBegin() { }
+
+            public void OnActiveProjectCfgChangeBatchEnd() { }
         }
     }
 }


### PR DESCRIPTION
After discussion with Project System team, we now started listening to solution event UpdateSolution_QueryDelayFirstUpdateAction to delay build until any NuGet operation is already in progress without blocking UI thread. If NuGet operation is in progress, and some one hit build, then we set delay time to 1 sec which makes solution build manager system to call it again after 1 sec and keeps repeating it until we set it to 0. And we set it to 0 when our current NuGet operation is completed and releases NuGet lock.

It helps solve couple of our recent VS hangs where some NuGet operation is in progress like install package or auto restore, and at the same time, user trigger build so it will hang the VS. Now we won't block UI thread with this change so it won't hang the VS rather delay build until existing operation is completed.

Fixes https://github.com/NuGet/Home/issues/4420

@rrelyea @AArnott @emgarten @alpaix