### PR TITLE
Add Tizen TFM for netstandard 2.0

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -92,6 +92,7 @@ namespace NuGet.Frameworks
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.NetCore, "netcore"),
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.WinRT, "winrt"), // legacy
                             new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.UAP, "uap"),
+                            new KeyValuePair<string, string>(FrameworkConstants.FrameworkIdentifiers.Tizen, "tizen"),
                         };
                 }
 
@@ -195,6 +196,11 @@ namespace NuGet.Frameworks
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WindowsPhoneApp, FrameworkConstants.EmptyVersion),
                                 FrameworkConstants.CommonFrameworks.WPA81),
+
+                            // tizen <-> tizen3
+                            new KeyValuePair<NuGetFramework, NuGetFramework>(
+                                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.Tizen, FrameworkConstants.EmptyVersion),
+                                FrameworkConstants.CommonFrameworks.Tizen3),
 
                             // dnx <-> dnx45
                             new KeyValuePair<NuGetFramework, NuGetFramework>(
@@ -332,6 +338,11 @@ namespace NuGet.Frameworks
                             new FrameworkRange(
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, FrameworkConstants.EmptyVersion),
                                 new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.WinRT, new Version(4, 5, 0, 0)))),
+
+                        // Tizen3 projects support NETStandard2.0
+                        CreateStandardMapping(
+                            FrameworkConstants.CommonFrameworks.Tizen3,
+                            FrameworkConstants.CommonFrameworks.NetStandard20),
 
                         // NetCoreApp1.0 projects support NetStandard1.6
                         CreateStandardMapping(

--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -67,6 +67,7 @@ namespace NuGet.Frameworks
             public const string XamarinXbox360 = "Xamarin.Xbox360";
             public const string XamarinXboxOne = "Xamarin.XboxOne";
             public const string UAP = "UAP";
+            public const string Tizen = "Tizen";
         }
 
         /// <summary>
@@ -104,6 +105,8 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework WP81 = new NuGetFramework(FrameworkIdentifiers.WindowsPhone, new Version(8, 1, 0, 0));
 
             public static readonly NuGetFramework WPA81 = new NuGetFramework(FrameworkIdentifiers.WindowsPhoneApp, new Version(8, 1, 0, 0));
+
+            public static readonly NuGetFramework Tizen3 = new NuGetFramework(FrameworkIdentifiers.Tizen, new Version(3, 0, 0, 0));
 
             public static readonly NuGetFramework AspNet = new NuGetFramework(FrameworkIdentifiers.AspNet, EmptyVersion);
             public static readonly NuGetFramework AspNetCore = new NuGetFramework(FrameworkIdentifiers.AspNetCore, EmptyVersion);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -47,6 +47,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.Contains("Tizen,Version=v3.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.6", actual); // only the minimum support version is returned
@@ -54,7 +55,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain(".NETPlatform,Version=v5.3", actual); // frameworks with no relationship are not returned
 
             // count
-            Assert.Equal(25, actual.Length);
+            Assert.Equal(26, actual.Length);
         }
 
         [Fact]
@@ -89,6 +90,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.Contains("Tizen,Version=v3.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -96,7 +98,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
 
             // count
-            Assert.Equal(18, actual.Length);
+            Assert.Equal(19, actual.Length);
         }
 
         [Fact]
@@ -130,6 +132,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.Contains("Tizen,Version=v3.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -138,7 +141,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(17, actual.Length);
+            Assert.Equal(18, actual.Length);
         }
 
         [Fact]
@@ -172,6 +175,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.Contains("Tizen,Version=v3.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -180,7 +184,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(17, actual.Length);
+            Assert.Equal(18, actual.Length);
         }
         
         [Fact]
@@ -213,6 +217,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.WatchOS,Version=v0.0", actual);
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
+            Assert.Contains("Tizen,Version=v3.0", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -221,7 +226,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(17, actual.Length);
+            Assert.Equal(18, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -396,6 +396,25 @@ namespace NuGet.Test
         [InlineData("win8", "dotnet5.2", true)]
         [InlineData("win8", "dotnet5.1", true)]
 
+        // tizen3 -> netstandard
+        [InlineData("tizen3.0", "netstandard2.1", false)]
+        [InlineData("tizen3.0", "netstandard2.0", true)]
+        [InlineData("tizen3.0", "netstandard1.7", true)]
+        [InlineData("tizen3.0", "netstandard1.6", true)]
+        [InlineData("tizen3.0", "netstandard1.5", true)]
+        [InlineData("tizen3.0", "netstandard1.4", true)]
+        [InlineData("tizen3.0", "netstandard1.3", true)]
+        [InlineData("tizen3.0", "netstandard1.2", true)]
+        [InlineData("tizen3.0", "netstandard1.1", true)]
+        [InlineData("tizen3.0", "netstandard1.0", true)]
+        [InlineData("tizen3.0", "dotnet5.6", false)]
+        [InlineData("tizen3.0", "dotnet5.5", false)]
+        [InlineData("tizen3.0", "dotnet5.4", false)]
+        [InlineData("tizen3.0", "dotnet5.3", false)]
+        [InlineData("tizen3.0", "dotnet5.2", false)]
+        [InlineData("tizen3.0", "dotnet5.1", false)]
+        [InlineData("tizen3.0", "dotnet5.1", false)]
+
         // Older things don't support dotnet, netstandard, netstandardapp, or netcoreapp at all
         [InlineData("sl4", "netcoreapp1.0", false)]
         [InlineData("net40", "netcoreapp1.0", false)]


### PR DESCRIPTION
"Tizen" TFM has been merged into 4.1 and dev branches already. 
And Tizen3 will support netstandard2.0 when the .NETCore 2.0 is released. 

- Identifier : Tizen(tizen)
- Tizen3 supports netstandard2.0

@emgarten @rrelyea 