### PR TITLE
pack pri file for inner builds in multi-targeting scenarios

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -165,7 +165,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
-      Targets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup"
+      Targets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;_AddPriFileToPackBuildOutput"
       Properties="TargetFramework=%(_TargetFrameworks.Identity);
                   BuildProjectReferences=false;">
 
@@ -174,15 +174,6 @@ Copyright (c) .NET Foundation. All rights reserved.
           ItemName="_TargetPathsToAssemblies" />
     </MSBuild>
     
-    <!--Projects with target framework like UWP, Win8, wpa81 produce a Pri file
-    in their bin dir. This Pri file is not included in the BuiltProjectGroupOutput, and
-    has to be added manually here.-->
-    <ItemGroup Condition="'$(IncludeProjectPriFile)' == 'true'">
-      <_TargetPathsToAssemblies Include="$(ProjectPriFullPath)">
-        <FinalOutputPath>$(ProjectPriFullPath)</FinalOutputPath>
-      </_TargetPathsToAssemblies>
-    </ItemGroup>
-
     <MSBuild
       Condition="'$(IncludeSymbols)' == 'true' OR '$(IncludeSource)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
@@ -206,6 +197,18 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_SourceFiles" />
     </MSBuild>
+  </Target>
+  
+  <!--Projects with target framework like UWP, Win8, wpa81 produce a Pri file
+    in their bin dir. This Pri file is not included in the BuiltProjectGroupOutput, and
+    has to be added manually here.-->
+  <Target Name="_AddPriFileToPackBuildOutput"
+          Returns="@(_PathToPriFile)">
+    <ItemGroup Condition="'$(IncludeProjectPriFile)' == 'true'">
+      <_PathToPriFile Include="$(ProjectPriFullPath)">
+        <FinalOutputPath>$(ProjectPriFullPath)</FinalOutputPath>
+      </_PathToPriFile>
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/4136

The last fix for adding pri files to get packed in UWP apps worked for single framework scenarios only because the pri file was being added in the outer build.

This fix makes sure that multi-targeting scenarios work too - pri files get added if you have ```TargetFramework``` or ```TargetFrameworks``` defined in your project.

CC: @rrelyea @emgarten @alpaix @mishra14 @jainaashish @zhili1208 @nkolev92 