### PR TITLE
Use a fixed version in the test

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -4504,7 +4504,7 @@ namespace NuGet.Test
 
                 var nugetProjectActions = await nuGetPackageManager.PreviewInstallPackageAsync(
                     nuGetProject,
-                    target,
+                    new PackageIdentity(target,new NuGetVersion(3,17,5)),
                     new ResolutionContext(DependencyBehavior.Lowest, false, false, VersionConstraints.None),
                     new TestNuGetProjectContext(),
                     sourceRepositoryProvider.GetRepositories().First(),


### PR DESCRIPTION
This test depends on packages from nuget.org which is just bad. 

A recent update in T4MVCExtensions updated the dependency to the latest Microsoft.AspNet.Mvc.
The test fails with:
```
ystem.InvalidOperationException : Unable to find a version of 'Microsoft.AspNet.Mvc' that is compatible with 'T4MVCExtensions 4.0.0 constraint: Microsoft.AspNet.Mvc (>= 5.2.3)'.
---- NuGet.Resolver.NuGetResolverConstraintException : Unable to find a version of 'Microsoft.AspNet.Mvc' that is compatible with 'T4MVCExtensions 4.0.0 constraint: Microsoft.AspNet.Mvc (>= 5.2.3)'.
```

A task to analyze whether this is a test error or an actual problem is created https://github.com/NuGet/Home/issues/4676:
The short-term is to fix the test to ask for a specific version of the package to upgrade. 

\\cc
@alpaix @emgarten @rohit21agrawal @mishra14 

PS.
This change will go into RTM as well.