### PR TITLE
Increasing timeout for DownloadStream tests

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/DownloadTimeoutStreamTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/DownloadTimeoutStreamTests.cs
@@ -101,7 +101,7 @@ namespace NuGet.Core.FuncTest
             var timeoutStream = new DownloadTimeoutStream(
                 "download",
                 slowStream,
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(10));
             
             // Act & Assert
             var actual = await Assert.ThrowsAsync<IOException>(() =>


### PR DESCRIPTION
It seems that the CI machines are slow and need more time for some of the tests. These download stream tests expect the stream to throw an I/O Error in the exception but since the machines are slow, they do not get a chance to throw that but timeout instead. 

This PR should fix some of those, if not all.