### PR TITLE
.NET code style settings for .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-; EditorConfig to support per-solution formatting.
+﻿; EditorConfig to support per-solution formatting.
 ; Use the EditorConfig VS add-in to make this work.
 ; http://editorconfig.org/
 
@@ -6,22 +6,82 @@
 root = true
 
 [*]
+; Don't use tabs for indentation.
 indent_style = space
+; (Please don't specify an indent_size here; that has too many unintended consequences.)
 charset = utf-8
 trim_trailing_whitespace = true
 
+; Code files
 [*.{cs}]
 indent_size = 4
 
 ; All XML-based file formats
-[*.{config,csproj,nuspec,props,resx,targets,xaml,xml}]
+[*.{config,csproj,nuspec,props,resx,ruleset,targets,vsct,vsixmanifest,xaml,xml}]
 indent_size = 2
 
-[*.{json}]
+; JSON files
+[*.json]
 indent_size = 2
 
+; PowerShell scripts
 [*.{ps1}]
 indent_size = 4
 
 [*.{sh}]
 indent_size = 4
+
+; Dotnet code style settings
+[*.{cs,vb}]
+; Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+; IDE0003 Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+; IDE0012 Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+; IDE0013
+dotnet_style_predefined_type_for_member_access = true:warning
+
+; Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+; CSharp code style settings
+[*.cs]
+; IDE0007 Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+
+; Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+; Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+; Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:none
+csharp_style_pattern_matching_over_as_with_null_check = true:none
+csharp_style_inlined_variable_declaration = true:none
+csharp_style_throw_expression = true:none
+csharp_style_conditional_delegate_call = true:suggestion
+
+; Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true

--- a/NuGet.Clients.sln
+++ b/NuGet.Clients.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26223.1
+VisualStudioVersion = 15.0.26228.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{3EF356B5-E2D3-45E3-B515-99F4611ACBDA}"
 EndProject
@@ -116,12 +116,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tools", "src\NuGet.Cl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tools.Test", "test\NuGet.Clients.Tests\NuGet.Tools.Test\NuGet.Tools.Test.csproj", "{5E2D927E-87E3-431A-A062-16DF6EC98BFB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{216989C4-1EE9-4CD3-A790-2B60A6BAF5C3}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 		Debug VS14|Any CPU = Debug VS14|Any CPU
+		Debug|Any CPU = Debug|Any CPU
 		Release VS14|Any CPU = Release VS14|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{306CDDFA-FF0B-4299-930C-9EC6C9308160}.Debug VS14|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Contributes to NuGet/Home#4722.

Enforce team code style settings (with IDE warnings):
- use `var`
- avoid `this.`
- use language keywords