### PR TITLE
Merge Scott's PR and Remove CPS capability check from legacy csproj

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -150,19 +150,22 @@ namespace NuGet.SolutionRestoreManager
         {
             Reset(isDisposing: true);
 
-            _joinableFactory.Run(async () =>
+            if (_initialized != 0)
             {
-                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                _solutionEvents.AfterClosing -= SolutionEvents_AfterClosing;
-#if VS15
-                Unadvise();
-#endif
-                if (_errorListProvider.IsValueCreated)
+                _joinableFactory.Run(async () =>
                 {
-                    (await _errorListProvider.GetValueAsync()).Dispose();
-                }
-            });
+                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    _solutionEvents.AfterClosing -= SolutionEvents_AfterClosing;
+#if VS15
+                    Unadvise();
+#endif
+                    if (_errorListProvider.IsValueCreated)
+                    {
+                        (await _errorListProvider.GetValueAsync()).Dispose();
+                    }
+                });
+            }
         }
 
         private void Reset(bool isDisposing = false)


### PR DESCRIPTION
This PR does 2 things:
- Bring back the support for RestoreProjectStyle with minimal memory perf impact.
- Remove CPS capability check from legacy csproj since CPS based project systems have started implementing VSProject4 so they can also move from Packages.config to PackageReference

Fixes https://github.com/NuGet/Home/issues/4599

@rrelyea 