### PR TITLE
Fix warnings from CLSCompliant

### DIFF
--- a/src/NuGet.Core/NuGet.Indexing/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.Indexing/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System;
+
+[assembly: CLSCompliant(true)]

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/ODataServiceDocumentResourceV2Provider.cs
@@ -15,7 +15,7 @@ namespace NuGet.Protocol
     public class ODataServiceDocumentResourceV2Provider : ResourceProvider
     {
         private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromMinutes(40);
-        protected readonly ConcurrentDictionary<string, ODataServiceDocumentCacheInfo> _cache;
+        private readonly ConcurrentDictionary<string, ODataServiceDocumentCacheInfo> _cache;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Protocol/Properties/AssemblyInfo.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System;
+
+[assembly: CLSCompliant(true)]

--- a/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/ServiceIndexResourceV3Provider.cs
@@ -21,7 +21,7 @@ namespace NuGet.Protocol
     public class ServiceIndexResourceV3Provider : ResourceProvider
     {
         private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromMinutes(40);
-        protected readonly ConcurrentDictionary<string, ServiceIndexCacheInfo> _cache;
+        private readonly ConcurrentDictionary<string, ServiceIndexCacheInfo> _cache;
         private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
         /// <summary>


### PR DESCRIPTION
Minor fixes for CLSCompliant warnings in the protocol.

Adding this to NuGet.Indexing also which is CLSCompliant already.