### PR TITLE
Add lib placeholder files for Visual Studio restores

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -330,33 +330,52 @@ namespace NuGet.Commands
                 // Add files under asset groups
                 object filesObject;
                 object msbuildPath;
-                if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.ProjectRestoreMetadataFiles, out filesObject)
-                     && localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.MSBuildProjectPath, out msbuildPath))
+                if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.MSBuildProjectPath, out msbuildPath))
                 {
-                    var files = (List<ProjectRestoreMetadataFile>)filesObject;
+                    var files = new List<ProjectRestoreMetadataFile>();
                     var fileLookup = new Dictionary<string, ProjectRestoreMetadataFile>(StringComparer.OrdinalIgnoreCase);
 
-                    foreach (var file in files)
-                    {
-                        var path = file.PackagePath;
-
-                        // LIBANY avoid compatibility checks and will always be used.
-                        if (LIBANY.Equals(path, StringComparison.Ordinal))
-                        {
-                            path = $"lib/{targetGraph.Framework.GetShortFolderName()}/any.dll";
-                        }
-
-                        if (!fileLookup.ContainsKey(path))
-                        {
-                            fileLookup.Add(path, file);
-                        }
-                    }
-
+                    // Find the project path, this is provided by the resolver
                     var msbuildFilePathInfo = new FileInfo((string)msbuildPath);
 
                     // Ensure a trailing slash for the relative path helper.
                     var projectDir = msbuildFilePathInfo.Directory.FullName
                         .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+
+                    // Read files from the project if they were provided.
+                    if (localMatch.LocalLibrary.Items.TryGetValue(KnownLibraryProperties.ProjectRestoreMetadataFiles, out filesObject))
+                    {
+                        files.AddRange((List<ProjectRestoreMetadataFile>)filesObject);
+                    }
+
+                    var targetFrameworkShortName = targetGraph.Framework.GetShortFolderName();
+                    var libAnyPath = $"lib/{targetFrameworkShortName}/any.dll";
+
+                    if (files.Count == 0)
+                    {
+                        // If the project did not provide a list of assets, add in default ones.
+                        // These are used to detect transitive vs non-transitive project references.
+                        var absolutePath = Path.Combine(projectDir, "bin", "placeholder", $"{localMatch.Library.Name}.dll");
+
+                        files.Add(new ProjectRestoreMetadataFile(libAnyPath, absolutePath));
+                    }
+
+                    // Process and de-dupe files
+                    for (var i = 0; i < files.Count; i++)
+                    {
+                        var path = files[i].PackagePath;
+
+                        // LIBANY avoid compatibility checks and will always be used.
+                        if (LIBANY.Equals(path, StringComparison.Ordinal))
+                        {
+                            path = libAnyPath;
+                        }
+
+                        if (!fileLookup.ContainsKey(path))
+                        {
+                            fileLookup.Add(path, files[i]);
+                        }
+                    }
 
                     var contentItems = new ContentItemCollection();
                     contentItems.Load(fileLookup.Keys);
@@ -483,7 +502,7 @@ namespace NuGet.Commands
                     yield return props;
                 }
 
-                var targets = ordered.FirstOrDefault(c => 
+                var targets = ordered.FirstOrDefault(c =>
                     $"{packageId}.targets".Equals(
                         Path.GetFileName(c.Path),
                         StringComparison.OrdinalIgnoreCase));
@@ -572,7 +591,7 @@ namespace NuGet.Commands
         /// Clears a lock file group and replaces the first item with _._ if 
         /// the group has items. Empty groups are left alone.
         /// </summary>
-        private static void ClearIfExists<T>(IList<T> group) where T: LockFileItem
+        private static void ClearIfExists<T>(IList<T> group) where T : LockFileItem
         {
             if (GroupHasNonEmptyItems(group))
             {
@@ -592,7 +611,7 @@ namespace NuGet.Commands
                 group.Clear();
 
                 // Create a new item with the _._ path
-                var emptyItem = (T)Activator.CreateInstance(typeof(T), new [] { emptyDir });
+                var emptyItem = (T)Activator.CreateInstance(typeof(T), new[] { emptyDir });
 
                 // Copy over the properties from the first 
                 foreach (var pair in firstItem.Properties)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -236,48 +236,10 @@ namespace NuGet.Commands
                     {
                         projectDir = Path.GetDirectoryName(result.RestoreMetadata.ProjectPath);
                     }
-
-                    AddPlaceHolderFiles(result, projectDir);
                 }
             }
 
             return result;
-        }
-
-        /// <summary>
-        /// Add placeholder files, these will be used under the compile and runtime sections.
-        /// </summary>
-        private static void AddPlaceHolderFiles(PackageSpec spec,  string projectDir)
-        {
-            var files = new List<ProjectRestoreMetadataFile>();
-
-            // Create fake placeholder file names
-            var assemblyName = $"{spec.RestoreMetadata.ProjectName}.dll";
-            var absoluteRoot = Path.Combine(projectDir, "bin", "placeholder");
-
-            if (spec.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
-                || spec.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson)
-            {
-                // Add paths based on actual frameworks if they exist
-                foreach (var framework in spec.TargetFrameworks
-                    .Select(tfi => tfi.FrameworkName)
-                    .Where(f => f.IsSpecificFramework))
-                {
-                    var packagePath = $"lib/{framework.GetShortFolderName()}/{assemblyName}";
-                    var absolutePath = Path.Combine(absoluteRoot, framework.GetShortFolderName(), assemblyName);
-
-                    files.Add(new ProjectRestoreMetadataFile(packagePath, absolutePath));
-                }
-            }
-
-            // If no TFMs exist use LIBANY which to guarantee something is added
-            if (files.Count == 0)
-            {
-                var absolutePath = Path.Combine(absoluteRoot, "any", assemblyName);
-                files.Add(new ProjectRestoreMetadataFile(LockFileUtils.LIBANY, absolutePath));
-            }
-
-            spec.RestoreMetadata.Files = files;
         }
 
         private static void AddPackageTargetFallbacks(PackageSpec spec, IEnumerable<IMSBuildItem> items)


### PR DESCRIPTION
This change moves the step to add placeholder files for transitive project detection from MSBuild into restore so that it will be applied to all restores. Previously only command line restores were getting this step.

Instead of calling AddPlaceHolderFiles when creating the spec, it will now be done automatically in restore. This gives the same result and makes it less error prone.

✔️  tests already exist for this in nuget.commandline.tests and nuget.command.tests

https://github.com/NuGet/Home/issues/4629