### PR TITLE
RestoreArgs cache settings based on all config paths

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -144,10 +144,11 @@ namespace NuGet.CommandLine
                         // Remove input list, everything has been loaded already
                         restoreContext.Inputs.Clear();
 
+                        // Create requests using settings based on the project directory. This is to provide
+                        // the same behavior as dotnet.exe restore and msbuild /t:restore
                         restoreContext.PreLoadedRequestProviders.Add(new DependencyGraphSpecRequestProvider(
                             providerCache,
-                            restoreInputs.ProjectReferenceLookup,
-                            Settings));
+                            restoreInputs.ProjectReferenceLookup));
                     }
                     else
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -105,7 +105,7 @@ namespace NuGet.Commands
 
             // Load from environment, nuget.config or default location, and resolve relative paths
             // to the project root.
-            string globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
+            var globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
             return Path.GetFullPath(Path.Combine(rootDirectory, globalPath));
         }
 
@@ -124,7 +124,9 @@ namespace NuGet.Commands
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            return _sourcesCache.GetOrAdd(settings.Root, (root) => GetEffectiveSourcesCore(settings));
+            var cacheKey = string.Join("|", settings.Priority.Select(e => e.Root));
+
+            return _sourcesCache.GetOrAdd(cacheKey, (root) => GetEffectiveSourcesCore(settings));
         }
 
         private List<SourceRepository> GetEffectiveSourcesCore(ISettings settings)


### PR DESCRIPTION
RestoreArgs will cache settings based on the path of all config files, not just the root.

This also includes a fix for nuget.exe to allow RestoreArgs to find nuget.config in the project folder. Previously it was overridden the by the solution config. 

Fixes https://github.com/NuGet/Home/issues/4979