### PR TITLE
On retargeting TFM, run NuGet restore for legacy csproj projects

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -171,7 +171,7 @@ namespace NuGetVSExtension
                 DeleteOnRestartManager.Value.DeleteMarkedPackageDirectories(ProjectContext);
             }
 
-            ProjectRetargetingHandler = new ProjectRetargetingHandler(_dte, SolutionManager, this);
+            ProjectRetargetingHandler = new ProjectRetargetingHandler(_dte, SolutionManager, this, componentModel);
             ProjectUpgradeHandler = new ProjectUpgradeHandler(this, SolutionManager);
 
             SolutionUserOptions.LoadSettings();


### PR DESCRIPTION
When retargeting TFM happens, then we need to make sure to re-run NuGet restore to re-generate assets file with updated TFM so that design-time builds can pick these changes and update assembly references accordingly.

Fixes https://github.com/NuGet/Home/issues/4613

@rrelyea 