### PR TITLE
Support for PackageId in .NET Core project system

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -29,6 +29,7 @@ namespace NuGet.SolutionRestoreManager
     [Export(typeof(IVsSolutionRestoreService))]
     public sealed class VsSolutionRestoreService : IVsSolutionRestoreService
     {
+        private const string PackageId = nameof(PackageId);
         private const string PackageVersion = nameof(PackageVersion);
         private const string Version = nameof(Version);
         private const string IncludeAssets = "IncludeAssets";
@@ -203,7 +204,7 @@ namespace NuGet.SolutionRestoreManager
 
             var packageSpec = new PackageSpec(tfis)
             {
-                Name = projectNames.ShortName,
+                Name = GetPackageId(projectNames, projectRestoreInfo.TargetFrameworks),
                 Version = GetPackageVersion(projectRestoreInfo.TargetFrameworks),
                 FilePath = projectFullPath,
                 RestoreMetadata = new ProjectRestoreMetadata
@@ -227,6 +228,12 @@ namespace NuGet.SolutionRestoreManager
             };
 
             return packageSpec;
+        }
+
+        private static string GetPackageId(ProjectNames projectNames, IVsTargetFrameworks tfms)
+        {
+            var packageId = GetNonEvaluatedPropertyOrNull(tfms, PackageId, v => v);
+            return packageId ?? projectNames.ShortName;
         }
 
         private static NuGetVersion GetPackageVersion(IVsTargetFrameworks tfms)

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -331,6 +331,31 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.False(result, "Project restore nomination must fail.");
         }
 
+        [Fact]
+        public async Task NominateProjectAsync_PackageId()
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("PackageId", "TestPackage") }))
+                .Build();
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+            Assert.Equal("TestPackage", actualProjectSpec.Name);
+        }
+
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(
             string projectFullPath, IVsProjectRestoreInfo pri)
         {


### PR DESCRIPTION
Resolve NuGet/Home#4586.

Retrieve `PackageId` global un-evaluated property from the
`ProjectRestoreInfo` on RPS nomination. Assign the value to
`PackageSpec.Name` attribute. Use `ShortName` if the property is not
defined (current behavior).

//cc @rrelyea @DoRonMotter @natidea