### PR TITLE
Fixing RPS perf issue

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/EnvDTEProjectAdapter.cs
@@ -167,7 +167,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     else
                     {
                         // Check for RestoreProjectStyle property
-                        var restoreProjectStyle = GetMSBuildProperty(AsIVsBuildPropertyStorage, RestoreProjectStyle, configName: null);
+                        var restoreProjectStyle = GetMSBuildProperty(AsIVsBuildPropertyStorage, RestoreProjectStyle);
 
                         // For legacy csproj, either the RestoreProjectStyle must be set to PackageReference or
                         // project has atleast one package dependency defined as PackageReference
@@ -398,19 +398,16 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static string GetMSBuildProperty(IVsBuildPropertyStorage buildPropertyStorage, string name)
         {
-            return GetMSBuildProperty(buildPropertyStorage, name, string.Empty);
-        }
-
-        private static string GetMSBuildProperty(IVsBuildPropertyStorage buildPropertyStorage, string name, string configName)
-        {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             string output;
+            // passing pszConfigName as null since string.Empty causes it to reevaluate
+            // for each property read.
             var result = buildPropertyStorage.GetPropertyValue(
-                name,
-                configName,
-                (uint)_PersistStorageType.PST_PROJECT_FILE,
-                out output);
+                pszPropName: name,
+                pszConfigName: null,
+                storage: (uint)_PersistStorageType.PST_PROJECT_FILE,
+                pbstrPropValue: out output);
 
             if (result != NuGetVSConstants.S_OK || string.IsNullOrWhiteSpace(output))
             {

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/VsHierarchyUtility.cs
@@ -56,10 +56,10 @@ namespace NuGet.PackageManagement.VisualStudio
             if (buildPropertyStorage != null)
             {
                 var result = buildPropertyStorage.GetPropertyValue(
-                    name,
-                    string.Empty,
-                    (uint)_PersistStorageType.PST_PROJECT_FILE,
-                    out output);
+                    pszPropName: name,
+                    pszConfigName: null,
+                    storage: (uint)_PersistStorageType.PST_PROJECT_FILE,
+                    pbstrPropValue: out output);
 
                 if (result != NuGetVSConstants.S_OK || string.IsNullOrWhiteSpace(output))
                 {


### PR DESCRIPTION
While reading MSBuild properties via IVsBuildPropertyStorage when we passed pszConfigName as empty string, it causes double reevaluation for each property read which degrade performance. So now we're passing it as NULL which is the correct way of using it and it designed to handle it.

Fixes Internal Bug 394802

@rrelyea 