### PR TITLE
add support for marking netcore project as development dependency

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -24,6 +24,7 @@ namespace NuGet.Build.Tasks.Pack
         bool ContinuePackingAfterGeneratingNuspec { get; }
         string Copyright { get; }
         string Description { get; }
+        bool DevelopmentDependency { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -152,6 +152,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               IconUrl="$(PackageIconUrl)"
               ReleaseNotes="$(PackageReleaseNotes)"
               Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
               BuildOutputInPackage="@(_BuildOutputInPackage)"
               TargetPathsToSymbols="@(_TargetPathsToSymbols)"
               TargetFrameworks="@(_TargetFrameworks)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -25,6 +25,7 @@ namespace NuGet.Build.Tasks.Pack
         public string Title { get; set; }
         public string[] Authors { get; set; }
         public string Description { get; set; }
+        public bool DevelopmentDependency { get; set; }
         public string Copyright { get; set; }
         public bool RequireLicenseAcceptance { get; set; }
         public string RestoreOutputPath { get; set; }
@@ -127,6 +128,7 @@ namespace NuGet.Build.Tasks.Pack
                 ContentTargetFolders = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(ContentTargetFolders),
                 Copyright = MSBuildStringUtility.TrimAndGetNullForEmpty(Copyright),
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
+                DevelopmentDependency = DevelopmentDependency,
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,
                 IncludeSource = IncludeSource,

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -104,6 +104,11 @@ namespace NuGet.Build.Tasks.Pack
                 RequireLicenseAcceptance = request.RequireLicenseAcceptance,
                 PackageTypes = ParsePackageTypes(request)
             };
+
+            if (request.DevelopmentDependency)
+            {
+                builder.DevelopmentDependency = true;
+            }
             
             if (request.PackageVersion != null)
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -17,6 +17,7 @@ namespace NuGet.Build.Tasks.Pack
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string Copyright { get; set; }
         public string Description { get; set; }
+        public bool DevelopmentDependency { get; set; }
         public string IconUrl { get; set; }
         public bool IncludeBuildOutput { get; set; }
         public bool IncludeSource { get; set; }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -178,6 +178,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 IsTool = value,
                 NoPackageAnalysis = value,
                 RequireLicenseAcceptance = value,
+                DevelopmentDependency = value,
                 Serviceable = value
             };
 
@@ -192,6 +193,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             Assert.Equal(value, actual.IsTool);
             Assert.Equal(value, actual.NoPackageAnalysis);
             Assert.Equal(value, actual.RequireLicenseAcceptance);
+            Assert.Equal(value, actual.DevelopmentDependency);
             Assert.Equal(value, actual.Serviceable);
         }
 
@@ -267,6 +269,7 @@ namespace NuGet.Build.Tasks.Pack.Test
                 ContinuePackingAfterGeneratingNuspec = true,
                 Copyright = "Copyright",
                 Description = "Description",
+                DevelopmentDependency = true,
                 IconUrl = "IconUrl",
                 IncludeBuildOutput = true,
                 IncludeSource = true,


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4694

Package authors can now set ```<DevelopmentDependency>true</DevelopmentDependency>``` in their project file which would set in the nuspec file contained in the generated package.

CC: @emgarten @alpaix @rrelyea @mishra14 @jainaashish @zhili1208 @nkolev92 