### PR TITLE
Nuget powershell actions must be executed outside of powershell pipeline thread

### DIFF
--- a/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
+++ b/src/NuGet.Clients/PackageManagement.PowerShellCmdlets/Cmdlets/UninstallPackageCommand.cs
@@ -64,16 +64,19 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
             TelemetryService = new TelemetryServiceHelper();
             TelemetryUtility.StartorResumeTimer();
 
+            // Run Preprocess outside of JTF
+            Preprocess();
+
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await _lockService.ExecuteNuGetOperationAsync(async () =>
+                await _lockService.ExecuteNuGetOperationAsync(() =>
                 {
-                    Preprocess();
-
                     SubscribeToProgressEvents();
-                    await UninstallPackageAsync();
+                    Task.Run(UninstallPackageAsync);
                     WaitAndLogPackageActions();
                     UnsubscribeFromProgressEvents();
+
+                    return Task.FromResult(true);
                 }, Token);
             });
 


### PR DESCRIPTION
Since we started executing nuget powershell actions like install/update inside powershell pipeline thread which made it to block this thread until this action is complete and meantime, if that same action tries to execute some ps scripts like init/install then it will hang since it will wait to get the pipeline thread.

So, the solution is we move to threadpool thead to execute nuget specific code for these operations and doesn't block pipeline thread.

This PR also fixes end to end tests hang.

Fixes https://github.com/NuGet/Home/issues/4885 

@rrelyea 