### PR TITLE
Turn on and fix flaky tests on mono/mac

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -39,7 +39,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public void MSBuildProjectSystem_AddFile()
         {
             // Arrange
@@ -62,7 +63,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public void MSBuildProjectSystem_RemoveFile()
         {
             // Arrange
@@ -88,7 +90,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public void MSBuildProjectSystem_FileExistInProject()
         {
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine.Test
 {
     public class NuGetUpdateCommandTests
     {
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_Update_DeletedFile()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -131,7 +131,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -210,7 +210,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_References_MultipleProjects()
         {
 
@@ -339,7 +339,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Fails_References_MultipleProjectsInSameDirectory()
         {
             // Arrange
@@ -435,7 +435,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_NOPrerelease()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -513,7 +513,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Success_Prerelease()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -593,7 +594,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Success_Version_Upgrade()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -684,7 +686,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_Version_Downgrade()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -775,7 +777,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_ProjectFile_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -854,7 +856,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public async Task UpdateCommand_Success_PackagesConfig_References()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())
@@ -935,7 +937,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Success_ContentFiles()
         {
             // Arrange
@@ -1048,7 +1051,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Success_CustomPackagesFolder_RelativePath()
         {
             // Arrange
@@ -1141,7 +1145,8 @@ namespace NuGet.CommandLine.Test
         }
 
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Success_CustomPackagesFolder_AbsolutePath()
         {
             // Arrange
@@ -1234,7 +1239,8 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public async Task UpdateCommand_Native_JS_Projects_Success()
         {
             using (var packagesSourceDirectory = TestDirectory.Create())

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -21,7 +21,7 @@ namespace NuGet.CommandLine
 
     public class ProjectFactoryTest
     {
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public void ProjectFactoryInitializesPropertiesForPreprocessorFromAssemblyMetadata()
         {
             // Arrange
@@ -91,7 +91,8 @@ namespace NuGet.CommandLine
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+
+        [Fact]
         public void CommandLinePropertiesOverrideAssemblyMetadataForPreprocessor()
         {
             // Arrange
@@ -165,7 +166,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public void CommandLinePropertiesApplyForPreprocessor()
         {
             // Arrange
@@ -239,7 +240,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        [PlatformFact(Platform.Windows)]
+        [Fact]
         public void CommandLineIdPropertyOverridesAssemblyNameForPreprocessor()
         {
             // Arrange
@@ -404,7 +405,7 @@ namespace NuGet.CommandLine
                 Authors = new[] { "Outercurve Foundation" },
             };
             var projectMock = new Mock<MockProject>();
-            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildDirectory("4.0", console: null);
+            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsBuildDirectory(null, null);
             var factory = new ProjectFactory(msbuildDirectory, projectMock.Object);
 
             // act


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4868

One of the tests was explicitly loading `xbuild`. This was causing conflicts between `msbuild` and `xbuild` on mono on mac.

