### PR TITLE
Throw correct error if reg-key is not found

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledRepositoryProvider.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/PreinstalledRepositoryProvider.cs
@@ -14,10 +14,12 @@ using NuGet.VisualStudio.Implementation.Resources;
 
 namespace NuGet.VisualStudio
 {
-    internal sealed class PreinstalledRepositoryProvider : ISourceRepositoryProvider
+    public sealed class PreinstalledRepositoryProvider : ISourceRepositoryProvider
     {
-        private const string RegistryKeyRoot = @"SOFTWARE\NuGet\Repository";
-        private List<SourceRepository> _repositories;
+        public const string DefaultRegistryKeyRoot = @"SOFTWARE\NuGet\Repository";
+
+        private readonly string _registryKeyRoot;
+        private readonly List<SourceRepository> _repositories;
         private readonly Action<string> _errorHandler;
         private readonly ISourceRepositoryProvider _provider;
 
@@ -25,8 +27,34 @@ namespace NuGet.VisualStudio
         private readonly ConcurrentDictionary<Configuration.PackageSource, SourceRepository> _sourceCache
              = new ConcurrentDictionary<Configuration.PackageSource, SourceRepository>();
 
-        public PreinstalledRepositoryProvider(Action<string> errorHandler, ISourceRepositoryProvider provider)
+        public PreinstalledRepositoryProvider(
+            Action<string> errorHandler, 
+            ISourceRepositoryProvider provider)
+            : this(DefaultRegistryKeyRoot, errorHandler, provider)
         {
+        }
+
+        public PreinstalledRepositoryProvider(
+            string registryKeyRoot,
+            Action<string> errorHandler,
+            ISourceRepositoryProvider provider)
+        {
+            if (registryKeyRoot == null)
+            {
+                throw new ArgumentNullException(nameof(registryKeyRoot));
+            }
+
+            if (errorHandler == null)
+            {
+                throw new ArgumentNullException(nameof(errorHandler));
+            }
+
+            if (provider == null)
+            {
+                throw new ArgumentNullException(nameof(provider));
+            }
+
+            _registryKeyRoot = registryKeyRoot;
             _repositories = new List<SourceRepository>();
             _errorHandler = errorHandler;
             _provider = provider;
@@ -34,7 +62,7 @@ namespace NuGet.VisualStudio
 
         public void AddFromRegistry(string keyName, bool isPreUnzipped)
         {
-            string path = GetRegistryRepositoryPath(keyName, null, _errorHandler);
+            var path = GetRegistryRepositoryPath(keyName);
 
             // Override the feed type as unzipped if specified, otherwise allow the source to determine what it is.
             var feedType = isPreUnzipped ? FeedType.FileSystemUnzipped : FeedType.Undefined;
@@ -45,7 +73,7 @@ namespace NuGet.VisualStudio
 
         public void AddFromExtension(ISourceRepositoryProvider provider, string extensionId)
         {
-            string path = GetExtensionRepositoryPath(extensionId, null, _errorHandler);
+            var path = GetExtensionRepositoryPath(extensionId);
 
             var source = new Configuration.PackageSource(path);
             _repositories.Add(CreateRepository(source));
@@ -85,22 +113,19 @@ namespace NuGet.VisualStudio
         /// Gets the folder location where packages have been laid down for the specified extension.
         /// </summary>
         /// <param name="extensionId">The installed extension.</param>
-        /// <param name="vsExtensionManager">The VS Extension manager instance.</param>
-        /// <param name="throwingErrorHandler">
-        /// An error handler that accepts the error message string and then throws
-        /// the appropriate exception.
-        /// </param>
         /// <returns>The absolute path to the extension's packages folder.</returns>
-        internal string GetExtensionRepositoryPath(string extensionId, object vsExtensionManager, Action<string> throwingErrorHandler)
+        private string GetExtensionRepositoryPath(string extensionId)
         {
-            var extensionManagerShim = new ExtensionManagerShim(vsExtensionManager, throwingErrorHandler);
+            var extensionManagerShim = new ExtensionManagerShim(extensionManager: null, errorHandler: _errorHandler);
             string installPath;
 
             if (!extensionManagerShim.TryGetExtensionInstallPath(extensionId, out installPath))
             {
-                throwingErrorHandler(String.Format(VsResources.PreinstalledPackages_InvalidExtensionId,
-                    extensionId));
-                Debug.Fail("The throwingErrorHandler did not throw");
+                var errorMessage = string.Format(VsResources.PreinstalledPackages_InvalidExtensionId, extensionId);
+                _errorHandler(errorMessage);
+
+                // The error is fatal, cannot continue
+                throw new InvalidOperationException(errorMessage);
             }
 
             return Path.Combine(installPath, "Packages");
@@ -110,20 +135,14 @@ namespace NuGet.VisualStudio
         /// Gets the folder location where packages have been laid down in a registry-specified location.
         /// </summary>
         /// <param name="keyName">The registry key name that specifies the packages location.</param>
-        /// <param name="registryKeys">The optional list of parent registry keys to look in (used for unit tests).</param>
-        /// <param name="throwingErrorHandler">
-        /// An error handler that accepts the error message string and then throws
-        /// the appropriate exception.
-        /// </param>
         /// <returns>The absolute path to the packages folder specified in the registry.</returns>
-        internal string GetRegistryRepositoryPath(string keyName, IEnumerable<IRegistryKey> registryKeys, Action<string> throwingErrorHandler)
+        private string GetRegistryRepositoryPath(string keyName)
         {
             IRegistryKey repositoryKey = null;
             string repositoryValue = null;
 
             // When pulling the repository from the registry, use CurrentUser first, falling back onto LocalMachine
-            registryKeys = registryKeys ??
-                           new[]
+            var registryKeys = new[]
                                {
                                    new RegistryKeyWrapper(Registry.CurrentUser),
                                    new RegistryKeyWrapper(Registry.LocalMachine)
@@ -132,13 +151,13 @@ namespace NuGet.VisualStudio
             // Find the first registry key that supplies the necessary subkey/value
             foreach (var registryKey in registryKeys)
             {
-                repositoryKey = registryKey.OpenSubKey(RegistryKeyRoot);
+                repositoryKey = registryKey.OpenSubKey(_registryKeyRoot);
 
                 if (repositoryKey != null)
                 {
                     repositoryValue = repositoryKey.GetValue(keyName) as string;
 
-                    if (!String.IsNullOrEmpty(repositoryValue))
+                    if (!string.IsNullOrEmpty(repositoryValue))
                     {
                         break;
                     }
@@ -149,14 +168,20 @@ namespace NuGet.VisualStudio
 
             if (repositoryKey == null)
             {
-                throwingErrorHandler(String.Format(VsResources.PreinstalledPackages_RegistryKeyError, RegistryKeyRoot));
-                Debug.Fail("throwingErrorHandler did not throw");
+                var errorMessage = string.Format(VsResources.PreinstalledPackages_RegistryKeyError, _registryKeyRoot);
+                _errorHandler(errorMessage);
+
+                // The error is fatal, cannot continue
+                throw new InvalidOperationException(errorMessage);
             }
 
-            if (String.IsNullOrEmpty(repositoryValue))
+            if (string.IsNullOrEmpty(repositoryValue))
             {
-                throwingErrorHandler(String.Format(VsResources.PreinstalledPackages_InvalidRegistryValue, keyName, RegistryKeyRoot));
-                Debug.Fail("throwingErrorHandler did not throw");
+                var errorMessage = string.Format(VsResources.PreinstalledPackages_InvalidRegistryValue, keyName, _registryKeyRoot);
+                _errorHandler(errorMessage);
+
+                // The error is fatal, cannot continue
+                throw new InvalidOperationException(errorMessage);
             }
 
             // Ensure a trailing slash so that the path always gets read as a directory

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/NuGet.VisualStudio.Implementation.Test.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Extensibility\VsGlobalPackagesInitScriptExecutorTests.cs" />
     <Compile Include="Extensibility\VsPathContextProviderTests.cs" />
     <Compile Include="Extensibility\VsSemanticVersionComparerTests.cs" />
+    <Compile Include="PreinstalledRepositoryProviderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/PreinstalledRepositoryProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/PreinstalledRepositoryProviderTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Win32;
+using Moq;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.VisualStudio.Implementation.Test
+{
+    public class PreinstalledRepositoryProviderTests : IDisposable
+    {
+        private readonly TestDirectory _testDirectory;
+
+        public PreinstalledRepositoryProviderTests()
+        {
+            _testDirectory = TestDirectory.Create();
+        }
+
+        public void Dispose()
+        {
+            _testDirectory.Dispose();
+        }
+
+        [Fact]
+        public void AddFromRegistry_WithValidRegistryValue_Succeeds()
+        {
+            var srp = Mock.Of<ISourceRepositoryProvider>();
+            Mock.Get(srp)
+                .Setup(x => x.CreateRepository(It.IsAny<PackageSource>(), It.IsAny<FeedType>()))
+                .Returns((PackageSource ps, FeedType ft) => new SourceRepository(
+                    ps, Enumerable.Empty<INuGetResourceProvider>()));
+
+            var provider = new PreinstalledRepositoryProvider(_ => { }, srp);
+
+            // Act
+            using (var tc = new TestContext(_testDirectory.Path))
+            {
+                provider.AddFromRegistry(tc.RepoKeyName, isPreUnzipped: true);
+            }
+
+            Assert.NotNull(provider.GetRepositories().Single());
+
+            Mock.Get(srp)
+                .Verify(
+                    x => x.CreateRepository(It.IsAny<PackageSource>(), It.IsAny<FeedType>()),
+                    Times.Once());
+        }
+
+        [Fact]
+        public void AddFromRegistry_WithMissingRegistryKey_Fails()
+        {
+            var srp = Mock.Of<ISourceRepositoryProvider>();
+
+            string errorHandlerMessage = null;
+            var provider = new PreinstalledRepositoryProvider(
+                registryKeyRoot: $"NuGetTest_{Guid.NewGuid()}",
+                errorHandler: errorMessage => { errorHandlerMessage = errorMessage; }, 
+                provider: srp);
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                provider.AddFromRegistry("InvalidKeyName", isPreUnzipped: true)
+            );
+
+            // VsResources.PreinstalledPackages_RegistryKeyError
+            const string ExpectedErrorMessage = "error accessing registry key";
+
+            Assert.Contains(ExpectedErrorMessage, errorHandlerMessage,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(ExpectedErrorMessage, exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void AddFromRegistry_WithInvalidRegistryValue_Fails()
+        {
+            var srp = Mock.Of<ISourceRepositoryProvider>();
+
+            string errorHandlerMessage = null;
+            var provider = new PreinstalledRepositoryProvider(
+                errorMessage => { errorHandlerMessage = errorMessage; }, srp);
+
+            // Act
+            using (var tc = new TestContext(string.Empty))
+            {
+                var exception = Assert.Throws<InvalidOperationException>(() =>
+                    provider.AddFromRegistry(tc.RepoKeyName, isPreUnzipped: true)
+                );
+
+                // VsResources.PreinstalledPackages_InvalidRegistryValue
+                const string ExpectedErrorMessage = "Could not find a registry key with name";
+
+                Assert.Contains(ExpectedErrorMessage, errorHandlerMessage,
+                    StringComparison.OrdinalIgnoreCase);
+                Assert.Contains(ExpectedErrorMessage, exception.Message,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private class TestContext : IDisposable
+        {
+            private readonly RegistryKey _repoKey;
+            public string RepoKeyName { get; } = $"NuGetTest_{Guid.NewGuid()}";
+
+            public TestContext(string repositoryPath)
+            {
+                _repoKey = Registry.CurrentUser.CreateSubKey(
+                    PreinstalledRepositoryProvider.DefaultRegistryKeyRoot);
+                _repoKey.SetValue(RepoKeyName, repositoryPath);
+            }
+
+            public void Dispose()
+            {
+                _repoKey.DeleteValue(RepoKeyName);
+                _repoKey.Dispose();
+            }
+
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/project.json
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/project.json
@@ -1,5 +1,6 @@
-{
+﻿{
   "dependencies": {
+    "Test.Utility": "4.3.0-*",
     "Moq": "4.2.1507.118",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"


### PR DESCRIPTION
Resolves NuGet/Home#4284.

Ensure correct exception is thrown in fatal error code paths.
Hardened public methods with null-check.
Added tests.

//cc @rrelyea 