### PR TITLE
Add strict version check for dependencies in NuspecReader

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -107,81 +107,15 @@ namespace NuGet.Packaging
         /// </summary>
         public IEnumerable<PackageDependencyGroup> GetDependencyGroups()
         {
-            var ns = MetadataNode.GetDefaultNamespace().NamespaceName;
+            return GetAllDependencyGroups(useStrictVersionCheck: false);
+        }
 
-            var groupFound = false;
-
-            foreach (var depGroup in MetadataNode.Elements(XName.Get(Dependencies, ns)).Elements(XName.Get(Group, ns)))
-            {
-                groupFound = true;
-
-                var groupFramework = GetAttributeValue(depGroup, TargetFramework);
-
-                var packages = new HashSet<PackageDependency>();
-
-                foreach (var depNode in depGroup.Elements(XName.Get(Dependency, ns)))
-                {
-                    VersionRange range = null;
-
-                    var rangeNode = GetAttributeValue(depNode, Version);
-
-                    if (!String.IsNullOrEmpty(rangeNode))
-                    {
-                        VersionRange.TryParse(rangeNode, out range);
-
-                        Debug.Assert(range != null, "Unable to parse range: " + rangeNode);
-                    }
-
-                    var includeFlags = GetFlags(GetAttributeValue(depNode, IncludeFlags));
-                    var excludeFlags = GetFlags(GetAttributeValue(depNode, ExcludeFlags));
-
-                    var dependency = new PackageDependency(
-                        GetAttributeValue(depNode, Id), 
-                        range,
-                        includeFlags,
-                        excludeFlags);
-
-                    packages.Add(dependency);
-                }
-
-                var framework = String.IsNullOrEmpty(groupFramework) 
-                    ? NuGetFramework.AnyFramework 
-                    : NuGetFramework.Parse(groupFramework, _frameworkProvider);
-
-                yield return new PackageDependencyGroup(framework, packages);
-            }
-
-            // legacy behavior
-            if (!groupFound)
-            {
-                var depNodes = MetadataNode.Elements(XName.Get(Dependencies, ns))
-                    .Elements(XName.Get(Dependency, ns));
-
-                var packages = new HashSet<PackageDependency>();
-
-                foreach (var depNode in depNodes)
-                {
-                    VersionRange range = null;
-
-                    var rangeNode = GetAttributeValue(depNode, Version);
-
-                    if (!String.IsNullOrEmpty(rangeNode))
-                    {
-                        VersionRange.TryParse(rangeNode, out range);
-
-                        Debug.Assert(range != null, "Unable to parse range: " + rangeNode);
-                    }
-
-                    packages.Add(new PackageDependency(GetAttributeValue(depNode, Id), range));
-                }
-
-                if (packages.Any())
-                {
-                    yield return new PackageDependencyGroup(NuGetFramework.AnyFramework, packages);
-                }
-            }
-
-            yield break;
+        /// <summary>
+        /// Read package dependencies for all frameworks
+        /// </summary>
+        public IEnumerable<PackageDependencyGroup> GetDependencyGroups(bool useStrictVersionCheck)
+        {
+            return GetAllDependencyGroups(useStrictVersionCheck);
         }
 
         /// <summary>
@@ -199,9 +133,9 @@ namespace NuGet.Packaging
 
                 var groupFramework = GetAttributeValue(group, TargetFramework);
 
-                var items = group.Elements(XName.Get(Reference, ns)).Select(n => GetAttributeValue(n, File)).Where(n => !String.IsNullOrEmpty(n)).ToArray();
+                var items = group.Elements(XName.Get(Reference, ns)).Select(n => GetAttributeValue(n, File)).Where(n => !string.IsNullOrEmpty(n)).ToArray();
 
-                var framework = String.IsNullOrEmpty(groupFramework) ? NuGetFramework.AnyFramework : NuGetFramework.Parse(groupFramework, _frameworkProvider);
+                var framework = string.IsNullOrEmpty(groupFramework) ? NuGetFramework.AnyFramework : NuGetFramework.Parse(groupFramework, _frameworkProvider);
 
                 yield return new FrameworkSpecificGroup(framework, items);
             }
@@ -210,7 +144,7 @@ namespace NuGet.Packaging
             if (!groupFound)
             {
                 var items = MetadataNode.Elements(XName.Get(References, ns))
-                    .Elements(XName.Get(Reference, ns)).Select(n => GetAttributeValue(n, File)).Where(n => !String.IsNullOrEmpty(n)).ToArray();
+                    .Elements(XName.Get(Reference, ns)).Select(n => GetAttributeValue(n, File)).Where(n => !string.IsNullOrEmpty(n)).ToArray();
 
                 if (items.Length > 0)
                 {
@@ -239,7 +173,7 @@ namespace NuGet.Packaging
                 var frameworks = new List<NuGetFramework>();
 
                 // Empty frameworks go under Any
-                if (String.IsNullOrEmpty(group.Key))
+                if (string.IsNullOrEmpty(group.Key))
                 {
                     frameworks.Add(NuGetFramework.AnyFramework);
                 }
@@ -247,7 +181,7 @@ namespace NuGet.Packaging
                 {
                     foreach (var fwString in group.Key.Split(CommaArray, StringSplitOptions.RemoveEmptyEntries))
                     {
-                        if (!String.IsNullOrEmpty(fwString))
+                        if (!string.IsNullOrEmpty(fwString))
                         {
                             frameworks.Add(NuGetFramework.Parse(fwString.Trim(), _frameworkProvider));
                         }
@@ -265,7 +199,7 @@ namespace NuGet.Packaging
                     }
 
                     // Merge items and ignore duplicates
-                    items.UnionWith(group.Select(item => GetAttributeValue(item, AssemblyName)).Where(item => !String.IsNullOrEmpty(item)));
+                    items.UnionWith(group.Select(item => GetAttributeValue(item, AssemblyName)).Where(item => !string.IsNullOrEmpty(item)));
                 }
             }
 
@@ -465,6 +399,7 @@ namespace NuGet.Packaging
         }
 
         private static readonly List<string> EmptyList = new List<string>();
+
         private static List<string> GetFlags(string flags)
         {
             if (string.IsNullOrEmpty(flags))
@@ -478,6 +413,91 @@ namespace NuGet.Packaging
                 StringComparer.OrdinalIgnoreCase);
 
             return set.OrderBy(s => s, StringComparer.OrdinalIgnoreCase).ToList();
+        }
+
+        private IEnumerable<PackageDependencyGroup> GetAllDependencyGroups(bool useStrictVersionCheck)
+        {
+            var ns = MetadataNode.GetDefaultNamespace().NamespaceName;
+            var dependencyNode = MetadataNode
+                .Elements(XName.Get(Dependencies, ns));
+
+            var groupFound = false;
+            var dependencyGroups = dependencyNode
+                .Elements(XName.Get(Group, ns));
+
+            foreach (var depGroup in dependencyGroups)
+            {
+                groupFound = true;
+
+                var groupFramework = GetAttributeValue(depGroup, TargetFramework);
+
+                var dependencies = depGroup
+                    .Elements(XName.Get(Dependency, ns));
+
+                var packages = GetPackageDependencies(dependencies, useStrictVersionCheck);
+
+                var framework = string.IsNullOrEmpty(groupFramework)
+                    ? NuGetFramework.AnyFramework
+                    : NuGetFramework.Parse(groupFramework, _frameworkProvider);
+
+                yield return new PackageDependencyGroup(framework, packages);
+            }
+
+            // legacy behavior
+            if (!groupFound)
+            {
+                var legacyDependencies = dependencyNode
+                    .Elements(XName.Get(Dependency, ns));
+
+                var packages = GetPackageDependencies(legacyDependencies, useStrictVersionCheck);
+
+                if (packages.Any())
+                {
+                    yield return new PackageDependencyGroup(NuGetFramework.AnyFramework, packages);
+                }
+            }
+
+            yield break;
+        }
+
+        private HashSet<PackageDependency> GetPackageDependencies(IEnumerable<XElement> nodes, bool useStrictVersionCheck)
+        {
+            var packages = new HashSet<PackageDependency>();
+
+            foreach (var depNode in nodes)
+            {
+                VersionRange range = null;
+
+                var rangeNode = GetAttributeValue(depNode, Version);
+
+                if (!string.IsNullOrEmpty(rangeNode))
+                {
+                    if (useStrictVersionCheck && !VersionRange.TryParse(rangeNode, out range))
+                    {
+                        // Invalid version
+                        var message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            Strings.ErrorInvalidPackageVersion,
+                            rangeNode,
+                            GetIdentity());
+
+                        throw new PackagingException(message);
+                    }
+                }
+
+                var includeFlags = GetFlags(GetAttributeValue(depNode, IncludeFlags));
+                var excludeFlags = GetFlags(GetAttributeValue(depNode, ExcludeFlags));
+
+                var dependency = new PackageDependency(
+                    GetAttributeValue(depNode, Id),
+                    range,
+                    includeFlags,
+                    excludeFlags);
+
+                packages.Add(dependency);
+            }
+
+            return packages;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -472,7 +472,8 @@ namespace NuGet.Packaging
 
                 if (!string.IsNullOrEmpty(rangeNode))
                 {
-                    if (useStrictVersionCheck && !VersionRange.TryParse(rangeNode, out range))
+                    var versionParsedSuccessfully = VersionRange.TryParse(rangeNode, out range);
+                    if (!versionParsedSuccessfully && useStrictVersionCheck)
                     {
                         // Invalid version
                         var message = string.Format(

--- a/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/NuspecReader.cs
@@ -476,11 +476,13 @@ namespace NuGet.Packaging
                     if (!versionParsedSuccessfully && useStrictVersionCheck)
                     {
                         // Invalid version
+                        var dependencyId = GetAttributeValue(depNode, Id);
                         var message = string.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.ErrorInvalidPackageVersion,
-                            rangeNode,
-                            GetIdentity());
+                            Strings.ErrorInvalidPackageVersionForDependency,
+                            dependencyId,
+                            GetIdentity(),
+                            rangeNode);
 
                         throw new PackagingException(message);
                     }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -105,6 +105,15 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Invalid package version for a dependency with id &apos;{0}&apos; in package &apos;{1}&apos;: &apos;{2}&apos;.
+        /// </summary>
+        public static string ErrorInvalidPackageVersionForDependency {
+            get {
+                return ResourceManager.GetString("ErrorInvalidPackageVersionForDependency", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Null or empty package id.
         /// </summary>
         public static string ErrorNullOrEmptyPackageId {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -129,6 +129,9 @@
   <data name="ErrorInvalidPackageVersion" xml:space="preserve">
     <value>Invalid package version for package id '{0}': '{1}'</value>
   </data>
+  <data name="ErrorInvalidPackageVersionForDependency" xml:space="preserve">
+    <value>Invalid package version for a dependency with id '{0}' in package '{1}': '{2}'</value>
+  </data>
   <data name="ErrorNullOrEmptyPackageId" xml:space="preserve">
     <value>Null or empty package id</value>
   </data>

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -131,6 +131,9 @@
   </data>
   <data name="ErrorInvalidPackageVersionForDependency" xml:space="preserve">
     <value>Invalid package version for a dependency with id '{0}' in package '{1}': '{2}'</value>
+    <comment>{0} is the dependency's package id.
+{1} is the package's identity.
+{2} is the dependency's version range.</comment>
   </data>
   <data name="ErrorNullOrEmptyPackageId" xml:space="preserve">
     <value>Null or empty package id</value>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NuspecReaderTests.cs
@@ -255,6 +255,24 @@ namespace NuGet.Packaging.Test
                   </metadata>
                 </package>";
 
+        private const string InvalidVersionRangeInDependency = @"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+                <package xmlns=""http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd"">
+                  <metadata>
+                    <id>ServiceStack.Extras.Serilog</id>
+                    <version>2.0.1.0</version>
+                    <title>ServiceStack.Extras.Serilog</title>
+                    <authors>Alexey Zimarev, Nick Van Eeckhout</authors>
+                    <licenseUrl>https://github.com/alexeyzimarev/ServiceStack.Extras.Serilog/blob/master/LICENSE</licenseUrl>
+                    <projectUrl>https://github.com/alexeyzimarev/ServiceStack.Extras.Serilog</projectUrl>
+                    <description>Serilog logging adapter for ServiceStack</description>
+                    <tags>ServiceStack Serilog</tags>
+                    <dependencies>
+                      <dependency id=""ServiceStack.Interfaces"" version=""0.0.0-~4"" />
+                      <dependency id=""Serilog"" version=""0.0.0-~1.5"" />
+                    </dependencies>
+                  </metadata>
+                </package>";
+
         [Fact]
         public void NuspecReaderTests_NamespaceOnMetadata()
         {
@@ -305,6 +323,23 @@ namespace NuGet.Packaging.Test
             var dependencies = reader.GetDependencyGroups().ToList();
 
             Assert.Equal(2, dependencies.Count);
+        }
+
+        [Fact]
+        public void NuspecReaderTests_InvalidVersionRangeInDependency()
+        {
+            NuspecReader reader = GetReader(InvalidVersionRangeInDependency);
+            try
+            {
+                var dependencies = reader.GetDependencyGroups(useStrictVersion: true).ToList();
+                Assert.True(false, "No exception was thrown");
+            }
+            catch(Exception ex)
+            {
+                Assert.NotNull(ex);
+                // check the message contains invalid version range
+                Assert.NotNull(ex.Message);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This is part 1 of the work for fixing issue: 
https://github.com/NuGet/NuGetGallery/issues/3482 - Gallery accepts packages with illegal package dependency version ranges. 

Gallery uses `NuGet.Packaging` Nuspec reader, which currently does not do any strict version check for invalid versions in dependencies, for processing packages. This PR adds that ability and throws an exception based of which the gallery will reject bad packages.

I have refactored code a bit, for reusability. Added unit tests for this feature. All unit tests seem to be passing for me. Let me know if I am missing something here.

Feel free to add more reviewers to this PR.