### PR TITLE
Get package metadata from all enabled sources for checking license

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -411,8 +411,8 @@ namespace NuGet.PackageManagement.UI
                     licenseCheck.Add(pkg.New);
                 }
             }
-
-            var licenseMetadata = await GetPackageMetadataAsync(uiService, licenseCheck, token);
+            var sources = _sourceProvider.GetRepositories().Where(e => e.PackageSource.IsEnabled);
+            var licenseMetadata = await GetPackageMetadataAsync(sources, licenseCheck, token);
 
             TelemetryUtility.StopTimer();
 
@@ -633,16 +633,16 @@ namespace NuGet.PackageManagement.UI
         /// Get the package metadata to see if RequireLicenseAcceptance is true
         /// </summary>
         private async Task<List<IPackageSearchMetadata>> GetPackageMetadataAsync(
-            INuGetUI uiService,
+            IEnumerable<SourceRepository> sources,
             IEnumerable<PackageIdentity> packages,
             CancellationToken token)
         {
             var results = new List<IPackageSearchMetadata>();
 
             // local sources
-            var sources = new List<SourceRepository>();
-            sources.Add(_packageManager.PackagesFolderSourceRepository);
-            sources.AddRange(_packageManager.GlobalPackageFolderRepositories);
+            var localSources = new List<SourceRepository>();
+            localSources.Add(_packageManager.PackagesFolderSourceRepository);
+            localSources.AddRange(_packageManager.GlobalPackageFolderRepositories);
 
             var allPackages = packages.ToArray();
 
@@ -661,7 +661,7 @@ namespace NuGet.PackageManagement.UI
 
                 var remoteResults = (await TaskCombinators.ThrottledAsync(
                     remainingPackages,
-                    (p, t) => GetPackageMetadataAsync(uiService.ActiveSources, p, t),
+                    (p, t) => GetPackageMetadataAsync(sources, p, t),
                     token)).Where(metadata => metadata != null).ToArray();
 
                 results.AddRange(remoteResults);

--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -649,7 +649,7 @@ namespace NuGet.PackageManagement.UI
             // first check all the packages with local sources.
             var completed = (await TaskCombinators.ThrottledAsync(
                 allPackages,
-                (p, t) => GetPackageMetadataAsync(sources, p, t),
+                (p, t) => GetPackageMetadataAsync(localSources, p, t),
                 token)).Where(metadata => metadata != null).ToArray();
 
             results.AddRange(completed);


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/4768

the issue is nuget UI is fetching package metadata only from current active source during checking license.

the fix is fetching metadata from all enabled sources.