### PR TITLE
Throw proper exception when project isn't restored

### DIFF
--- a/src/NuGet.Clients/PackageManagement.UI/Common/VisualStudioActivityLogger.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Common/VisualStudioActivityLogger.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
+using NuGet.Common;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -10,8 +11,9 @@ namespace NuGet.PackageManagement.UI
     /// Logger routing messages into VS ActivityLog
     /// </summary>
     /// 
+    [Export("VisualStudioActivityLogger", typeof(ILogger))]
     [Export(typeof(VisualStudioActivityLogger))]
-    public sealed class VisualStudioActivityLogger : NuGet.Common.ILogger
+    public sealed class VisualStudioActivityLogger : ILogger
     {
         private const string LogEntrySource = "NuGet Package Manager";
 


### PR DESCRIPTION
Resolves NuGet/Home#4826.

This change improves the `IVsPathContextProvider` behaviour.
The provider should correctly handle errors occured in the process of path context creation, such as project is not restored, lock file is missing, package directory is not found, etc. It will throw `InvalidOperationException` as agreed in the API contract.

//cc @debonte @rrelyea 