### PR TITLE
Logging and error list improvements

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using NuGet.PackageManagement.UI;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// Add/Remove warnings/errors from the error list.
+    /// This persists messages once they are added.
+    /// </summary>
+    [Export(typeof(ErrorListTableDataSource))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    internal sealed class ErrorListTableDataSource : ITableDataSource
+    {
+        private readonly object _lockObj = new object();
+        private readonly IServiceProvider _serviceProvider;
+
+        private TableSubscription _tableSubscription;
+
+        public string SourceTypeIdentifier => StandardTableDataSources.ErrorTableDataSource;
+
+        public string Identifier => "NuGetRestoreManagerListTable";
+
+        public string DisplayName => "NuGet_Restore_Manager_Table_Data_Source";
+
+        public IErrorList _errorList;
+        public ITableManager _tableManager;
+        private bool _initialized;
+
+        [ImportingConstructor]
+        public ErrorListTableDataSource(
+            [Import(typeof(SVsServiceProvider))]
+            IServiceProvider serviceProvider)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            _serviceProvider = serviceProvider;
+        }
+
+        public IDisposable Subscribe(ITableDataSink sink)
+        {
+            lock (_lockObj)
+            {
+                _tableSubscription = new TableSubscription(sink, _lockObj);
+                return _tableSubscription;
+            }
+        }
+
+        /// <summary>
+        /// Clear only nuget entries.
+        /// </summary>
+        public void ClearNuGetEntries()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            EnsureInitialized();
+
+            lock (_lockObj)
+            {
+                var sink = _tableSubscription?.TableDataSink;
+
+                if (sink != null)
+                {
+                    var entries = _errorList.TableControl?.Entries?.Where(IsNuGetEntry).ToArray()
+                        ?? new ITableEntryHandle[0];
+
+                    sink.RemoveEntries(entries);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add error list entries
+        /// </summary>
+        public void AddEntries(params ErrorListTableEntry[] entries)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            EnsureInitialized();
+
+            lock (_lockObj)
+            {
+                var sink = _tableSubscription?.TableDataSink;
+
+                if (sink != null)
+                {
+                    sink.AddEntries(entries.ToList(), removeAllEntries: false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Show error window.
+        /// </summary>
+        public void BringToFront()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            EnsureInitialized();
+
+            // Give the error list focus.
+            var vsErrorList = _errorList as IVsErrorList;
+            vsErrorList?.BringToFront();
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                ThreadHelper.ThrowIfNotOnUIThread();
+
+                _errorList = _serviceProvider.GetService(typeof(SVsErrorList)) as IErrorList;
+                _tableManager = _errorList?.TableControl?.Manager;
+
+                if (_tableManager != null)
+                {
+                    _initialized = true;
+                    _tableManager.AddSource(this);
+                }
+            }
+        }
+
+        private static bool IsNuGetEntry(ITableEntryHandle entry)
+        {
+            object sourceObj;
+            return (entry != null
+                && entry.TryGetValue(StandardTableColumnDefinitions.ErrorSource, out sourceObj)
+                && StringComparer.Ordinal.Equals(ErrorListTableEntry.ErrorSouce, (sourceObj as string)));
+        }
+
+        public void Dispose()
+        {
+            if (_tableManager != null && _initialized)
+            {
+                try
+                {
+                    NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                    {
+                        await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                        _tableManager.RemoveSource(this);
+                    });
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Ignore disposed exceptions
+                }
+            }
+        }
+
+        /// <summary>
+        /// Holds an ITableDataSink and lock.
+        /// </summary>
+        private class TableSubscription : IDisposable
+        {
+            public ITableDataSink TableDataSink { get; private set; }
+
+            private readonly object _lockObj;
+
+            public TableSubscription(ITableDataSink sink, object lockObj)
+            {
+                TableDataSink = sink;
+                _lockObj = lockObj;
+            }
+
+            public void Dispose()
+            {
+                lock (_lockObj)
+                {
+                    TableDataSink = null;
+                }
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableDataSource.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.VisualStudio.Shell;
@@ -17,7 +20,7 @@ namespace NuGet.SolutionRestoreManager
     /// </summary>
     [Export(typeof(ErrorListTableDataSource))]
     [PartCreationPolicy(CreationPolicy.Shared)]
-    internal sealed class ErrorListTableDataSource : ITableDataSource
+    internal sealed class ErrorListTableDataSource : ITableDataSource, IDisposable
     {
         private readonly object _initLockObj = new object();
         private readonly object _subscribeLockObj = new object();
@@ -30,8 +33,8 @@ namespace NuGet.SolutionRestoreManager
 
         public string DisplayName => "NuGet_Restore_Manager_Table_Data_Source";
 
-        public IErrorList _errorList;
-        public ITableManager _tableManager;
+        private IErrorList _errorList;
+        private ITableManager _tableManager;
         private bool _initialized;
 
         [ImportingConstructor]

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.Shell.Interop;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information. 
+
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Shell.TableControl;
 using Microsoft.VisualStudio.Shell.TableManager;
 using NuGet.Common;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.TableControl;
+using Microsoft.VisualStudio.Shell.TableManager;
+using NuGet.Common;
+
+namespace NuGet.SolutionRestoreManager
+{
+    internal class ErrorListTableEntry : ITableEntry
+    {
+        internal const string ErrorSouce = "NuGet";
+
+        public object Identity
+        {
+            get
+            {
+                return Message;
+            }
+        }
+
+        public string Message { get; set; }
+
+        public LogLevel LogLevel { get; set; }
+
+        public ErrorListTableEntry(string message, LogLevel level)
+        {
+            Message = message;
+            LogLevel = level;
+        }
+
+        public bool CanSetValue(string keyName)
+        {
+            return false;
+        }
+
+        public bool TryGetValue(string keyName, out object content)
+        {
+            content = null;
+
+            switch (keyName)
+            {
+                case StandardTableColumnDefinitions.Text:
+                    content = Message;
+                    return true;
+                case StandardTableColumnDefinitions.ErrorSeverity:
+                    content = GetErrorCategory(LogLevel);
+                    return true;
+                case StandardTableColumnDefinitions.Priority:
+                    content = "high";
+                    return true;
+                case StandardTableColumnDefinitions.ErrorSource:
+                    content = ErrorSouce;
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool TrySetValue(string keyName, object content)
+        {
+            content = null;
+            return false;
+        }
+
+        private static __VSERRORCATEGORY GetErrorCategory(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel.Error:
+                    return __VSERRORCATEGORY.EC_ERROR;
+                case LogLevel.Warning:
+                    return __VSERRORCATEGORY.EC_WARNING;
+                default:
+                    return __VSERRORCATEGORY.EC_MESSAGE;
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
@@ -20,9 +20,9 @@ namespace NuGet.SolutionRestoreManager
             }
         }
 
-        public string Message { get; set; }
+        public string Message { get; }
 
-        public LogLevel LogLevel { get; set; }
+        public LogLevel LogLevel { get; }
 
         public ErrorListTableEntry(string message, LogLevel level)
         {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -31,6 +31,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ErrorListTableEntry.cs" />
+    <Compile Include="ErrorListTableDataSource.cs" />
     <Compile Include="Guids.cs" />
     <Compile Include="ISolutionRestoreJob.cs" />
     <Compile Include="PkgCmdID.cs" />

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -27,8 +27,8 @@ namespace NuGet.SolutionRestoreManager
         private readonly IServiceProvider _serviceProvider;
         private readonly IOutputConsoleProvider _outputConsoleProvider;
 
+        private Lazy<ErrorListTableDataSource> _errorListDataSource;
         private RestoreOperationSource _operationSource;
-        private ErrorListProvider _errorListProvider;
         private JoinableTaskFactory _taskFactory;
         private CancellationTokenSource _externalCts;
         private Func<CancellationToken, Task<RestoreOperationProgressUI>> _progressFactory;
@@ -36,6 +36,7 @@ namespace NuGet.SolutionRestoreManager
 
         private bool _cancelled;
         private bool _hasHeaderBeenShown;
+        private bool _showErrorList;
 
         // The value of the "MSBuild project build output verbosity" setting
         // of VS. From 0 (quiet) to 4 (Diagnostic).
@@ -63,13 +64,13 @@ namespace NuGet.SolutionRestoreManager
 
         public async Task StartAsync(
             RestoreOperationSource operationSource,
-            ErrorListProvider errorListProvider,
+            Lazy<ErrorListTableDataSource> errorListDataSource,
             JoinableTaskFactory jtf,
             CancellationTokenSource cts)
         {
-            if (errorListProvider == null)
+            if (errorListDataSource == null)
             {
-                throw new ArgumentNullException(nameof(errorListProvider));
+                throw new ArgumentNullException(nameof(errorListDataSource));
             }
 
             if (jtf == null)
@@ -83,7 +84,7 @@ namespace NuGet.SolutionRestoreManager
             }
 
             _operationSource = operationSource;
-            _errorListProvider = errorListProvider;
+            _errorListDataSource = errorListDataSource;
             _taskFactory = jtf;
             _externalCts = cts;
             _externalCts.Token.Register(() => _cancelled = true);
@@ -116,8 +117,26 @@ namespace NuGet.SolutionRestoreManager
                         break;
                 }
 
-                errorListProvider.Tasks.Clear();
+                if (_errorListDataSource.IsValueCreated)
+                {
+                    // Clear old entries
+                    _errorListDataSource.Value.ClearNuGetEntries();
+                }
             });
+        }
+
+        public async Task StopAsync()
+        {
+            if (_showErrorList)
+            {
+                await _taskFactory.RunAsync(async () =>
+                {
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    // Give the error list focus
+                    _errorListDataSource.Value.BringToFront();
+                });
+            }
         }
 
         public void LogDebug(string data)
@@ -180,36 +199,57 @@ namespace NuGet.SolutionRestoreManager
                 return;
             }
 
-            Do((_, progress) =>
+            ErrorListTableEntry errorListEntry = null;
+
+            // VerbosityLevel.Quiet corresponds to ILogger.LogError, and,
+            // VerbosityLevel.Minimal corresponds to ILogger.LogWarning
+            // In these 2 cases, we add an error or warning to the error list window
+            if (verbosityLevel == VerbosityLevel.Quiet ||
+                verbosityLevel == VerbosityLevel.Minimal)
             {
-                // Only show messages with VerbosityLevel.Normal. That is, info messages only.
-                // Do not show errors, warnings, verbose or debug messages on the progress dialog
-                // Avoid showing indented messages, these are typically not useful for the progress dialog since
-                // they are missing the context of the parent text above it
-                if (verbosityLevel == VerbosityLevel.Normal &&
-                    message.Length == message.TrimStart().Length)
-                {
-                    progress?.ReportProgress(message);
-                }
+                var errorLevel = verbosityLevel == VerbosityLevel.Quiet ? LogLevel.Error : LogLevel.Warning;
+                errorListEntry = new ErrorListTableEntry(message, errorLevel);
 
-                // Write to the output window. Based on _msBuildOutputVerbosity, the message may or may not
-                // get shown on the output window. Default is VerbosityLevel.Minimal
-                WriteLine(verbosityLevel, message);
+                // Display the error list after restore completes
+                _showErrorList = true;
+            }
 
-                // VerbosityLevel.Quiet corresponds to ILogger.LogError, and,
-                // VerbosityLevel.Minimal corresponds to ILogger.LogWarning
-                // In these 2 cases, we add an error or warning to the error list window
-                if (verbosityLevel == VerbosityLevel.Quiet ||
-                    verbosityLevel == VerbosityLevel.Minimal)
+            // Only show messages with VerbosityLevel.Normal. That is, info messages only.
+            // Do not show errors, warnings, verbose or debug messages on the progress dialog
+            // Avoid showing indented messages, these are typically not useful for the progress dialog since
+            // they are missing the context of the parent text above it
+            var reportProgress = RestoreOperationProgressUI.Current != null
+                && verbosityLevel == VerbosityLevel.Normal
+                && message.Length == message.TrimStart().Length;
+
+            // Write to the output window if the verbosity level is high enough.
+            var showAsOutputMessage = ShowMessageAsOutput(verbosityLevel);
+
+            // Avoid moving to the UI thread unless there is work to do
+            if (reportProgress || showAsOutputMessage || errorListEntry != null)
+            {
+                // Run on the UI thread
+                Do((_, progress) =>
                 {
-                    MessageHelper.ShowError(
-                        _errorListProvider,
-                        verbosityLevel == VerbosityLevel.Quiet ? TaskErrorCategory.Error : TaskErrorCategory.Warning,
-                        TaskPriority.High,
-                        message,
-                        hierarchyItem: null);
-                }
-            });
+                    // Progress dialog
+                    if (reportProgress)
+                    {
+                        progress?.ReportProgress(message);
+                    }
+
+                    // Output console
+                    if (showAsOutputMessage)
+                    {
+                        WriteLine(verbosityLevel, message);
+                    }
+
+                    // Write to the error list
+                    if (errorListEntry != null)
+                    {
+                        _errorListDataSource.Value.AddEntries(errorListEntry);
+                    }
+                });
+            }
         }
 
         /// <summary>
@@ -224,10 +264,15 @@ namespace NuGet.SolutionRestoreManager
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (OutputVerbosity >= (int)verbosity && _outputConsole != null)
+            if (ShowMessageAsOutput(verbosity))
             {
                 _outputConsole.WriteLine(format, args);
             }
+        }
+
+        public bool ShowMessageAsOutput(VerbosityLevel verbosity)
+        {
+            return _outputConsole != null && OutputVerbosity >= (int)verbosity;
         }
 
         public Task LogExceptionAsync(Exception ex)
@@ -266,12 +311,10 @@ namespace NuGet.SolutionRestoreManager
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            MessageHelper.ShowError(
-                _errorListProvider,
-                TaskErrorCategory.Error,
-                TaskPriority.High,
-                errorText,
-                hierarchyItem: null);
+            var entry = new ErrorListTableEntry(errorText, LogLevel.Error);
+
+            _errorListDataSource.Value.AddEntries(entry);
+            _errorListDataSource.Value.BringToFront();
         }
 
         public Task WriteHeaderAsync()
@@ -317,7 +360,7 @@ namespace NuGet.SolutionRestoreManager
                         WriteLine(
                             quietOrMinimal,
                             Resources.PackageRestoreCanceled);
-                            break;
+                        break;
                     case NuGetOperationStatus.NoOp:
                         if (forceStatusWrite)
                         {
@@ -330,7 +373,7 @@ namespace NuGet.SolutionRestoreManager
                         WriteLine(
                             quietOrMinimal,
                             Resources.PackageRestoreFinishedWithError);
-                            break;
+                        break;
                     case NuGetOperationStatus.Succeeded:
                         WriteLine(
                             quietOrNormal,

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -206,7 +206,7 @@ namespace NuGet.SolutionRestoreManager
                 var errorListEntry = new ErrorListTableEntry(message, errorLevel);
 
                 // Add the entry to the list
-                _errorListDataSource.Value.AddEntries(errorListEntry);
+                _errorListDataSource.Value.AddNuGetEntries(errorListEntry);
 
                 // Display the error list after restore completes
                 _showErrorList = true;
@@ -221,7 +221,7 @@ namespace NuGet.SolutionRestoreManager
                 && message.Length == message.TrimStart().Length;
 
             // Write to the output window if the verbosity level is high enough.
-            var showAsOutputMessage = ShowMessageAsOutput(verbosityLevel);
+            var showAsOutputMessage = ShouldShowMessageAsOutput(verbosityLevel);
 
             // Avoid moving to the UI thread unless there is work to do
             if (reportProgress || showAsOutputMessage)
@@ -256,13 +256,16 @@ namespace NuGet.SolutionRestoreManager
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
-            if (ShowMessageAsOutput(verbosity))
+            if (ShouldShowMessageAsOutput(verbosity))
             {
                 _outputConsole.WriteLine(format, args);
             }
         }
 
-        public bool ShowMessageAsOutput(VerbosityLevel verbosity)
+        /// <summary>
+        /// True if this message will be written out.
+        /// </summary>
+        public bool ShouldShowMessageAsOutput(VerbosityLevel verbosity)
         {
             return _outputConsole != null && OutputVerbosity >= (int)verbosity;
         }
@@ -303,7 +306,7 @@ namespace NuGet.SolutionRestoreManager
         {
             var entry = new ErrorListTableEntry(errorText, LogLevel.Error);
 
-            _errorListDataSource.Value.AddEntries(entry);
+            _errorListDataSource.Value.AddNuGetEntries(entry);
             _errorListDataSource.Value.BringToFront();
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -432,25 +432,26 @@ namespace NuGet.SolutionRestoreManager
             {
                 var componentModel = await _componentModel.GetValueAsync(jobCts.Token);
 
-                var logger = componentModel.GetService<RestoreOperationLogger>();
-
-                try
+                using (var logger = componentModel.GetService<RestoreOperationLogger>())
                 {
-                    // Start logging
-                    await logger.StartAsync(
-                        request.RestoreSource,
-                        _errorListTableDataSource,
-                        _joinableFactory,
-                        jobCts);
+                    try
+                    {
+                        // Start logging
+                        await logger.StartAsync(
+                            request.RestoreSource,
+                            _errorListTableDataSource,
+                            _joinableFactory,
+                            jobCts);
 
-                    // Run restore
-                    var job = componentModel.GetService<ISolutionRestoreJob>();
-                    return await job.ExecuteAsync(request, _restoreJobContext, logger, jobCts.Token);
-                }
-                finally
-                {
-                    // Complete all logging
-                    await logger.StopAsync();
+                        // Run restore
+                        var job = componentModel.GetService<ISolutionRestoreJob>();
+                        return await job.ExecuteAsync(request, _restoreJobContext, logger, jobCts.Token);
+                    }
+                    finally
+                    {
+                        // Complete all logging
+                        await logger.StopAsync();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Replacing the warning/error list logging helper with an error table data source.

The older helper this replaces is here: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/MessageHelper.cs#L71-L82

This change takes the time to log 6000 warnings from 90 seconds down to 5 seconds or less.

The larger improvement here is that even without warnings restore of corefxlab went from 15s to 5s by reducing the number of moves to the UI thread by checking the verbosity level first.
