### PR TITLE
Fixed end-to-end tests

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -102,7 +102,7 @@ namespace NuGet.PackageManagement.VisualStudio
             IProjectSystemCache projectSystemCache,
             NuGetProjectFactory projectSystemFactory,
             ICredentialServiceProvider credentialServiceProvider,
-            [Import(typeof(VisualStudioActivityLogger))]
+            [Import("VisualStudioActivityLogger")]
             Common.ILogger logger)
         {
             if (serviceProvider == null)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Utility\VCProjectHelper.cs" />
     <Compile Include="Utility\VSProjectRestoreReferenceUtility.cs" />
     <Compile Include="VisualStudioAccountProvider.cs" />
+    <Compile Include="VisualStudioActivityLogger.cs" />
     <Compile Include="VisualStudioCredentialProvider.cs" />
     <Compile Include="VsCredentialProviderAdapter.cs" />
     <Compile Include="VsCredentialProviderImporter.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioActivityLogger.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/VisualStudioActivityLogger.cs
@@ -5,14 +5,12 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Common;
 
-namespace NuGet.VisualStudio
+namespace NuGet.PackageManagement.VisualStudio
 {
     /// <summary>
     /// Logger routing messages into VS ActivityLog
     /// </summary>
-    /// 
-    [Export("VisualStudioActivityLogger", typeof(ILogger))]
-    [Export(typeof(VisualStudioActivityLogger))]
+    [Export, Export("VisualStudioActivityLogger", typeof(ILogger))]
     public sealed class VisualStudioActivityLogger : ILogger
     {
         private const string LogEntrySource = "NuGet Package Manager";

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreEventPublisher.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreEventPublisher.cs
@@ -20,7 +20,7 @@ namespace NuGet.SolutionRestoreManager
         
         [ImportingConstructor]
         public RestoreEventPublisher(
-            [Import(typeof(VisualStudioActivityLogger))]
+            [Import("VisualStudioActivityLogger")]
             Lazy<ILogger> logger)
         {
             if (logger == null)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -63,7 +63,7 @@ namespace NuGet.SolutionRestoreManager
             IServiceProvider serviceProvider,
             Lazy<IVsSolutionManager> solutionManager,
             Lazy<INuGetLockService> lockService,
-            [Import(typeof(VisualStudioActivityLogger))]
+            [Import("VisualStudioActivityLogger")]
             Lazy<Common.ILogger> logger,
             Lazy<ErrorListTableDataSource> errorListTableDataSource)
         {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -48,7 +48,7 @@ namespace NuGet.SolutionRestoreManager
         public VsSolutionRestoreService(
             IProjectSystemCache projectSystemCache,
             ISolutionRestoreWorker restoreWorker,
-            [Import(typeof(VisualStudioActivityLogger))]
+            [Import("VisualStudioActivityLogger")]
             NuGet.Common.ILogger logger)
         {
             if (projectSystemCache == null)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -49,6 +49,7 @@
       <Link>NuGet.targets</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="source.extension.vs15.insertable.vsixmanifest" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\VsConsole\PowerShellHost\Scripts\about_NuGet.PackageManagement.PowerShellCmdlets.help.txt">
@@ -125,6 +126,8 @@
     <ProjectReference Include="..\..\NuGet.Core\NuGet.PackageManagement\NuGet.PackageManagement.csproj">
       <Project>{394aeb96-493c-4839-a5ac-8d93cd2fad40}</Project>
       <Name>NuGet.PackageManagement</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj">
       <Project>{d65583e4-8084-466a-ba4b-55a797ea047b}</Project>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs14.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs14.vsixmanifest
@@ -18,15 +18,10 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.PackageManagement.VisualStudio" Path="|NuGet.PackageManagement.VisualStudio|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.UI.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Protocol.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" Path="|NuGet.PackageManagement|" d:ProjectName="NuGet.PackageManagement" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Console" Path="|NuGet.Console|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Configuration.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio.Interop" Path="|NuGet.VisualStudio.Interop|" AssemblyName="|NuGet.VisualStudio.Interop;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.VisualStudioImplement" Path="|NuGet.VisualStudio.Implementation|" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio" Path="|NuGet.VisualStudio|" AssemblyName="|NuGet.VisualStudio;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Lucene.Net.dll" AssemblyName="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.insertable.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.insertable.vsixmanifest
@@ -22,15 +22,10 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.PackageManagement.VisualStudio" Path="|NuGet.PackageManagement.VisualStudio|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.UI.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Protocol.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" Path="|NuGet.PackageManagement|" d:ProjectName="NuGet.PackageManagement" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Console" Path="|NuGet.Console|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Configuration.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio.Interop" Path="|NuGet.VisualStudio.Interop|" AssemblyName="|NuGet.VisualStudio.Interop;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.VisualStudio.Implementation" Path="|NuGet.VisualStudio.Implementation|" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio" Path="|NuGet.VisualStudio|" AssemblyName="|NuGet.VisualStudio;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Lucene.Net.dll" AssemblyName="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.vsixmanifest
@@ -22,15 +22,10 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.PackageManagement.VisualStudio" Path="|NuGet.PackageManagement.VisualStudio|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.PackageManagement.UI.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Protocol.dll" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" Path="|NuGet.PackageManagement|" d:ProjectName="NuGet.PackageManagement" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Tools" Path="|NuGet.Tools|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.Console" Path="|NuGet.Console|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="NuGet.Configuration.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio.Interop" Path="|NuGet.VisualStudio.Interop|" AssemblyName="|NuGet.VisualStudio.Interop;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.VisualStudio.Implementation" Path="|NuGet.VisualStudio.Implementation|" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="NuGet.VisualStudio" Path="|NuGet.VisualStudio|" AssemblyName="|NuGet.VisualStudio;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="NuGet.SolutionRestoreManager" Path="|NuGet.SolutionRestoreManager;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="Lucene.Net.dll" AssemblyName="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181" />


### PR DESCRIPTION
`VisualStudioActivityLogger` should be imported by the contract name to avoid ambiguity and type coupling at the same time.

Also cleaned up the manifest(s) by removing redundnand MEF entries.