### PR TITLE
restore fails when project references have inconsistent casing

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/test1.dg
@@ -36,14 +36,14 @@
           "net461": {
             "projectReferences": {
               "44B29B8D-8413-42D2-8DF4-72225659619B": {
-                "projectPath": "c:\\a\\a.csproj"
+                "projectPath": "c:\\z\\z.csproj"
               }
             }
           },
           "net45": {
             "projectReferences": {
               "78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F": {
-                "projectPath": "c:\\b\\b.csproj"
+                "projectPath": "c:\\y\\y.csproj"
               }
             }
           }


### PR DESCRIPTION
Fixes : https://github.com/NuGet/Home/issues/4574

Failure condition:
this only repro's when more than one project( say ProjB and ProjC) reference a project (say ProjA) such that the casing of their reference is inconsistent. Something like this:

ProjB: ```<ProjectReference Include = "..\..\FolderA\projA.csproj"/>```
ProjC: ```<ProjectReference Include = "..\..\folderA\projA.csproj"/>```

OR

ProjB: ``` <ProjectReference Include = "..\..\FolderA\projA.csproj"/>```
ProjC: ``` <ProjectReference Include = "..\folderA\projA.csproj"/>```

In this case the relative path string are different.

CC: @rrelyea @emgarten @mishra14 @nkolev92 @jainaashish @zhili1208 
