### PR TITLE
Fixing VS hang issue with PMC

### DIFF
--- a/src/NuGet.Clients/VsConsole/Console/Console/ConsoleDispatcher.cs
+++ b/src/NuGet.Clients/VsConsole/Console/Console/ConsoleDispatcher.cs
@@ -183,7 +183,9 @@ namespace NuGetConsole.Implementation.Console
                     CultureInfo currentCulture = CultureInfo.CurrentCulture;
                     CultureInfo currentUICulture = CultureInfo.CurrentUICulture;
 
-                    Task.Factory.StartNew(
+                    // changed from Task.Factory.StartNew to Task.Run in order to run with
+                    // default TaskSchedular instead of current.
+                    Task.Run(
                         // gives the host a chance to do initialization works before the console starts accepting user inputs
                         () =>
                             {


### PR DESCRIPTION
While starting the `ConsoleDispatcher`, we creates a new task with StartNew(action) which inherited its parent task scheduler and waiting to go to powershell pipeline thread, whereas pipeline thread was also executing some action and waiting to go to UI thread, so the deadlock.

Solution is to move from `Task.Factory.StartNew` to `Task.Run` which by default uses `TaskSchedular.Default` so it always executes the task on threadpool and the caller doesn't decides the behavior at runtime.

Fixes https://github.com/NuGet/Home/issues/4976

@rrelyea 