### PR TITLE
Fixing the remaining Functional tests and removing test cli

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -202,7 +202,6 @@ Function Install-DotnetCLI {
             DotNetInstallUrl = 'https://raw.githubusercontent.com/dotnet/cli/58b0566d9ac399f5fa973315c6827a040b7aae1f/scripts/obtain/dotnet-install.ps1'
             Version = '1.0.1'
         }
-    }
     
     if ([Environment]::Is64BitOperatingSystem) {
         $arch = "x64";

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -193,22 +193,12 @@ Function Install-NuGet {
 Function Install-DotnetCLI {
     [CmdletBinding()]
     param(
-        [switch]$Test,
         [switch]$Force
     )
 
-    $cli = if (-not $Test) {
-        @{
+    $cli = @{
             Root = $CLIRoot
             DotNetExe = Join-Path $CLIRoot 'dotnet.exe'
-            DotNetInstallUrl = 'https://raw.githubusercontent.com/dotnet/cli/58b0566d9ac399f5fa973315c6827a040b7aae1f/scripts/obtain/dotnet-install.ps1'
-            Version = '1.0.1'
-        }
-    }
-    else {
-        @{
-            Root = $CLIRootTest
-            DotNetExe = Join-Path $CLIRootTest 'dotnet.exe'
             DotNetInstallUrl = 'https://raw.githubusercontent.com/dotnet/cli/58b0566d9ac399f5fa973315c6827a040b7aae1f/scripts/obtain/dotnet-install.ps1'
             Version = '1.0.1'
         }

--- a/build/common.test.props
+++ b/build/common.test.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsNetCoreProject>true</IsNetCoreProject>
     <TestProject>true</TestProject>
-    <SkipTests>true</SkipTests>
   </PropertyGroup>
   
   <!-- Load config -->

--- a/build/common.test.props
+++ b/build/common.test.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsNetCoreProject>true</IsNetCoreProject>
     <TestProject>true</TestProject>
+    <SkipTests>true</SkipTests>
   </PropertyGroup>
   
   <!-- Load config -->

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -77,7 +77,7 @@ if (-not $BuildNumber) {
 }
 
 Invoke-BuildStep 'Installing .NET CLI for tests' {
-        Install-DotnetCLI -Test -Force:$Force
+        Install-DotnetCLI -Force:$Force
     } -ev +BuildErrors
 
 Trace-Log "Test suite run #$BuildNumber started at $startTime"

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/Dotnet.Integration.Test.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
     <TestProject>true</TestProject>
-    <SkipTests>false</SkipTests>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -18,7 +18,7 @@ namespace Dotnet.Integration.Test
 {
     public class MsbuildIntegrationTestFixture : IDisposable
     {
-        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli(false);
+        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli();
         internal readonly string TestDotnetCli;
         internal readonly string MsBuildSdksPath;
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -46,9 +46,9 @@ namespace NuGet.XPlat.FuncTest
         /// <code>String</code> containing the path to the dotnet cli within the local repository.
         /// Can return <code>null</code> if no cli directory or dotnet cli is found, in which case the tests can fail.
         /// </returns>
-        public static string GetDotnetCli(bool getTestCLI = false)
+        public static string GetDotnetCli()
         {
-            var cliDirName = getTestCLI ? "cli_test" : "cli";
+            var cliDirName = "cli";
             var dir = ParentDirectoryLookup()
                 .FirstOrDefault(d => DirectoryContains(d, cliDirName));
             if (dir != null)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/DotnetCliUtil.cs
@@ -31,11 +31,12 @@ namespace NuGet.XPlat.FuncTest
                 "15.0",
                 "bin",
 #if DEBUG
-                "debug",
+                "Debug",
 #else
-                "release",
+                "Release",
 #endif
-                "netcoreapp1.0", XPlatDll);
+                "netcoreapp1.0",
+                XPlatDll);
         }
 
         /// <summary>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
     <TestProject>true</TestProject>
     <TestProjectType>functional</TestProjectType>
-    <SkipTests>false</SkipTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
     <TestProject>true</TestProject>
     <TestProjectType>functional</TestProjectType>
-    <SkipTests>true</SkipTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/NuGet.XPlat.FuncTest.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
     <TestProject>true</TestProject>
     <TestProjectType>functional</TestProjectType>
+    <SkipTests>false</SkipTests>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -15,14 +15,14 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
+
+    [Collection("NuGet XPlat Test Collection")]
     public class XPlatAddPkgTests
     {
         private static readonly string projectName = "test_project_addpkg";
 
-        private static MSBuildAPIUtility MsBuild
-        {
-            get { return new MSBuildAPIUtility(new TestCommandOutputLogger()); }
-        }
+        private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());
+
 
         // Argument parsing related tests
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatCollection.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatCollection.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    [CollectionDefinition("NuGet XPlat Test Collection")]
+    public class XPlatCollection : ICollectionFixture<XPlatMsbuildTestFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatMsbuildTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatMsbuildTestFixture.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XPlatMsbuildTestFixture : IDisposable
+    {
+        private readonly string _dotnetCli = DotnetCliUtil.GetDotnetCli();
+
+        public XPlatMsbuildTestFixture()
+        {
+            var cliDirectory = Directory.GetParent(_dotnetCli);
+            var msBuildSdksPath = Path.Combine(Directory.GetDirectories(Path.Combine(cliDirectory.FullName, "sdk")).First(), "Sdks");
+            Environment.SetEnvironmentVariable("MSBuildSDKsPath", msBuildSdksPath);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("MSBuildSDKsPath", null);
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
+    [Collection("NuGet XPlat Test Collection")]
     public class XPlatRemovePkgTests
     {
         private static readonly string projectName = "test_project_removepkg";


### PR DESCRIPTION
1.  Turns on the last remaining tests post migration and fixes: https://github.com/NuGet/Client.Engineering/issues/17
2. Also removes the test cli download since we do not need 2 versions of cli.

