### PR TITLE
Use 15.99.99 as default version so we insert locally built VSIXs

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/source.extension.vs15.insertable.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.Tools/source.extension.vs15.insertable.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="99.99.99" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="15.99.99" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 2017</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <PackageId>Microsoft.VisualStudio.NuGet.Core</PackageId>

--- a/src/NuGet.Clients/NuGet.Tools/source.extension.vs15.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.Tools/source.extension.vs15.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="99.99.99" Language="en-US" Publisher="Microsoft Corporation" />
+    <Identity Id="NuGet.72c5d240-f742-48d4-a0f1-7016671e405b" Version="15.99.99" Language="en-US" Publisher="Microsoft Corporation" />
     <DisplayName>NuGet Package Manager for Visual Studio 2017</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <PackageId>Microsoft.VisualStudio.NuGet.Core</PackageId>


### PR DESCRIPTION
Use 15.99.99 as default version so we insert locally built VSIXs. 

Due to the https://github.com/NuGet/Home/issues/4682 bug, we sometimes need to insert locally built VSIXs for testing in VS15. 
The version number allowed for these VSIXs is [15.0,16.0)

//cc
@jainaashish @emgarten @mishra14 @rohit21agrawal @zhili1208 