### PR TITLE
Fix for NuGet/Home#2449

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -386,7 +386,7 @@ namespace NuGet.Common
             dynamic targetElement = null;
             foreach (dynamic target in Project.Xml.Targets)
             {
-                if (string.Equals(target.Name, targetsPath, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(target.Name, TargetName, StringComparison.OrdinalIgnoreCase))
                 {
                     targetElement = target;
                     break;

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -413,7 +413,7 @@ namespace NuGet.Common
             }
 
             taskElement.Parent.RemoveChild(taskElement);
-            if (targetElement.Tasks.Count == 0)
+            if (((System.Collections.ICollection)targetElement.Tasks).Count == 0)
             {
                 targetElement.Parent.RemoveChild(targetElement);
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 using NuGet.Common;
 using NuGet.Test.Utility;
 using Test.Utility;
@@ -114,6 +116,35 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 Assert.True(fileExistsInProject, "a.js does not exist in project");
+            }
+        }
+
+        [Fact]
+        public void MSBuildProjectSystem_RemoveImport()
+        {
+            // Arrange
+            var import = @"packages\mypackage.1.0.0\build\mypackage.targets";
+            var projectFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Import Project=""packages\mypackage.1.0.0\build\mypackage.targets"" Condition=""Exists('packages\mypackage.1.0.0\build\mypackage.targets')"" />
+  <Target Name=""EnsureNuGetPackageBuildImports"" BeforeTargets=""PrepareForBuild"" >
+    <PropertyGroup>   
+      <ErrorText>This project references NuGet package(s) that are missing on this computer.Enable NuGet Package Restore to download them.For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition=""!Exists('packages\mypackage.1.0.0\build\mypackage.targets')"" Text=""$([System.String]::Format('$(ErrorText)', 'packages\mypackage.1.0.0\build\mypackage.targets'))"" />
+  </Target>
+</Project>";
+
+            using (var testInfo = new TestInfo(projectFileContent))
+            {
+                var targetFullPath = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, import);
+
+                // Act
+                testInfo.MSBuildProjectSystem.RemoveImport(targetFullPath);
+
+                // Assert
+                var proj = XElement.Load(testInfo.MSBuildProjectSystem.ProjectFileFullPath);
+                Assert.False(proj.HasElements, "The <Import /> and <Target Name=\"EnsureNuGetPackageBuildImports\" /> elements should have been removed.");
             }
         }
     }


### PR DESCRIPTION
`nuget.exe update` fails to find the `EnsureNuGetPackageBuildImports` target when trying to remove previous `<Error />` elements.

To find it, we need to use `TargetName`, not `targetsPath` 😉 

Fix NuGet/Home#2449