### PR TITLE
Fixing RPS test performance regression

### DIFF
--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/ExtensibleSourceRepositoryProvider.cs
@@ -22,7 +22,7 @@ namespace NuGet.PackageManagement.VisualStudio
         // TODO: add support for reloading sources when changes occur
         private readonly Configuration.IPackageSourceProvider _packageSourceProvider;
         private IEnumerable<Lazy<INuGetResourceProvider>> _resourceProviders;
-        private List<SourceRepository> _repositories;
+        private Lazy<List<SourceRepository>> _repositories;
 
         /// <summary>
         /// Public parameter-less constructor for SourceRepositoryProvider
@@ -64,7 +64,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 ResetRepositories();
             }
 
-            return _repositories;
+            return _repositories.Value;
         }
 
         /// <summary>
@@ -90,6 +90,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void ResetRepositories()
         {
+            // initialize it lazy since it doesn't impact RPS test performance and evaluate
+            // only when somebody reads repositories value.
+            _repositories = new Lazy<List<SourceRepository>>(GetRepositoriesCore);
+        }
+
+        private List<SourceRepository> GetRepositoriesCore()
+        {
             var repositories = new List<SourceRepository>();
             foreach (var source in _packageSourceProvider.LoadPackageSources())
             {
@@ -100,7 +107,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 }
             }
 
-            _repositories = repositories;
+            return repositories;
         }
     }
 }


### PR DESCRIPTION
Since we moved initializing repositories out of MEF constructor and started creating a empty list of `SourceRepository` every time we try to reset repositories list, it added ~26ms to the close solution scenario.

So the solution here is we lazy initialize this repositories list and only load when someone calls into `GetRepositories()` api.

Fixes bug# 400669

@rrelyea 