### PR TITLE
Skipping UWP related dev15 E2E tests which fail on win2016 server machine

### DIFF
--- a/test/EndToEnd/tests/LegacyCsprojPackageRefTests.ps1
+++ b/test/EndToEnd/tests/LegacyCsprojPackageRefTests.ps1
@@ -1,26 +1,28 @@
-# basic create for uwp package ref based project
-function Test-UwpPackageRefClassLibraryCreate {
+## Skipping these Tests because current E2E machines (Win2016 Server) do not allow creating new UWP projects.
 
-    # Arrange & Act
-    $project = New-UwpPackageRefClassLibrary UwpLibrary1
+# # basic create for uwp package ref based project
+# function Test-UwpPackageRefClassLibraryCreate {
 
-    # Assert
-    Assert-NetCoreProjectCreation $project
-}
+#     # Arrange & Act
+#     $project = New-UwpPackageRefClassLibrary UwpLibrary1
 
-# install package test for uwp legacy csproj package ref
-function Test-UwpPackageRefClassLibInstallPackage {
+#     # Assert
+#     Assert-NetCoreProjectCreation $project
+# }
 
-    # Arrange
-    $project = New-UwpPackageRefClassLibrary UwpLibrary1
-    $id = 'Nuget.versioning'
-    $version = '3.5.0'
-    Assert-NetCoreProjectCreation $project
+# # install package test for uwp legacy csproj package ref
+# function Test-UwpPackageRefClassLibInstallPackage {
 
-    # Act
-    Install-Package $id -ProjectName $project.Name -version $version
-    $project.Save($project.FullName)
+#     # Arrange
+#     $project = New-UwpPackageRefClassLibrary UwpLibrary1
+#     $id = 'Nuget.versioning'
+#     $version = '3.5.0'
+#     Assert-NetCoreProjectCreation $project
 
-    # Assert
-    Assert-NetCorePackageInstall $project $id $version
-}
+#     # Act
+#     Install-Package $id -ProjectName $project.Name -version $version
+#     $project.Save($project.FullName)
+
+#     # Assert
+#     Assert-NetCorePackageInstall $project $id $version
+# }

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -12,39 +12,40 @@
     Assert-NotNull $installerServices
     Assert-NotNull $installerEvents
 }
+## Skipping the Test below, because current E2E machines (Win2016 Server) do not allow creating new UWP projects.
 
-function Test-MigrateVanilaUwpProjectJsonToPackageReference {
-    param(
-        $context
-    )
+# function Test-MigrateVanilaUwpProjectJsonToPackageReference {
+#     param(
+#         $context
+#     )
 
-    # Arrange
-    $p = New-UwpClassLibrary UwpClassLibrary1
-    $cm = Get-VsComponentModel
-    $projectDir = Get-ProjectDir $p
-    $result = [API.Test.InternalAPITestHook]::MigrateJsonProject($p.FullName) 
+#     # Arrange
+#     $p = New-UwpClassLibrary UwpClassLibrary1
+#     $cm = Get-VsComponentModel
+#     $projectDir = Get-ProjectDir $p
+#     $result = [API.Test.InternalAPITestHook]::MigrateJsonProject($p.FullName) 
     
-    # Assert
+#     # Assert
 
-    # Check if runtimes were migrated correctly
-    $expectRuntimeIds = 'win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot'
-    Assert-True($result.IsSuccess)
-    $actualRuntimes = Get-MsBuildPropertyValue $p 'RuntimeIdentifiers'
-    Assert-AreEqual $expectRuntimeIds $actualRuntimes
+#     # Check if runtimes were migrated correctly
+#     $expectRuntimeIds = 'win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot'
+#     Assert-True($result.IsSuccess)
+#     $actualRuntimes = Get-MsBuildPropertyValue $p 'RuntimeIdentifiers'
+#     Assert-AreEqual $expectRuntimeIds $actualRuntimes
     
-    # Check if project.json file was deleted
-    Assert-True !(Test-Path (Join-Path $projectDir project.json))
+#     # Check if project.json file was deleted
+#     Assert-True !(Test-Path (Join-Path $projectDir project.json))
     
-    # Check if backup was created
-    Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup project.json)))
-    Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup UwpClassLibrary1.csproj)))
+#     # Check if backup was created
+#     Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup project.json)))
+#     Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup UwpClassLibrary1.csproj)))
 
-    # Check if package reference was added correctly
-    $packageRefs = @(Get-MsBuildItems $p 'PackageReference')
-    Assert-AreEqual 1 $packageRefs.Count
-    Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'Microsoft.NETCore.UniversalWindowsPlatform'
-    Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '5.2.2'
-}
+#     # Check if package reference was added correctly
+#     $packageRefs = @(Get-MsBuildItems $p 'PackageReference')
+#     Assert-AreEqual 1 $packageRefs.Count
+#     Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'Microsoft.NETCore.UniversalWindowsPlatform'
+#     Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '5.2.2'
+# }
 
 function Test-VsPackageInstallerServices {
     param(


### PR DESCRIPTION
Removes 3 test failures on dev15 which cannot be run on the current machines since win2016 server does not allow creating UWP projects without Client/developer experience (which can be added during install).

I have opened another tracking issue to re enable the tests once we create new machines - https://github.com/NuGet/Home/issues/4866

//cc: @rohit21agrawal @emgarten @jainaashish 