### PR TITLE
Fixed condition when RestoreProjectStyle was not defined

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -170,7 +170,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                         // For legacy csproj, either the RestoreProjectStyle must be set to PackageReference or
                         // project has atleast one package dependency defined as PackageReference
-                        if (restoreProjectStyle?.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase) ?? true
+                        if (restoreProjectStyle?.Equals(ProjectStyle.PackageReference.ToString(), StringComparison.OrdinalIgnoreCase) ?? false
                             || (AsVSProject4.PackageReferences?.InstalledPackages?.Length ?? 0) > 0)
                         {
                             _isLegacyCSProjPackageReferenceProject = true;


### PR DESCRIPTION
Fixed condition when RestoreProjectStyle was not defined, to return false instead of true. So that it doesn't fall into Legacy csproj project.

Fixes https://github.com/NuGet/Home/issues/4739

@rrelyea 