### PR TITLE
Only execute scripts if solution is fully loaded

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/CpsPackageReferenceProject.cs
@@ -98,13 +98,30 @@ namespace NuGet.PackageManagement.VisualStudio
                         _envDTEProject, throwOnFailure);
         }
 
-        public override Task<String> GetAssetsFilePathAsync()
+        public override async Task<String> GetAssetsFilePathAsync()
+        {
+            return await GetAssetsFilePathAsync(shouldThrow: true);
+        }
+
+        public override async Task<String> GetAssetsFilePathOrNullAsync()
+        {
+            return await GetAssetsFilePathAsync(shouldThrow: false);
+        }
+
+        private Task<string> GetAssetsFilePathAsync(bool shouldThrow)
         {
             var packageSpec = GetPackageSpec();
             if (packageSpec == null)
             {
-                throw new InvalidOperationException(
-                    string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
+                }
+                else
+                {
+                    return Task.FromResult<string>(null);
+                }
             }
 
             return Task.FromResult(Path.Combine(

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -42,7 +42,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private readonly IRestoreEvents _restoreEvents;
         private readonly IRunspaceManager _runspaceManager;
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
-        private readonly ISolutionManager _solutionManager;
+        private readonly IVsSolutionManager _solutionManager;
         private readonly ISettings _settings;
         private readonly ISourceControlManagerProvider _sourceControlManagerProvider;
         private readonly ICommonOperations _commonOperations;
@@ -105,7 +105,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             // TODO: Take these as ctor arguments
             _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            _solutionManager = ServiceLocator.GetInstance<ISolutionManager>();
+            _solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
             _settings = ServiceLocator.GetInstance<ISettings>();
             _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
             _scriptExecutor = ServiceLocator.GetInstance<IScriptExecutor>();
@@ -398,6 +398,11 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 // make sure all projects are loaded before start to execute init scripts. Since
                 // projects might not be loaded when DPL is enabled.
                 _solutionManager.EnsureSolutionIsLoaded();
+
+                if (!_solutionManager.IsSolutionFullyLoaded)
+                {
+                    return;
+                }
 
                 // invoke init.ps1 files in the order of package dependency.
                 // if A -> B, we invoke B's init.ps1 before A's.

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -35,9 +35,16 @@ namespace NuGet.ProjectManagement.Projects
         public abstract string MSBuildProjectPath { get; }
 
         /// <summary>
-        /// Returns the path to the assets file or the lock file.
+        /// Returns the path to the assets file or the lock file. Throws an exception if the assets file path cannot be
+        /// determined.
         /// </summary>
         public abstract Task<string> GetAssetsFilePathAsync();
+
+        /// <summary>
+        /// Returns the path to the assets file or the lock file. Returns null if the assets file path cannot be
+        /// determined.
+        /// </summary>
+        public abstract Task<string> GetAssetsFilePathOrNullAsync();
 
         public abstract Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context);
 

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -112,6 +112,12 @@ namespace NuGet.ProjectManagement.Projects
             return Task.FromResult(ProjectJsonPathUtilities.GetLockFilePath(JsonConfigPath));
         }
 
+        public override Task<string> GetAssetsFilePathOrNullAsync()
+        {
+            // project.json projects can always have their lock file path determined.
+            return GetAssetsFilePathAsync();
+        }
+
         /// <summary>
         /// project.json path
         /// </summary>

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -41,7 +41,13 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static async Task<LockFile> GetLockFileOrNull(BuildIntegratedNuGetProject buildIntegratedProject)
         {
-            var lockFilePath = await buildIntegratedProject.GetAssetsFilePathAsync();
+            var lockFilePath = await buildIntegratedProject.GetAssetsFilePathOrNullAsync();
+            
+            if (lockFilePath == null)
+            {
+                return null;
+            }
+
             return GetLockFileOrNull(lockFilePath);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/LegacyCSProjPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/LegacyCSProjPackageReferenceProjectTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.Shell;
 using Moq;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
-using NuGet.ProjectModel;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
@@ -43,6 +42,25 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 // Assert
                 Assert.Equal(Path.Combine(testBaseIntermediateOutputPath, "project.assets.json"), assetsPath);
+            }
+        }
+
+        [Fact]
+        public async Task LCPRP_WhenThereIsNoBaseIntermediateOutputPath_ThrowsException()
+        {
+            // Arrange
+            using (var randomTestFolder = TestDirectory.Create())
+            {
+                var testEnvDTEProjectAdapter = new Mock<IEnvDTEProjectAdapter>();
+
+                var testProject = new LegacyCSProjPackageReferenceProject(
+                    project: testEnvDTEProjectAdapter.Object,
+                    projectId: String.Empty,
+                    callerIsUnitTest: true);
+
+                // Act & Assert
+                await Assert.ThrowsAsync<InvalidDataException>(
+                    () => testProject.GetAssetsFilePathAsync());
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1576,6 +1576,7 @@ namespace NuGet.Commands.FuncTest
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
+            using (var sourceCacheContext = new SourceCacheContext())
             {
                 var specPath = Path.Combine(projectDir, "TestProject", "project.json");
                 var spec = JsonPackageSpecReader.GetPackageSpec(BasicConfig.ToString(), "TestProject", specPath);
@@ -1583,7 +1584,7 @@ namespace NuGet.Commands.FuncTest
                 AddDependency(spec, "NotARealPackage.ThisShouldNotExists.DontCreateIt.Seriously.JustDontDoIt.Please", "2.8.3");
 
                 var logger = new TestLogger();
-                var request = new TestRestoreRequest(spec, sources, packagesDir, logger);
+                var request = new TestRestoreRequest(spec, sources, packagesDir, sourceCacheContext, logger);
 
                 request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
 


### PR DESCRIPTION
This PR makes two changes to improve the resiliency of PMC open.

1. Only execute scripts if the solution is fully loaded (via `IVsSolutionManager.IsSolutionFullyLoaded`).
1. If we are executing scripts but nomination for a project has not occurred, handle the exception that occurs when the dependencies for that project cannot be detected.
1. (unrelated **test fix**) Use a real source cache context on a test that actually hits the web.

Manual testing:
1. .NET Core and .NET Framework web projects
1. .NET Framework console app with EF 6 installed.
1. Opening PMC before solution load, during, and after.
1. With lightweight solution load enabled.

I am planning on taking this for 4.0 RTM.

Address https://github.com/NuGet/Home/issues/4564.