### PR TITLE
fix pack targets to add tfm metadata to output lib files

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -18,6 +18,7 @@ namespace NuGet.Build.Tasks.Pack
         string AssemblyName { get; }
         TItem[] AssemblyReferences { get; }
         string[] Authors { get; }
+        TItem[] BuildOutputInPackage { get; }
         string BuildOutputFolder { get; }
         string[] ContentTargetFolders { get; }
         bool ContinuePackingAfterGeneratingNuspec { get; }
@@ -53,8 +54,7 @@ namespace NuGet.Build.Tasks.Pack
         TItem[] SourceFiles { get; }
         string[] Tags { get; }
         string[] TargetFrameworks { get; }
-        string[] TargetPathsToAssemblies { get; }
-        string[] TargetPathsToSymbols { get; }
+        TItem[] TargetPathsToSymbols { get; }
         string Title { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -46,6 +46,14 @@ Copyright (c) .NET Foundation. All rights reserved.
     <_TargetFrameworks Condition="'$(TargetFramework)' == ''" Include="$(TargetFrameworks.Split(';'))"/>
     <_TargetFrameworks Condition="'$(TargetFramework)' != ''" Include="$(TargetFramework)"/>
   </ItemGroup>
+  <ItemDefinitionGroup>
+    <BuildOutputInPackage>
+      <TargetFramework>$(TargetFramework)</TargetFramework>
+    </BuildOutputInPackage>
+    <TfmSpecificPackageFile>
+      <BuildAction>None</BuildAction>
+    </TfmSpecificPackageFile>
+  </ItemDefinitionGroup>
 
   <!--
     ============================================================
@@ -93,8 +101,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       <NuGetPackInput Include="$(MSBuildAllProjects)"/>
       <NuGetPackInput Include="@(_PackageFiles)"/>
       <NuGetPackInput Include="@(_PackageFilesToExclude)"/>
-      <NuGetPackInput Include="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"/>
-      <NuGetPackInput Include="@(_TargetPathsToSymbols)"/>
+      <NuGetPackInput Include="@(_BuildOutputInPackage->'%(FinalOutputPath)')"/>
+      <NuGetPackInput Include="@(_TargetPathsToSymbols->'%(FinalOutputPath)')"/>
       <NuGetPackInput Include="@(_SourceFiles)"/>
       <NuGetPackInput Include="@(_References)"/>
       <NuGetPackOutput Include="$(RestoreOutputAbsolutePath)$(PackageId).$(PackageVersion).nuspec"/>
@@ -144,7 +152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               IconUrl="$(PackageIconUrl)"
               ReleaseNotes="$(PackageReleaseNotes)"
               Tags="$(PackageTags)"
-              TargetPathsToAssemblies="@(_TargetPathsToAssemblies->'%(FinalOutputPath)')"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"
               AssemblyName="$(AssemblyName)"
@@ -193,21 +201,30 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuild
       Condition="'$(IncludeBuildOutput)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
-      Targets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;_AddPriFileToPackBuildOutput"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      Targets="_GetBuildOutputFilesWithTfm"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
 
       <Output
           TaskParameter="TargetOutputs"
-          ItemName="_TargetPathsToAssemblies" />
+          ItemName="_BuildOutputInPackage" />
     </MSBuild>
     
     <MSBuild
+      Condition="'$(TargetsForTfmSpecificContentInPackage)' != ''"
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetTfmSpecificContentForPackage"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
+      
+    <Output
+        TaskParameter="TargetOutputs"
+        ItemName="_PackageFiles"/>
+    </MSBuild>
+
+    <MSBuild
       Condition="'$(IncludeSymbols)' == 'true' OR '$(IncludeSource)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
-      Targets="DebugSymbolsProjectOutputGroup"
-      Properties="TargetFramework=%(_TargetFrameworks.Identity);
-                  BuildProjectReferences=false;">
+      Targets="_GetDebugSymbolsWithTfm"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);">
 
       <Output
           TaskParameter="TargetOutputs"
@@ -227,6 +244,32 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
   </Target>
   
+  <Target Name="_GetBuildOutputFilesWithTfm"
+          DependsOnTargets="BuiltProjectOutputGroup;DocumentationProjectOutputGroup;SatelliteDllsProjectOutputGroup;_AddPriFileToPackBuildOutput;$(TargetsForTfmSpecificBuildOutput)"
+          Returns="@(BuildOutputInPackage)">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(SatelliteDllsProjectOutputGroupOutput);
+                            @(BuiltProjectOutputGroupOutput);
+                            @(DocumentationProjectOutputGroupOutput);
+                            @(_PathToPriFile)"/>
+    </ItemGroup>
+  </Target>
+  
+  <Target Name="_GetTfmSpecificContentForPackage"
+          DependsOnTargets="$(TargetsForTfmSpecificContentInPackage)"
+          Returns="@(TfmSpecificPackageFile)">
+  </Target>
+
+  <Target Name="_GetDebugSymbolsWithTfm"
+          DependsOnTargets="DebugSymbolsProjectOutputGroup"
+          Returns="@(_TargetPathsToSymbolsWithTfm)">
+    <ItemGroup>
+      <_TargetPathsToSymbolsWithTfm Include="@(DebugSymbolsProjectOutputGroupOutput)">
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </_TargetPathsToSymbolsWithTfm>
+    </ItemGroup>
+  </Target>
+  
   <!--Projects with target framework like UWP, Win8, wpa81 produce a Pri file
     in their bin dir. This Pri file is not included in the BuiltProjectGroupOutput, and
     has to be added manually here.-->
@@ -235,6 +278,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup Condition="'$(IncludeProjectPriFile)' == 'true'">
       <_PathToPriFile Include="$(ProjectPriFullPath)">
         <FinalOutputPath>$(ProjectPriFullPath)</FinalOutputPath>
+        <TargetPath>$(ProjectPriFileName)</TargetPath>
       </_PathToPriFile>
     </ItemGroup>
   </Target>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -17,6 +17,7 @@ namespace NuGet.Build.Tasks.Pack
         public ITaskItem[] PackageFilesToExclude { get; set; }
         public string[] TargetFrameworks { get; set; }
         public string[] PackageTypes { get; set; }
+        public ITaskItem[] BuildOutputInPackage { get; set; }
         public string PackageId { get; set; }
         public string PackageVersion { get; set; }
         public string Title { get; set; }
@@ -30,8 +31,7 @@ namespace NuGet.Build.Tasks.Pack
         public string IconUrl { get; set; }
         public string[] Tags { get; set; }
         public string ReleaseNotes { get; set; }
-        public string[] TargetPathsToAssemblies { get; set; }
-        public string[] TargetPathsToSymbols { get; set; }
+        public ITaskItem[] TargetPathsToSymbols { get; set; }
         public string AssemblyName { get; set; }
         public string PackageOutputPath { get; set; }
         public bool IsTool { get; set; }
@@ -110,6 +110,7 @@ namespace NuGet.Build.Tasks.Pack
                 AssemblyName = MSBuildStringUtility.TrimAndGetNullForEmpty(AssemblyName),
                 AssemblyReferences = MSBuildUtility.WrapMSBuildItem(AssemblyReferences),
                 Authors = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Authors),
+                BuildOutputInPackage = MSBuildUtility.WrapMSBuildItem(BuildOutputInPackage),
                 BuildOutputFolder = MSBuildStringUtility.TrimAndGetNullForEmpty(BuildOutputFolder),
                 ContinuePackingAfterGeneratingNuspec = ContinuePackingAfterGeneratingNuspec,
                 ContentTargetFolders = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(ContentTargetFolders),
@@ -145,8 +146,7 @@ namespace NuGet.Build.Tasks.Pack
                 SourceFiles = MSBuildUtility.WrapMSBuildItem(SourceFiles),
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
-                TargetPathsToAssemblies = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToAssemblies),
-                TargetPathsToSymbols = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetPathsToSymbols),
+                TargetPathsToSymbols = MSBuildUtility.WrapMSBuildItem(TargetPathsToSymbols),
                 Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title),
             };
         }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -11,6 +11,7 @@ namespace NuGet.Build.Tasks.Pack
         public string AssemblyName { get; set; }
         public IMSBuildItem[] AssemblyReferences { get; set; }
         public string[] Authors { get; set; }
+        public IMSBuildItem[] BuildOutputInPackage { get; set; }
         public string BuildOutputFolder { get; set; }
         public string[] ContentTargetFolders { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
@@ -46,8 +47,7 @@ namespace NuGet.Build.Tasks.Pack
         public IMSBuildItem[] SourceFiles { get; set; }
         public string[] Tags { get; set; }
         public string[] TargetFrameworks { get; set; }
-        public string[] TargetPathsToAssemblies { get; set; }
-        public string[] TargetPathsToSymbols { get; set; }
+        public IMSBuildItem[] TargetPathsToSymbols { get; set; }
         public string Title { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.Designer.cs
@@ -78,6 +78,15 @@ namespace NuGet.Build.Tasks.Pack {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The file &apos;{0}&apos; to be packed was not found on disk..
+        /// </summary>
+        public static string Error_FileNotFound {
+            get {
+                return ResourceManager.GetString("Error_FileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to MinClientVersion string specified &apos;{0}&apos; is invalid..
         /// </summary>
         public static string InvalidMinClientVersion {
@@ -110,6 +119,15 @@ namespace NuGet.Build.Tasks.Pack {
         public static string InvalidPackageVersion {
             get {
                 return ResourceManager.GetString("InvalidPackageVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Invalid target framework for the file &apos;{0}&apos;..
+        /// </summary>
+        public static string InvalidTargetFramework {
+            get {
+                return ResourceManager.GetString("InvalidTargetFramework", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Strings.resx
@@ -125,6 +125,10 @@
     <value>The assets file produced by restore does not exist. Try restoring the project again. The expected location of the assets file is {0}.</value>
     <comment>{0} is the path to the assets file.</comment>
   </data>
+  <data name="Error_FileNotFound" xml:space="preserve">
+    <value>The file '{0}' to be packed was not found on disk.</value>
+    <comment>{0} is the file being packed.</comment>
+  </data>
   <data name="InvalidMinClientVersion" xml:space="preserve">
     <value>MinClientVersion string specified '{0}' is invalid.</value>
     <comment>{0} is the version.</comment>
@@ -139,6 +143,9 @@
   <data name="InvalidPackageVersion" xml:space="preserve">
     <value>PackageVersion string specified '{0}' is invalid.</value>
     <comment>{0} is the version.</comment>
+  </data>
+  <data name="InvalidTargetFramework" xml:space="preserve">
+    <value>Invalid target framework for the file '{0}'.</value>
   </data>
   <data name="NoPackItemProvided" xml:space="preserve">
     <value>No project was provided to the PackTask.</value>

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -9,12 +9,11 @@ namespace NuGet.Commands
 {
     public class MSBuildPackTargetArgs
     {
-        public string[] TargetPathsToSymbols { get; set; }
-        public string[] TargetPathsToAssemblies { get; set; }
+        public IEnumerable<OutputLibFile> TargetPathsToSymbols { get; set; } 
+        public IEnumerable<OutputLibFile> TargetPathsToAssemblies { get; set; }
         public string AssemblyName { get; set; }
         public string NuspecOutputPath { get; set; }
-        public IEnumerable<ProjectToProjectReference>  ProjectReferences { get; set; }
-        public Dictionary<string, HashSet<ContentMetadata>> ContentFiles { get; set; }
+        public Dictionary<string, IEnumerable<ContentMetadata>> ContentFiles { get; set; }
         public ISet<NuGetFramework> TargetFrameworks { get; set; }
         public IDictionary<string, string> SourceFiles { get; set; }
         public bool IncludeBuildOutput { get; set; }
@@ -23,14 +22,28 @@ namespace NuGet.Commands
 
         public MSBuildPackTargetArgs()
         {
-            ProjectReferences = new List<ProjectToProjectReference>();
             SourceFiles = new Dictionary<string, string>();
+            TargetPathsToAssemblies = new List<OutputLibFile>();
+            TargetPathsToSymbols = new List<OutputLibFile>();
         }
     }
 
-    public struct ProjectToProjectReference
+    public struct OutputLibFile
     {
-        public string AssemblyName { get; set; }
+        /// <summary>
+        /// This is the final output path of the assembly on disk as set by msbuild.
+        /// </summary>
+        public string FinalOutputPath { get; set; }
+        
+        /// <summary>
+        /// This denotes the TargetPath as set by msbuild. Usually this is just the file name, but for satellite DLLs,
+        /// this is Culture\filename.
+        ///  </summary>
         public string TargetPath { get; set; }
+        
+        /// <summary>
+        /// This is the target framework for which this assembly was built.
+        /// </summary>
+        public string TargetFramework { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Test.Utility/SimpleTestSetup/ProjectFileUtils.cs
@@ -84,6 +84,12 @@ namespace NuGet.Test.Utility
             }
         }
 
+        public static void AddCustomXmlToProjectRoot(XDocument doc, string xml)
+        {
+            var element = XElement.Parse(xml);
+            doc.Root.Add(element);
+        }
+
         public static void SetTargetFrameworkForProject(XDocument doc, string targetFrameworkPropertyName, string targetFrameworkValue)
         {
             var existingFrameworkProperty = "TargetFramework";

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -86,7 +86,7 @@ namespace Dotnet.Integration.Test
         {
             var result = CommandRunner.Run(TestDotnetCli,
                 workingDirectory,
-                $"pack {projectName}.csproj {args} /p:AppendRuntimeIdentifierToOutputPath=false",
+                $"pack {projectName}.csproj {args} ",
                 waitForExit: true);
             Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.Item3}");
             Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.Item3}");

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Integration.Test
     [Collection("Dotnet Integration Tests")]
     public class PackCommandTests
     {
-        MsbuilldIntegrationTestFixture msbuildFixture;
+        private MsbuilldIntegrationTestFixture msbuildFixture;
 
         public PackCommandTests(MsbuilldIntegrationTestFixture fixture)
         {
@@ -62,14 +62,74 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     Assert.Equal(1, libItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
-                    Assert.Equal(new[] { "lib/netstandard1.4/ClassLibrary1.dll" }, libItems[0].Items);
+                    Assert.Equal(new[] {"lib/netstandard1.4/ClassLibrary1.dll"}, libItems[0].Items);
+                }
+
+            }
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PackCommand_PackConsoleAppWithRID_NupkgValid(bool includeSymbols)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ConsoleApp1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                // Act
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " console");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.AddProperty(xml, "RuntimeIdentifier", "win7-x64");
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                var args = includeSymbols ? $"-o {workingDirectory} --include-symbols" : $"-o {workingDirectory}";
+                msbuildFixture.PackProject(workingDirectory, projectName, args);
+
+                var nupkgPath = includeSymbols
+                    ? Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg")
+                    : Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    // Validate the assets.
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(1, libItems.Count);
+                    Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp11, libItems[0].TargetFramework);
+                    if (includeSymbols)
+                    {
+                        Assert.Equal(new[]
+                        {
+                            "lib/netcoreapp1.1/ConsoleApp1.dll",
+                            "lib/netcoreapp1.1/ConsoleApp1.pdb",
+                            "lib/netcoreapp1.1/ConsoleApp1.runtimeconfig.json"
+                        }, libItems[0].Items);
+                    }
+                    else
+                    {
+                        Assert.Equal(
+                            new[]
+                            {"lib/netcoreapp1.1/ConsoleApp1.dll", "lib/netcoreapp1.1/ConsoleApp1.runtimeconfig.json"},
+                            libItems[0].Items);
+                    }
                 }
 
             }
@@ -93,31 +153,30 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFrameworks", "netcoreapp1.0;net45");
                     ProjectFileUtils.AddProperty(xml, "RuntimeIdentifier", "win7-x64");
 
-                    var attributes = new Dictionary<string,string>();
+                    var attributes = new Dictionary<string, string>();
 
                     attributes["Version"] = "1.0.1";
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "PackageReference",
-                            "Microsoft.NETCore.App",
-                            "netcoreapp1.0",
-                            new Dictionary<string, string>(),
-                            attributes);
+                        xml,
+                        "PackageReference",
+                        "Microsoft.NETCore.App",
+                        "netcoreapp1.0",
+                        new Dictionary<string, string>(),
+                        attributes);
 
                     attributes["Version"] = "9.0.1";
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "PackageReference",
-                            "Newtonsoft.Json",
-                            "net45",
-                            new Dictionary<string, string>(),
-                            attributes);
+                        xml,
+                        "PackageReference",
+                        "Newtonsoft.Json",
+                        "net45",
+                        new Dictionary<string, string>(),
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
-                // This is a hack to make restore work with <TargetFrameworks> . Once we update the CLI_TEST in our repo, we can remove this.
-                msbuildFixture.RestoreProject(workingDirectory, projectName, "/p:RestoreProjectStyle=PackageReference");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
                 // Act
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
@@ -133,22 +192,22 @@ namespace Dotnet.Integration.Test
                     var nuspecReader = nupkgReader.NuspecReader;
 
                     var dependencyGroups = nuspecReader
-                    .GetDependencyGroups()
-                    .OrderBy(x => x.TargetFramework,
-                                    new NuGetFrameworkSorter())
-                    .ToList();
+                        .GetDependencyGroups()
+                        .OrderBy(x => x.TargetFramework,
+                            new NuGetFrameworkSorter())
+                        .ToList();
 
                     Assert.Equal(2,
-                                    dependencyGroups.Count);
+                        dependencyGroups.Count);
 
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp10,
-                                    dependencyGroups[0].TargetFramework);
+                        dependencyGroups[0].TargetFramework);
                     var packagesA = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(1,
-                                    packagesA.Count);
+                        packagesA.Count);
                     Assert.Equal("Microsoft.NETCore.App", packagesA[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.0.1")), packagesA[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers","Build"}, packagesA[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packagesA[0].Exclude);
                     Assert.Empty(packagesA[0].Include);
 
                     Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, dependencyGroups[1].TargetFramework);
@@ -156,7 +215,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, packagesB.Count);
                     Assert.Equal("Newtonsoft.Json", packagesB[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("9.0.1")), packagesB[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packagesB[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packagesB[0].Exclude);
                     Assert.Empty(packagesB[0].Include);
 
                     // Validate the assets.
@@ -164,27 +223,31 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(2, libItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetCoreApp10, libItems[0].TargetFramework);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.Net45, libItems[1].TargetFramework);
-                    Assert.Equal(new[] { "lib/netcoreapp1.0/ClassLibrary1.dll", "lib/netcoreapp1.0/ClassLibrary1.runtimeconfig.json" }, libItems[0].Items);
-                    Assert.Equal(new[] { "lib/net45/ClassLibrary1.exe", "lib/net45/ClassLibrary1.runtimeconfig.json" }, libItems[1].Items);
+                    Assert.Equal(
+                        new[]
+                        {"lib/netcoreapp1.0/ClassLibrary1.dll", "lib/netcoreapp1.0/ClassLibrary1.runtimeconfig.json"},
+                        libItems[0].Items);
+                    Assert.Equal(new[] {"lib/net45/ClassLibrary1.exe", "lib/net45/ClassLibrary1.runtimeconfig.json"},
+                        libItems[1].Items);
                 }
             }
         }
 
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData(null,                null,               null,               true,               "",                                                "Analyzers,Build")]
-        [InlineData(null,               "Native",            null,               true,               "",                                                "Analyzers,Build,Native")]
-        [InlineData("Compile",           null,               null,               true,               "",                                                "Analyzers,Build,Native,Runtime")]
-        [InlineData("Compile;Runtime",   null,               null,               true,               "",                                                "Analyzers,Build,Native")]
-        [InlineData("All",               null,               "None",             true,               "All",                                             "")]
-        [InlineData("All",               null,               "Compile",          true,               "Analyzers,Build,ContentFiles,Native,Runtime",     "")]
-        [InlineData("All",               null,               "Compile;Build",    true,               "Analyzers,ContentFiles,Native,Runtime",           "")]
-        [InlineData("All",               "Native",           "Compile;Build",    true,               "Analyzers,ContentFiles,Runtime",                  "")]
-        [InlineData("All",               "Native",           "Native;Build",     true,               "Analyzers,Compile,ContentFiles,Runtime",          "")]
-        [InlineData("Compile",           "Native",           "Native;Build",     true,               "",                                                "Analyzers,Build,Native,Runtime")]
-        [InlineData("All",               "All",              null,               false,              null,                                               null)]
-        [InlineData("Compile;Runtime",   "All",              null,               false,              null,                                               null)]
-        [InlineData(null,                null,               "All",              false,              null,                                               null)]
+        [InlineData(null, null, null, true, "", "Analyzers,Build")]
+        [InlineData(null, "Native", null, true, "", "Analyzers,Build,Native")]
+        [InlineData("Compile", null, null, true, "", "Analyzers,Build,Native,Runtime")]
+        [InlineData("Compile;Runtime", null, null, true, "", "Analyzers,Build,Native")]
+        [InlineData("All", null, "None", true, "All", "")]
+        [InlineData("All", null, "Compile", true, "Analyzers,Build,ContentFiles,Native,Runtime", "")]
+        [InlineData("All", null, "Compile;Build", true, "Analyzers,ContentFiles,Native,Runtime", "")]
+        [InlineData("All", "Native", "Compile;Build", true, "Analyzers,ContentFiles,Runtime", "")]
+        [InlineData("All", "Native", "Native;Build", true, "Analyzers,Compile,ContentFiles,Runtime", "")]
+        [InlineData("Compile", "Native", "Native;Build", true, "", "Analyzers,Build,Native,Runtime")]
+        [InlineData("All", "All", null, false, null, null)]
+        [InlineData("Compile;Runtime", "All", null, false, null, null)]
+        [InlineData(null, null, "All", false, null, null)]
         public void PackCommand_SupportsIncludeExcludePrivateAssets_OnPackages(
             string includeAssets,
             string excludeAssets,
@@ -224,12 +287,12 @@ namespace Dotnet.Integration.Test
                     }
 
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "PackageReference",
-                            "Newtonsoft.Json",
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "PackageReference",
+                        "Newtonsoft.Json",
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -289,15 +352,15 @@ namespace Dotnet.Integration.Test
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
 
                     var attributes = new Dictionary<string, string>();
-                    
+
                     var properties = new Dictionary<string, string>();
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "ProjectReference",
-                            @"..\ClassLibrary2\ClassLibrary2.csproj",
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "ProjectReference",
+                        @"..\ClassLibrary2\ClassLibrary2.csproj",
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -318,34 +381,37 @@ namespace Dotnet.Integration.Test
                     var nuspecReader = nupkgReader.NuspecReader;
 
                     var dependencyGroups = nuspecReader
-                    .GetDependencyGroups()
-                    .OrderBy(x => x.TargetFramework,
-                                    new NuGetFrameworkSorter())
-                    .ToList();
+                        .GetDependencyGroups()
+                        .OrderBy(x => x.TargetFramework,
+                            new NuGetFrameworkSorter())
+                        .ToList();
 
                     Assert.Equal(1,
-                                    dependencyGroups.Count);
+                        dependencyGroups.Count);
 
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14,
-                                    dependencyGroups[0].TargetFramework);
+                        dependencyGroups[0].TargetFramework);
                     var packagesA = dependencyGroups[0].Packages.ToList();
                     Assert.Equal(2,
-                                    packagesA.Count);
+                        packagesA.Count);
                     Assert.Equal("NETStandard.Library", packagesA[1].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packagesA[1].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packagesA[1].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packagesA[1].Exclude);
                     Assert.Empty(packagesA[1].Include);
-                    
+
                     Assert.Equal("ClassLibrary2", packagesA[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.0.0")), packagesA[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packagesA[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packagesA[0].Exclude);
                     Assert.Empty(packagesA[0].Include);
 
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     Assert.Equal(1, libItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
-                    Assert.Equal(new[] { "lib/netstandard1.4/ClassLibrary1.dll", "lib/netstandard1.4/ClassLibrary1.runtimeconfig.json" }, libItems[0].Items);
+                    Assert.Equal(
+                        new[]
+                        {"lib/netstandard1.4/ClassLibrary1.dll", "lib/netstandard1.4/ClassLibrary1.runtimeconfig.json"},
+                        libItems[0].Items);
                 }
             }
         }
@@ -377,7 +443,8 @@ namespace Dotnet.Integration.Test
                 File.WriteAllText(Path.Combine(workingDirectory, "input.nuspec"), nuspecFileContent);
                 File.WriteAllText(Path.Combine(workingDirectory, "abc.txt"), "sample text");
 
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:NuspecFile=input.nuspec");
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"-o {workingDirectory} /p:NuspecFile=input.nuspec");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"PackedFromNuspec.1.2.1.nupkg");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
@@ -393,7 +460,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal("NuGet", nuspecReader.GetOwners());
                     Assert.Equal("This was packed from nuspec", nuspecReader.GetDescription());
                     Assert.False(nuspecReader.GetRequireLicenseAcceptance());
-                    
+
                     // Validate the assets.
                     var libItems = nupkgReader.GetFiles("CoreCLR").ToArray();
                     Assert.Equal("CoreCLR/abc.txt", libItems[0]);
@@ -405,11 +472,14 @@ namespace Dotnet.Integration.Test
         [Platform(Platform.Windows)]
         [Theory]
         // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello world"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello world\"\\\"", "MyPackage", "1.2.3", "hello world")]
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello world\"\\\"", "MyPackage",
+            "1.2.3", "hello world")]
         // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello = world"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world\"\\\"", "MyPackage", "1.2.3", "hello = world")]
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world\"\\\"", "MyPackage",
+            "1.2.3", "hello = world")]
         // Command line : /p:NuspecProperties=\"id=MyPackage;version=1.2.3;description="hello = world with a %3B"\"
-        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world with a %3B\"\\\"", "MyPackage", "1.2.3", "hello = world with a ;")]
+        [InlineData("/p:NuspecProperties=\\\"id=MyPackage;version=1.2.3;description=\"hello = world with a %3B\"\\\"",
+            "MyPackage", "1.2.3", "hello = world with a ;")]
         public void PackCommand_PackProject_PacksFromNuspecWithTokenSubstitution(
             string nuspecProperties,
             string expectedId,
@@ -440,7 +510,8 @@ namespace Dotnet.Integration.Test
                 File.WriteAllText(Path.Combine(workingDirectory, "input.nuspec"), nuspecFileContent);
                 File.WriteAllText(Path.Combine(workingDirectory, "abc.txt"), "sample text");
 
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:NuspecFile=input.nuspec " + nuspecProperties);
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"-o {workingDirectory} /p:NuspecFile=input.nuspec " + nuspecProperties);
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{expectedId}.{expectedVersion}.nupkg");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
@@ -482,7 +553,7 @@ namespace Dotnet.Integration.Test
     <file src=""abc.txt"" target=""CoreCLR/"" />
   </files>
 </package>";
-            using(var basePathDirectory = TestDirectory.Create())
+            using (var basePathDirectory = TestDirectory.Create())
             using (var testDirectory = TestDirectory.Create())
             {
                 var projectName = "ClassLibrary1";
@@ -493,7 +564,8 @@ namespace Dotnet.Integration.Test
                 File.WriteAllText(Path.Combine(workingDirectory, "input.nuspec"), nuspecFileContent);
                 File.WriteAllText(Path.Combine(basePathDirectory, "abc.txt"), "sample text");
 
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:NuspecFile=input.nuspec /p:NuspecBasePath={basePathDirectory.Path}");
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"-o {workingDirectory} /p:NuspecFile=input.nuspec /p:NuspecBasePath={basePathDirectory.Path}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"PackedFromNuspec.1.2.1.nupkg");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
@@ -510,58 +582,61 @@ namespace Dotnet.Integration.Test
 
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData("abc.txt",                  null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("folderA/abc.txt",          null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  null,                                       "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
-        [InlineData("../abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt",                  "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt")]
-        [InlineData("abc.txt",                  "",                                         "abc.txt")]
-        [InlineData("abc.txt",                  "/",                                        "abc.txt")]
-        [InlineData("abc.txt",                  "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt")]
-        [InlineData("folderA/abc.txt",          "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "",                                         "abc.txt")]
-        [InlineData("folderA/abc.txt",          "/",                                        "abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA/xyz.txt",                          "folderA/xyz.txt")]
-        [InlineData("C:/abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt")]
-        [InlineData("C:/abc.txt",               "",                                         "abc.txt")]
-        [InlineData("C:/abc.txt",               "/",                                        "abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        [InlineData("../abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("../abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt")]
-        [InlineData("../abc.txt",               "",                                         "abc.txt")]
-        [InlineData("../abc.txt",               "/",                                        "abc.txt")]
-        [InlineData("../abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("folderA/abc.txt", null, "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", null,
+            "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt", "folderA/", "folderA/abc.txt")]
+        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("abc.txt", "", "abc.txt")]
+        [InlineData("abc.txt", "/", "abc.txt")]
+        [InlineData("abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("folderA/abc.txt", "folderA/", "folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "", "abc.txt")]
+        [InlineData("folderA/abc.txt", "/", "abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("C:/abc.txt", "folderA/", "folderA/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("C:/abc.txt", "", "abc.txt")]
+        [InlineData("C:/abc.txt", "/", "abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("../abc.txt", "folderA/", "folderA/abc.txt")]
+        [InlineData("../abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("../abc.txt", "", "abc.txt")]
+        [InlineData("../abc.txt", "/", "abc.txt")]
+        [InlineData("../abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         // ## is a special syntax specifically for this test which means that ## should be replaced by the absolute path to the project directory.
-        [InlineData("##/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("##/../abc.txt",            null,                                       "content/abc.txt")]
-        [InlineData("##/abc.txt",               "",                                         "abc.txt")]
-        [InlineData("##/abc.txt",               "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
-        [InlineData("##/../abc.txt",            "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
-        
-        public void PackCommand_PackProject_PackagePathPacksContentCorrectly(string sourcePath, string packagePath, string expectedTargetPaths)
+        [InlineData("##/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/folderA/abc.txt", null,
+            "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("##/../abc.txt", null, "content/abc.txt")]
+        [InlineData("##/abc.txt", "", "abc.txt")]
+        [InlineData("##/abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/folderA/abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/../abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+
+        public void PackCommand_PackProject_PackagePathPacksContentCorrectly(string sourcePath, string packagePath,
+            string expectedTargetPaths)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -595,12 +670,12 @@ namespace Dotnet.Integration.Test
                         properties["PackagePath"] = packagePath;
                     }
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "Content",
-                            sourcePath,
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "Content",
+                        sourcePath,
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -637,15 +712,16 @@ namespace Dotnet.Integration.Test
 
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData(null,           null,           null,           "1.0.0")]
-        [InlineData("1.2.3",        null,           null,           "1.2.3")]
-        [InlineData(null,           "rtm-1234",     null,           "1.0.0-rtm-1234")]
-        [InlineData("1.2.3",        "rtm-1234",     null,           "1.2.3-rtm-1234")]
-        [InlineData(null,           null,           "2.3.1",        "2.3.1")]
-        [InlineData("1.2.3",        null,           "2.3.1",        "2.3.1")]
-        [InlineData(null,           "rtm-1234",     "2.3.1",        "2.3.1")]
-        [InlineData("1.2.3",        "rtm-1234",     "2.3.1",        "2.3.1")]
-        public void PackCommand_PackProject_OutputsCorrectVersion(string versionPrefix, string versionSuffix, string packageVersion, string expectedVersion)
+        [InlineData(null, null, null, "1.0.0")]
+        [InlineData("1.2.3", null, null, "1.2.3")]
+        [InlineData(null, "rtm-1234", null, "1.0.0-rtm-1234")]
+        [InlineData("1.2.3", "rtm-1234", null, "1.2.3-rtm-1234")]
+        [InlineData(null, null, "2.3.1", "2.3.1")]
+        [InlineData("1.2.3", null, "2.3.1", "2.3.1")]
+        [InlineData(null, "rtm-1234", "2.3.1", "2.3.1")]
+        [InlineData("1.2.3", "rtm-1234", "2.3.1", "2.3.1")]
+        public void PackCommand_PackProject_OutputsCorrectVersion(string versionPrefix, string versionSuffix,
+            string packageVersion, string expectedVersion)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -660,16 +736,16 @@ namespace Dotnet.Integration.Test
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
-                    
+
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
 
-                var args = "" + 
-                    (versionPrefix  !=null  ? $" /p:VersionPrefix={versionPrefix} "   : string.Empty) +
-                    (versionSuffix  != null ? $" /p:VersionSuffix={versionSuffix} "   : string.Empty) + 
-                    (packageVersion != null ? $" /p:PackageVersion={packageVersion} " : string.Empty);
+                var args = "" +
+                           (versionPrefix != null ? $" /p:VersionPrefix={versionPrefix} " : string.Empty) +
+                           (versionSuffix != null ? $" /p:VersionSuffix={versionSuffix} " : string.Empty) +
+                           (packageVersion != null ? $" /p:PackageVersion={packageVersion} " : string.Empty);
                 // Act
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} {args}");
 
@@ -691,55 +767,56 @@ namespace Dotnet.Integration.Test
 
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData("abc.txt",                  null,                                       "any/netstandard1.4/abc.txt")]
-        [InlineData("folderA/abc.txt",          null,                                       "any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  null,                                       "any/netstandard1.4/folderA/folderB/abc.txt")]
-        [InlineData("../abc.txt",               null,                                       "any/netstandard1.4/abc.txt")]
-        [InlineData("##/abc.txt",               null,                                       "any/netstandard1.4/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       null,                                       "any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("##/../abc.txt",            null,                                       "any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt",                  "contentFiles",                             "abc.txt")]
-        [InlineData("folderA/abc.txt",          "contentFiles",                             "abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  "contentFiles",                             "abc.txt")]
-        [InlineData("../abc.txt",               "contentFiles",                             "abc.txt")]
-        [InlineData("##/abc.txt",               "contentFiles",                             "abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "contentFiles",                             "abc.txt")]
-        [InlineData("##/../abc.txt",            "contentFiles",                             "abc.txt")]
-        [InlineData("abc.txt",                  "contentFiles\\",                           "abc.txt")]
-        [InlineData("folderA/abc.txt",          "contentFiles\\",                           "abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  "contentFiles\\",                           "abc.txt")]
-        [InlineData("../abc.txt",               "contentFiles\\",                           "abc.txt")]
-        [InlineData("##/abc.txt",               "contentFiles\\",                           "abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "contentFiles\\",                           "abc.txt")]
-        [InlineData("##/../abc.txt",            "contentFiles\\",                           "abc.txt")]
-        [InlineData("abc.txt",                  "contentFiles\\",                           "abc.txt")]
-        [InlineData("folderA/abc.txt",          "contentFiles/",                            "abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  "contentFiles/",                            "abc.txt")]
-        [InlineData("../abc.txt",               "contentFiles/",                            "abc.txt")]
-        [InlineData("##/abc.txt",               "contentFiles/",                            "abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "contentFiles/",                            "abc.txt")]
-        [InlineData("##/../abc.txt",            "contentFiles/",                            "abc.txt")]
-        [InlineData("folderA/abc.txt",          "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("folderA/folderB/abc.txt",  "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("../abc.txt",               "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("##/abc.txt",               "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("##/folderA/abc.txt",       "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("##/../abc.txt",            "contentFiles/xyz.txt",                     "xyz.txt")]
-        [InlineData("abc.txt",                  "folderA",                                  null)]
-        [InlineData("folderA/abc.txt",          "folderA",                                  null)]
-        [InlineData("folderA/folderB/abc.txt",  "folderA",                                  null)]
-        [InlineData("../abc.txt",               "folderA",                                  null)]
-        [InlineData("##/abc.txt",               "folderA",                                  null)]
-        [InlineData("##/folderA/abc.txt",       "folderA",                                  null)]
-        [InlineData("##/../abc.txt",            "folderA",                                  null)]
-        [InlineData("abc.txt",                  "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("../abc.txt",               "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("##/abc.txt",               "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "contentFiles/folderA",                     "folderA/abc.txt")]
-        [InlineData("##/../abc.txt",            "contentFiles/folderA",                     "folderA/abc.txt")]
-        public void PackCommand_PackProject_OutputsContentFilesInNuspecForSingleFramework(string sourcePath, string packagePath, string expectedIncludeString)
+        [InlineData("abc.txt", null, "any/netstandard1.4/abc.txt")]
+        [InlineData("folderA/abc.txt", null, "any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", null, "any/netstandard1.4/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt", null, "any/netstandard1.4/abc.txt")]
+        [InlineData("##/abc.txt", null, "any/netstandard1.4/abc.txt")]
+        [InlineData("##/folderA/abc.txt", null, "any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("##/../abc.txt", null, "any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("folderA/abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("../abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("##/abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("##/folderA/abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("##/../abc.txt", "contentFiles", "abc.txt")]
+        [InlineData("abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("folderA/abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("../abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("##/abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("##/folderA/abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("##/../abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("abc.txt", "contentFiles\\", "abc.txt")]
+        [InlineData("folderA/abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("../abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("##/abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("##/folderA/abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("##/../abc.txt", "contentFiles/", "abc.txt")]
+        [InlineData("folderA/abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("folderA/folderB/abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("../abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("##/abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("##/folderA/abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("##/../abc.txt", "contentFiles/xyz.txt", "xyz.txt")]
+        [InlineData("abc.txt", "folderA", null)]
+        [InlineData("folderA/abc.txt", "folderA", null)]
+        [InlineData("folderA/folderB/abc.txt", "folderA", null)]
+        [InlineData("../abc.txt", "folderA", null)]
+        [InlineData("##/abc.txt", "folderA", null)]
+        [InlineData("##/folderA/abc.txt", "folderA", null)]
+        [InlineData("##/../abc.txt", "folderA", null)]
+        [InlineData("abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("../abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("##/abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("##/folderA/abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        [InlineData("##/../abc.txt", "contentFiles/folderA", "folderA/abc.txt")]
+        public void PackCommand_PackProject_OutputsContentFilesInNuspecForSingleFramework(string sourcePath,
+            string packagePath, string expectedIncludeString)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -781,12 +858,12 @@ namespace Dotnet.Integration.Test
                         properties["PackagePath"] = packagePath;
                     }
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "Content",
-                            sourcePath,
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "Content",
+                        sourcePath,
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -827,14 +904,16 @@ namespace Dotnet.Integration.Test
 
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData("abc.txt",                     "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
-        [InlineData("folderA/abc.txt",             "any/net45/folderA/abc.txt;any/netstandard1.3/folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",     "any/net45/folderA/folderB/abc.txt;any/netstandard1.3/folderA/folderB/abc.txt")]
-        [InlineData("../abc.txt",                  "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
-        [InlineData("##/abc.txt",                  "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
-        [InlineData("##/folderA/abc.txt",          "any/net45/folderA/abc.txt;any/netstandard1.3/folderA/abc.txt")]
-        [InlineData("##/../abc.txt",               "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
-        public void PackCommand_PackProject_OutputsContentFilesInNuspecForMultipleFrameworks(string sourcePath, string expectedIncludeString)
+        [InlineData("abc.txt", "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
+        [InlineData("folderA/abc.txt", "any/net45/folderA/abc.txt;any/netstandard1.3/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt",
+            "any/net45/folderA/folderB/abc.txt;any/netstandard1.3/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt", "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
+        [InlineData("##/abc.txt", "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
+        [InlineData("##/folderA/abc.txt", "any/net45/folderA/abc.txt;any/netstandard1.3/folderA/abc.txt")]
+        [InlineData("##/../abc.txt", "any/net45/abc.txt;any/netstandard1.3/abc.txt")]
+        public void PackCommand_PackProject_OutputsContentFilesInNuspecForMultipleFrameworks(string sourcePath,
+            string expectedIncludeString)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -872,12 +951,12 @@ namespace Dotnet.Integration.Test
                     var properties = new Dictionary<string, string>();
 
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "Content",
-                            sourcePath,
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "Content",
+                        sourcePath,
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -941,7 +1020,7 @@ namespace Dotnet.Integration.Test
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
                 msbuildFixture.BuildProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
-                
+
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
 
@@ -967,14 +1046,14 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
                     // Validate the assets.
                     var libItems = nupkgReader.GetLibItems().ToList();
                     Assert.Equal(1, libItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
-                    Assert.Equal(new[] { "lib/netstandard1.4/ClassLibrary1.dll" }, libItems[0].Items);
+                    Assert.Equal(new[] {"lib/netstandard1.4/ClassLibrary1.dll"}, libItems[0].Items);
                 }
 
             }
@@ -1031,7 +1110,7 @@ namespace Dotnet.Integration.Test
 
                     var dependencyGroups = nuspecReader.GetDependencyGroups().ToList();
                     Assert.Equal(count, dependencyGroups.Count);
-                    
+
                     // Validate the assets.
                     var libItems = nupkgReader.GetFiles("lib").ToList();
                     Assert.Equal(count, libItems.Count());
@@ -1056,7 +1135,8 @@ namespace Dotnet.Integration.Test
                 // Act
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:IncludeBuildOutput=false");
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"-o {workingDirectory} /p:IncludeBuildOutput=false");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
@@ -1082,7 +1162,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
                     // Validate the assets.
@@ -1106,7 +1186,8 @@ namespace Dotnet.Integration.Test
                 // Act
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory} /p:BuildOutputTargetFolder={buildOutputTargetFolder}");
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"-o {workingDirectory} /p:BuildOutputTargetFolder={buildOutputTargetFolder}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
@@ -1121,7 +1202,8 @@ namespace Dotnet.Integration.Test
                     libItems = nupkgReader.GetLibItems(buildOutputTargetFolder).ToList();
                     Assert.Equal(1, libItems.Count);
                     Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
-                    Assert.Equal(new[] { $"{buildOutputTargetFolder}/netstandard1.4/ClassLibrary1.dll" }, libItems[0].Items);
+                    Assert.Equal(new[] {$"{buildOutputTargetFolder}/netstandard1.4/ClassLibrary1.dll"},
+                        libItems[0].Items);
                 }
             }
         }
@@ -1157,7 +1239,8 @@ namespace Dotnet.Integration.Test
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
 
                 // Run the clean target
-                msbuildFixture.BuildProject(workingDirectory, projectName, $"/t:Clean /p:PackageOutputPath={workingDirectory}\\");
+                msbuildFixture.BuildProject(workingDirectory, projectName,
+                    $"/t:Clean /p:PackageOutputPath={workingDirectory}\\");
 
                 Assert.True(!File.Exists(nupkgPath), "The output .nupkg was not deleted by the Clean target");
                 Assert.True(!File.Exists(nuspecPath), "The intermediate nuspec file was not deleted by the Clean target");
@@ -1168,49 +1251,55 @@ namespace Dotnet.Integration.Test
         // TODO : Uncomment all the test cases once the above bug is fixed.
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData("abc.txt",                  null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("folderA/abc.txt",          null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt",  null,                                       "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
-        [InlineData("../abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("folderA/abc.txt", null, "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt", null,
+            "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         //[InlineData("abc.txt",                  "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
+        [InlineData("abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         //[InlineData("abc.txt",                  "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt",                  "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        [InlineData("abc.txt",                  "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
         //[InlineData("folderA/abc.txt",          "folderA/",                                 "folderA/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;folderB",                          "folderA/folderA/abc.txt;folderB/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles",                     "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles\\",                   "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;folderB", "folderA/folderA/abc.txt;folderB/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles",
+            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles\\",
+            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
         //[InlineData("folderA/abc.txt",          "folderA;contentFiles/",                    "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA;contentFiles/folderA",             "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt",          "folderA/xyz.txt",                          "folderA/xyz.txt/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA;contentFiles/folderA",
+            "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/folderA/abc.txt")]
         //[InlineData("C:/abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         //[InlineData("C:/abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("C:/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         //[InlineData("../abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("../abc.txt",               "folderA/xyz.txt",                          "folderA/xyz.txt/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;folderB",                          "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles",                     "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
+        [InlineData("../abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         //[InlineData("../abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles\\",                   "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("../abc.txt",               "folderA;contentFiles/folderA",             "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         // ## is a special syntax specifically for this test which means that ## should be replaced by the absolute path to the project directory.
-        [InlineData("##/abc.txt",               null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       null,                                       "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("##/../abc.txt",            null,                                       "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("##/abc.txt",               "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
-        [InlineData("##/folderA/abc.txt",       "folderX;folderY",                          "folderX/folderA/abc.txt;folderY/folderA/abc.txt")]
-        [InlineData("##/../abc.txt",            "folderX;folderY",                          "folderX/abc.txt;folderY/abc.txt")]
-        
-        public void PackCommand_PackProject_ContentTargetFoldersPacksContentCorrectly(string sourcePath, string contentTargetFolders, string expectedTargetPaths)
+        [InlineData("##/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/folderA/abc.txt", null,
+            "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("##/../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/folderA/abc.txt", "folderX;folderY", "folderX/folderA/abc.txt;folderY/folderA/abc.txt")]
+        [InlineData("##/../abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+
+        public void PackCommand_PackProject_ContentTargetFoldersPacksContentCorrectly(string sourcePath,
+            string contentTargetFolders, string expectedTargetPaths)
         {
             // Arrange
             using (var testDirectory = TestDirectory.Create())
@@ -1241,12 +1330,12 @@ namespace Dotnet.Integration.Test
 
                     var properties = new Dictionary<string, string>();
                     ProjectFileUtils.AddItem(
-                            xml,
-                            "Content",
-                            sourcePath,
-                            string.Empty,
-                            properties,
-                            attributes);
+                        xml,
+                        "Content",
+                        sourcePath,
+                        string.Empty,
+                        properties,
+                        attributes);
 
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
@@ -1332,7 +1421,7 @@ namespace Dotnet.Integration.Test
                     Assert.Equal(1, packages.Count);
                     Assert.Equal("NETStandard.Library", packages[0].Id);
                     Assert.Equal(new VersionRange(new NuGetVersion("1.6.1")), packages[0].VersionRange);
-                    Assert.Equal(new List<string> { "Analyzers", "Build" }, packages[0].Exclude);
+                    Assert.Equal(new List<string> {"Analyzers", "Build"}, packages[0].Exclude);
                     Assert.Empty(packages[0].Include);
 
                     // Validate title property in intermediate nuspec
@@ -1372,7 +1461,8 @@ namespace ClassLibrary
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "Utils"));
                 Directory.CreateDirectory(Path.Combine(workingDirectory, "Extensions"));
                 File.WriteAllText(Path.Combine(workingDirectory, "Utils", "Utility.cs"), utilitySrcFileContent);
-                File.WriteAllText(Path.Combine(workingDirectory, "Extensions", "ExtensionMethods.cs"), extensionSrcFileContent);
+                File.WriteAllText(Path.Combine(workingDirectory, "Extensions", "ExtensionMethods.cs"),
+                    extensionSrcFileContent);
 
                 msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
 
@@ -1380,12 +1470,13 @@ namespace ClassLibrary
                 {
                     var xml = XDocument.Load(stream);
                     ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
-                    
+
                     ProjectFileUtils.WriteXmlToFile(xml, stream);
                 }
 
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
-                msbuildFixture.PackProject(workingDirectory, projectName, $"--include-source /p:PackageOutputPath={workingDirectory}");
+                msbuildFixture.PackProject(workingDirectory, projectName,
+                    $"--include-source /p:PackageOutputPath={workingDirectory}");
 
                 var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
                 var symbolsNupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.symbols.nupkg");
@@ -1407,6 +1498,144 @@ namespace ClassLibrary
                     Assert.Contains("src/ClassLibrary1/Utils/Utility.cs", srcItems);
                 }
 
+            }
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("TargetFramework", "netstandard1.4")]
+        [InlineData("TargetFrameworks", "netstandard1.4;net46")]
+        public void PackCommand_ContentInnerTargetExtension_AddsTfmSpecificContent(string tfmProperty, string tfmValue)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                Directory.CreateDirectory(Path.Combine(workingDirectory, "Extensions"));
+                File.WriteAllText(Path.Combine(workingDirectory, "abc.txt"), "hello world");
+                File.WriteAllText(Path.Combine(workingDirectory, "Extensions", "ext.txt"), "hello world again");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var target = @"<Target Name=""CustomContentTarget"">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include=""abc.txt"">
+        <PackagePath>mycontent/$(TargetFramework)</PackagePath>
+      </TfmSpecificPackageFile>
+      <TfmSpecificPackageFile Include=""Extensions/ext.txt"" Condition=""'$(TargetFramework)' == 'net46'"">
+        <PackagePath>net46content</PackagePath>
+      </TfmSpecificPackageFile>  
+    </ItemGroup>
+  </Target>";
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
+                    ProjectFileUtils.AddProperty(xml, "TargetsForTfmSpecificContentInPackage", "CustomContentTarget");
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, target);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var files = nupkgReader.GetFiles("mycontent");
+                    var tfms = tfmValue.Split(';');
+                    Assert.Equal(tfms.Length, files.Count());
+
+                    foreach (var tfm in tfms)
+                    {
+                        Assert.Contains($"mycontent/{tfm}/abc.txt", files);
+                        var net46files = nupkgReader.GetFiles("net46content");
+                        if (tfms.Length > 1)
+                        {
+                            Assert.Equal(1, net46files.Count());
+                            Assert.Contains("net46content/ext.txt", net46files);
+                        }
+                        else
+                        {
+                            Assert.Equal(0, net46files.Count());
+                        }
+                    }
+                }
+            }
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("TargetFramework", "netstandard1.4")]
+        [InlineData("TargetFrameworks", "netstandard1.4;net46")]
+        public void PackCommand_BuildOutputInnerTargetExtension_AddsTfmSpecificBuildOuput(string tfmProperty,
+    string tfmValue)
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                Directory.CreateDirectory(workingDirectory);
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+                File.WriteAllText(Path.Combine(workingDirectory, "abc.dll"), "hello world");
+                var pathToDll = Path.Combine(workingDirectory, "abc.dll");
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var target =
+                        $@"<Target Name=""CustomBuildOutputTarget"">
+    <ItemGroup>
+      <BuildOutputInPackage Include=""abc.dll"">
+        <FinalOutputPath>{pathToDll}</FinalOutputPath>
+      </BuildOutputInPackage>
+    </ItemGroup>
+  </Target>";
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, tfmProperty, tfmValue);
+                    ProjectFileUtils.AddProperty(xml, "TargetsForTfmSpecificBuildOutput", "CustomBuildOutputTarget");
+                    ProjectFileUtils.AddCustomXmlToProjectRoot(xml, target);
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                msbuildFixture.PackProject(workingDirectory, projectName, $"/p:PackageOutputPath={workingDirectory}");
+
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var tfms = tfmValue.Split(';');
+                    // Validate the assets.
+                    var libItems = nupkgReader.GetLibItems().ToList();
+                    Assert.Equal(tfms.Length, libItems.Count);
+
+                    if (tfms.Length == 2)
+                    {
+                        Assert.Equal(FrameworkConstants.CommonFrameworks.Net46, libItems[0].TargetFramework);
+                        Assert.Equal(new[] {"lib/net46/abc.dll", "lib/net46/ClassLibrary1.dll"},
+                            libItems[0].Items);
+                        Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[1].TargetFramework);
+                        Assert.Equal(new[] { "lib/netstandard1.4/abc.dll", "lib/netstandard1.4/ClassLibrary1.dll" },
+                            libItems[1].Items);
+                    }
+                    else
+                    {
+                        Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
+                        Assert.Equal(new[] { "lib/netstandard1.4/abc.dll", "lib/netstandard1.4/ClassLibrary1.dll" },
+                            libItems[0].Items);
+                    }
+                }
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -404,7 +404,11 @@ namespace NuGet.Build.Tasks.Pack.Test
                     RestoreOutputPath = Path.Combine(testDir, "obj"),
                     ContinuePackingAfterGeneratingNuspec = true,
                     TargetFrameworks = new[] { "net45" },
-                    TargetPathsToAssemblies = new[] { dllPath },
+                    BuildOutputInPackage = new[] { new MSBuildItem(dllPath, new Dictionary<string, string>
+                    {
+                        {"FinalOutputPath", dllPath },
+                        {"TargetFramework", "net45" }
+                    })},
                     Logger = new TestLogger()
                 };
             }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -150,9 +150,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 Authors = new[] { "", "  ", " Authors \t ", null },
                 PackageTypes = new[] { "", "  ", " PackageTypes \t ", null },
                 Tags = new[] { "", "  ", " Tags \t ", null },
-                TargetFrameworks = new[] { "", "  ", " TargetFrameworks \t ", null },
-                TargetPathsToAssemblies = new[] { "", "  ", " TargetPathsToAssemblies \t ", null },
-                TargetPathsToSymbols = new[] { "", "  ", " TargetPathsToSymbols \t ", null }
+                TargetFrameworks = new[] { "", "  ", " TargetFrameworks \t ", null }
             };
 
             // Act
@@ -163,8 +161,6 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Equal(new[] { "PackageTypes" }, actual.PackageTypes);
             Assert.Equal(new[] { "Tags" }, actual.Tags);
             Assert.Equal(new[] { "TargetFrameworks" }, actual.TargetFrameworks);
-            Assert.Equal(new[] { "TargetPathsToAssemblies" }, actual.TargetPathsToAssemblies);
-            Assert.Equal(new[] { "TargetPathsToSymbols" }, actual.TargetPathsToSymbols);
         }
 
         [Theory]
@@ -237,7 +233,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 SourceFiles = null,
                 Tags = null,
                 TargetFrameworks = null,
-                TargetPathsToAssemblies = null,
+                BuildOutputInPackage = null,
                 TargetPathsToSymbols = null
             };
 
@@ -253,7 +249,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Equal(0, actual.SourceFiles.Length);
             Assert.Equal(0, actual.Tags.Length);
             Assert.Equal(0, actual.TargetFrameworks.Length);
-            Assert.Equal(0, actual.TargetPathsToAssemblies.Length);
+            Assert.Equal(0, actual.BuildOutputInPackage.Length);
             Assert.Equal(0, actual.TargetPathsToSymbols.Length);
         }
 
@@ -297,8 +293,8 @@ namespace NuGet.Build.Tasks.Pack.Test
                 SourceFiles = new ITaskItem[0],
                 Tags = new string[0],
                 TargetFrameworks = new string[0],
-                TargetPathsToAssemblies = new string[0],
-                TargetPathsToSymbols = new string[0]
+                BuildOutputInPackage = new ITaskItem[0],
+                TargetPathsToSymbols = new ITaskItem[0]
             };
 
             var settings = new JsonSerializerSettings


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4840
Fixes: https://github.com/NuGet/Home/issues/4698
Fixes: https://github.com/NuGet/Home/issues/4704

1) This is long overdue work of adding TargetFramework metadata to build items that need to go into the lib folder in the nupkg. By adding this metadata, we know precisely where in the lib folder an item will go instead of having to search for framework in the path of the file on disk.

2) This change also adds outputs from SatelliteDLLsProjectOutputGroupOutput and does the appropriate plumbing so they go under their respective culture folders.

3) An extension point has been provided for executing custom target in the inner build for files that go in the lib (or folder specified via ```BuildOutputTargetFolder```) . A user can write their own custom target and specify it as the value of the property ```$(TargetsForTfmSpecificBuildOutput)```. The target should write out any files that need to go into the ```lib``` folder into the ItemGroup ```BuildOutputInPackage``` and set the following two metadata values :
a) ```FinalOutputPath``` : This is the absolute path of the file on disk (if not provided, the Identity is used to evaluate source path)
b) ```TargetPath``` : This is optional and defaults to the name of the file. Users need to set it when the file needs to go into a subfolder within ```lib\<TFM>``` like satellite assemblies which go under their respective culture folders.

4) An extension point has been provided for files that need to go in the nupkg outside of lib folder but are still TFM specific. A user can write their own custom target and specify it as the value of the property ```$(TargetsForTfmSpecificContentInPackage)```. The target should write out any files that need to be included in the nupkg into the ItemGroup ```TfmSpecificPackageFile``` and set the following metadata:
a) ```PackagePath``` : Path where the file should be output in the package. NuGet will throw a warning if more than one file is added to the same package path. 
b) ```BuildAction```: Default value has been set to None. This is only required if the package path is in ```contentFiles``` folder.  

CC: @emgarten @alpaix @jainaashish @nkolev92 @rrelyea @mishra14 @zhili1208 

CC: @AArnott  to take a look if i covered most of his feedback in https://github.com/NuGet/Home/issues/4698

CC: @onovotny for point 3 and point 4. Would appreciate any feedback on the design.