### PR TITLE
Fix Tizen TFMs to package based

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGetFramework.cs
@@ -416,6 +416,7 @@ namespace NuGet.Frameworks
                         FrameworkConstants.FrameworkIdentifiers.NetStandardApp,
                         FrameworkConstants.FrameworkIdentifiers.NetCoreApp,
                         FrameworkConstants.FrameworkIdentifiers.UAP,
+                        FrameworkConstants.FrameworkIdentifiers.Tizen,
             },
             StringComparer.OrdinalIgnoreCase);
     }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/NuGetFrameworkTests.cs
@@ -252,6 +252,7 @@ namespace NuGet.Test
         [InlineData("aspnet451", false)]
         [InlineData("uap10.0", true)]
         [InlineData("uap11.0", true)]
+        [InlineData("tizen3.0", true)]
         public void NuGetFramework_IsPackageBased(string framework, bool isPackageBased)
         {
             var fw = NuGetFramework.Parse(framework);


### PR DESCRIPTION
Tizen is a package based TargetFramework that supports netstandard.
But this was missing.

Due to this bug, the frameworkAssemblies described in .nuspec file are included in the reference assemblies when using Tizen TFM.
