### PR TITLE
Fixing a typo in log string

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.Designer.cs
@@ -295,7 +295,7 @@ namespace NuGet.PackageManagement.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project &apos;{0}&apos; could not be casted to a build property storage interace, which is required to get MSBuild properties inside Visual Studio..
+        ///   Looks up a localized string similar to The project &apos;{0}&apos; could not be casted to a build property storage interface, which is required to get MSBuild properties inside Visual Studio..
         /// </summary>
         public static string ProjectCouldNotBeCastedToBuildPropertyStorage {
             get {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -205,7 +205,7 @@
     <comment>{0} is the full path to the project.</comment>
   </data>
   <data name="ProjectCouldNotBeCastedToBuildPropertyStorage" xml:space="preserve">
-    <value>The project '{0}' could not be casted to a build property storage interace, which is required to get MSBuild properties inside Visual Studio.</value>
+    <value>The project '{0}' could not be casted to a build property storage interface, which is required to get MSBuild properties inside Visual Studio.</value>
     <comment>{0} is the full path to the project.</comment>
   </data>
   <data name="UnableToGetCPSPackageInstallationService" xml:space="preserve">

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Strings.resx
@@ -205,7 +205,7 @@
     <comment>{0} is the full path to the project.</comment>
   </data>
   <data name="ProjectCouldNotBeCastedToBuildPropertyStorage" xml:space="preserve">
-    <value>The project '{0}' could not be casted to a build property storage interface, which is required to get MSBuild properties inside Visual Studio.</value>
+    <value>The project '{0}' could not be cast to a build property storage interface, which is required to get MSBuild properties inside Visual Studio.</value>
     <comment>{0} is the full path to the project.</comment>
   </data>
   <data name="UnableToGetCPSPackageInstallationService" xml:space="preserve">


### PR DESCRIPTION
Got this typo bug from loc vendors during translations. 

//cc: @joelverhagen @emgarten @rrelyea 