### PR TITLE
Allowing executing nuget operation via ps scripts while installing packages

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -64,15 +64,18 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             TelemetryService = new TelemetryServiceHelper();
             TelemetryUtility.StartorResumeTimer();
 
-            using (var lck = _lockService.AcquireLock())
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                Preprocess();
+                await _lockService.ExecuteNuGetOperationAsync(async () =>
+                {
+                    Preprocess();
 
-                SubscribeToProgressEvents();
-                Task.Run(UninstallPackageAsync);
-                WaitAndLogPackageActions();
-                UnsubscribeFromProgressEvents();
-            }
+                    SubscribeToProgressEvents();
+                    await UninstallPackageAsync();
+                    WaitAndLogPackageActions();
+                    UnsubscribeFromProgressEvents();
+                }, Token);
+            });
 
             TelemetryUtility.StopTimer();
             var actionTelemetryEvent = TelemetryUtility.GetActionTelemetryEvent(

--- a/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Actions/UIActionEngine.cs
@@ -204,133 +204,132 @@ namespace NuGet.PackageManagement.UI
             var telemetryService = new TelemetryServiceHelper();
             uiService.ProjectContext.TelemetryService = telemetryService;
 
-            var lck = await _lockService.AcquireLockAsync(token);
-
-            try
+            await _lockService.ExecuteNuGetOperationAsync(async () =>
             {
-                uiService.BeginOperation();
-
-                var acceptedFormat = await CheckPackageManagementFormat(uiService, token);
-                if (!acceptedFormat)
+                try
                 {
-                    return;
-                }
+                    uiService.BeginOperation();
 
-                TelemetryUtility.StartorResumeTimer();
-
-                var actions = await resolveActionsAsync();
-                var results = GetPreviewResults(actions);
-
-                if (operationType == NuGetOperationType.Uninstall)
-                {
-                    packageCount = results.SelectMany(result => result.Deleted).
-                        Select(package => package.Id).Distinct().Count();
-                }
-                else
-                {
-                    var addCount = results.SelectMany(result => result.Added).
-                        Select(package => package.Id).Distinct().Count();
-
-                    var updateCount = results.SelectMany(result => result.Updated).
-                        Select(result => result.New.Id).Distinct().Count();
-
-                    // update packages count
-                    packageCount = addCount + updateCount;
-
-                    if (updateCount > 0)
-                    {
-                        // set operation type to update when there are packages being updated
-                        operationType = NuGetOperationType.Update;
-                    }
-                }
-
-                TelemetryUtility.StopTimer();
-
-                // Show the preview window.
-                if (uiService.DisplayPreviewWindow)
-                {
-                    var shouldContinue = uiService.PromptForPreviewAcceptance(results);
-                    if (!shouldContinue)
+                    var acceptedFormat = await CheckPackageManagementFormat(uiService, token);
+                    if (!acceptedFormat)
                     {
                         return;
                     }
-                }
-
-                TelemetryUtility.StartorResumeTimer();
-
-                // Show the license acceptance window.
-                var accepted = await CheckLicenseAcceptanceAsync(uiService, results, token);
-
-                TelemetryUtility.StartorResumeTimer();
-
-                if (!accepted)
-                {
-                    return;
-                }
-
-                // Warn about the fact that the "dotnet" TFM is deprecated.
-                if (uiService.DisplayDeprecatedFrameworkWindow)
-                {
-                    var shouldContinue = ShouldContinueDueToDotnetDeprecation(uiService, actions, token);
 
                     TelemetryUtility.StartorResumeTimer();
 
-                    if (!shouldContinue)
+                    var actions = await resolveActionsAsync();
+                    var results = GetPreviewResults(actions);
+
+                    if (operationType == NuGetOperationType.Uninstall)
+                    {
+                        packageCount = results.SelectMany(result => result.Deleted).
+                            Select(package => package.Id).Distinct().Count();
+                    }
+                    else
+                    {
+                        var addCount = results.SelectMany(result => result.Added).
+                            Select(package => package.Id).Distinct().Count();
+
+                        var updateCount = results.SelectMany(result => result.Updated).
+                            Select(result => result.New.Id).Distinct().Count();
+
+                        // update packages count
+                        packageCount = addCount + updateCount;
+
+                        if (updateCount > 0)
+                        {
+                            // set operation type to update when there are packages being updated
+                            operationType = NuGetOperationType.Update;
+                        }
+                    }
+
+                    TelemetryUtility.StopTimer();
+
+                    // Show the preview window.
+                    if (uiService.DisplayPreviewWindow)
+                    {
+                        var shouldContinue = uiService.PromptForPreviewAcceptance(results);
+                        if (!shouldContinue)
+                        {
+                            return;
+                        }
+                    }
+
+                    TelemetryUtility.StartorResumeTimer();
+
+                    // Show the license acceptance window.
+                    var accepted = await CheckLicenseAcceptanceAsync(uiService, results, token);
+
+                    TelemetryUtility.StartorResumeTimer();
+
+                    if (!accepted)
                     {
                         return;
                     }
-                }
 
-                if (!token.IsCancellationRequested)
-                {
-                    // execute the actions
-                    await executeActionsAsync(actions);
+                    // Warn about the fact that the "dotnet" TFM is deprecated.
+                    if (uiService.DisplayDeprecatedFrameworkWindow)
+                    {
+                        var shouldContinue = ShouldContinueDueToDotnetDeprecation(uiService, actions, token);
 
-                    // fires ActionsExecuted event to update the UI
-                    uiService.OnActionsExecuted(actions);
+                        TelemetryUtility.StartorResumeTimer();
+
+                        if (!shouldContinue)
+                        {
+                            return;
+                        }
+                    }
+
+                    if (!token.IsCancellationRequested)
+                    {
+                        // execute the actions
+                        await executeActionsAsync(actions);
+
+                        // fires ActionsExecuted event to update the UI
+                        uiService.OnActionsExecuted(actions);
+                    }
                 }
-            }
-            catch (System.Net.Http.HttpRequestException ex)
-            {
-                status = NuGetOperationStatus.Failed;
-                if (ex.InnerException != null)
+                catch (System.Net.Http.HttpRequestException ex)
                 {
-                    uiService.ShowError(ex.InnerException);
+                    status = NuGetOperationStatus.Failed;
+                    if (ex.InnerException != null)
+                    {
+                        uiService.ShowError(ex.InnerException);
+                    }
+                    else
+                    {
+                        uiService.ShowError(ex);
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
+                    status = NuGetOperationStatus.Failed;
                     uiService.ShowError(ex);
                 }
-            }
-            catch (Exception ex)
-            {
-                status = NuGetOperationStatus.Failed;
-                uiService.ShowError(ex);
-            }
-            finally
-            {
-                lck.Dispose();
+                finally
+                {
+                    TelemetryUtility.StopTimer();
 
-                TelemetryUtility.StopTimer();
+                    var duration = TelemetryUtility.GetTimerElapsedTime();
 
-                var duration = TelemetryUtility.GetTimerElapsedTime();
+                    uiService.ProjectContext.Log(MessageLevel.Info,
+                        string.Format(CultureInfo.CurrentCulture, Resources.Operation_TotalTime, duration));
 
-                uiService.ProjectContext.Log(MessageLevel.Info,
-                    string.Format(CultureInfo.CurrentCulture, Resources.Operation_TotalTime, duration));
+                    uiService.EndOperation();
 
-                uiService.EndOperation();
+                    var actionTelemetryEvent = TelemetryUtility.GetActionTelemetryEvent(
+                        uiService.Projects,
+                        operationType,
+                        OperationSource.UI,
+                        startTime,
+                        status,
+                        packageCount,
+                        duration.TotalSeconds);
 
-                var actionTelemetryEvent = TelemetryUtility.GetActionTelemetryEvent(
-                    uiService.Projects,
-                    operationType,
-                    OperationSource.UI,
-                    startTime,
-                    status,
-                    packageCount,
-                    duration.TotalSeconds);
-
-                ActionsTelemetryService.Instance.EmitActionEvent(actionTelemetryEvent, telemetryService.TelemetryEvents);
-            }
+                    ActionsTelemetryService.Instance.EmitActionEvent(actionTelemetryEvent, telemetryService.TelemetryEvents);
+                }
+            }, token);
         }
 
         private async Task<bool> CheckPackageManagementFormat(INuGetUI uiService, CancellationToken token)

--- a/src/NuGet.Clients/PackageManagement.UI/Services/INuGetLockService.cs
+++ b/src/NuGet.Clients/PackageManagement.UI/Services/INuGetLockService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace NuGet.PackageManagement.UI
 {
@@ -17,16 +18,20 @@ namespace NuGet.PackageManagement.UI
         bool IsLockHeld { get; }
 
         /// <summary>
-        /// Obtains a lock, asynchronously awaiting for the lock if it is not immediately awailable.
+        /// Obtains NuGet specific lock and execute action.
         /// </summary>
-        /// <param name="token">A token whose cancellation indicates lost interest in obtaining the lock.</param>
-        /// <returns>An awaitable object whose result is the lock releaser.</returns>
-        IAsyncLockAwaitable AcquireLockAsync(CancellationToken token);
+        /// <param name="action">NuGet action to be executed</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Awaitable Task</returns>
+        Task ExecuteNuGetOperationAsync(Func<Task> action, CancellationToken token);
 
         /// <summary>
-        /// Obtains a lock in synchronous/blocking manner.
+        /// Obtains NuGet specific lock and execute action. And return an awaitable task of T.
         /// </summary>
-        /// <returns>A disposable object that will release the lock on disposed event.</returns>
-        IDisposable AcquireLock();
+        /// <typeparam name="T">Return type template</typeparam>
+        /// <param name="action">NuGet action to be executed</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Awaitable Task with T</returns>
+        Task<T> ExecuteNuGetOperationAsync<T>(Func<Task<T>> action, CancellationToken token);
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Services/NuGetLockServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/Services/NuGetLockServiceTests.cs
@@ -53,62 +53,59 @@ namespace NuGet.PackageManagement.UI.Test
         }
 
         [Fact]
-        public void AcquireLock_ObtainsLock()
+        public async Task ExecuteNuGetOperationAsync()
         {
-            var releaser = _lockService.AcquireLock();
+            var isLockHeld = await _lockService.ExecuteNuGetOperationAsync(() =>
+            {
+                return Task.FromResult(_lockService.IsLockHeld);
+            }, _cts.Token);
 
-            Assert.True(_lockService.IsLockHeld);
-        }
-
-        [Fact]
-        public void Dispose_ReleasesLock()
-        {
-            var releaser = _lockService.AcquireLock();
-
-            releaser.Dispose();
-
+            Assert.True(isLockHeld);
             Assert.False(_lockService.IsLockHeld);
         }
 
         [Fact]
-        public async Task AcquireLockAsync_ObtainsLock()
+        public async Task ExecuteNuGetOperationAsync_Reentrant()
         {
-            var releaser = await _lockService.AcquireLockAsync(_cts.Token);
+            var isReentrantSuccessful = false;
 
-            Assert.True(_lockService.IsLockHeld);
-        }
+            await _lockService.ExecuteNuGetOperationAsync(async () =>
+            {
+                isReentrantSuccessful = await _lockService.ExecuteNuGetOperationAsync(() =>
+                {
+                    return Task.FromResult(true);
+                }, _cts.Token);
 
-        [Fact]
-        public async Task Dispose_Async_ReleasesLock()
-        {
-            var releaser = await _lockService.AcquireLockAsync(_cts.Token);
+                return Task.FromResult(true);
+            }, _cts.Token);
 
-            releaser.Dispose();
-
+            Assert.True(isReentrantSuccessful);
             Assert.False(_lockService.IsLockHeld);
         }
 
         [Fact]
-        public async Task AcquireLockAsync_WhenCanceledBefore_Throws()
+        public async Task ExecuteNuGetOperationAsync_WhenCanceledBefore_Throws()
         {
             _cts.Cancel();
 
-            await Assert.ThrowsAsync<OperationCanceledException>(async () => await _lockService.AcquireLockAsync(_cts.Token));
+            await Assert.ThrowsAsync<SemaphoreFullException>(async () => await _lockService.ExecuteNuGetOperationAsync(() =>
+            {
+                return Task.FromResult(true);
+            }, _cts.Token));
 
             Assert.False(_lockService.IsLockHeld);
         }
 
         [Fact]
-        public async Task AcquireLockAsync_WhenCanceledAfter_Throws()
+        public async Task ExecuteNuGetOperationAsync_WhenCanceledAfter_Throws()
         {
-            using (var x = await _lockService.AcquireLockAsync(CancellationToken.None))
+            await _lockService.ExecuteNuGetOperationAsync(async () =>
             {
-                await Task.Run(async () =>
-                {
-                    _cts.CancelAfter(TimeSpan.FromSeconds(3));
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () => await _lockService.AcquireLockAsync(_cts.Token));
-                });
-            }
+                _cts.Cancel();
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                return Task.FromResult(true);
+            }, _cts.Token);
 
             Assert.False(_lockService.IsLockHeld);
         }
@@ -125,22 +122,24 @@ namespace NuGet.PackageManagement.UI.Test
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 // awaits global lock acquisition on the main thread (JTF)
-                using (var x = await _lockService.AcquireLockAsync(_cts.Token))
-                using (var resource = new ProtectedResource())
+                await _lockService.ExecuteNuGetOperationAsync(async () =>
                 {
-                    await JoinableTaskFactory.RunAsync(async () =>
+                    using (var resource = new ProtectedResource())
                     {
-                        // once lock is acquired proceeds with long running task on a pool thread.
-                        await TaskScheduler.Default;
+                        await JoinableTaskFactory.RunAsync(async () =>
+                        {
+                            // once lock is acquired proceeds with long running task on a pool thread.
+                            await TaskScheduler.Default;
 
-                        // signals the second task the lock is acquired
-                        tcs1.TrySetResult(true);
-                        // waits for the second task get started
-                        await tcs2.Task;
-                        // dealys for some extra time emulating long operation
-                        await Task.Delay(TimeSpan.FromSeconds(5));
-                    });
-                }
+                            // signals the second task the lock is acquired
+                            tcs1.TrySetResult(true);
+                            // waits for the second task get started
+                            await tcs2.Task;
+                            // dealys for some extra time emulating long operation
+                            await Task.Delay(TimeSpan.FromSeconds(5));
+                        });
+                    }
+                }, _cts.Token);
             });
 
             var jt2 = JoinableTaskFactory.RunAsync(async () =>
@@ -150,15 +149,20 @@ namespace NuGet.PackageManagement.UI.Test
 
                 await JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                var awaiter = _lockService.AcquireLockAsync(_cts.Token);
+                var awaiter = _lockService.ExecuteNuGetOperationAsync(() =>
+                {
+                    using (var resource = new ProtectedResource())
+                    {
+                        secondTaskAcquiredTheLock = true;
+                    }
+                    return Task.FromResult(true);
+
+                }, _cts.Token);
+
                 // signal the first task
                 tcs2.TrySetResult(true);
 
-                using (var x = await awaiter)
-                using (var resource = new ProtectedResource())
-                {
-                    secondTaskAcquiredTheLock = true;
-                }
+                var x = await awaiter;
             });
 
             await Task.WhenAll(jt1.Task, jt2.Task);


### PR DESCRIPTION
Currently NuGet lock which allows only one NuGet operation like restore, install, update at one time, doesn't support reentrancy. Which is why when install package command tried to execute install.ps1 which further tried to execute uninstall command, it hanged at uninstall command to acquire NuGet lock.

So now, we're using AsyncLocal to maintain reentrancy along with SemaphoreSlim.WaitAsync. AsyncLocal represents local data for an async control flow and will allow data sharing between multiple threads with same async control. This PR also refactor NuGetLockService class and simplifies it to have single async API ExecuteNuGetOperationAsync to acquire lock and execute NuGet action asynchronously.

Fixes https://github.com/NuGet/Home/issues/4811

@rrelyea @AArnott 