### PR TITLE
Replace -f by -Force for "SpecCommandFileExists"

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -427,7 +427,7 @@
     <value>Created '{0}' successfully.</value>
   </data>
   <data name="SpecCommandFileExists" xml:space="preserve">
-    <value>'{0}' already exists, use -f to overwrite it.</value>
+    <value>'{0}' already exists, use -Force to overwrite it.</value>
   </data>
   <data name="Warning_NoPromptDeprecated" xml:space="preserve">
     <value>Option 'NoPrompt' has been deprecated. Use 'NonInteractive' instead.</value>
@@ -4761,43 +4761,43 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
     <value>已成功建立 '{0}'。</value>
   </data>
   <data name="SpecCommandFileExists_csy" xml:space="preserve">
-    <value>{0} již existuje, k přepsání použijte -f.</value>
+    <value>{0} již existuje, k přepsání použijte -Force.</value>
   </data>
   <data name="SpecCommandFileExists_deu" xml:space="preserve">
-    <value>"{0}" ist bereits vorhanden. Verwenden Sie "-f" zum Überschreiben.</value>
+    <value>"{0}" ist bereits vorhanden. Verwenden Sie "-Force" zum Überschreiben.</value>
   </data>
   <data name="SpecCommandFileExists_esp" xml:space="preserve">
-    <value>{0}' ya existe, use -f para sobrescribirlo.</value>
+    <value>{0}' ya existe, use -Force para sobrescribirlo.</value>
   </data>
   <data name="SpecCommandFileExists_fra" xml:space="preserve">
-    <value>'{0}' existe déjà. Utilisez -f pour le remplacer.</value>
+    <value>'{0}' existe déjà. Utilisez -Force pour le remplacer.</value>
   </data>
   <data name="SpecCommandFileExists_ita" xml:space="preserve">
-    <value>{0}' già esistente, usere  -f per sostituire.</value>
+    <value>{0}' già esistente, usere  -Force per sostituire.</value>
   </data>
   <data name="SpecCommandFileExists_jpn" xml:space="preserve">
-    <value>'{0}' は既に存在します。上書きするには、-f を使用してください。</value>
+    <value>'{0}' は既に存在します。上書きするには、-Force を使用してください。</value>
   </data>
   <data name="SpecCommandFileExists_kor" xml:space="preserve">
-    <value>'{0}'이(가) 이미 있습니다. 덮어쓰려면 -f를 사용하십시오.</value>
+    <value>'{0}'이(가) 이미 있습니다. 덮어쓰려면 -Force를 사용하십시오.</value>
   </data>
   <data name="SpecCommandFileExists_plk" xml:space="preserve">
-    <value>Plik „{0}” już istnieje, użyj argumentu -f, aby go zastąpić.</value>
+    <value>Plik „{0}” już istnieje, użyj argumentu -Force, aby go zastąpić.</value>
   </data>
   <data name="SpecCommandFileExists_ptb" xml:space="preserve">
-    <value>{0}' já existe, use -f para substituí-lo.</value>
+    <value>{0}' já existe, use -Force para substituí-lo.</value>
   </data>
   <data name="SpecCommandFileExists_rus" xml:space="preserve">
-    <value>"{0}" уже существует. Для перезаписи используйте параметр -f.</value>
+    <value>"{0}" уже существует. Для перезаписи используйте параметр -Force.</value>
   </data>
   <data name="SpecCommandFileExists_trk" xml:space="preserve">
-    <value>{0}' zaten mevcut, geçersiz kılmak için -f seçimini kullanın.</value>
+    <value>{0}' zaten mevcut, geçersiz kılmak için -Force seçimini kullanın.</value>
   </data>
   <data name="SpecCommandFileExists_chs" xml:space="preserve">
-    <value>“{0}”已存在，请使用 -f 覆盖它。</value>
+    <value>“{0}”已存在，请使用 -Force 覆盖它。</value>
   </data>
   <data name="SpecCommandFileExists_cht" xml:space="preserve">
-    <value>{0}' 己存在，使用 -f 加以覆寫。</value>
+    <value>{0}' 己存在，使用 -Force 加以覆寫。</value>
   </data>
   <data name="Warning_NoPromptDeprecated_csy" xml:space="preserve">
     <value>Možnost NoPrompt se již nepoužívá. Použijte místo toho možnost NonInteractive.</value>


### PR DESCRIPTION
The actual option is -Force but the hint suggests -f.

(Trying to use -f will result in : "Ambiguous option 'f'. Possible values: Force ForceEnglishOutput.")