### PR TITLE
fix directory separator issues in pack

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -356,14 +356,9 @@ namespace NuGet.Build.Tasks.Pack
             PackArgs packArgs, string[] contentTargetFolders)
         {
             var targetPaths = contentTargetFolders
-                .Where(f => !f.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                .Select(f => string.Concat(f, Path.DirectorySeparatorChar))
+                .Select(PathUtility.EnsureTrailingSlash)
                 .ToList();
             
-            targetPaths.AddRange(
-                contentTargetFolders
-                .Where(f => f.EndsWith(Path.DirectorySeparatorChar.ToString())));
-
             var isPackagePathSpecified = packageFile.Properties.Contains("PackagePath");
             // if user specified a PackagePath, then use that. Look for any ** which are indicated by the RecrusiveDir metadata in msbuild.
             if (isPackagePathSpecified)
@@ -382,17 +377,16 @@ namespace NuGet.Build.Tasks.Pack
                 if (!string.IsNullOrEmpty(recursiveDir))
                 {
                     var newTargetPaths = new List<string>();
+                    var fileName = Path.GetFileName(sourcePath);
                     foreach (var targetPath in targetPaths)
                     {
-                        if (targetPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                        {
-                            newTargetPaths.Add(Path.Combine(targetPath, recursiveDir));
-                        }
-                        else
-                        {
-                            newTargetPaths.Add(targetPath);
-                        }
+                        newTargetPaths.Add(PathUtility.GetStringComparerBasedOnOS().
+                            Compare(Path.GetExtension(fileName), 
+                            Path.GetExtension(targetPath)) == 0
+                                ? targetPath
+                                : Path.Combine(targetPath, recursiveDir));
                     }
+
                     targetPaths = newTargetPaths;
                 }
             }
@@ -403,20 +397,21 @@ namespace NuGet.Build.Tasks.Pack
             var language = buildAction.Equals(BuildAction.Compile) ? "cs" : "any";
 
 
-            var setOfTargetPaths = new HashSet<string>(targetPaths, StringComparer.Ordinal);
+            var setOfTargetPaths = new HashSet<string>(targetPaths, PathUtility.GetStringComparerBasedOnOS());
 
             // If package path wasn't specified, then we expand the "contentFiles" value we
             // got from ContentTargetFolders and expand it to contentFiles/any/<TFM>/
             if (!isPackagePathSpecified)
             {
                 if (setOfTargetPaths.Remove("contentFiles" + Path.DirectorySeparatorChar)
-                || setOfTargetPaths.Remove("contentFiles" + Path.AltDirectorySeparatorChar)
                 || setOfTargetPaths.Remove("contentFiles"))
                 {
                     foreach (var framework in packArgs.PackTargetArgs.TargetFrameworks)
                     {
-                        setOfTargetPaths.Add(Path.Combine("contentFiles",
-                            Path.Combine(language, framework.GetShortFolderName())) + Path.DirectorySeparatorChar);
+                        setOfTargetPaths.Add(PathUtility.EnsureTrailingSlash(
+                            Path.Combine("contentFiles",
+                            Path.Combine(language, framework.GetShortFolderName())
+                            )));
                     }
                 }
             }
@@ -434,11 +429,11 @@ namespace NuGet.Build.Tasks.Pack
             {
                 var newTargetPaths = new List<string>();
                 var identity = packageFile.GetProperty(IdentityProperty);
-                
+
                 // Identity can be a rooted absolute path too, in which case find the path relative to the current directory
                 if (Path.IsPathRooted(identity))
                 {
-                    identity = PathUtility.GetRelativePath(packArgs.CurrentDirectory + Path.DirectorySeparatorChar, identity);
+                    identity = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(packArgs.CurrentDirectory), identity);
                     identity = Path.GetDirectoryName(identity);
                 }
 
@@ -454,13 +449,10 @@ namespace NuGet.Build.Tasks.Pack
                     // We need to do this because evaluated identity in the above line of code can be an empty string
                     // in the case when the original identity string was the absolute path to a file in project directory, and is in
                     // the same directory as the csproj file. 
-                    if (!newTargetPath.EndsWith(Path.DirectorySeparatorChar.ToString()))
-                    {
-                        newTargetPath = newTargetPath + Path.DirectorySeparatorChar;
-                    }
+                    newTargetPath = PathUtility.EnsureTrailingSlash(newTargetPath);
                     newTargetPaths.Add(newTargetPath);
                 }
-                setOfTargetPaths = new HashSet<string>(newTargetPaths, StringComparer.Ordinal);
+                setOfTargetPaths = new HashSet<string>(newTargetPaths, PathUtility.GetStringComparerBasedOnOS());
             }
 
             // we take the final set of evaluated target paths and append the file name to it if not

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -409,8 +409,7 @@ namespace NuGet.Build.Tasks.Pack
                     foreach (var framework in packArgs.PackTargetArgs.TargetFrameworks)
                     {
                         setOfTargetPaths.Add(PathUtility.EnsureTrailingSlash(
-                            Path.Combine("contentFiles",
-                            Path.Combine(language, framework.GetShortFolderName())
+                            Path.Combine("contentFiles", language, framework.GetShortFolderName()
                             )));
                     }
                 }

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -77,7 +77,7 @@ namespace NuGet.Common
             }
             // This condition checks if there is a different valid path separator than the one requested for.
             // In that case we replace this path separator.
-            else if (HasTrailingValidDirectorySeparator(path))
+            else if (HasTrailingDirectorySeparator(path))
             {
                 return path.Substring(0, path.Length - 1) +  trailingCharacter;
             }
@@ -101,7 +101,7 @@ namespace NuGet.Common
             return candidate.StartsWith(dir, StringComparison.OrdinalIgnoreCase);
         }
 
-        public static bool HasTrailingValidDirectorySeparator(string path)
+        public static bool HasTrailingDirectorySeparator(string path)
         {
             if (string.IsNullOrEmpty(path))
             {

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -75,6 +75,12 @@ namespace NuGet.Common
             {
                 return path;
             }
+            // This condition checks if there is a different valid path separator than the one requested for.
+            // In that case we replace this path separator.
+            else if (HasTrailingValidDirectorySeparator(path))
+            {
+                return path.Substring(0, path.Length - 1) +  trailingCharacter;
+            }
 
             return path + trailingCharacter;
         }
@@ -93,6 +99,27 @@ namespace NuGet.Common
             dir = EnsureTrailingSlash(dir);
             candidate = Path.GetFullPath(candidate);
             return candidate.StartsWith(dir, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool HasTrailingValidDirectorySeparator(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+            else
+            {
+                if (RuntimeEnvironmentHelper.IsWindows)
+                {
+                    // Windows has both '/' and '\' as valid directory separators.
+                    return (path[path.Length - 1] == Path.DirectorySeparatorChar ||
+                            path[path.Length - 1] == Path.AltDirectorySeparatorChar);
+                }
+                else
+                {
+                    return path[path.Length - 1] == Path.DirectorySeparatorChar;
+                }
+            }
         }
         
         public static void EnsureParentDirectory(string filePath)

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -134,14 +134,14 @@ namespace Dotnet.Integration.Test
         private void UpdateCliWithLatestNuGetAssemblies(string cliDirectory)
         {
             var nupkgsDirectory = DotnetCliUtil.GetNupkgDirectoryInRepo();
-            var productVersionInfo = FileVersionInfo.GetVersionInfo(DotnetCliUtil.GetXplatDll());
-            var pathToPackNupkg = nupkgsDirectory + Path.DirectorySeparatorChar + "NuGet.Build.Tasks.Pack." +
-                                  productVersionInfo.ProductVersion + ".nupkg";
+            var pathToPackNupkg = FindMostRecentPackNupkg(nupkgsDirectory);
+            string nupkgVersion;
             var pathToSdkInCli = Path.Combine(
                     Directory.GetDirectories(Path.Combine(cliDirectory, "sdk"))
                         .First());
             using (var nupkg = new PackageArchiveReader(pathToPackNupkg))
             {
+                nupkgVersion = nupkg.NuspecReader.GetMetadataValue("version");
                 var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
                 var files = nupkg.GetFiles()
                 .Where(fileName => fileName.StartsWith("Desktop")
@@ -163,7 +163,7 @@ namespace Dotnet.Integration.Test
             }
 
             var pathToRestoreNupkg = nupkgsDirectory + Path.DirectorySeparatorChar + "NuGet.Build.Tasks." +
-                                  productVersionInfo.ProductVersion + ".nupkg";
+                                  nupkgVersion + ".nupkg";
             using (var nupkg = new PackageArchiveReader(pathToRestoreNupkg))
             {
                 var files = nupkg.GetFiles()
@@ -193,6 +193,30 @@ namespace Dotnet.Integration.Test
         private void DeleteFiles(string destinationDir)
         {
             Directory.Delete(destinationDir, true);
+        }
+
+        private static string FindMostRecentPackNupkg(string nupkgDirectory)
+        {
+            var listOfMatchingNupkgs = Directory.GetFiles(nupkgDirectory, "NuGet.Build.Tasks.Pack.*", SearchOption.TopDirectoryOnly)
+                .Where(t => !t.Contains("symbols")
+                          && !t.Contains("NuGet.Build.Tasks.Pack.Library")).ToList();
+            if (listOfMatchingNupkgs.Count == 0)
+            {
+                throw new FileNotFoundException($"Could not find any nupkg with id = NuGet.Build.Tasks.Pack");
+            }
+            else if (listOfMatchingNupkgs.Count == 1)
+            {
+                return listOfMatchingNupkgs.First();
+            }
+            else
+            {
+                return FindLastModified(listOfMatchingNupkgs);
+            }
+        }
+
+        private static string FindLastModified(IEnumerable<string> listOfNupkgs)
+        {
+            return listOfNupkgs.Select(t => new FileInfo(t)).OrderByDescending(p => p.LastWriteTime).First().FullName;
         }
 
         public void Dispose()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -8,6 +8,7 @@ using NuGet.XPlat.FuncTest;
 using NuGet.Test.Utility;
 using NuGet.Packaging;
 using NuGet.Packaging.PackageExtraction;
+using NuGet.Protocol;
 using Xunit;
 
 namespace Dotnet.Integration.Test
@@ -134,14 +135,13 @@ namespace Dotnet.Integration.Test
         private void UpdateCliWithLatestNuGetAssemblies(string cliDirectory)
         {
             var nupkgsDirectory = DotnetCliUtil.GetNupkgDirectoryInRepo();
-            var pathToPackNupkg = FindMostRecentPackNupkg(nupkgsDirectory);
-            string nupkgVersion;
+            var pathToPackNupkg = FindMostRecentNupkg(nupkgsDirectory, "NuGet.Build.Tasks.Pack");
+            var pathToRestoreNupkg = FindMostRecentNupkg(nupkgsDirectory, "NuGet.Build.Tasks");
             var pathToSdkInCli = Path.Combine(
                     Directory.GetDirectories(Path.Combine(cliDirectory, "sdk"))
                         .First());
             using (var nupkg = new PackageArchiveReader(pathToPackNupkg))
             {
-                nupkgVersion = nupkg.NuspecReader.GetMetadataValue("version");
                 var pathToPackSdk = Path.Combine(pathToSdkInCli, "Sdks", "NuGet.Build.Tasks.Pack");
                 var files = nupkg.GetFiles()
                 .Where(fileName => fileName.StartsWith("Desktop")
@@ -162,8 +162,6 @@ namespace Dotnet.Integration.Test
                 }
             }
 
-            var pathToRestoreNupkg = nupkgsDirectory + Path.DirectorySeparatorChar + "NuGet.Build.Tasks." +
-                                  nupkgVersion + ".nupkg";
             using (var nupkg = new PackageArchiveReader(pathToRestoreNupkg))
             {
                 var files = nupkg.GetFiles()
@@ -195,28 +193,14 @@ namespace Dotnet.Integration.Test
             Directory.Delete(destinationDir, true);
         }
 
-        private static string FindMostRecentPackNupkg(string nupkgDirectory)
+        private static string FindMostRecentNupkg(string nupkgDirectory, string id)
         {
-            var listOfMatchingNupkgs = Directory.GetFiles(nupkgDirectory, "NuGet.Build.Tasks.Pack.*", SearchOption.TopDirectoryOnly)
-                .Where(t => !t.Contains("symbols")
-                          && !t.Contains("NuGet.Build.Tasks.Pack.Library")).ToList();
-            if (listOfMatchingNupkgs.Count == 0)
-            {
-                throw new FileNotFoundException($"Could not find any nupkg with id = NuGet.Build.Tasks.Pack");
-            }
-            else if (listOfMatchingNupkgs.Count == 1)
-            {
-                return listOfMatchingNupkgs.First();
-            }
-            else
-            {
-                return FindLastModified(listOfMatchingNupkgs);
-            }
-        }
+            var info = LocalFolderUtility.GetPackagesV2(nupkgDirectory, new TestLogger());
 
-        private static string FindLastModified(IEnumerable<string> listOfNupkgs)
-        {
-            return listOfNupkgs.Select(t => new FileInfo(t)).OrderByDescending(p => p.LastWriteTime).First().FullName;
+            return info.Where(t => t.Identity.Id.Equals(id, StringComparison.OrdinalIgnoreCase))
+                .Where(t => !Path.GetExtension(Path.GetFileNameWithoutExtension(t.Path)).Equals(".symbols"))
+                .OrderByDescending(p => p.LastWriteTimeUtc)
+                .First().Path;
         }
 
         public void Dispose()

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1247,56 +1247,49 @@ namespace Dotnet.Integration.Test
             }
         }
 
-        // All commented out tests are because of the bug : https://github.com/NuGet/Home/issues/4407
-        // TODO : Uncomment all the test cases once the above bug is fixed.
         [Platform(Platform.Windows)]
         [Theory]
-        [InlineData("abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("folderA/abc.txt", null, "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/folderB/abc.txt", null,
-            "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
-        [InlineData("../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        //[InlineData("abc.txt",                  "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
-        [InlineData("abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        //[InlineData("abc.txt",                  "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
-        //[InlineData("folderA/abc.txt",          "folderA/",                                 "folderA/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt", "folderA;folderB", "folderA/folderA/abc.txt;folderB/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt", "folderA;contentFiles",
-            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt", "folderA;contentFiles\\",
-            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        //[InlineData("folderA/abc.txt",          "folderA;contentFiles/",                    "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt", "folderA;contentFiles/folderA",
-            "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
-        [InlineData("folderA/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/folderA/abc.txt")]
-        //[InlineData("C:/abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        //[InlineData("C:/abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
-        //[InlineData("../abc.txt",               "folderA/",                                 "folderA/abc.txt")]
-        [InlineData("../abc.txt", "folderA/xyz.txt", "folderA/xyz.txt/abc.txt")]
-        [InlineData("../abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("../abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        //[InlineData("../abc.txt",               "folderA;contentFiles/",                    "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("../abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("../abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt",                  null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("folderA/abc.txt",          null,                               "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/folderB/abc.txt",  null,                               "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
+        [InlineData("../abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA/",                         "folderA/abc.txt")]
+        [InlineData("abc.txt",                  "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles",             "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles/",            "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles\\",           "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("abc.txt",                  "folderA;contentFiles/folderA",     "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("abc.txt",                  "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA/",                         "folderA/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;folderB",                  "folderA/folderA/abc.txt;folderB/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles",             "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles\\",           "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles/",            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA;contentFiles/folderA",     "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
+        [InlineData("folderA/abc.txt",          "folderA/xyz.txt",                  "folderA/xyz.txt/folderA/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA/",                         "folderA/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles",             "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles\\",           "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles/",            "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("C:/abc.txt",               "folderA;contentFiles/folderA",     "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("../abc.txt",               "folderA/",                         "folderA/abc.txt")]
+        [InlineData("../abc.txt",               "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles",             "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles/",            "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles\\",           "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("../abc.txt",               "folderA;contentFiles/folderA",     "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         // ## is a special syntax specifically for this test which means that ## should be replaced by the absolute path to the project directory.
-        [InlineData("##/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("##/folderA/abc.txt", null,
-            "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
-        [InlineData("##/../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("##/abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
-        [InlineData("##/folderA/abc.txt", "folderX;folderY", "folderX/folderA/abc.txt;folderY/folderA/abc.txt")]
-        [InlineData("##/../abc.txt", "folderX;folderY", "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/folderA/abc.txt",       null,                               "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
+        [InlineData("##/../abc.txt",            null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("##/abc.txt",               "folderX;folderY",                  "folderX/abc.txt;folderY/abc.txt")]
+        [InlineData("##/folderA/abc.txt",       "folderX;folderY",                  "folderX/folderA/abc.txt;folderY/folderA/abc.txt")]
+        [InlineData("##/../abc.txt",            "folderX;folderY",                  "folderX/abc.txt;folderY/abc.txt")]
 
         public void PackCommand_PackProject_ContentTargetFoldersPacksContentCorrectly(string sourcePath,
             string contentTargetFolders, string expectedTargetPaths)
@@ -1634,6 +1627,79 @@ namespace ClassLibrary
                         Assert.Equal(FrameworkConstants.CommonFrameworks.NetStandard14, libItems[0].TargetFramework);
                         Assert.Equal(new[] { "lib/netstandard1.4/abc.dll", "lib/netstandard1.4/ClassLibrary1.dll" },
                             libItems[0].Items);
+                    }
+                }
+            }
+        }
+
+        [Platform(Platform.Windows)]
+        [Theory]
+        [InlineData("folderA\\**\\*",                           null,                           "content/folderA/folderA.txt;content/folderA/folderB/folderB.txt;" +
+                                                                                                "contentFiles/any/netstandard1.4/folderA/folderA.txt;" +
+                                                                                                "contentFiles/any/netstandard1.4/folderA/folderB/folderB.txt")]
+        [InlineData("folderA\\**\\*",                           "pkgA",                         "pkgA/folderA.txt;pkgA/folderB/folderB.txt")]
+        [InlineData("folderA\\**\\*",                           "pkgA/",                        "pkgA/folderA.txt;pkgA/folderB/folderB.txt")]
+        [InlineData("folderA\\**\\*",                           "pkgA\\",                       "pkgA/folderA.txt;pkgA/folderB/folderB.txt")]
+        [InlineData("folderA\\**",                              "pkgA",                         "pkgA/folderA.txt;pkgA/folderB/folderB.txt")]
+        public void PackCommand_PackProject_GlobbingPathsPacksContentCorrectly(string sourcePath, string packagePath,
+            string expectedTargetPaths)
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                //XPlatTestUtils.WaitForDebugger();
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                
+                // Create the subdirectory structure for testing possible source paths for the content file
+                Directory.CreateDirectory(Path.Combine(workingDirectory, "folderA", "folderB"));
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, "TargetFramework", "netstandard1.4");
+
+                    var attributes = new Dictionary<string, string>();
+
+                    var properties = new Dictionary<string, string>();
+                    if (packagePath != null)
+                    {
+                        properties["PackagePath"] = packagePath;
+                    }
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "Content",
+                        sourcePath,
+                        string.Empty,
+                        properties,
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                File.WriteAllText(Path.Combine(workingDirectory, "folderA", "folderA.txt"), "hello world from subfolder A directory");
+                File.WriteAllText(Path.Combine(workingDirectory, "folderA", "folderB", "folderB.txt"), "hello world from subfolder B directory");
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                // Assert
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var items = new HashSet<string>(nupkgReader.GetFiles());
+                    var expectedPaths = expectedTargetPaths.Split(';');
+                    foreach (var path in expectedPaths)
+                    {
+                        Assert.Contains(path, items);
                     }
                 }
             }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1683,20 +1683,21 @@ namespace ClassLibrary
                 File.WriteAllText(Path.Combine(workingDirectory, "folderA", "folderA.txt"), "hello world from subfolder A directory");
                 File.WriteAllText(Path.Combine(workingDirectory, "folderA", "folderB", "folderB.txt"), "hello world from subfolder B directory");
                 msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
 
                 // Act
                 msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
 
                 // Assert
-                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
-                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
                 Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
                 Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
-
                 using (var nupkgReader = new PackageArchiveReader(nupkgPath))
                 {
                     var items = new HashSet<string>(nupkgReader.GetFiles());
                     var expectedPaths = expectedTargetPaths.Split(';');
+                    // we add 5 because of the 5 standard files present in the nupkg that won't change.
+                    Assert.Equal(items.Count(), expectedPaths.Length + 5);
                     foreach (var path in expectedPaths)
                     {
                         Assert.Contains(path, items);

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/project.json
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/project.json
@@ -13,6 +13,9 @@
     "NuGet.XPlat.FuncTest": {
       "target": "project"
     },
+    "NuGet.Protocol.Core.v3": {
+      "target": "project"
+    },
     "xunit": "2.1.0"
   },
   "frameworks": {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4407
Fixes: https://github.com/NuGet/Home/issues/4795

This fix involves making sure the right directory separator characters are being user as allowed per OS. Have added tests related to both the bugs listed above.

CC: @rrelyea @alpaix @emgarten @zhili1208 @nkolev92 @jainaashish @mishra14 