### PR TITLE
Avoid reading NuGetTargetFramework property

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -192,15 +192,6 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                // Uncached, in case project file edited
-                // ex-project.json (e.g. UWP)
-                var nuGetTargetFramework = GetMSBuildProperty(AsIVsBuildPropertyStorage, "NuGetTargetFramework");
-                if (!string.IsNullOrEmpty(nuGetTargetFramework))
-                {
-                    return NuGetFramework.ParseFrameworkName(nuGetTargetFramework, DefaultFrameworkNameProvider.Instance);
-                }
-
-                // ex-packages.config
                 return EnvDTEProjectUtility.GetTargetNuGetFramework(_project);
             }
         }


### PR DESCRIPTION
We already have a utility API to get right TargetFrameworkMoniker based on target platform, which should be used across restore paths like VS restore, dotnet/nuget.exe restore, or msbuild /t:restore so we don't need this NuGetTargetFramework property. If anyone needs to set it separately then they can always set TargetFrameworkMoniker which will be used by all tools including NuGet. 

There is another PR https://github.com/NuGet/NuGet.Client/pull/1224 which also enhance this fix by using TargetPlatformMinVersion across all the NuGet restore paths.

Fixes https://github.com/NuGet/Home/issues/4531 

@rrelyea 