### PR TITLE
Improve auto restore performance and also NuGet sln load time

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -138,7 +138,7 @@ namespace NuGet.SolutionRestoreManager
             // Advise has been called.
             // IsSolutionFullyLoaded may be expensive so make sure it's called only once.
             if (!_solutionLoadedEvent.IsSet
-                && SolutionManager.IsSolutionFullyLoaded)
+                && await SolutionManager.IsSolutionFullyLoadedAsync())
             {
                 _solutionLoadedEvent.Set();
             }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/IVsSolutionManager.cs
@@ -33,7 +33,7 @@ namespace NuGet.PackageManagement.VisualStudio
         /// <summary>
         /// Return true if all projects in the solution have been loaded in background.
         /// </summary>
-        bool IsSolutionFullyLoaded { get; }
+        Task<bool> IsSolutionFullyLoadedAsync();
 
         /// <summary>
         /// Returns true if solution has any project in deferred state.

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -470,19 +470,13 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public bool IsSolutionFullyLoaded
+        public async Task<bool> IsSolutionFullyLoadedAsync()
         {
-            get
-            {
-                return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
-                {
-                    await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                    EnsureInitialize();
-                    var value = GetVSSolutionProperty((int)(__VSPROPID4.VSPROPID_IsSolutionFullyLoaded));
-                    return (bool)value;
-                });
-            }
+            EnsureInitialize();
+            var value = GetVSSolutionProperty((int)(__VSPROPID4.VSPROPID_IsSolutionFullyLoaded));
+            return (bool)value;
         }
 
         public void EnsureSolutionIsLoaded()

--- a/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
+++ b/src/NuGet.Clients/VisualStudio.Facade/NuGet.VisualStudio.Facade.csproj
@@ -45,23 +45,23 @@
       <HintPath>$(EnlistmentRoot)\packages\Microsoft.Build.15.1.262-preview5\lib\net46\Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <PackageReference Version="15.98.0-preview" Include="Microsoft.TeamFoundationServer.ExtendedClient" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.CoreUtility" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Editor" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Language.Intellisense" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Language.StandardClassification" />
-    <PackageReference Version="15.107.0-preview" Include="Microsoft.VisualStudio.Services.Client" />
-    <PackageReference Version="15.107.0-preview" Include="Microsoft.VisualStudio.Services.InteractiveClient" />
+    <PackageReference Version="15.112.1" Include="Microsoft.TeamFoundationServer.ExtendedClient" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.CoreUtility" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Language.Intellisense" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Language.StandardClassification" />
+    <PackageReference Version="15.112.1" Include="Microsoft.VisualStudio.Services.Client" />
+    <PackageReference Version="15.112.1" Include="Microsoft.VisualStudio.Services.InteractiveClient" />
     <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Shell.15.0" />
     <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Shell.Immutable.15.0" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Text.Data" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Text.Logic" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Text.UI" />
-    <PackageReference Version="15.0.25123-Dev15Preview" Include="Microsoft.VisualStudio.Text.UI.Wpf" />
-    <PackageReference Version="15.0.20-pre" Include="Microsoft.VisualStudio.Threading" />
-    <PackageReference Version="15.0.25604-Preview4" Include="Microsoft.VSSDK.BuildTools" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Text.Data" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Text.Logic" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Text.UI" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <PackageReference Version="15.0.240" Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Version="15.0.26201" Include="Microsoft.VSSDK.BuildTools" />
     <PackageReference Version="15.0.691-master31907920" Include="Microsoft.VisualStudio.Telemetry" />
-    <PackageReference Version="6.0.4" Include="Newtonsoft.Json" />
+    <PackageReference Version="8.0.3" Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26201" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
+++ b/src/NuGet.Clients/VsConsole/PowerShellHost/PowerShellHost.cs
@@ -399,7 +399,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 // projects might not be loaded when DPL is enabled.
                 _solutionManager.EnsureSolutionIsLoaded();
 
-                if (!_solutionManager.IsSolutionFullyLoaded)
+                if (!await _solutionManager.IsSolutionFullyLoadedAsync())
                 {
                     return;
                 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="3.0.0-beta1-61516-01" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0-beta1-61516-01" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/NuGet.Common.Test.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.0.1" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
   </ItemGroup>
 

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnvDTE" Version="8.0.0" />
+    <PackageReference Include="EnvDTE" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,7 +28,7 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)PackageManagement.UI\NuGet.PackageManagement.UI.csproj" />
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
 
   <Target Name="DeployToArtifacts" AfterTargets="Build;Rebuild">
   <!--
@@ -40,9 +40,6 @@
     </PropertyGroup>
     <Message Text="Publishing test extension artifacts..." Importance="high" />
     <Message Text="$(TargetPath) -&gt; $(PublishDestination)" Importance="high" />
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(PublishDestination)"
-      OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(PublishDestination)" OverwriteReadOnlyFiles="true" />
   </Target>
 </Project>

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -37,8 +37,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
-    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.0.1" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
   </ItemGroup>
 
   <!-- Remove files that do not support netstandard -->


### PR DESCRIPTION
This PR improves auto restore performance by almost ~50%. Previously it was taking ~80 secs to complete auto restore on NuGet sln (without cleaning cache) now it takes ~45 secs for the same sln. Apart from the CPU time, it also improves responsiveness or less UI freeze (there are still intermittent freezes everytime it access UI thread) since it now doesn't block UI thread too often.

It primarily does 2 things:
1. Avoid blocking threadpool thread when it tries to move to UI thread so `IsSolutionFullyLoaded` API is being converted to `async` so it will improve overall auto restore performance and will be applicable across solutions.
2. Avoid downgrade warnings which was specific to NuGet solution.

There are still couple of areas to further improve it such as `ExecuteAndCommitAsync` API in `RestoreRunner` ideally this method should be executed as async instead of running under `Task.Run`. Will continue to improve it further.

@rrelyea @DoRonMotter 