### PR TITLE
Changing E2E setup to test with Insertable vsix and some test fix

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -34,12 +34,6 @@ $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 
 Copy-Item $VSIXSrcPath $VSIXPath
 
-$success = UninstallVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
-if ($success -eq $false)
-{
-    exit 1
-}
-
 $success = InstallVSIX $VSIXPath $VSVersion $VSIXInstallerWaitTimeInSecs
 if ($success -eq $false)
 {

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -40,8 +40,4 @@ if ($success -eq $false)
     exit 1
 }
 
-$success = ClearMEFCache $VSVersion $VSIXInstallerWaitTimeInSecs
-if ($success -eq $false)
-{
-    exit 1
-}
+ClearDev15MEFCache

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -34,10 +34,24 @@ $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 
 Copy-Item $VSIXSrcPath $VSIXPath
 
+# Since dev14 vsix is not uild with vssdk 3.0, we can uninstall and re installing
+# For dev 15, we upgrade an installed system component vsix
+if($VSVersion -eq '14.0')
+{
+	$success = UninstallVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+	if ($success -eq $false)
+	{
+		exit 1
+	}
+}
+else 
+{
+	# Clearing MEF cache helps load the right dlls for vsix
+	ClearDev15MEFCache
+}
+
 $success = InstallVSIX $VSIXPath $VSVersion $VSIXInstallerWaitTimeInSecs
 if ($success -eq $false)
 {
     exit 1
 }
-
-ClearDev15MEFCache

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -39,3 +39,9 @@ if ($success -eq $false)
 {
     exit 1
 }
+
+$success = ClearMEFCache $VSVersion $VSIXInstallerWaitTimeInSecs
+if ($success -eq $false)
+{
+    exit 1
+}

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -121,6 +121,21 @@ function GetVSIXInstallerPath
     return $VSIXInstallerPath
 }
 
+function GetDevenvPath
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
+        [string]$VSVersion
+    )
+
+    $VSIDEFolderPath = GetVSIDEFolderPath $VSVersion
+    $DevenvPath = Join-Path $VSIDEFolderPath "devenv.exe"
+
+    return $DevenvPath
+}
+
+
 function UninstallVSIX
 {
     param(
@@ -184,6 +199,34 @@ function InstallVSIX
 
     start-sleep -Seconds $VSIXInstallerWaitTimeInSecs
     Write-Host "VSIX has been installed successfully."
+
+    return $true
+}
+
+
+function ClearMEFCache
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
+        [string]$VSVersion,
+        [Parameter(Mandatory=$true)]
+        [int]$VSIXInstallerWaitTimeInSecs
+    )
+    
+    $DevenvPath = GetDevenvPath $VSVersion
+
+    Write-Host "running $DevenvPath /setup... to clear MEF cache"
+    $p = start-process "$DevenvPath" -Wait -PassThru -NoNewWindow -ArgumentList "/setup"
+
+    if ($p.ExitCode -ne 0)
+    {
+        Write-Error "Error clearing MEF cache! Exit code: " $p.ExitCode
+        return $false
+    }
+
+    # start-sleep -Seconds $VSIXInstallerWaitTimeInSecs
+    Write-Host "MEF Cache has been cleared!"
 
     return $true
 }

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -135,6 +135,15 @@ function GetDevenvPath
     return $DevenvPath
 }
 
+function GetDev15MEFCachePath
+{
+
+    $cachePath = $env:localappdata
+    @( "Microsoft", "VisualStudio", "15.*", "ComponentModelCache" ) | %{ $cachePath = Join-Path $cachePath $_ }
+    
+    return $cachePath
+}
+
 
 function UninstallVSIX
 {
@@ -204,29 +213,14 @@ function InstallVSIX
 }
 
 
-function ClearMEFCache
+function ClearDev15MEFCache
 {
-    param(
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
-        [string]$VSVersion,
-        [Parameter(Mandatory=$true)]
-        [int]$VSIXInstallerWaitTimeInSecs
-    )
     
-    $DevenvPath = GetDevenvPath $VSVersion
+    $dev15MEFCachePath = GetDev15MEFCachePath
 
-    Write-Host "running $DevenvPath /setup... to clear MEF cache"
-    $p = start-process "$DevenvPath" -Wait -PassThru -NoNewWindow -ArgumentList "/setup"
+    Write-Host "rm -r $dev15MEFCachePath..."
+    rm -r $dev15MEFCachePath
+    
+    Write-Host "Done clearing dev15 MEF cache..."
 
-    if ($p.ExitCode -ne 0)
-    {
-        Write-Error "Error clearing MEF cache! Exit code: " $p.ExitCode
-        return $false
-    }
-
-    # start-sleep -Seconds $VSIXInstallerWaitTimeInSecs
-    Write-Host "MEF Cache has been cleared!"
-
-    return $true
 }

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -121,20 +121,6 @@ function GetVSIXInstallerPath
     return $VSIXInstallerPath
 }
 
-function GetDevenvPath
-{
-    param(
-        [Parameter(Mandatory=$true)]
-        [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
-        [string]$VSVersion
-    )
-
-    $VSIDEFolderPath = GetVSIDEFolderPath $VSVersion
-    $DevenvPath = Join-Path $VSIDEFolderPath "devenv.exe"
-
-    return $DevenvPath
-}
-
 function GetDev15MEFCachePath
 {
 

--- a/test/EndToEnd/tests/NetCoreProjectTests.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTests.ps1
@@ -579,8 +579,8 @@ function Test-NetStandardClassLibraryInstallMultiplePackages {
     $project = New-NetStandardClassLibrary ClassLibrary1
     $id1 = 'NuGet.Versioning'
     $version1 = '3.5.0'
-    $id2 = 'NUnit'
-    $version2 = '3.6.0'
+    $id2 = 'Newtonsoft.Json'
+    $version2 = '9.0.1'
 
     # Act
     Install-Package $id1 -ProjectName $project.Name -version $version1
@@ -599,8 +599,8 @@ function Test-NetStandardClassLibraryUninstallMultiplePackage {
     $project = New-NetStandardClassLibrary ClassLibrary1
     $id1 = 'NuGet.Versioning'
     $version1 = '3.5.0'
-    $id2 = 'NUnit'
-    $version2 = '3.6.0'
+    $id2 = 'Newtonsoft.Json'
+    $version2 = '9.0.1'
 
     # Act
     Install-Package $id1 -ProjectName $project.Name -version $version1


### PR DESCRIPTION
This fixes: https://github.com/NuGet/Home/issues/4759

1. Fixes the way we run E2E tests. This change (and some artifact dependency changes on CI), will make sure we use Insertable vsix for E2E tests.

2. This also fixes couple of test failures on dev.

//cc: @emgarten @nkolev92 @rohit21agrawal @jainaashish @alpaix 