### PR TITLE
ILMerge Pack

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -14,6 +14,7 @@
     <ArtifactsDirectory>$(RepositoryRootDirectory)artifacts\</ArtifactsDirectory>
     <DotnetExePath>$(RepositoryRootDirectory)cli\dotnet.exe</DotnetExePath>
     <DotnetExePath Condition=" '$(IsXPlat)' == 'true' ">$(RepositoryRootDirectory)cli\dotnet</DotnetExePath>
+    <DotnetSharedSDKDirectory>$(RepositoryRootDirectory)cli\shared\Microsoft.NETCore.App\1.0.4\</DotnetSharedSDKDirectory>
     <NuGetExePath>$(RepositoryRootDirectory).nuget\nuget.exe</NuGetExePath>
     <SharedDirectory>$(BuildCommonDirectory)Shared</SharedDirectory>
     <NuGetCoreSrcDirectory>$(RepositoryRootDirectory)src\NuGet.Core\</NuGetCoreSrcDirectory>
@@ -27,7 +28,7 @@
     <EnlistmentRootSrc>$(RepositoryRootDirectory)\src</EnlistmentRootSrc>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(RepositoryRootDirectory)</SolutionDir>
     <ArtifactRoot>$(ArtifactsDirectory)</ArtifactRoot>
-	<TestUtilitiesDirectory>$(RepositoryRootDirectory)test\TestUtilities\</TestUtilitiesDirectory>
+    <TestUtilitiesDirectory>$(RepositoryRootDirectory)test\TestUtilities\</TestUtilitiesDirectory>
   </PropertyGroup>
 
   <!-- Defaults -->

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.Library.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.Library.csproj
@@ -5,11 +5,13 @@
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AssemblyName>NuGet.Build.Tasks.Pack</AssemblyName>
-	<RootNamespace>$(AssemblyName)</RootNamespace>
-    <PackageId>NuGet.Build.Tasks.Pack.Library</PackageId>
+    <RootNamespace>$(AssemblyName)</RootNamespace>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <Shipping>true</Shipping>
     <PackProject>true</PackProject>
+    <NoBuild>true</NoBuild>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -47,6 +49,28 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Target Name="PublishAndMergePackNupkg" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' == 'false' AND '$(BuildingInsideVisualStudio)' != 'true'">
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="Publish;ILMergeNuGetPack"/>
+  </Target>
+
+  <Target Name="ILMergeNuGetPack"  Condition="'$(TargetFramework)' != ''">
+    <PropertyGroup>
+      <ILMergeResultDir>$(OutputPath)ilmerge</ILMergeResultDir>
+    </PropertyGroup>
+    <MakeDir Directories="$(ILMergeResultDir)"/>
+    <ItemGroup>
+      <BuildArtifacts Include="$(OutputPath)*.dll" Exclude="$(OutputPath)*Pack.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <PathToMergedNuGetPack>$(ILMergeResultDir)\NuGet.Build.Tasks.Pack.dll</PathToMergedNuGetPack>
+      <IlmergeCommand>$(ILMergeExePath) $(OutputPath)NuGet.Build.Tasks.Pack.dll @(BuildArtifacts, ' ') /out:$(PathToMergedNuGetPack) /lib:$(DotnetSharedSDKDirectory) /lib:$(OutputPath)$(RuntimeIdentifier)\publish /internalize /xmldocs /log:$(ILMergeResultDir)\IlMergeLog.txt</IlmergeCommand>
+      <IlmergeCommand Condition="Exists($(MS_PFX_PATH))">$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)</IlmergeCommand>
+    </PropertyGroup>
+    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
+  </Target>
 
   <Import Project="$(BuildCommonDirectory)common.targets" />
 

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.nuspec
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.nuspec
@@ -8,8 +8,10 @@
     <description>NuGet 3 pack for dotnet CLI</description>
   </metadata>
   <files>
-    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\net45\*.dll" target="Desktop\" />
-    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\netstandard1.3\*.dll" target="CoreCLR\" />
+    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\net45\ilmerge\NuGet.Build.Tasks.Pack.dll" target="Desktop\" />
+    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\net45\ilmerge\NuGet.Build.Tasks.Pack.xml" target="Desktop\" />
+    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.dll" target="CoreCLR\" />
+    <file src="..\..\..\artifacts\NuGet.Build.Tasks.Pack.Library\15.0\bin\$configuration$\netstandard1.3\ilmerge\NuGet.Build.Tasks.Pack.xml" target="CoreCLR\" />
     <file src="Pack.targets" target="buildCrossTargeting\NuGet.Build.Tasks.Pack.targets" />
     <file src="Pack.targets" target="build\NuGet.Build.Tasks.Pack.targets" />
   </files>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -15,7 +15,7 @@ namespace Dotnet.Integration.Test
 {
     public class MsbuildIntegrationTestFixture : IDisposable
     {
-        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli(true);
+        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli(false);
         internal readonly string TestDotnetCli;
 
         public MsbuildIntegrationTestFixture()
@@ -151,30 +151,6 @@ namespace Dotnet.Integration.Test
 
                 DeleteFiles(pathToPackSdk);
                 CopyNupkgFilesToTarget(nupkg, pathToPackSdk, files);
-
-                foreach (var coreClrDll in Directory.GetFiles(Path.Combine(pathToPackSdk, "CoreCLR")))
-                {
-                    var fileName = Path.GetFileName(coreClrDll);
-                    if (fileName != "NuGet.Build.Tasks.Pack.dll")
-                    {
-                        File.Copy(coreClrDll, Path.Combine(pathToSdkInCli, fileName), true);
-                    }
-                }
-            }
-
-            using (var nupkg = new PackageArchiveReader(pathToRestoreNupkg))
-            {
-                var files = nupkg.GetFiles()
-                    .Where(fileName => fileName.StartsWith("lib/netstandard1.3")
-                                       || fileName.StartsWith("runtimes"));
-                File.Delete(Path.Combine(pathToSdkInCli, "NuGet.Build.Tasks.dll"));
-                File.Delete(Path.Combine(pathToSdkInCli, "NuGet.Build.Tasks.xml"));
-                File.Delete(Path.Combine(pathToSdkInCli, "NuGet.targets"));
-                foreach (var file in files)
-                {
-                    var stream = nupkg.GetStream(file);
-                    stream.CopyToFile(Path.Combine(pathToSdkInCli, Path.GetFileName(file)));
-                }
             }
         }
 


### PR DESCRIPTION
Switched from ILRepack to ILMerge to enable delaysigning.

Adding ``/lib:<path to the shared SDK>`` in addition to referencing the publish folder (still required) seems to be required for ILMerge and not ILRepack. This is possibly what was missing before.

This will write to ``$(OutputPath)\ilmerge`` instead of the output folder due to an issue with overwriting the pdb file while it was being read in.

This also unblocks the test setup for pack integration tests. actually enabling them will come in a separate PR>