### PR TITLE
Handle nugetProject Null case, log info to activity log

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -258,7 +258,7 @@ namespace NuGet.SolutionRestoreManager
                     WriteLine(VerbosityLevel.Quiet, message);
                 }
 
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             });
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -776,7 +776,7 @@ namespace NuGetVSExtension
             catch (Exception exception)
             {
                 MessageHelper.ShowErrorMessage(exception, Resources.ErrorDialogBoxTitle);
-                ExceptionHelper.WriteToActivityLog(exception);
+                ExceptionHelper.WriteErrorToActivityLog(exception);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstallerServices.cs
@@ -148,23 +148,26 @@ namespace NuGet.VisualStudio
                                             project,
                                             new VSAPIProjectContext());
 
-                        var installedPackages = await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None);
-
-                        foreach (var package in installedPackages)
+                        if (nuGetProject != null)
                         {
-                            // Get the install path for package
-                            string installPath = _packageManager.PackagesFolderNuGetProject.GetInstalledPath(
-                                                    package.PackageIdentity);
+                            var installedPackages = await nuGetProject.GetInstalledPackagesAsync(CancellationToken.None);
 
-                            if (!string.IsNullOrEmpty(installPath))
+                            foreach (var package in installedPackages)
                             {
-                                // normalize the path and take the dir if the nupkg path was given
-                                var dir = new DirectoryInfo(installPath);
-                                installPath = dir.FullName;
-                            }
+                                // Get the install path for package
+                                string installPath = _packageManager.PackagesFolderNuGetProject.GetInstalledPath(
+                                                        package.PackageIdentity);
 
-                            var metadata = new VsPackageMetadata(package.PackageIdentity, installPath);
-                            packages.Add(metadata);
+                                if (!string.IsNullOrEmpty(installPath))
+                                {
+                                    // normalize the path and take the dir if the nupkg path was given
+                                    var dir = new DirectoryInfo(installPath);
+                                    installPath = dir.FullName;
+                                }
+
+                                var metadata = new VsPackageMetadata(package.PackageIdentity, installPath);
+                                packages.Add(metadata);
+                            }
                         }
                     }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageRestorer.cs
@@ -54,7 +54,7 @@ namespace NuGet.VisualStudio
             }
             catch (Exception ex)
             {
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/RegistryKeyWrapper.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/RegistryKeyWrapper.cs
@@ -32,7 +32,7 @@ namespace NuGet.VisualStudio
             catch (SecurityException ex)
             {
                 // If the user doesn't have access to the registry, then we'll return null
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             }
 
             return null;
@@ -47,7 +47,7 @@ namespace NuGet.VisualStudio
             catch (SecurityException ex)
             {
                 // If the user doesn't have access to the registry, then we'll return null
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
                 return null;
             }
         }

--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/NuGetPowerShellBaseCommand.cs
@@ -216,7 +216,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             }
             catch (Exception ex)
             {
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
 
                 // unhandled exceptions should be terminating
                 ErrorHandler.HandleException(ex, terminating: true);

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/NuGetProjectFactory.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/NuGetProjectFactory.cs
@@ -49,6 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             ThreadHelper.ThrowIfNotOnUIThread();
 
+            var exceptions = new List<Exception>();
             result = _providers
                 .Select(p =>
                 {
@@ -60,15 +61,21 @@ namespace NuGet.PackageManagement.VisualStudio
                             return nuGetProject;
                         }
                     }
-                    catch
+                    catch (Exception e)
                     {
                         // Ignore failures. If this method returns null, the problem falls 
                         // into one of the other NuGet project types.
+                        exceptions.Add(e);
                     }
 
                     return null;
                 })
                 .FirstOrDefault(p => p != null);
+
+            if (result == null)
+            {
+                exceptions.ForEach(ExceptionHelper.WriteWarningToActivityLog);
+            }
 
             return result != null;
         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -786,7 +786,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 catch (Exception ex1)
                 {
-                    ExceptionHelper.WriteToActivityLog(ex1);
+                    ExceptionHelper.WriteErrorToActivityLog(ex1);
                 }
 
                 // Remove the NuGetImportStamp so that VC++ project file won't be updated with this stamp on disk,
@@ -797,7 +797,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 catch (Exception ex2)
                 {
-                    ExceptionHelper.WriteToActivityLog(ex2);
+                    ExceptionHelper.WriteErrorToActivityLog(ex2);
                 }
             }
         }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/TFSSourceControlManagerProviderPicker.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/SourceControl/TFSSourceControlManagerProviderPicker.cs
@@ -42,7 +42,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 catch (Exception ex)
                 {
-                    ExceptionHelper.WriteToActivityLog(ex);
+                    ExceptionHelper.WriteErrorToActivityLog(ex);
                     _cachedTFSSourceControlManagerProvider = null;
                 }
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1414,7 +1414,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             catch (Exception ex)
             {
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             }
         }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ExceptionHelper.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ExceptionHelper.cs
@@ -11,7 +11,7 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         public const string LogEntrySource = "NuGet Package Manager";
 
-        public static void WriteToActivityLog(Exception exception)
+        public static void WriteErrorToActivityLog(Exception exception)
         {
             if (exception == null)
             {
@@ -19,6 +19,16 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             ActivityLog.LogError(LogEntrySource, exception.ToString());
+        }
+
+        public static void WriteWarningToActivityLog(Exception exception)
+        {
+            if (exception == null)
+            {
+                return;
+            }
+
+            ActivityLog.LogWarning(LogEntrySource, exception.ToString());
         }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/MicrosoftBuildEvaluationProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/MicrosoftBuildEvaluationProjectUtility.cs
@@ -29,7 +29,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
                 catch (Exception exception)
                 {
-                    ExceptionHelper.WriteToActivityLog(exception);
+                    ExceptionHelper.WriteErrorToActivityLog(exception);
                     // Swallow any exceptions we might get because of malformed assembly names
                 }
 

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/ProjectRetargetingUtility.cs
@@ -127,7 +127,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             catch (Exception ex)
             {
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             }
 
             // When all items are not compatible, the installed package should be retargeted.
@@ -211,7 +211,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     }
                     catch (Exception ex)
                     {
-                        ExceptionHelper.WriteToActivityLog(ex);
+                        ExceptionHelper.WriteErrorToActivityLog(ex);
                     }
                 }
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RefreshFileUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/RefreshFileUtility.cs
@@ -48,7 +48,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 catch (UnauthorizedAccessException exception)
                 {
                     // log IO permission error
-                    ExceptionHelper.WriteToActivityLog(exception);
+                    ExceptionHelper.WriteErrorToActivityLog(exception);
                 }
             }
         }
@@ -96,7 +96,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 catch (UnauthorizedAccessException exception)
                 {
                     // log IO permission error
-                    ExceptionHelper.WriteToActivityLog(exception);
+                    ExceptionHelper.WriteErrorToActivityLog(exception);
                 }
             }
         }

--- a/src/NuGet.Clients/VsConsole/Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/VsConsole/Console/PowerConsoleToolWindow.cs
@@ -154,7 +154,7 @@ namespace NuGetConsole.Implementation
                     }
                     catch (Exception x)
                     {
-                        ExceptionHelper.WriteToActivityLog(x);
+                        ExceptionHelper.WriteErrorToActivityLog(x);
                     }
                 };
             timer.Start();
@@ -489,7 +489,7 @@ namespace NuGetConsole.Implementation
                     ConsoleParentPane.NotifyInitializationCompleted();
 
                     WpfConsole.WriteLine(x.GetBaseException().ToString());
-                    ExceptionHelper.WriteToActivityLog(x);
+                    ExceptionHelper.WriteErrorToActivityLog(x);
                 }
             }
             else

--- a/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsole.cs
+++ b/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsole.cs
@@ -697,7 +697,7 @@ namespace NuGetConsole.Implementation.Console
                         }
                         catch (Exception exception)
                         {
-                            ExceptionHelper.WriteToActivityLog(exception);
+                            ExceptionHelper.WriteErrorToActivityLog(exception);
                         }
 
                         _bufferAdapter = null;

--- a/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsoleKeyProcessor.cs
+++ b/src/NuGet.Clients/VsConsole/Console/WpfConsole/WpfConsoleKeyProcessor.cs
@@ -543,7 +543,7 @@ namespace NuGetConsole.Implementation.Console
             catch (Exception x)
             {
                 // Ignore exception from expansion, but write it to the activity log
-                ExceptionHelper.WriteToActivityLog(x);
+                ExceptionHelper.WriteErrorToActivityLog(x);
             }
             finally
             {

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/AsyncPowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/AsyncPowerShellHost.cs
@@ -52,12 +52,12 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             catch (RuntimeException e)
             {
                 ReportError(e.ErrorRecord);
-                ExceptionHelper.WriteToActivityLog(e);
+                ExceptionHelper.WriteErrorToActivityLog(e);
             }
             catch (Exception e)
             {
                 ReportError(e);
-                ExceptionHelper.WriteToActivityLog(e);
+                ExceptionHelper.WriteErrorToActivityLog(e);
             }
 
             return false; // Error occurred, command not executing

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -259,7 +259,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 }
                 catch (Exception ex)
                 {
-                    ExceptionHelper.WriteToActivityLog(ex);
+                    ExceptionHelper.WriteErrorToActivityLog(ex);
                 }
                 return prompt;
             });
@@ -342,7 +342,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                             IsCommandEnabled = false;
                             ReportError(ex);
 
-                            ExceptionHelper.WriteToActivityLog(ex);
+                            ExceptionHelper.WriteErrorToActivityLog(ex);
                         }
                     }
                 });
@@ -597,7 +597,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 // If execution of an init.ps1 scripts fails, do not let it crash our console.
                 ReportError(ex);
 
-                ExceptionHelper.WriteToActivityLog(ex);
+                ExceptionHelper.WriteErrorToActivityLog(ex);
             }
         }
 

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/SyncPowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/SyncPowerShellHost.cs
@@ -29,7 +29,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             }
             catch (Exception e)
             {
-                ExceptionHelper.WriteToActivityLog(e);
+                ExceptionHelper.WriteErrorToActivityLog(e);
                 throw;
             }
 


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/4563

the bug is solutionManager.GetOrCreateProjectAsync() can return null, that will cause null exception.

the fix here is check null in GetInstalledPackage(), if NuGetProject is null, skip the rest.

also log all exceptions as warning to activity log if solutionManager.GetOrCreateProjectAsync() return null,
