### PR TITLE
Change version number for .NET Core projects

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -172,7 +172,8 @@
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <!-- Assembly attributes for net core projects -->
-    <AssemblyVersion>$(SemanticVersion).$(PreReleaseVersion)</AssemblyVersion>
+    <!--AssemblyVersion should not contain the build number as all NuGet.Core projects had the build number as 0 every time -->
+    <AssemblyVersion>$(SemanticVersion).0</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
     <Company>Microsoft Corporation</Company>


### PR DESCRIPTION
We hit a known when we tried to insert into dotnet SDK here: https://github.com/dotnet/sdk/pull/1101
The underlying bug is this one https://github.com/dotnet/cli/issues/4214, and until that is fixed we will have to do some gymnastics when inserting in the CLI/SDK. 

This fix aims to avoid running into the problems specified in the above PR every time we insert, but only hit it when changing the major/minor NuGet version.
The problem stems from the fact that the AssemblyVersion now contains the build number as well, while before all NuGet.Core projects had the build number as 0 every time.  

This has some side-effects as some client projects are now .NET as well and the versions for those will be changed too. 

//cc
@rrelyea 