### PR TITLE
Fixes End2End tests for Dev14

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -64,6 +64,7 @@ namespace NuGet.Common
                         targetFramework: GetPropertyValue("TargetFramework"),
                         targetFrameworkMoniker: GetPropertyValue("TargetFrameworkMoniker"),
                         targetPlatformIdentifier: GetPropertyValue("TargetPlatformIdentifier"),
+                        targetPlatformVersion: GetPropertyValue("TargetPlatformVersion"),
                         targetPlatformMinVersion: GetPropertyValue("TargetPlatformMinVersion"));
 
                     // Parse the framework of the project or return unsupported.

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/DeferredProjectRestoreUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/DeferredProjectRestoreUtility.cs
@@ -37,6 +37,7 @@ namespace NuGet.PackageManagement.VisualStudio
         private static readonly string TargetFrameworks = "TargetFrameworks";
         private static readonly string PackageTargetFallback = "PackageTargetFallback";
         private static readonly string TargetPlatformIdentifier = "TargetPlatformIdentifier";
+        private static readonly string TargetPlatformVersion = "TargetPlatformVersion";
         private static readonly string TargetPlatformMinVersion = "TargetPlatformMinVersion";
         private static readonly string TargetFrameworkMoniker = "TargetFrameworkMoniker";
 
@@ -419,6 +420,7 @@ namespace NuGet.PackageManagement.VisualStudio
             string projectPath)
         {
             var targetPlatformIdentifier = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetPlatformIdentifier);
+            var targetPlatformVersion = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetPlatformVersion);
             var targetPlatformMinVersion = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetPlatformMinVersion);
             var targetFrameworkMoniker = await deferredWorkspaceService.GetProjectPropertyAsync(dataService, TargetFrameworkMoniker);
 
@@ -428,6 +430,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 targetFramework: null,
                 targetFrameworkMoniker: targetFrameworkMoniker,
                 targetPlatformIdentifier: targetPlatformIdentifier,
+                targetPlatformVersion: targetPlatformVersion,
                 targetPlatformMinVersion: targetPlatformMinVersion);
 
             var frameworkString = frameworkStrings.FirstOrDefault();

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -627,7 +627,8 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var projectPath = GetFullProjectPath(envDTEProject);
             var platformIdentifier = GetPropertyValue<string>(envDTEProject, "TargetPlatformIdentifier");
-            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformMinVersion");
+            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
+            var platformMinVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformMinVersion");
             var targetFrameworkMoniker = GetPropertyValue<string>(envDTEProject, "TargetFrameworkMoniker");
             var isManagementPackProject = IsManagementPackProject(envDTEProject);
             var isXnaWindowsPhoneProject = IsXnaWindowsPhoneProject(envDTEProject);
@@ -640,7 +641,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 targetFramework: null,
                 targetFrameworkMoniker: targetFrameworkMoniker,
                 targetPlatformIdentifier: platformIdentifier,
-                targetPlatformMinVersion: platformVersion,
+                targetPlatformVersion: platformVersion,
+                targetPlatformMinVersion: platformMinVersion,
                 isManagementPackProject: isManagementPackProject,
                 isXnaWindowsPhoneProject: isXnaWindowsPhoneProject);
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectFrameworks.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreProjectFrameworks.cs
@@ -31,9 +31,14 @@ namespace NuGet.Build.Tasks
         public string TargetPlatformIdentifier { get; set; }
 
         /// <summary>
-        /// Optional TargetPlatformVersion property value.
+        /// Optional TargetPlatformMinVersion property value.
         /// </summary>
         public string TargetPlatformMinVersion { get; set; }
+
+        /// <summary>
+        /// Optional TargetPlatformVersion property value.
+        /// </summary>
+        public string TargetPlatformVersion { get; set; }
 
         /// <summary>
         /// Optional TargetFrameworks property value.
@@ -57,6 +62,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) ProjectPath '{ProjectPath}'");
             log.LogDebug($"(in) TargetFrameworkMoniker '{TargetFrameworkMoniker}'");
             log.LogDebug($"(in) TargetPlatformIdentifier '{TargetPlatformIdentifier}'");
+            log.LogDebug($"(in) TargetPlatformVersion '{TargetPlatformVersion}'");
             log.LogDebug($"(in) TargetPlatformMinVersion '{TargetPlatformMinVersion}'");
             log.LogDebug($"(in) TargetFrameworks '{TargetFrameworks}'");
             log.LogDebug($"(in) TargetFramework '{TargetFramework}'");
@@ -68,6 +74,7 @@ namespace NuGet.Build.Tasks
                 targetFramework: TargetFramework,
                 targetFrameworkMoniker: TargetFrameworkMoniker,
                 targetPlatformIdentifier: TargetPlatformIdentifier,
+                targetPlatformVersion: TargetPlatformVersion,
                 targetPlatformMinVersion: TargetPlatformMinVersion);
 
             ProjectTargetFrameworks = string.Join(";", frameworks);

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -370,6 +370,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       TargetFramework="$(TargetFramework)"
       TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
       TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+      TargetPlatformVersion="$(TargetPlatformVersion)"
       TargetPlatformMinVersion="$(TargetPlatformMinVersion)">
       <Output
         TaskParameter="ProjectTargetFrameworks"

--- a/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MSBuildProjectFrameworkUtility.cs
@@ -18,6 +18,7 @@ namespace NuGet.Commands
             string targetFramework,
             string targetFrameworkMoniker,
             string targetPlatformIdentifier,
+            string targetPlatformVersion,
             string targetPlatformMinVersion)
         {
             return GetProjectFrameworkStrings(
@@ -26,6 +27,7 @@ namespace NuGet.Commands
                 targetFramework,
                 targetFrameworkMoniker,
                 targetPlatformIdentifier,
+                targetPlatformVersion,
                 targetPlatformMinVersion,
                 isManagementPackProject: false,
                 isXnaWindowsPhoneProject: false);
@@ -40,6 +42,7 @@ namespace NuGet.Commands
             string targetFramework,
             string targetFrameworkMoniker,
             string targetPlatformIdentifier,
+            string targetPlatformVersion,
             string targetPlatformMinVersion,
             bool isXnaWindowsPhoneProject,
             bool isManagementPackProject)
@@ -86,6 +89,12 @@ namespace NuGet.Commands
             // UAP/Windows store projects
             var platformIdentifier = MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformIdentifier);
             var platformVersion = MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformMinVersion);
+
+            // if targetPlatformMinVersion isn't defined then fallback to targetPlatformVersion
+            if (string.IsNullOrEmpty(platformVersion))
+            {
+                platformVersion = MSBuildStringUtility.TrimAndGetNullForEmpty(targetPlatformVersion);
+            }
 
             // Check for JS project
             if (projectFilePath?.EndsWith(".jsproj", StringComparison.OrdinalIgnoreCase) == true)

--- a/test/EndToEnd/tests/install.ps1
+++ b/test/EndToEnd/tests/install.ps1
@@ -2342,12 +2342,13 @@ function Test-FileTransformWorksOnDependentFile
     Install-Package test -Source $context.RepositoryPath
 
     # Assert
+	Assert-Package $p TTFile
+	Assert-Package $p test
 
-    $projectDir = Split-Path -parent -path $p.FullName
+	$projectDir = Split-Path -parent -path $p.FullName
     $configFilePath = Join-Path -path $projectDir -childpath "one.config"
-    $content = get-content $configFilePath
-    $matches = @($content | ? { ($_.IndexOf('foo="bar"') -gt -1) })
-    Assert-True ($matches.Count -gt 0)
+	$content = [xml](Get-Content $configFilePath)
+    Assert-AreEqual "bar" $content.configuration["system.web"].compilation.foo
 }
 
 # Solution level package used

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreUAPPackageReferenceTests.cs
@@ -71,6 +71,59 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task RestoreUAP_VerifyTargetPlatformVersionIsUsed()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.AnyFramework);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                projectA.Properties.Add("TargetPlatformIdentifier", "UAP");
+                projectA.Properties.Add("TargetPlatformVersion", "10.0.14393.0");
+                projectA.Properties.Add("TargetPlatformMinVersion", "");
+                projectA.Properties.Add("RestoreProjectStyle", "PackageReference");
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = RestoreSolution(pathContext);
+
+                var dgPath = Path.Combine(pathContext.WorkingDirectory, "out.dg");
+                var dgSpec = DependencyGraphSpec.Load(dgPath);
+
+                var propsXML = XDocument.Load(projectA.PropsOutput);
+                var styleNode = propsXML.Root.Elements().First().Elements(XName.Get("NuGetProjectStyle", "http://schemas.microsoft.com/developer/msbuild/2003")).FirstOrDefault();
+
+                var projectSpec = dgSpec.Projects.Single();
+
+                // Assert
+                Assert.Equal(ProjectStyle.PackageReference, projectSpec.RestoreMetadata.ProjectStyle);
+                Assert.Equal("PackageReference", styleNode.Value);
+                Assert.Equal(NuGetFramework.Parse("UAP10.0.14393.0"), projectSpec.TargetFrameworks.Single().FrameworkName);
+            }
+        }
+
+        [Fact]
         public async Task RestoreUAP_VerifyNoContentFiles()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFrameworkUtilityTests.cs
@@ -233,6 +233,7 @@ namespace NuGet.Commands.Test
             string targetFrameworkMoniker = "",
             string targetPlatformIdentifier = "",
             string targetPlatformVersion="",
+            string targetPlatformMinVersion = "",
             bool isXnaWindowsPhoneProject=false,
             bool isManagementPackProject=false)
         {
@@ -244,6 +245,7 @@ namespace NuGet.Commands.Test
                     targetFrameworkMoniker,
                     targetPlatformIdentifier,
                     targetPlatformVersion,
+                    targetPlatformMinVersion,
                     isXnaWindowsPhoneProject,
                     isManagementPackProject))
                     .ToList();


### PR DESCRIPTION
This PR fixes all the failing end2end tests for Dev14. There are couple of other changes besides this:
- Install missing Universal Window sdk on CI machine which runs Dev14 End2End tests.
- Ignored running silverlight tests which are no more supported and usually fails intermittently.

Fixes https://github.com/NuGet/Home/issues/4760

@rrelyea 