### PR TITLE
restrict 21 flaky mono tests on mac to run only on windows

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -40,6 +40,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void MSBuildProjectSystem_AddFile()
         {
             // Arrange
@@ -63,6 +64,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void MSBuildProjectSystem_RemoveFile()
         {
             // Arrange
@@ -89,6 +91,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void MSBuildProjectSystem_FileExistInProject()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -22,6 +22,7 @@ namespace NuGet.CommandLine.Test
     public class NuGetUpdateCommandTests
     {
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_Update_DeletedFile()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -132,6 +133,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -211,6 +213,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_References_MultipleProjects()
         {
 
@@ -340,6 +343,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Fails_References_MultipleProjectsInSameDirectory()
         {
             // Arrange
@@ -436,6 +440,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_NOPrerelease()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -514,6 +519,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_Prerelease()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -594,6 +600,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_Version_Upgrade()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -685,6 +692,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_Version_Downgrade()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -776,6 +784,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_ProjectFile_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -855,6 +864,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_PackagesConfig_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -936,6 +946,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_ContentFiles()
         {
             // Arrange
@@ -1049,6 +1060,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_CustomPackagesFolder_RelativePath()
         {
             // Arrange
@@ -1142,6 +1154,7 @@ namespace NuGet.CommandLine.Test
 
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Success_CustomPackagesFolder_AbsolutePath()
         {
             // Arrange
@@ -1235,6 +1248,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public async Task UpdateCommand_Native_JS_Projects_Success()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -23,6 +23,7 @@ namespace NuGet.CommandLine
     public class ProjectFactoryTest
     {
         [Fact]
+        [Platform(Platform.Windows)]
         public void ProjectFactoryInitializesPropertiesForPreprocessorFromAssemblyMetadata()
         {
             // Arrange
@@ -93,6 +94,7 @@ namespace NuGet.CommandLine
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void CommandLinePropertiesOverrideAssemblyMetadataForPreprocessor()
         {
             // Arrange
@@ -167,6 +169,7 @@ namespace NuGet.CommandLine
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void CommandLinePropertiesApplyForPreprocessor()
         {
             // Arrange
@@ -241,6 +244,7 @@ namespace NuGet.CommandLine
         }
 
         [Fact]
+        [Platform(Platform.Windows)]
         public void CommandLineIdPropertyOverridesAssemblyNameForPreprocessor()
         {
             // Arrange


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4868

CC: @mishra14 @emgarten @zhili1208 @rrelyea @nkolev92 @alpaix @jainaashish 