### PR TITLE
fix pack input item to not restrict on csproj files

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -182,17 +182,12 @@ Copyright (c) .NET Foundation. All rights reserved.
   <!--
     ============================================================
     _LoadPackGraphEntryPoints
-    Find project entry points and load them into items.
+    Find project entry point and load them into items.
     ============================================================
   -->
   <Target Name="_LoadPackInputItems">
-    <!-- Allow overriding items with ProjectFileToPack -->
+    <!-- Allow overriding items with PackProjectInputFile -->
     <PropertyGroup Condition="'$(PackProjectInputFile)' == ''">
-      <PackProjectInputFile>$(ProjectFileToPack)</PackProjectInputFile>
-    </PropertyGroup>
-
-    <!-- Project case -->
-    <PropertyGroup Condition="$(MSBuildProjectFullPath.EndsWith('.csproj')) == 'true' AND '$(PackProjectInputFile)' == ''">
       <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4886

This fix removes the restriction of only packing csproj files until ```PackProjectInputFile``` has been set as the path to a project file .

CC: @emgarten @alpaix @rrelyea @mishra14 @jainaashish @nkolev92 @zhili1208 