### PR TITLE
Unblocking E2E tests post migration merge

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -21,7 +21,7 @@
     <Compile Include="$(BuildCommonDirectory)TestShared\*.cs" />
   </ItemGroup>
 
-  <ImportGroup>
+  <ImportGroup Condition=" '$(SkipSigning)' != 'true' ">
     <Import Project="sign.targets" />
   </ImportGroup>
 

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Use NuGet SNK by default for all projects and since we own NuGet SNK we can sign assemblies for good. -->
-  <PropertyGroup>
+  <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('API.Test')) == 'false' ">
     <StrongNameKey>$(NUGET_PFX_PATH)</StrongNameKey>
   </PropertyGroup>
 

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- Use NuGet SNK by default for all projects and since we own NuGet SNK we can sign assemblies for good. -->
+  <!-- Use NuGet SNK by default for all projects except API.Test. -->
   <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('API.Test')) == 'false' ">
     <StrongNameKey>$(NUGET_PFX_PATH)</StrongNameKey>
   </PropertyGroup>

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- Use NuGet SNK by default for all projects except API.Test. -->
-  <PropertyGroup Condition = " $(MSBuildProjectFullPath.Contains('API.Test')) == 'false' ">
+  <PropertyGroup>
     <StrongNameKey>$(NUGET_PFX_PATH)</StrongNameKey>
   </PropertyGroup>
 

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -4,8 +4,6 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <SignAssembly>false</SignAssembly>
-    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -4,6 +4,8 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <SignAssembly>false</SignAssembly>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
+    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
During the merge process @emgarten  and I moved props and targets. That cause API.test.dll to be delay signed that caused problems when E2E machine tried to import it.

Fix - Do not delay sign API.Test.dll