### PR TITLE
Fixing assembly and file versions for net core projects

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -328,7 +328,7 @@
       <!-- Build exe commands -->
       <TestResultsHtml Condition=" '$(TestResultsFileName)' != '' ">$(TestResultsDirectory)$(TestResultsFileName).html</TestResultsHtml>
       <VSTestCommand>$(DotnetExePath) vstest $(CoreInputTestAssembliesSpaced)</VSTestCommand>
-      <DesktopTestCommand>$(XunitConoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
+      <DesktopTestCommand>$(XunitConsoleExePath) $(DesktopInputTestAssembliesSpaced)</DesktopTestCommand>
       <DesktopTestCommand Condition=" '$(TestResultsHtml)' != '' ">$(DesktopTestCommand) -html $(TestResultsHtml)</DesktopTestCommand>
     </PropertyGroup>
 

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -133,13 +133,13 @@
   </PropertyGroup>
   
   <!-- Generate AssemblyFileVersion and AssemblyVersion attributes. -->
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(IsNetCoreProject)' != 'true' ">
     <!-- Turn on dynamic assembly attribute generation -->
     <AssemblyAttributesPath>$(IntermediateOutputPath)AssemblyInfo.g.cs</AssemblyAttributesPath>
     <GenerateAdditionalSources>true</GenerateAdditionalSources>
   </PropertyGroup>
 
-  <!-- Assembly attributes -->
+  <!-- Assembly attributes for non net core projects-->
   <ItemGroup Condition=" '$(SkipAssemblyAttributes)' != 'true' AND '$(IsNetCoreProject)' != 'true' ">
     <!--
       AssemblyVersion and AssemblyFileVersion attributes are generated automatically for every build.
@@ -167,6 +167,16 @@
       <_Parameter1>en-US</_Parameter1>
     </AssemblyAttributes>
   </ItemGroup>
+
+  <!-- Assembly attributes for net core projects -->
+  <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
+    <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
+    <AssemblyFileVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyFileVersion>
+    <AssemblyInformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</AssemblyInformationalVersion>
+    <AssemblyCompany>Microsoft Corporation</AssemblyCompany>
+    <AssemblyProduct>NuGet</AssemblyProduct>
+    <AssemblyCopyright>Microsoft Corporation. All rights reserved.</AssemblyCopyright>
+  </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <SchemaVersion>2.0</SchemaVersion>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -171,11 +171,11 @@
   <!-- Assembly attributes for net core projects -->
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
-    <AssemblyFileVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyFileVersion>
+    <!--<AssemblyFileVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyFileVersion>
     <AssemblyInformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</AssemblyInformationalVersion>
-    <AssemblyCompany>Microsoft Corporation</AssemblyCompany>
+    <AssemblyCompany>Microsoft CoASDasdrporation</AssemblyCompany>
     <AssemblyProduct>NuGet</AssemblyProduct>
-    <AssemblyCopyright>Microsoft Corporation. All rights reserved.</AssemblyCopyright>
+    <AssemblyCopyright>Microsoft Corporation. All rights reserved.</AssemblyCopyright>-->
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -168,7 +168,6 @@
     </AssemblyAttributes>
   </ItemGroup>
 
-  
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <!-- Assembly attributes for net core projects -->
     <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
@@ -179,7 +178,7 @@
   </PropertyGroup>
 
   <!-- Add symbols to the dll for test dlls -->
-  <PropertyGroup Condition=" '$(TestProject)' == 'true' ">		
+  <PropertyGroup Condition=" '$(TestProject)' == 'true' ">
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -176,8 +176,10 @@
     <SchemaVersion>2.0</SchemaVersion>
     <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
 
-    <!-- Add symbols to the dll for test dlls -->
+  <!-- Add symbols to the dll for test dlls -->
+  <PropertyGroup Condition=" '$(TestProject)' == 'true' ">		
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -137,7 +137,6 @@
     <!-- Turn on dynamic assembly attribute generation -->
     <AssemblyAttributesPath>$(IntermediateOutputPath)AssemblyInfo.g.cs</AssemblyAttributesPath>
     <GenerateAdditionalSources>true</GenerateAdditionalSources>
-    <PreReleaseVersion>0</PreReleaseVersion>
   </PropertyGroup>
 
   <!-- Assembly attributes -->

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -21,7 +21,7 @@
     <NupkgOutputDirectory Condition=" '$(BuildRTM)' != 'true' ">$(ArtifactsDirectory)nupkgs\</NupkgOutputDirectory>
     <NupkgOutputDirectory Condition=" '$(BuildRTM)' == 'true' ">$(ArtifactsDirectory)ReleaseNupkgs\</NupkgOutputDirectory>
     <SolutionPackagesFolder>$(RepositoryRootDirectory)packages\</SolutionPackagesFolder>
-    <XunitConoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.2.0\tools\xunit.console.x86.exe</XunitConoleExePath>
+    <XunitConsoleExePath>$(SolutionPackagesFolder)xunit.runner.console.2.2.0\tools\xunit.console.x86.exe</XunitConsoleExePath>
     <EnlistmentRoot>$(RepositoryRootDirectory)</EnlistmentRoot>
     <EnlistmentRootSrc>$(RepositoryRootDirectory)\src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>
@@ -168,19 +168,17 @@
     </AssemblyAttributes>
   </ItemGroup>
 
-  <!-- Assembly attributes for net core projects -->
+  
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
+    <!-- Assembly attributes for net core projects -->
     <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
-  </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <SchemaVersion>2.0</SchemaVersion>
     <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
-  </PropertyGroup>
 
-  <!-- Add symbols to the dll for test dlls -->
-  <PropertyGroup Condition=" '$(TestProject)' == 'true' ">
+    <!-- Add symbols to the dll for test dlls -->
     <DebugType>embedded</DebugType>
   </PropertyGroup>
+
 </Project>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -171,11 +171,6 @@
   <!-- Assembly attributes for net core projects -->
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
-    <!--<AssemblyFileVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyFileVersion>
-    <AssemblyInformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</AssemblyInformationalVersion>
-    <AssemblyCompany>Microsoft CoASDasdrporation</AssemblyCompany>
-    <AssemblyProduct>NuGet</AssemblyProduct>
-    <AssemblyCopyright>Microsoft Corporation. All rights reserved.</AssemblyCopyright>-->
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">

--- a/build/common.props
+++ b/build/common.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <IsNetCoreProject>true</IsNetCoreProject>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <!-- Load config -->

--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,6 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
     <IsNetCoreProject>true</IsNetCoreProject>
-    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <!-- Load config -->

--- a/build/common.targets
+++ b/build/common.targets
@@ -125,7 +125,7 @@
       Condition=" '$(IsDesktop)' == 'true' AND '$(SkipDesktopTests)' != 'true' " />
 
     <!-- For desktop frameworks use the console runner -->
-    <Exec Command="$(XunitConoleExePath) $(TestAssemblyPath) -html $(TestResultsDirectory)$(ProjectName).VS$(VisualStudioVersion).html"
+    <Exec Command="$(XunitConsoleExePath) $(TestAssemblyPath) -html $(TestResultsDirectory)$(ProjectName).VS$(VisualStudioVersion).html"
           Condition=" '$(IsDesktop)' == 'true' AND '$(SkipDesktopTests)' != 'true' " />
 
     <!-- For other frameworks call dotnet test -->


### PR DESCRIPTION
Currently net core projects are using auto generated build numbers. this PR fixes that.

