### PR TITLE
Avoid running duplicate/ unnecessary auto restore

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -64,5 +64,10 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <param name="project">Existing project to upgrade.</param>
         /// <returns>New project instance.</returns>
         Task<NuGetProject> UpgradeProjectToPackageReferenceAsync(NuGetProject project);
+
+        /// <summary>
+        /// Return true if all the .net core projects are nominated.
+        /// </summary>
+        bool IsAllProjectsNominated();
     }
 }


### PR DESCRIPTION
This PR will delay auto restore when we're still expecting some nominations to come from project system and make sure to run a single auto restore for all the projects which will save performance as well as avoid unnecessary error/ warning messages from multiple auto restores.

Also, this will maximum delay auto restore for 20 secs, even after 20 secs we're missing some nominations then we'll continue with it and let it fail assuming there is something wrong with project system which is why they were not able to nominate. This is the fallback mechanism so that we never delay auto restore indefinitely.

And lastly, Solution restore requests are never delayed and processed immediately as soon as they arrive so that it doesn't change any behavior for explicit restore.

Fixes https://github.com/NuGet/Home/issues/4307

@rrelyea @DoRonMotter  @alpaix @emgarten  