### PR TITLE
Load RestoreManagerPackage asynchronously with UI context auto-load

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -24,10 +24,10 @@ namespace NuGet.SolutionRestoreManager
     /// Visual Studio extension package designed to bootstrap solution restore components.
     /// Loads on solution open to attach to build events.
     /// </summary>
-    // Flag AllowsBackgroundLoading is set to False because switching to Main thread wiht JTF is creating
-    // performance overhead in InitializeAsync() API.
+    // Flag AllowsBackgroundLoading is set to True and Flag PackageAutoLoadFlags is set to BackgroundLoad
+    // which will allow this package to be loaded asynchronously
     [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
-    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string)]
+    [ProvideAutoLoad(VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
     [Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -56,7 +56,14 @@ namespace NuGet.SolutionRestoreManager
             var menuCommandId = new CommandID(CommandSet, CommandId);
             var menuItem = new OleMenuCommand(
                 OnRestorePackages, null, BeforeQueryStatusForPackageRestore, menuCommandId);
-            commandService?.AddCommand(menuItem);
+
+            // call AddCommand through explicitly moving to UI thread since this is now being 
+            // initiliazed as part of AsynPackage
+            ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                commandService?.AddCommand(menuItem);
+            });
 
             _vsMonitorSelection = vsMonitorSelection;
 


### PR DESCRIPTION
NuGet.SolutionRestoreManager.RestoreManagerPackage is an async package; however, it is being loaded synchronously due to a UI context auto-load. Thus when it tries to initialize or use AppInsights, it deadlocks because AppInsights stuck in their RPC channel.

So, passing PackageAutoLoadFlags.BackgroundLoad which allow the auto-load to happen entirely asynchronously.

Fixes NuGet/Home#4679

@rrelyea 