### PR TITLE
Avoid requesting Main thread in MEF constructor

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -31,9 +31,9 @@ namespace NuGet.VisualStudio
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
         private readonly Configuration.ISettings _settings;
         private readonly IVsSolutionManager _solutionManager;
-        private readonly INuGetProjectContext _projectContext;
         private readonly IVsPackageInstallerServices _packageServices;
         private readonly IDeleteOnRestartManager _deleteOnRestartManager;
+        private readonly Lazy<INuGetProjectContext> _projectContext;
 
         private JoinableTaskFactory PumpingJTF { get; }
 
@@ -48,9 +48,11 @@ namespace NuGet.VisualStudio
             _sourceRepositoryProvider = sourceRepositoryProvider;
             _settings = settings;
             _solutionManager = solutionManager;
-            _projectContext = new VSAPIProjectContext();
             _packageServices = packageServices;
             _deleteOnRestartManager = deleteOnRestartManager;
+
+            _projectContext = new Lazy<INuGetProjectContext>(() => new VSAPIProjectContext());
+
             PumpingJTF = new PumpingJTF(NuGetUIThreadHelper.JoinableTaskFactory.Context);
         }
 
@@ -271,10 +273,7 @@ namespace NuGet.VisualStudio
             {
                 return msg =>
                     {
-                        if (_projectContext != null)
-                        {
-                            _projectContext.Log(ProjectManagement.MessageLevel.Error, msg);
-                        }
+                        _projectContext.Value.Log(ProjectManagement.MessageLevel.Error, msg);
                     };
             }
         }


### PR DESCRIPTION
There are still few places in NuGet where we try requesting Main thread in MEF constructor which sometimes cause visual studio to hang if there if service initialization happened on UI thread or some other service started on UI thread which internally tries to create this NuGet service. This primarily causes hangs for IVsPackageInstaller service which is being used to install NuGet packages via template wizard or 3rd party tools/ extensions like Resharper uses it for their operations.

So the solution is to avoid requesting Main thread in MEF constructor and do it afterwards.

Fixes https://github.com/NuGet/Home/issues/4665

@rrelyea @alpaix @emgarten @DoRonMotter 