### PR TITLE
Fixing nuget.exe download to v3.5.0

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -181,7 +181,7 @@ Function Install-NuGet {
     )
     if ($Force -or -not (Test-Path $NuGetExe)) {
         Trace-Log 'Downloading nuget.exe'
-        wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $NuGetExe
+        wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $NuGetExe
     }
 
     # Display nuget info

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -177,11 +177,17 @@ Function Update-Submodules {
 Function Install-NuGet {
     [CmdletBinding()]
     param(
-        [switch]$Force
+        [switch]$Force,
+        [switch]$CI
     )
     if ($Force -or -not (Test-Path $NuGetExe)) {
         Trace-Log 'Downloading nuget.exe'
-        wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $NuGetExe
+        if($CI){
+            wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $NuGetExe
+        }
+        else {
+            wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $NuGetExe
+        }
     }
 
     # Display nuget info

--- a/configure.ps1
+++ b/configure.ps1
@@ -42,7 +42,7 @@ Invoke-BuildStep 'Configuring git repo' {
 } -ev +BuildErrors
 
 Invoke-BuildStep 'Installing NuGet.exe' {
-    Install-NuGet -Force:$Force
+    Install-NuGet -Force:$Force -CI:$CI
 } -ev +BuildErrors
 
 Invoke-BuildStep 'Installing .NET CLI' {

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -89,7 +89,7 @@ XunitConsole="$DIR/packages/xunit.runner.console.2.1.0/tools/xunit.console.exe"
 NuGetExe="$DIR/.nuget/nuget.exe"
 
 #Get NuGet.exe
-wget -O $NuGetExe https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe 
+wget -O $NuGetExe https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe
 
 #restore solution packages
 mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -89,7 +89,7 @@ XunitConsole="$DIR/packages/xunit.runner.console.2.1.0/tools/xunit.console.exe"
 NuGetExe="$DIR/.nuget/nuget.exe"
 
 #Get NuGet.exe
-wget -O $NuGetExe https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe
+wget -O $NuGetExe https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe
 
 #restore solution packages
 mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -22,9 +22,9 @@ if ((Test-Path $nugetExePath) -eq $False)
 {
     Write-Host -BackgroundColor Yellow -ForegroundColor Black 'nuget.exe cannot be found at' $nugetExePath
     Write-Host "Downloading nuget.exe"
-    wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $nugetExePath
+    wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $nugetExePath
 }
-
+
 # Enable NuGet Test Mode
 $env:NuGetTestModeEnabled = "True"
 

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -22,7 +22,7 @@ if ((Test-Path $nugetExePath) -eq $False)
 {
     Write-Host -BackgroundColor Yellow -ForegroundColor Black 'nuget.exe cannot be found at' $nugetExePath
     Write-Host "Downloading nuget.exe"
-    wget https://dist.nuget.org/win-x86-commandline/v3.5.0/nuget.exe -OutFile $nugetExePath
+    wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $nugetExePath
 }
 
 # Enable NuGet Test Mode


### PR DESCRIPTION
This locks the nuget.exe download on the CI machines to v3.5.0.

Post 4.0.0 rtm we should update our CI build machines to dev14U3 and then we can try the later versions of nuget.exe.

@joelverhagen @alpaix @nkolev92 @emgarten 