### PR TITLE
Implemented build restore without blocking UI thread

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -38,6 +38,7 @@
     <Compile Include="RestoreManagerPackage.cs" />
     <Compile Include="RestoreOperationLogger.cs" />
     <Compile Include="RestoreOperationProgressUI.cs" />
+    <Compile Include="SolutionRestoreBuildHandler.cs" />
     <Compile Include="SolutionRestoreCommand.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -2,18 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
-using NuGet.Configuration;
-using NuGet.PackageManagement;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
@@ -31,50 +24,17 @@ namespace NuGet.SolutionRestoreManager
     [Guid(PackageGuidString)]
     public sealed class RestoreManagerPackage : AsyncPackage
     {
-        public const string ProductVersion = "4.0.0";
-
         /// <summary>
         /// RestoreManagerPackage GUID string.
         /// </summary>
         public const string PackageGuidString = "2b52ac92-4551-426d-bd34-c6d7d9fdd1c5";
 
-        private Lazy<ISolutionRestoreWorker> _restoreWorker;
-        private Lazy<ISettings> _settings;
-        private Lazy<IVsSolutionManager> _solutionManager;
-
-        private ISolutionRestoreWorker SolutionRestoreWorker => _restoreWorker.Value;
-        private ISettings Settings => _settings.Value;
-        private IVsSolutionManager SolutionManager => _solutionManager.Value;
-
-        private IVsSolutionBuildManager5 _solutionBuildManager;
-
-        private IVsSolutionBuildManager3 _solutionBuildManager3;
-
-        private uint _updateSolutionEventsCookie4;
-
-        private uint _updateSolutionEventsCookie3;
+        private IDisposable _handler;
 
         protected override async Task InitializeAsync(
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
-            var componentModel = await GetServiceAsync(typeof(SComponentModel)) as IComponentModel;
-            componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
-
-            _restoreWorker = new Lazy<ISolutionRestoreWorker>(
-                () => componentModel.GetService<ISolutionRestoreWorker>());
-
-            _settings = new Lazy<ISettings>(
-                () => componentModel.GetService<ISettings>());
-
-            _solutionManager = new Lazy<IVsSolutionManager>(
-                () => componentModel.GetService<IVsSolutionManager>());
-
-            var lockService = new Lazy<INuGetLockService>(
-                () => componentModel.GetService<INuGetLockService>());
-
-            var updateSolutionEvent = new VsUpdateSolutionEvent(lockService, this);
-
             // Don't use CPS thread helper because of RPS perf regression
             await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
@@ -83,17 +43,9 @@ namespace NuGet.SolutionRestoreManager
 
                 UserAgent.SetUserAgentString(
                     new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
-
-                _solutionBuildManager = (IVsSolutionBuildManager5)await GetServiceAsync(typeof(SVsSolutionBuildManager));
-                Assumes.Present(_solutionBuildManager);
-
-                _solutionBuildManager.AdviseUpdateSolutionEvents4(updateSolutionEvent, out _updateSolutionEventsCookie4);
-
-                _solutionBuildManager3 = (IVsSolutionBuildManager3)await GetServiceAsync(typeof(SVsSolutionBuildManager));
-                Assumes.Present(_solutionBuildManager3);
-
-                _solutionBuildManager3.AdviseUpdateSolutionEvents3(updateSolutionEvent, out _updateSolutionEventsCookie3);
             });
+
+            _handler = await SolutionRestoreBuildHandler.InitializeAsync(this);
 
             await SolutionRestoreCommand.InitializeAsync(this);
 
@@ -102,142 +54,17 @@ namespace NuGet.SolutionRestoreManager
 
         protected override void Dispose(bool disposing)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (_updateSolutionEventsCookie4 != 0)
+            // disposing is true when called from IDispose.Dispose; false when called from Finalizer.
+            if (disposing)
             {
-                _solutionBuildManager?.UnadviseUpdateSolutionEvents4(_updateSolutionEventsCookie4);
-            }
-
-            if (_updateSolutionEventsCookie3 != 0)
-            {
-                _solutionBuildManager3?.UnadviseUpdateSolutionEvents3(_updateSolutionEventsCookie3);
-            }
-        }
-
-        /// <summary>
-        /// Returns true if automatic package restore on build is enabled.
-        /// </summary>
-        private bool ShouldRestoreOnBuild
-        {
-            get
-            {
-                var packageRestoreConsent = new PackageRestoreConsent(Settings);
-                return packageRestoreConsent.IsAutomatic;
-            }
-        }
-
-        private sealed class VsUpdateSolutionEvent : IVsUpdateSolutionEvents4, IVsUpdateSolutionEvents3
-        {
-            private const uint REBUILD_FLAG = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_FORCE_UPDATE + (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
-
-            private Lazy<INuGetLockService> _lockService;
-
-            private RestoreManagerPackage _restoreManagerPackage;
-
-            private Task _restoreTask = Task.CompletedTask;
-
-            private bool _issRestoreRunning = false;
-
-            public VsUpdateSolutionEvent(Lazy<INuGetLockService> lockService, RestoreManagerPackage restoreManagerPackage)
-            {
-                Assumes.NotNull(restoreManagerPackage);
-
-                _restoreManagerPackage = restoreManagerPackage;
-                _lockService = lockService;
-            }
-
-            private void OnBuildRestore()
-            {
+                // Guarantees thread-safe execution of this method.
                 ThreadHelper.ThrowIfNotOnUIThread();
 
-                // Query build manager operation flag
-                uint buildManagerOperation;
-                _restoreManagerPackage._solutionBuildManager3.QueryBuildManagerBusyEx(out buildManagerOperation);
-
-                if (buildManagerOperation == (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_CLEAN)
-                {
-                    // Clear the project.json restore cache on clean to ensure that the next build restores again
-                    _restoreManagerPackage.SolutionRestoreWorker.CleanCache();
-
-                    return;
-                }
-
-                if (!_restoreManagerPackage.ShouldRestoreOnBuild)
-                {
-                    return;
-                }
-
-                var forceRestore = buildManagerOperation == REBUILD_FLAG;
-
-                // start a restore task
-                if (_restoreTask.IsCompleted)
-                {
-                    _restoreTask = NuGetUIThreadHelper.JoinableTaskFactory
-                        .RunAsync(() => _restoreManagerPackage.SolutionRestoreWorker.ScheduleRestoreAsync(
-                            SolutionRestoreRequest.OnBuild(forceRestore),
-                            CancellationToken.None))
-                        .Task;
-                }
+                _handler?.Dispose();
+                _handler = null;
             }
 
-            public void UpdateSolution_QueryDelayFirstUpdateAction(out int pfDelay)
-            {
-                // check if NuGet lock is already acquired by some other NuGet operation
-                if (_lockService.Value.IsLockHeld)
-                {
-                    // delay build by setting pfDelay to non-zero
-                    pfDelay = 1;
-                }
-                // check if no build restore is running, then start a new one
-                else if (!_issRestoreRunning)
-                {
-                    // disable running more build restore
-                    _issRestoreRunning = true;
-
-                    // run build restore
-                    OnBuildRestore();
-
-                    // delay build until restore is running
-                    pfDelay = 1;
-
-                }
-                else if (!_restoreTask.IsCompleted)
-                {
-                    // delay build by setting pfDelay to non-zero since restore is still running
-                    pfDelay = 1;
-                }
-                else
-                {
-                    // enable running build restore again.
-                    _issRestoreRunning = false;
-
-                    // Set delay to 0 which means allow build to proceed.
-                    pfDelay = 0;
-                }
-            }
-
-            public void UpdateSolution_BeginFirstUpdateAction() { }
-
-            public void UpdateSolution_EndLastUpdateAction() { }
-
-            public void UpdateSolution_BeginUpdateAction(uint dwAction) { }
-
-            public void UpdateSolution_EndUpdateAction(uint dwAction) { }
-
-            public void OnActiveProjectCfgChangeBatchBegin() { }
-
-            public void OnActiveProjectCfgChangeBatchEnd() { }
-
-            public int OnBeforeActiveSolutionCfgChange(IVsCfg pOldActiveSlnCfg, IVsCfg pNewActiveSlnCfg)
-            {
-                return VSConstants.S_OK;
-            }
-
-            public int OnAfterActiveSolutionCfgChange(IVsCfg pOldActiveSlnCfg, IVsCfg pNewActiveSlnCfg)
-            {
-                return VSConstants.S_OK;
-            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -1,0 +1,341 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using NuGet.Configuration;
+using NuGet.PackageManagement;
+using NuGet.VisualStudio;
+using ThreadHelper = Microsoft.VisualStudio.Shell.ThreadHelper;
+
+namespace NuGet.SolutionRestoreManager
+{
+    /// <summary>
+    /// A solution build manager events listener orchestrating on-build restore operations
+    /// </summary>
+    /// <remarks>
+    /// Utilizes four core events to start, monitor, and control restore operations:
+    /// UpdateSolution_Begin
+    /// UpdateSolution_QueryDelayFirstUpdateAction
+    /// UpdateSolution_Cancel
+    /// UpdateSolution_Done
+    /// </remarks>
+    public sealed class SolutionRestoreBuildHandler 
+        : IVsUpdateSolutionEvents4, IVsUpdateSolutionEvents2, IDisposable
+    {
+        private const uint REBUILD_FLAG = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_FORCE_UPDATE + (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+        private const uint VSCOOKIE_NIL = 0;
+
+        [Import]
+        private Lazy<INuGetLockService> LockService { get; set; }
+
+        [Import]
+        private Lazy<ISettings> Settings { get; set; }
+
+        [Import]
+        private Lazy<ISolutionRestoreWorker> SolutionRestoreWorker { get; set; }
+
+        /// <summary>
+        /// The <see cref="IVsSolutionBuildManager3"/> object controlling the update solution events.
+        /// </summary>
+        private IVsSolutionBuildManager3 _solutionBuildManager;
+
+        /// <summary>
+        /// The cookie associated to the the <see cref="IVsUpdateSolutionEvents4"/> events.
+        /// </summary>
+        private uint _updateSolutionEventsCookie4;
+
+        /// <summary>
+        /// The cookie associated to the the <see cref="IVsUpdateSolutionEvents2"/> events.
+        /// </summary>
+        private uint _updateSolutionEventsCookie2;
+
+        private RestoreTask _restoreTask = RestoreTask.None;
+
+        private SolutionRestoreBuildHandler()
+        {
+        }
+
+        // A constructor utilized for running unit-tests
+        public SolutionRestoreBuildHandler(
+            INuGetLockService lockService,
+            ISettings settings,
+            ISolutionRestoreWorker restoreWorker,
+            IVsSolutionBuildManager3 buildManager)
+        {
+            Assumes.Present(lockService);
+            Assumes.Present(settings);
+            Assumes.Present(restoreWorker);
+            Assumes.Present(buildManager);
+
+            LockService = new Lazy<INuGetLockService>(() => lockService);
+            Settings = new Lazy<ISettings>(() => settings);
+            SolutionRestoreWorker = new Lazy<ISolutionRestoreWorker>(() => restoreWorker);
+
+            _solutionBuildManager = buildManager;
+        }
+
+        public void Dispose()
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (_updateSolutionEventsCookie4 != VSCOOKIE_NIL)
+            {
+                ((IVsSolutionBuildManager5)_solutionBuildManager).UnadviseUpdateSolutionEvents4(_updateSolutionEventsCookie4);
+                _updateSolutionEventsCookie4 = VSCOOKIE_NIL;
+            }
+
+            if (_updateSolutionEventsCookie2 != VSCOOKIE_NIL)
+            {
+                ((IVsSolutionBuildManager2)_solutionBuildManager).UnadviseUpdateSolutionEvents(_updateSolutionEventsCookie4);
+                _updateSolutionEventsCookie2 = VSCOOKIE_NIL;
+            }
+
+            _restoreTask.Dispose();
+        }
+
+        // A factory method invoked internally only
+        internal static async Task<IDisposable> InitializeAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider serviceProvider)
+        {
+            Assumes.Present(serviceProvider);
+
+            var instance = new SolutionRestoreBuildHandler();
+
+            var componentModel = await serviceProvider.GetComponentModelAsync();
+            componentModel.DefaultCompositionService.SatisfyImportsOnce(instance);
+
+            await instance.SubscribeAsync(serviceProvider);
+
+            return instance;
+        }
+
+        private async Task SubscribeAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider serviceProvider)
+        {
+            // Don't use CPS thread helper because of RPS perf regression
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            _solutionBuildManager = await serviceProvider.GetServiceAsync<SVsSolutionBuildManager, IVsSolutionBuildManager3>();
+            Assumes.Present(_solutionBuildManager);
+
+            ((IVsSolutionBuildManager5)_solutionBuildManager).AdviseUpdateSolutionEvents4(this, out _updateSolutionEventsCookie4);
+
+            ErrorHandler.ThrowOnFailure(
+                ((IVsSolutionBuildManager2)_solutionBuildManager).AdviseUpdateSolutionEvents(
+                    this, out _updateSolutionEventsCookie2));
+        }
+
+        #region IVsUpdateSolutionEvents4
+
+        public void UpdateSolution_QueryDelayFirstUpdateAction(out int pfDelay)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // check if NuGet lock is already acquired by some other NuGet operation
+            if (LockService.Value.IsLockHeld)
+            {
+                // delay build by setting pfDelay to non-zero
+                pfDelay = 10;
+            }
+            else if (!_restoreTask.IsCompleted)
+            {
+                // delay build by setting pfDelay to non-zero since restore is still running
+                pfDelay = 10;
+            }
+            else
+            {
+                // Set delay to 0 which means allow build to proceed.
+                pfDelay = 0;
+            }
+        }
+
+        public void UpdateSolution_BeginFirstUpdateAction() { }
+
+        public void UpdateSolution_EndLastUpdateAction() { }
+
+        public void UpdateSolution_BeginUpdateAction(uint dwAction) { }
+
+        public void UpdateSolution_EndUpdateAction(uint dwAction) { }
+
+        public void OnActiveProjectCfgChangeBatchBegin() { }
+
+        public void OnActiveProjectCfgChangeBatchEnd() { }
+
+        #endregion IVsUpdateSolutionEvents4
+
+        #region IVsUpdateSolutionEvents2
+
+        /// <summary>
+        /// Called when the active project configuration for a project in the solution has changed.
+        /// </summary>
+        /// <param name="hierarchy">The project whose configuration has changed.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int OnActiveProjectCfgChange(IVsHierarchy hierarchy)
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called right before a project configuration begins to build.
+        /// </summary>
+        /// <param name="hierarchy">The project that is to be build.</param>
+        /// <param name="configProject">A configuration project object.</param>
+        /// <param name="configSolution">A configuration solution object.</param>
+        /// <param name="action">The action taken.</param>
+        /// <param name="cancel">A flag indicating cancel.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        /// <remarks>The values for the action are defined in the enum _SLNUPDACTION env\msenv\core\slnupd2.h</remarks>
+        public int UpdateProjectCfg_Begin(IVsHierarchy hierarchy, IVsCfg configProject, IVsCfg configSolution, uint action, ref int cancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called right after a project configuration is finished building.
+        /// </summary>
+        /// <param name="hierarchy">The project that has finished building.</param>
+        /// <param name="configProject">A configuration project object.</param>
+        /// <param name="configSolution">A configuration solution object.</param>
+        /// <param name="action">The action taken.</param>
+        /// <param name="success">Flag indicating success.</param>
+        /// <param name="cancel">Flag indicating cancel.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        /// <remarks>The values for the action are defined in the enum _SLNUPDACTION env\msenv\core\slnupd2.h</remarks>
+        public int UpdateProjectCfg_Done(IVsHierarchy hierarchy, IVsCfg configProject, IVsCfg configSolution, uint action, int success, int cancel)
+        {
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called before any build actions have begun. This is the last chance to cancel the build before any building begins.
+        /// </summary>
+        /// <param name="cancelUpdate">Flag indicating cancel update.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int UpdateSolution_Begin(ref int cancelUpdate)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            // Query build manager operation flag
+            uint buildManagerOperation;
+            ErrorHandler.ThrowOnFailure(
+                _solutionBuildManager.QueryBuildManagerBusyEx(out buildManagerOperation));
+
+            if (buildManagerOperation == (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_CLEAN)
+            {
+                // Clear the project.json restore cache on clean to ensure that the next build restores again
+                SolutionRestoreWorker.Value.CleanCache();
+
+                return VSConstants.S_OK;
+            }
+
+            if (!ShouldRestoreOnBuild)
+            {
+                return VSConstants.S_OK;
+            }
+
+            // start a restore task
+            var forceRestore = buildManagerOperation == REBUILD_FLAG;
+            _restoreTask = RestoreTask.Start(SolutionRestoreWorker.Value, forceRestore);
+
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called when a build is being cancelled.
+        /// </summary>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int UpdateSolution_Cancel()
+        {
+            if (!_restoreTask.IsCompleted)
+            {
+                _restoreTask.Cancel();
+            }
+
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called when a build is completed.
+        /// </summary>
+        /// <param name="succeeded">true if no update actions failed.</param>
+        /// <param name="modified">true if any update action succeeded.</param>
+        /// <param name="cancelCommand">true if update actions were canceled.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int UpdateSolution_Done(int succeeded, int modified, int cancelCommand)
+        {
+            _restoreTask.Dispose();
+            _restoreTask = RestoreTask.None;
+
+            return VSConstants.S_OK;
+        }
+
+        /// <summary>
+        /// Called before the first project configuration is about to be built.
+        /// </summary>
+        /// <param name="cancelUpdate">A flag indicating cancel update.</param>
+        /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
+        public int UpdateSolution_StartUpdate(ref int cancelUpdate)
+        {
+            return VSConstants.S_OK;
+        }
+
+        #endregion IVsUpdateSolutionEvents2
+
+        /// <summary>
+        /// Returns true if automatic package restore on build is enabled.
+        /// </summary>
+        private bool ShouldRestoreOnBuild
+        {
+            get
+            {
+                var packageRestoreConsent = new PackageRestoreConsent(Settings.Value);
+                return packageRestoreConsent.IsAutomatic;
+            }
+        }
+
+        private class RestoreTask : IDisposable
+        {
+            private CancellationTokenSource _cts;
+            private Task _task;
+
+            public bool IsCompleted => _task.IsCompleted;
+
+            public TaskAwaiter GetAwaiter() => _task.GetAwaiter();
+
+            public static RestoreTask None => new RestoreTask { _task = Task.CompletedTask };
+
+            public static RestoreTask Start(ISolutionRestoreWorker worker, bool forceRestore)
+            {
+                var cts = new CancellationTokenSource();
+                var task = worker
+                    .JoinableTaskFactory
+                    .RunAsync(() => worker.ScheduleRestoreAsync(
+                        SolutionRestoreRequest.OnBuild(forceRestore),
+                        cts.Token))
+                    .Task;
+
+                return new RestoreTask
+                {
+                    _cts = cts,
+                    _task = task
+                };
+            }
+
+            public void Cancel()
+            {
+                _cts?.Cancel();
+            }
+
+            public void Dispose()
+            {
+                _cts?.Dispose();
+            }
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -58,6 +58,8 @@ namespace NuGet.SolutionRestoreManager
 
         public bool IsBusy => !_activeRestoreTask.IsCompleted;
 
+        public JoinableTaskFactory JoinableTaskFactory => _joinableFactory;
+
         [ImportingConstructor]
         public SolutionRestoreWorker(
             [Import(typeof(SVsServiceProvider))]

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
 
 namespace NuGet.VisualStudio
 {
@@ -20,6 +21,11 @@ namespace NuGet.VisualStudio
         /// Returns true when it's executing a restore operation.
         /// </summary>
         bool IsBusy { get; }
+
+        /// <summary>
+        /// Joinable task factory to syncronize with the worker.
+        /// </summary>
+        JoinableTaskFactory JoinableTaskFactory { get; }
 
         /// <summary>
         /// Schedules backgroud restore operation.

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/GlobalSuppressions.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "Test code does not need to follow this rule.")]

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/MainThreadCollection.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/MainThreadCollection.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Test.Utility.Threading;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    /// <summary>
+    /// Represents a test collection fixture shared among multiple test classes.
+    /// Provides access to a JTF instance for running tests.
+    /// This class has no code, and is never created. Its purpose is simply
+    /// to be the place to apply [CollectionDefinition] and all the
+    /// ICollectionFixture<> interfaces.
+    /// </summary>
+    [CollectionDefinition(CollectionName)]
+    public class DispatcherThreadCollection : ICollectionFixture<DispatcherThreadFixture>
+    {
+        public const string CollectionName = "Dispatcher thread collection";
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -4,46 +4,8 @@
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>
-    <NETCoreWPFProject>true</NETCoreWPFProject>
     <TestProject>true</TestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ErrorListTableDataSourceTests.cs" />
-    <Compile Include="ProjectRestoreInfoBuilder.cs" />
-    <Compile Include="VsItemList.cs" />
-    <Compile Include="VsProjectProperties.cs" />
-    <Compile Include="VsProjectProperty.cs" />
-    <Compile Include="VsProjectRestoreInfo.cs" />
-    <Compile Include="VsReferenceItem.cs" />
-    <Compile Include="VsReferenceItems.cs" />
-    <Compile Include="VsReferenceProperties.cs" />
-    <Compile Include="VsReferenceProperty.cs" />
-    <Compile Include="VsSolutionRestoreServiceTests.cs" />
-    <Compile Include="VsTargetFrameworkInfo.cs" />
-    <Compile Include="VsTargetFrameworks.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
-    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj">
-      <Project>{4003e1ab-70de-4b9c-8999-96160ee91d84}</Project>
-      <Name>NuGet.SolutionRestoreManager.Interop</Name>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj" />
-
-    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
-
-    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
-  </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
@@ -53,6 +15,13 @@
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.PackageManagement.VisualStudio\NuGet.PackageManagement.VisualStudio.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj" />
+    <ProjectReference Include="..\..\..\src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj" />
+    <ProjectReference Include="..\..\TestUtilities\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -1,0 +1,458 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using NuGet.Configuration;
+using NuGet.VisualStudio;
+using Test.Utility.Threading;
+using Xunit;
+
+namespace NuGet.SolutionRestoreManager.Test
+{
+    [Collection(DispatcherThreadCollection.CollectionName)]
+    public class SolutionRestoreBuildHandlerTests
+    {
+        private readonly JoinableTaskFactory _jtf;
+
+        public SolutionRestoreBuildHandlerTests(DispatcherThreadFixture fixture)
+        {
+            Assumes.Present(fixture);
+
+            _jtf = fixture.JoinableTaskFactory;
+        }
+
+        [Fact]
+        public async Task Begin_OnCleanBuild_CleansCacheAndNoOps()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+            var settings = Mock.Of<ISettings>();
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_CLEAN;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                // Act
+                var cancelUpdate = 0;
+                var hr = handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                Assert.Equal(VSConstants.S_OK, hr);
+                Assert.Equal(0, cancelUpdate);
+            }
+
+            Mock.Get(restoreWorker)
+                .Verify(x => x.CleanCache(), Times.Once);
+
+            Mock.Get(restoreWorker)
+                .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Begin_ShouldNotRestoreOnBuild_NoOps()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.FalseString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                // Act
+                var cancelUpdate = 0;
+                var hr = handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                Assert.Equal(VSConstants.S_OK, hr);
+                Assert.Equal(0, cancelUpdate);
+            }
+
+            Mock.Get(restoreWorker)
+                .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Begin_ShouldRestoreOnBuild_StartsRestoreTask()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                // Act
+                var cancelUpdate = 0;
+                var hr = handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                Assert.Equal(VSConstants.S_OK, hr);
+                Assert.Equal(0, cancelUpdate);
+            }
+
+            Mock.Get(restoreWorker)
+                .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenIsLockHeld_Delays()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+            Mock.Get(lockService)
+                .SetupGet(x => x.IsLockHeld)
+                .Returns(true);
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.FalseString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.NotEqual(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenTaskIsNotCompleted_Delays()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.NotEqual(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenTaskIsCompleted_DoesNotDelay()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                tcs.SetResult(true);
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.Equal(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenNoRestoreScheduled_DoesNotDelay()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.FalseString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.Equal(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenTaskIsCanceled_DoesNotDelay()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                tcs.SetCanceled();
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.Equal(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task QueryDelayFirstUpdateAction_WhenTaskHasFailed_DoesNotDelay()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                tcs.SetException(new InvalidOperationException());
+
+                // Act
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+
+                Assert.Equal(0, delayMs);
+            }
+        }
+
+        [Fact]
+        public async Task Cancel_Always_CancelsRestoreTask()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            var restoreHasBeenCancelled = false;
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task)
+                .Callback<SolutionRestoreRequest, CancellationToken>(
+                    (r, t) => t.Register(() => restoreHasBeenCancelled = true));
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                // Act
+                var hr = handler.UpdateSolution_Cancel();
+
+                Assert.Equal(VSConstants.S_OK, hr);
+                Assert.True(restoreHasBeenCancelled);
+            }
+        }
+
+        [Fact]
+        public async Task Done_Always_ResetsRestoreTask()
+        {
+            var lockService = Mock.Of<INuGetLockService>();
+
+            var settings = Mock.Of<ISettings>();
+            Mock.Get(settings)
+                .Setup(x => x.GetValue("packageRestore", "automatic", false))
+                .Returns(bool.TrueString);
+
+            var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
+            Mock.Get(restoreWorker)
+                .SetupGet(x => x.JoinableTaskFactory)
+                .Returns(_jtf);
+            var tcs = new TaskCompletionSource<bool>();
+            Mock.Get(restoreWorker)
+                .Setup(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
+                .Returns(tcs.Task);
+
+            var buildManager = Mock.Of<IVsSolutionBuildManager3>();
+            var buildManagerOperation = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD;
+            Mock.Get(buildManager)
+                .Setup(x => x.QueryBuildManagerBusyEx(out buildManagerOperation))
+                .Returns(VSConstants.S_OK);
+
+            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            {
+                await _jtf.SwitchToMainThreadAsync();
+
+                var cancelUpdate = 0;
+                handler.UpdateSolution_Begin(ref cancelUpdate);
+
+                // Act
+                var hr = handler.UpdateSolution_Done(succeeded: 1, modified: 1, cancelCommand:0);
+
+                Assert.Equal(VSConstants.S_OK, hr);
+
+                int delayMs;
+                handler.UpdateSolution_QueryDelayFirstUpdateAction(out delayMs);
+                Assert.Equal(0, delayMs);
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -11,10 +10,8 @@ using Moq;
 using NuGet.Commands;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.PackageManagement.VisualStudio;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
-using NuGet.Versioning;
 using NuGet.VisualStudio;
 using Xunit;
 

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -26,11 +26,27 @@
     </PackageReference>
   </ItemGroup>
 
+  <Choose>
+    <When Condition="$(VisualStudioVersion)=='14.0'">
+      <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+        <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.2.25123" />
+      </ItemGroup>
+    </When>
+    <When Condition="$(VisualStudioVersion)=='15.0'">
+      <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+        <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201">
+          <PrivateAssets>All</PrivateAssets>
+        </PackageReference>
+      </ItemGroup>
+    </When>
+  </Choose>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,6 +62,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <Compile Remove="PackageManagement\*.cs" />
     <Compile Remove="ProjectManagement\*.cs" />
+    <Compile Remove="Threading\*.cs" />
   </ItemGroup>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />

--- a/test/TestUtilities/Test.Utility/Threading/DispatcherThread.cs
+++ b/test/TestUtilities/Test.Utility/Threading/DispatcherThread.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Windows.Threading;
+
+namespace Test.Utility.Threading
+{
+    internal class DispatcherThread : IDisposable
+    {
+        private readonly Thread _thread;
+        private Dispatcher _dispatcher;
+        private readonly object _invokeSyncRoot = new object();
+        private SynchronizationContext _syncContext;
+        private Exception _invokeException;
+        private bool _isInvoking;
+        private bool _isClosed;
+
+        internal DispatcherThread()
+        {
+            using (var resetEvent = new AutoResetEvent(initialState: false))
+            {
+                _thread = new Thread(() =>
+                {
+                    // This is necessary to make sure a dispatcher exists for this thread.
+                    var unused = Dispatcher.CurrentDispatcher;
+
+                    unused.UnhandledException += new DispatcherUnhandledExceptionEventHandler(OnUnhandledException);
+
+                    resetEvent.Set();
+
+                    Dispatcher.Run();
+                })
+                {
+                    Name = GetType().FullName,
+                    IsBackground = true
+                };
+                _thread.SetApartmentState(ApartmentState.STA);
+                _thread.Start();
+
+                resetEvent.WaitOne();
+
+                AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
+            }
+
+            _dispatcher = Dispatcher.FromThread(_thread);
+        }
+
+        private void CurrentDomain_DomainUnload(object sender, EventArgs e)
+        {
+            // Need to dispose of the dispatch thread prior to the app domain going away.
+            Close();
+        }
+
+        internal Thread Thread => _thread;
+
+        internal SynchronizationContext SyncContext
+        {
+            get
+            {
+                if (_syncContext == null)
+                {
+                    _syncContext = new DispatcherSynchronizationContext(_dispatcher);
+                }
+                return _syncContext;
+            }
+        }
+
+        private void OnUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
+        {
+            // We don't deal with unhandled exceptions from BeginInvoke,
+            // since there's no one to throw them to.
+            if (_isInvoking)
+            {
+                // e.Exception should be a TargetInvocationException from calling Invoke,
+                // the InnerExceptionis the one to forward on
+                if (e.Exception is TargetInvocationException)
+                {
+                    _invokeException = e.Exception.InnerException;
+                }
+                else
+                {
+                    _invokeException = e.Exception;
+                }
+
+                e.Handled = true;
+            }
+        }
+
+        internal void Invoke(Action action)
+        {
+            if (_isClosed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            lock (_invokeSyncRoot)
+            {
+                _isInvoking = true;
+                _invokeException = null;
+
+                try
+                {
+                    _dispatcher.Invoke(DispatcherPriority.Normal, action);
+
+                    if (_invokeException != null)
+                    {
+                        throw _invokeException;
+                    }
+                }
+                finally
+                {
+                    _isInvoking = false;
+                }
+            }
+        }
+
+        internal DispatcherOperation BeginInvoke(Action action)
+        {
+            if (_isClosed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            return _dispatcher.BeginInvoke(DispatcherPriority.Normal, action);
+        }
+
+        internal void Close()
+        {
+            if (!_isClosed)
+            {
+                _dispatcher.InvokeShutdown();
+                _dispatcher = null;
+                try
+                {
+                    _thread.Abort();
+                }
+                catch (ThreadAbortException)
+                {
+                }
+            }
+
+            _isClosed = true;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Threading/DispatcherThreadFixture.cs
+++ b/test/TestUtilities/Test.Utility/Threading/DispatcherThreadFixture.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace Test.Utility.Threading
+{
+    public sealed class DispatcherThreadFixture : IDisposable
+    {
+        private readonly DispatcherThread _dispatcherThread;
+        private readonly JoinableTaskContextNode _joinableTaskContextNode;
+
+        public JoinableTaskFactory JoinableTaskFactory => _joinableTaskContextNode.Factory;
+
+        public DispatcherThreadFixture()
+        {
+            // ThreadHelper in VS requires a persistent dispatcher thread.  Because
+            // each unit test executes on a new thread, we create our own
+            // persistent thread that acts like a UI thread. This will be invoked just
+            // once for the module.
+            _dispatcherThread = new DispatcherThread();
+
+            _dispatcherThread.Invoke(() =>
+            {
+                // Internally this calls ThreadHelper.SetUIThread(), which
+                // causes ThreadHelper to remember this thread for the
+                // lifetime of the process as the dispatcher thread.
+                var serviceProvider = ServiceProvider.GlobalProvider;
+            });
+
+            _joinableTaskContextNode = new JoinableTaskContextNode(
+                new JoinableTaskContext(_dispatcherThread.Thread, _dispatcherThread.SyncContext));
+        }
+
+        public void Dispose()
+        {
+            _dispatcherThread.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
This PR avoid blocking UI thread to block build while running onbuild restore. So instead of using restore on `onBuildEvent` from dte, it now runs it with `UpdateSolution_QueryDelayFirstUpdateAction` and delay build until restore is in progress.

So, now VS won't be freezed or unresponsive during build restore and improve user experience as well as performance.

Fixes https://github.com/NuGet/Home/issues/4986
Resolves NuGet/Home#4457.

@rrelyea @DoRonMotter 