### PR TITLE
include pri files only after calling the target that computes the property

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -34,6 +34,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackDependsOn>GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
+    <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -270,7 +271,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     in their bin dir. This Pri file is not included in the BuiltProjectGroupOutput, and
     has to be added manually here.-->
   <Target Name="_AddPriFileToPackBuildOutput"
-          Returns="@(_PathToPriFile)">
+          Returns="@(_PathToPriFile)"
+          DependsOnTargets="$(AddPriFileDependsOn)">
     <ItemGroup Condition="'$(IncludeProjectPriFile)' == 'true'">
       <_PathToPriFile Include="$(ProjectPriFullPath)">
         <FinalOutputPath>$(ProjectPriFullPath)</FinalOutputPath>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5021

Only include pri files if they actually exist. Some portable target frameworks set this property even though a pri file might not exist.

CC: @alpaix @rrelyea @emgarten