### PR TITLE
Supporting floating version range for legacy packageReference

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/LegacyCSProjPackageReferenceProject.cs
@@ -373,7 +373,7 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 LibraryRange = new LibraryRange(
                     name: item.Name,
-                    versionRange: new VersionRange(new NuGetVersion(item.Version), originalString: item.Version),
+                    versionRange: VersionRange.Parse(item.Version),
                     typeConstraint: LibraryDependencyTarget.Package)
             };
 


### PR DESCRIPTION
Currently floating version ranges are not supported with legacy PackageReference projects, and it throw error while parsing floating range.

Fixes https://github.com/NuGet/Home/issues/4757

@rrelyea 