### PR TITLE
Assign back default nuget project after upgrading to pacakge ref

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -220,6 +220,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var added = _projectSystemCache.AddProject(oldEnvDTEProjectName, dteProject, nuGetProject);
 
+            if (DefaultNuGetProjectName == null)
+            {
+                DefaultNuGetProjectName = projectName;
+            } 
+
             if (NuGetProjectUpdated != null)
             {
                 NuGetProjectUpdated(this, new NuGetProjectEventArgs(nuGetProject));


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/4431

the bug is After upgrade NuGet project to package ref, the default project will be cleaned if the upgraded project is default one.

the fix is assign default project back