### PR TITLE
Moving slow tests to NuGet.Core.FuncTests

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -194,6 +194,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{96255044
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestUtilities", "TestUtilities", "{79266117-FEDD-45B3-B603-33A4B6E9F12F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Core.FuncTest", "test\NuGet.Core.FuncTests\NuGet.Core.FuncTest\NuGet.Core.FuncTest.csproj", "{34750BB3-4A21-433A-9C55-C051CA70C4AE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -592,6 +594,12 @@ Global
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Mono Release|Any CPU.Build.0 = Mono Release|Any CPU
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Mono Release|Any CPU.ActiveCfg = Mono Release|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Mono Release|Any CPU.Build.0 = Mono Release|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -670,5 +678,6 @@ Global
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{96255044-3776-439B-8496-C460DB9C4F97} = {A8F45E94-4CFD-478C-9FE2-8E6DEE7E0770}
 		{79266117-FEDD-45B3-B603-33A4B6E9F12F} = {D1549653-9631-4E16-9967-55427174A0DC}
+		{34750BB3-4A21-433A-9C55-C051CA70C4AE} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 	EndGlobalSection
 EndGlobal

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ActivityCorrelationIdFuncTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ActivityCorrelationIdFuncTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Common;
+using Xunit;
+
+namespace NuGet.Core.FuncTest
+{
+    public class ActivityCorrelationIdFuncTests
+    {
+        [Fact]
+        public async Task ActivityCorrelationId_StressTest()
+        {
+            // Arrange
+            var taskCount = 8;
+            var iterationCount = 250;
+
+            var tasks = Enumerable
+                .Range(0, taskCount)
+                .Select(t => Task.Run(async () =>
+                {
+                    for (var i = 0; i < iterationCount; i++)
+                    {
+                        await ActivityCorrelationId_FlowsDownAsyncCalls();
+                    }
+                }))
+                .ToArray();
+
+            // Act & Assert
+            await Task.WhenAll(tasks);
+        }
+
+        private async Task ActivityCorrelationId_FlowsDownAsyncCalls()
+        {
+            // Arrange
+            ActivityCorrelationId.StartNew();
+            var expected = ActivityCorrelationId.Current;
+
+            // Act
+            var actual = await AsyncCallA(TimeSpan.FromMilliseconds(1));
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        private async Task<string> AsyncCallA(TimeSpan delay)
+        {
+            await Task.Yield();
+            await Task.Delay(delay);
+            return await AsyncCallB(delay);
+        }
+
+        private async Task<string> AsyncCallB(TimeSpan delay)
+        {
+            await Task.Yield();
+            await Task.Delay(delay);
+            return await AsyncCallC(delay);
+        }
+
+        private async Task<string> AsyncCallC(TimeSpan delay)
+        {
+            await Task.Yield();
+            await Task.Delay(delay);
+            return ActivityCorrelationId.Current;
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ConcurrencyUtilitiesTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ConcurrencyUtilitiesTests.cs
@@ -9,8 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using NuGet.Test.Utility;
+using NuGet.Common;
 
-namespace NuGet.Common.Test
+namespace NuGet.Core.FuncTest
 {
     public class ConcurrencyUtilitiesTests
     {

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/DownloadTimeoutStreamTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/DownloadTimeoutStreamTests.cs
@@ -2,14 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol;
+using Test.Utility;
 using Xunit;
-using System.Diagnostics;
 
-namespace NuGet.Protocol.Tests
+namespace NuGet.Core.FuncTest
 {
     public class DownloadTimeoutStreamTests
     {
@@ -50,8 +51,7 @@ namespace NuGet.Protocol.Tests
             await VerifyTimeoutOnReadAsync(ReadStreamAsync);
         }
         
-        // Skipping this as it is flaky and blocking migration
-        // [Fact]
+        [Fact]
         public async Task DownloadTimeoutStream_FailureAsync()
         {
             await VerifyFailureOnReadAsync(ReadStreamAsync);

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Protocol;
+using NuGet.Test.Server;
+using NuGet.Test.Utility;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.Core.FuncTest
+{
+    public class HttpRetryHandlerTests
+    {
+        private const string TestUrl = "https://test.local/test.json";
+
+        [Fact]
+        public async Task HttpRetryHandler_AppliesTimeoutToRequestsIndividually()
+        {
+            // Arrange
+
+            // 20 requests that take 250ms each for a total of 5 seconds (plus noise).
+            var requestDuration = TimeSpan.FromMilliseconds(250);
+            var maxTries = 20;
+
+            // Make the request timeout longer than each request duration but less than the total
+            // duration of all attempts.
+            var requestTimeout = TimeSpan.FromMilliseconds(4000);
+
+            var hits = 0;
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
+            {
+                hits++;
+                await Task.Delay(requestDuration);
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            };
+
+            var retryHandler = new HttpRetryHandler();
+            var testHandler = new HttpRetryTestHandler(handler);
+            var httpClient = new HttpClient(testHandler);
+            var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
+            {
+                MaxTries = maxTries,
+                RequestTimeout = requestTimeout,
+                RetryDelay = TimeSpan.Zero
+            };
+            var log = new TestLogger();
+
+            // Act
+            using (await retryHandler.SendAsync(request, log, CancellationToken.None))
+            {
+            }
+
+            // Assert
+            Assert.Equal(maxTries, hits);
+        }
+
+        [Fact]
+        public async Task HttpRetryHandler_HandlesFailureToConnect()
+        {
+            // Arrange
+            var server = new NotListeningServer { Mode = TestServerMode.ConnectFailure };
+
+            // Act & Assert
+            var exception = await ThrowsException<HttpRequestException>(server);
+#if IS_CORECLR
+            Assert.NotNull(exception.InnerException);
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                Assert.Equal("Couldn't connect to server", exception.InnerException.Message);
+            }
+            else
+            {
+                Assert.Equal("A connection with the server could not be established", exception.InnerException.Message);
+            }
+#else
+            var innerException = Assert.IsType<WebException>(exception.InnerException);
+            Assert.Equal(WebExceptionStatus.ConnectFailure, innerException.Status);
+#endif
+        }
+
+        [Fact]
+        public async Task HttpRetryHandler_HandlesInvalidProtocol()
+        {
+            // Arrange
+            var server = new TcpListenerServer { Mode = TestServerMode.ServerProtocolViolation };
+
+            // Act & Assert
+            var exception = await ThrowsException<HttpRequestException>(server);
+#if IS_CORECLR
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                Assert.Null(exception.InnerException);
+                Assert.Equal("The server returned an invalid or unrecognized response.", exception.Message);
+            }
+            else
+            {
+                Assert.NotNull(exception.InnerException);
+                Assert.Equal("The server returned an invalid or unrecognized response", exception.InnerException.Message);
+            }
+#else
+            var innerException = Assert.IsType<WebException>(exception.InnerException);
+            Assert.Equal(WebExceptionStatus.ServerProtocolViolation, innerException.Status);
+#endif
+        }
+
+        [Fact]
+        public async Task HttpRetryHandler_HandlesNameResolutionFailure()
+        {
+            // Arrange
+            var server = new UnknownDnsServer { Mode = TestServerMode.NameResolutionFailure };
+
+            // Act & Assert
+            var exception = await ThrowsException<HttpRequestException>(server);
+#if IS_CORECLR
+            Assert.NotNull(exception.InnerException);
+            if (!RuntimeEnvironmentHelper.IsWindows)
+            {
+                Assert.Equal("Couldn't resolve host name", exception.InnerException.Message);
+            }
+            else
+            {
+                Assert.Equal("The server name or address could not be resolved", exception.InnerException.Message);
+            }
+#else
+            var innerException = Assert.IsType<WebException>(exception.InnerException);
+            Assert.Equal(WebExceptionStatus.NameResolutionFailure, innerException.Status);
+#endif
+        }
+
+        private static async Task<T> ThrowsException<T>(ITestServer server) where T : Exception
+        {
+            return await server.ExecuteAsync(async address =>
+            {
+                // Arrange
+                var retryHandler = new HttpRetryHandler();
+                var countingHandler = new CountingHandler { InnerHandler = new HttpClientHandler() };
+                var httpClient = new HttpClient(countingHandler);
+                var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, address))
+                {
+                    MaxTries = 2,
+                    RetryDelay = TimeSpan.Zero
+                };
+
+                // Act
+                Func<Task> actionAsync = () => retryHandler.SendAsync(
+                    request,
+                    new TestLogger(),
+                    CancellationToken.None);
+
+                // Act & Assert
+                var exception = await Assert.ThrowsAsync<T>(actionAsync);
+                Assert.Equal(2, countingHandler.Hits);
+                return exception;
+            });
+        }
+
+        private class CountingHandler : DelegatingHandler
+        {
+            public int Hits { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Hits++;
+
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/NuGet.Core.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/NuGet.Core.FuncTest.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
+    <TestProject>true</TestProject>
+    <UseParallelXunit>true</UseParallelXunit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="compiler\resources\*" />
+    <EmbeddedResource Include="compiler\resources\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+</Project>

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ResolverTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/ResolverTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NuGet.Configuration;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Resolver;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Core.FuncTest
+{
+    public class ResolverTests
+    {
+        [Fact]
+        public void ResolveDependenciesForVeryDeepGraph()
+        {
+            // Arrange
+            var target = CreatePackage("Package0", "1.0", new Dictionary<string, string>() {
+                { "Package1", "1.0.0" },
+                { "Package2", "1.0.0" },
+                { "Package3", "1.0.0" },
+                { "Package4", "1.0.0" },
+                { "Package5", "1.0.0" },
+                { "Package6", "1.0.0" },
+                { "Package7", "1.0.0" },
+                { "Package8", "1.0.0" },
+            });
+
+            var sourceRepository = new List<ResolverPackage>();
+            sourceRepository.Add(target);
+
+            var next = 1;
+
+            // make lots of packages
+            for (var j = 1; j < 1000; j++)
+            {
+                next = j + 1;
+                sourceRepository.Add(CreatePackage($"Package{j}", "1.0.0", new Dictionary<string, string>() { { $"Package{next}", "1.0.0" } }));
+            }
+
+            sourceRepository.Add(CreatePackage($"Package{next}", "1.0.0"));
+
+            var resolver = new PackageResolver();
+
+            var context = new PackageResolverContext(DependencyBehavior.Lowest,
+                new[] { target.Id }, Enumerable.Empty<string>(),
+                Enumerable.Empty<PackageReference>(),
+                new[] { target },
+                sourceRepository,
+                Enumerable.Empty<PackageSource>(),
+                Common.NullLogger.Instance);
+
+            // Act
+            var packages = resolver.Resolve(context, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(1001, packages.Count());
+        }
+
+        private ResolverPackage CreatePackage(string id, string version, IDictionary<string, string> dependencies = null)
+        {
+            var deps = new List<PackageDependency>();
+
+            if (dependencies != null)
+            {
+                foreach (var dep in dependencies)
+                {
+                    VersionRange range = null;
+
+                    if (dep.Value != null)
+                    {
+                        range = VersionRange.Parse(dep.Value);
+                    }
+
+                    deps.Add(new PackageDependency(dep.Key, range));
+                }
+            }
+
+            return new ResolverPackage(id, NuGetVersion.Parse(version), deps, true, false);
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/V2FeedParserTests.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Core.FuncTest
+{
+    public class V2FeedParserTests
+    {
+        [Fact]
+        public async Task V2FeedParser_DownloadFromUrl()
+        {
+            // Arrange
+            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v2/");
+
+            var httpSource = HttpSource.Create(repo);
+
+            var parser = new V2FeedParser(httpSource, "https://www.nuget.org/api/v2/");
+
+            // Act & Assert
+            using (var packagesFolder = TestDirectory.Create())
+            using (var cacheContext = new SourceCacheContext())
+            using (var downloadResult = await parser.DownloadFromUrl(
+                new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
+                new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
+                new PackageDownloadContext(cacheContext),
+                packagesFolder,
+                NullLogger.Instance,
+                CancellationToken.None))
+            {
+                var packageReader = downloadResult.PackageReader;
+                var files = packageReader.GetFiles();
+
+                Assert.Equal(11, files.Count());
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/ActivityCorrelationIdTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/ActivityCorrelationIdTests.cs
@@ -78,28 +78,6 @@ namespace NuGet.Common.Test
             Assert.Equal("00000000-0000-0000-0000-000000000000", ActivityCorrelationId.Current);
         }
 
-        [Fact]
-        public async Task ActivityCorrelationId_StressTest()
-        {
-            // Arrange
-            var taskCount = 8;
-            var iterationCount = 250;
-
-            var tasks = Enumerable
-                .Range(0, taskCount)
-                .Select(t => Task.Run(async () =>
-                {
-                    for (var i = 0; i < iterationCount; i++)
-                    {
-                        await ActivityCorrelationId_FlowsDownAsyncCalls();
-                    }
-                }))
-                .ToArray();
-
-            // Act & Assert
-            await Task.WhenAll(tasks);
-        }
-
         private async Task<string> AsyncCallA(TimeSpan delay)
         {
             await Task.Yield();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Test.Server;
 using NuGet.Test.Utility;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Tests
@@ -23,79 +24,6 @@ namespace NuGet.Protocol.Tests
         private const string TestUrl = "https://test.local/test.json";
         private static readonly TimeSpan SmallTimeout = TimeSpan.FromMilliseconds(50);
         private static readonly TimeSpan LargeTimeout = TimeSpan.FromSeconds(5);
-
-        [Fact]
-        public async Task HttpRetryHandler_HandlesFailureToConnect()
-        {
-            // Arrange
-            var server = new NotListeningServer { Mode = TestServerMode.ConnectFailure };
-
-            // Act & Assert
-            var exception = await ThrowsException<HttpRequestException>(server);
-#if IS_CORECLR
-            Assert.NotNull(exception.InnerException);
-            if (!RuntimeEnvironmentHelper.IsWindows)
-            {
-                Assert.Equal("Couldn't connect to server", exception.InnerException.Message);
-            }
-            else
-            {
-                Assert.Equal("A connection with the server could not be established", exception.InnerException.Message);
-            }
-#else
-            var innerException = Assert.IsType<WebException>(exception.InnerException);
-            Assert.Equal(WebExceptionStatus.ConnectFailure, innerException.Status);
-#endif
-        }
-
-        [Fact]
-        public async Task HttpRetryHandler_HandlesInvalidProtocol()
-        {
-            // Arrange
-            var server = new TcpListenerServer { Mode = TestServerMode.ServerProtocolViolation };
-
-            // Act & Assert
-            var exception = await ThrowsException<HttpRequestException>(server);
-#if IS_CORECLR
-            if (!RuntimeEnvironmentHelper.IsWindows)
-            {
-                Assert.Null(exception.InnerException);
-                Assert.Equal("The server returned an invalid or unrecognized response.", exception.Message);
-            }
-            else
-            {
-                Assert.NotNull(exception.InnerException);
-                Assert.Equal("The server returned an invalid or unrecognized response", exception.InnerException.Message);
-            }
-#else
-            var innerException = Assert.IsType<WebException>(exception.InnerException);
-            Assert.Equal(WebExceptionStatus.ServerProtocolViolation, innerException.Status);
-#endif
-        }
-
-        [Fact]
-        public async Task HttpRetryHandler_HandlesNameResolutionFailure()
-        {
-            // Arrange
-            var server = new UnknownDnsServer { Mode = TestServerMode.NameResolutionFailure };
-
-            // Act & Assert
-            var exception = await ThrowsException<HttpRequestException>(server);
-#if IS_CORECLR
-            Assert.NotNull(exception.InnerException);
-            if (!RuntimeEnvironmentHelper.IsWindows)
-            {
-                Assert.Equal("Couldn't resolve host name", exception.InnerException.Message);
-            }
-            else
-            {
-                Assert.Equal("The server name or address could not be resolved", exception.InnerException.Message);
-            }
-#else
-            var innerException = Assert.IsType<WebException>(exception.InnerException);
-            Assert.Equal(WebExceptionStatus.NameResolutionFailure, innerException.Status);
-#endif
-        }
 
         [Fact]
         public async Task HttpRetryHandler_DifferentRequestInstanceEachTime()
@@ -109,7 +37,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -129,51 +57,10 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task HttpRetryHandler_AppliesTimeoutToRequestsIndividually()
-        {
-            // Arrange
-
-            // 20 requests that take 250ms each for a total of 5 seconds (plus noise).
-            var requestDuration = TimeSpan.FromMilliseconds(250);
-            var maxTries = 20;
-
-            // Make the request timeout longer than each request duration but less than the total
-            // duration of all attempts.
-            var requestTimeout = TimeSpan.FromMilliseconds(4000);
-
-            int hits = 0;
-            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
-            {
-                hits++;
-                await Task.Delay(requestDuration);
-                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
-            };
-
-            var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
-            var httpClient = new HttpClient(testHandler);
-            var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
-            {
-                MaxTries = maxTries,
-                RequestTimeout = requestTimeout,
-                RetryDelay = TimeSpan.Zero
-            };
-            var log = new TestLogger();
-
-            // Act
-            using (await retryHandler.SendAsync(request, log, CancellationToken.None))
-            {
-            }
-
-            // Assert
-            Assert.Equal(maxTries, hits);
-        }
-
-        [Fact]
         public async Task HttpRetryHandler_CancelsRequestAfterTimeout()
         {
             // Arrange
-            CancellationToken requestToken = CancellationToken.None;
+            var requestToken = CancellationToken.None;
             Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler = async (requestMessage, token) =>
             {
                 requestToken = token;
@@ -182,7 +69,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -214,7 +101,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -245,7 +132,7 @@ namespace NuGet.Protocol.Tests
             var minTime = GetRetryMinTime(MaxTries, SmallTimeout);
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -285,7 +172,7 @@ namespace NuGet.Protocol.Tests
             };
             
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -317,7 +204,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -349,7 +236,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -388,7 +275,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -437,7 +324,7 @@ namespace NuGet.Protocol.Tests
             };
 
             var retryHandler = new HttpRetryHandler();
-            var testHandler = new TestHandler(handler);
+            var testHandler = new HttpRetryTestHandler(handler);
             var httpClient = new HttpClient(testHandler);
             var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, TestUrl))
             {
@@ -457,70 +344,9 @@ namespace NuGet.Protocol.Tests
             }
         }
 
-        private static async Task<T> ThrowsException<T>(ITestServer server) where T : Exception
-        {
-            return await server.ExecuteAsync(async address =>
-            {
-                // Arrange
-                var retryHandler = new HttpRetryHandler();
-                var countingHandler = new CountingHandler { InnerHandler = new HttpClientHandler() };
-                var httpClient = new HttpClient(countingHandler);
-                var request = new HttpRetryHandlerRequest(httpClient, () => new HttpRequestMessage(HttpMethod.Get, address))
-                {
-                    MaxTries = 2,
-                    RetryDelay = TimeSpan.Zero
-                };
-
-                // Act
-                Func<Task> actionAsync = () => retryHandler.SendAsync(
-                    request,
-                    new TestLogger(),
-                    CancellationToken.None);
-
-                // Act & Assert
-                var exception = await Assert.ThrowsAsync<T>(actionAsync);
-                Assert.Equal(2, countingHandler.Hits);
-                return exception;
-            });
-        }
-
         private static TimeSpan GetRetryMinTime(int tries, TimeSpan retryDelay)
         {
             return TimeSpan.FromTicks((tries - 1) * retryDelay.Ticks);
-        }
-
-        private class CountingHandler : DelegatingHandler
-        {
-            public int Hits { get; private set; }
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                Hits++;
-
-                return base.SendAsync(request, cancellationToken);
-            }
-        }
-
-        private class TestHandler : HttpMessageHandler
-        {
-            private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
-
-            public TestHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
-            {
-                _handler = (request, token) => Task.FromResult(handler(request));
-            }
-
-            public TestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
-            {
-                _handler = handler;
-            }
-
-            protected override async Task<HttpResponseMessage> SendAsync(
-                HttpRequestMessage request,
-                CancellationToken cancellationToken)
-            {
-                return await _handler(request, cancellationToken);
-            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
@@ -116,36 +116,6 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
-        public async Task V2FeedParser_DownloadFromUrl()
-        {
-            // Arrange
-            var repo = Repository.Factory.GetCoreV3("https://www.nuget.org/api/v2/");
-
-            var httpSource = HttpSource.Create(repo);
-
-            V2FeedParser parser = new V2FeedParser(httpSource, "https://www.nuget.org/api/v2/");
-
-            // Act & Assert
-            using (var packagesFolder = TestDirectory.Create())
-            using (var cacheContext = new SourceCacheContext())
-            using (var downloadResult = await parser.DownloadFromUrl(
-                new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
-                new Uri("https://www.nuget.org/api/v2/package/WindowsAzure.Storage/6.2.0"),
-                new PackageDownloadContext(cacheContext),
-                packagesFolder,
-                NullLogger.Instance,
-                CancellationToken.None))
-            {
-                var packageReader = downloadResult.PackageReader;
-                var files = packageReader.GetFiles();
-
-                Assert.Equal(11, files.Count());
-            }
-        }
-
-
-
-        [Fact]
         public async Task V2FeedParser_DownloadFromIdentityInvalidId()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Resolver.Test/ResolverTests.cs
@@ -229,46 +229,6 @@ namespace NuGet.Resolver.Test
         }
 
         [Fact]
-        public void ResolveDependenciesForVeryDeepGraph()
-        {
-            // Arrange
-            var target = CreatePackage("Package0", "1.0", new Dictionary<string, string>() {
-                { "Package1", "1.0.0" },
-                { "Package2", "1.0.0" },
-                { "Package3", "1.0.0" },
-                { "Package4", "1.0.0" },
-                { "Package5", "1.0.0" },
-                { "Package6", "1.0.0" },
-                { "Package7", "1.0.0" },
-                { "Package8", "1.0.0" },
-            });
-
-            var sourceRepository = new List<ResolverPackage>();
-            sourceRepository.Add(target);
-
-            int next = 1;
-
-            // make lots of packages
-            for (int j = 1; j < 1000; j++)
-            {
-                next = j + 1;
-                sourceRepository.Add(CreatePackage($"Package{j}", "1.0.0", new Dictionary<string, string>() { { $"Package{next}", "1.0.0" } }));
-            }
-
-            sourceRepository.Add(CreatePackage($"Package{next}", "1.0.0"));
-
-            var resolver = new PackageResolver();
-
-            var context = CreatePackageResolverContext(DependencyBehavior.Lowest, target, sourceRepository);
-
-            // Act
-            var packages = resolver.Resolve(context, CancellationToken.None);
-
-            // Assert
-            Assert.Equal(1001, packages.Count());
-        }
-
-        [Fact]
         public void ResolveDependenciesForInstallDiamondDependencyGraphMissingPackage()
         {
             // Arrange

--- a/test/TestUtilities/Test.Utility/HttpRetryTestHandler.cs
+++ b/test/TestUtilities/Test.Utility/HttpRetryTestHandler.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Test.Utility
+{
+    public class HttpRetryTestHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _handler;
+
+        public HttpRetryTestHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = (request, token) => Task.FromResult(handler(request));
+        }
+
+        public HttpRetryTestHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return await _handler(request, cancellationToken);
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/SlowStream.cs
+++ b/test/TestUtilities/Test.Utility/SlowStream.cs
@@ -1,13 +1,11 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace NuGet.Protocol.Tests
+namespace Test.Utility
 {
     public class SlowStream : Stream
     {

--- a/test/TestUtilities/Test.Utility/Test.Utility.csproj
+++ b/test/TestUtilities/Test.Utility/Test.Utility.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Commands\NuGet.Commands.csproj" />
+    <ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Resolver\NuGet.Resolver.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">


### PR DESCRIPTION
I've created a project ``NuGet.Core.FuncTests`` which will run timeout stress tests. When profiling the current core unit tests I found that most of the time taken was from a few tests across the different projects. For netcore tests the runner currently doesn't do well with parallel assemblies so a few tests taking 10-30s meant pushed the total time to around an extra 90s.

Here is a rough estimation of the perf improvement:
Desktop unit tests 33s -> 16s
NETCore unit tests 150s -> 45s
Total saved: 122s

The new project takes 16s on desktop and 20s on core. Which gives 36s total. The reason this is so much faster is because the slow tests now run in parallel with each other in the same assembly and that works on the core xunit runner.

Since these tests cover timeouts/stress/downloads I think the func test section is a better place for them.

Any new tests like this should also go in this new general core func test project.

