### PR TITLE
Fixing ResolveEventHandler behavior and invoking

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -89,6 +89,7 @@ namespace NuGet.CommandLine
                 projectProperties,
                 null);
             Initialize(project);
+            AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
         }
 
         public ProjectFactory(string msbuildDirectory, dynamic project)

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -83,13 +83,20 @@ namespace NuGet.CommandLine
 
             // Create project, allowing for assembly load failures
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(AssemblyResolve);
-            var project = Activator.CreateInstance(
-                _projectType,
-                path,
-                projectProperties,
-                null);
-            Initialize(project);
-            AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
+
+            try
+            {
+                var project = Activator.CreateInstance(
+                    _projectType,
+                    path,
+                    projectProperties,
+                    null);
+                Initialize(project);
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
+            }
         }
 
         public ProjectFactory(string msbuildDirectory, dynamic project)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -435,6 +435,7 @@ namespace NuGet.Common
             var project = Activator.CreateInstance(
                 _projectType,
                 new object[] { projectFile });
+            AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
             return project;
         }
     }

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -422,21 +422,27 @@ namespace NuGet.Common
         private dynamic GetProject(string projectFile)
         {
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(AssemblyResolve);
-            dynamic globalProjectCollection = _projectCollectionType
-                .GetProperty("GlobalProjectCollection")
-                .GetMethod
-                .Invoke(null, new object[] { });
-            var loadedProjects = globalProjectCollection.GetLoadedProjects(projectFile);
-            if (loadedProjects.Count > 0)
+            try
             {
-                return loadedProjects[0];
-            }
+                dynamic globalProjectCollection = _projectCollectionType
+                    .GetProperty("GlobalProjectCollection")
+                    .GetMethod
+                    .Invoke(null, new object[] { });
+                var loadedProjects = globalProjectCollection.GetLoadedProjects(projectFile);
+                if (loadedProjects.Count > 0)
+                {
+                    return loadedProjects[0];
+                }
 
-            var project = Activator.CreateInstance(
-                _projectType,
-                new object[] { projectFile });
-            AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
-            return project;
+                var project = Activator.CreateInstance(
+                    _projectType,
+                    new object[] { projectFile });
+                return project;
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(AssemblyResolve);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4780


Problems -
1. Currently `MSBuildUser.AssemblyResolve` does not check if the assembly exists. This PR fixes that.
2. `ProjectFactory `and `MSBuildProjectSystem ` add the `ResolveEventHandler ` but do not remove it after use. This is fixed as well.

//cc: @nkolev92 @zhili1208 @emgarten 