### PR TITLE
Removing a stray character from NuGet.Tests.psm1

### DIFF
--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -24,7 +24,7 @@ if ((Test-Path $nugetExePath) -eq $False)
     Write-Host "Downloading nuget.exe"
     wget https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe -OutFile $nugetExePath
 }
-
+
 # Enable NuGet Test Mode
 $env:NuGetTestModeEnabled = "True"
 


### PR DESCRIPTION
Removing a stray character added to NuGet.Tests.psm1 in https://github.com/NuGet/NuGet.Client/commit/17fc5ba73c68458ed8a05edf298323bf794d9fd1



//cc: @nkolev92 @toddmeinershagen