### PR TITLE
E2E Test - look for the VS Folder path in a different directory for VS15

### DIFF
--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -11,9 +11,12 @@
     {
         $ProgramFilesPath = ${env:ProgramFiles(x86)}
     }
-
-    $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)
-
+    $VS15RelativePath = "Microsoft Visual Studio\2017\Enterprise"
+    if(($VSVersion -eq "15.0") -and (Test-Path (Join-Path $ProgramFilesPath $VS15RelativePath))){
+        $VSFolderPath = Join-Path $ProgramFilesPath $VS15RelativePath
+    } else {
+        $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)
+    }
     return $VSFolderPath
 }
 


### PR DESCRIPTION
VS 2017 by default installs into:
Program Files\Microsoft Visual Studio\2017\Edition\
VS 2015 and earlier iterations of VS 2017 installed in
Program Files\Microsoft Visual Studio 15.0\
Program Files\Microsoft Visual Studio 14.0\ etc.


In our case we'll look in Program Files\Microsoft Visual Studio\2017\Enterprise

This change is safe for machines that already have their VS installed in Program Files\Microsoft Visual Studio 15.0

\\cc
@mishra14 @rohit21agrawal @jainaashish @alpaix @zhili1208 @emgarten 
