### PR TITLE
Add support for dotnet list package command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -162,7 +162,8 @@ namespace NuGet.CommandLine.XPlat
                     packageReferenceArgs.PackageDependency.Id,
                     packageReferenceArgs.ProjectPath));
 
-                var compatibleOriginalFrameworks = originalPackageSpec.RestoreMetadata
+                var compatibleOriginalFrameworks = originalPackageSpec
+                    .RestoreMetadata
                     .OriginalTargetFrameworks
                     .Where(s => compatibleFrameworks.Contains(NuGetFramework.Parse(s)));
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -11,7 +14,7 @@ using NuGet.Versioning;
 
 namespace NuGet.CommandLine.XPlat
 { 
-    class ListPackageReferenceCommand
+    public class ListPackageReferenceCommand
     {
         public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
         Func<IPackageReferenceCommandRunner> getCommandRunner)

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.CommandLineUtils;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+
+namespace NuGet.CommandLine.XPlat
+{ 
+    class ListPackageReferenceCommand
+    {
+        public static void Register(CommandLineApplication app, Func<ILogger> getLogger,
+        Func<IPackageReferenceCommandRunner> getCommandRunner)
+        {
+            app.Command("list", listPkg =>
+            {
+                listPkg.Description = Strings.ListPkg_Description;
+                listPkg.HelpOption(XPlatUtility.HelpOption);
+
+                listPkg.Option(
+                    CommandConstants.ForceEnglishOutputOption,
+                    Strings.ForceEnglishOutput_Description,
+                    CommandOptionType.NoValue);
+
+                var id = listPkg.Option(
+                    "--package",
+                    Strings.AddPkg_PackageIdDescription,
+                    CommandOptionType.SingleValue);
+
+                var projectPath = listPkg.Option(
+                    "-p|--project",
+                    Strings.AddPkg_ProjectPathDescription,
+                    CommandOptionType.SingleValue);
+
+                var frameworks = listPkg.Option(
+                    "-f|--framework",
+                    Strings.AddPkg_FrameworksDescription,
+                    CommandOptionType.SingleValue);
+
+
+                listPkg.OnExecute(() =>
+                {                    
+                    ValidateArgument(projectPath, listPkg.Name);
+                    ValidateProjectPath(projectPath, listPkg.Name);
+
+                    var logger = getLogger();
+                    PackageDependency packageDependency = null;
+                    if (id.HasValue())
+                    {
+                        packageDependency = new PackageDependency(id.Values[0], VersionRange.Parse("*"));
+                    }
+
+                    var packageReferenceArgs = new PackageReferenceArgs(projectPath.Value(), packageDependency, logger)
+                    {
+                        Frameworks = MSBuildStringUtility.Split(frameworks.Value()),
+                    };
+
+                    var msBuild = new MSBuildAPIUtility(logger);
+                    var listPackageCommandRunner = getCommandRunner();
+                    return listPackageCommandRunner.ExecuteCommand(packageReferenceArgs, msBuild);
+                });
+            });
+        }
+
+        private static void ValidateArgument(CommandOption arg, string commandName)
+        {
+            if (arg.Values.Count < 1)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_PkgMissingArgument,
+                    commandName,
+                    arg.Template));
+            }
+        }
+
+        private static void ValidateProjectPath(CommandOption projectPath, string commandName)
+        {
+            if (!File.Exists(projectPath.Value()) || !projectPath.Value().EndsWith("proj", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_PkgMissingOrInvalidProjectFile,
+                    commandName,
+                    projectPath.Value()));
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -48,13 +48,8 @@ namespace NuGet.CommandLine.XPlat
                     ValidateProjectPath(projectPath, listPkg.Name);
 
                     var logger = getLogger();
-                    PackageDependency packageDependency = null;
-                    if (id.HasValue())
-                    {
-                        packageDependency = new PackageDependency(id.Values[0], VersionRange.Parse("*"));
-                    }
 
-                    var packageReferenceArgs = new PackageReferenceArgs(projectPath.Value(), packageDependency, logger)
+                    var packageReferenceArgs = new PackageReferenceArgs(projectPath.Value(), logger)
                     {
                         Frameworks = MSBuildStringUtility.Split(frameworks.Value()),
                     };

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -51,6 +51,7 @@ namespace NuGet.CommandLine.XPlat
 
                     var packageReferenceArgs = new PackageReferenceArgs(projectPath.Value(), logger)
                     {
+                        PackageDependency = id.HasValue() ? new PackageDependency(id.Value(), VersionRange.Parse("*")) : null,
                         Frameworks = MSBuildStringUtility.Split(frameworks.Value()),
                     };
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -28,17 +28,17 @@ namespace NuGet.CommandLine.XPlat
 
                 var id = listPkg.Option(
                     "--package",
-                    Strings.AddPkg_PackageIdDescription,
+                    Strings.ListPkg_PackageIdDescription,
                     CommandOptionType.SingleValue);
 
                 var projectPath = listPkg.Option(
                     "-p|--project",
-                    Strings.AddPkg_ProjectPathDescription,
+                    Strings.ListPkg_ProjectPathDescription,
                     CommandOptionType.SingleValue);
 
                 var frameworks = listPkg.Option(
                     "-f|--framework",
-                    Strings.AddPkg_FrameworksDescription,
+                    Strings.ListPkg_FrameworksDescription,
                     CommandOptionType.SingleValue);
 
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,7 +42,7 @@ namespace NuGet.CommandLine.XPlat
                 var frameworks = listPkg.Option(
                     "-f|--framework",
                     Strings.ListPkg_FrameworksDescription,
-                    CommandOptionType.SingleValue);
+                    CommandOptionType.MultipleValue);
 
 
                 listPkg.OnExecute(() =>
@@ -55,7 +55,7 @@ namespace NuGet.CommandLine.XPlat
                     var packageReferenceArgs = new PackageReferenceArgs(projectPath.Value(), logger)
                     {
                         PackageDependency = id.HasValue() ? new PackageDependency(id.Value(), VersionRange.Parse("*")) : null,
-                        Frameworks = MSBuildStringUtility.Split(frameworks.Value()),
+                        Frameworks = CommandLineUtility.SplitAndJoinAcrossMultipleValues(frameworks.Values)
                     };
 
                     var msBuild = new MSBuildAPIUtility(logger);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
@@ -9,21 +9,43 @@ namespace NuGet.CommandLine.XPlat
 {
     class ListPackageReferenceCommandRunner : IPackageReferenceCommandRunner
     {
-        public Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
+         public Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
         {
-            var packagReferences = msBuild.ListPackageReference(packageReferenceArgs.ProjectPath,
+             var packagReferences = msBuild.ListPackageReference(packageReferenceArgs.ProjectPath,
                     packageReferenceArgs.PackageDependency, packageReferenceArgs.Frameworks);
 
-            PrintPackageReferences(packagReferences, packageReferenceArgs.Logger);
+            PrintPackageReferences(packagReferences, packageReferenceArgs.Logger, packageReferenceArgs.ProjectPath);
 
             return Task.FromResult(0);
         }
 
-        public void PrintPackageReferences(IEnumerable<ProjectItem> packageReferences, ILogger logger)
+        public void PrintPackageReferences(Dictionary<string, IEnumerable<Tuple<string, string>>> packageReferences, ILogger logger, string projectPath)
         {
-            foreach(var packageReference in packageReferences)
+            if(packageReferences.Keys.Count == 0)
             {
-                logger.LogInformation($"{packageReference.EvaluatedInclude}: {packageReference.GetMetadataValue("Version")}");
+                logger.LogInformation($"Project '{projectPath}' has no package references.");
+            }
+            else
+            {
+                logger.LogInformation($"Project '{projectPath}' has following package references.");
+
+                foreach (var framework in packageReferences.Keys)
+                {
+                    logger.LogInformation($"Framework '{framework}' - ");
+
+                    if(packageReferences[framework] == null)
+                    {
+                        logger.LogInformation($"This poject does not target '{framework}'");
+                    }
+                    else
+                    {
+                        logger.LogInformation($"Package ID \t\t Version");
+                        foreach (var packageReference in packageReferences[framework])
+                        {
+                            logger.LogInformation($"{packageReference.Item1} \t\t {packageReference.Item2}");
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Evaluation;
+using NuGet.Common;
+
+namespace NuGet.CommandLine.XPlat
+{
+    class ListPackageReferenceCommandRunner : IPackageReferenceCommandRunner
+    {
+        public Task<int> ExecuteCommand(PackageReferenceArgs packageReferenceArgs, MSBuildAPIUtility msBuild)
+        {
+            var packagReferences = msBuild.ListPackageReference(packageReferenceArgs.ProjectPath,
+                    packageReferenceArgs.PackageDependency, packageReferenceArgs.Frameworks);
+
+            PrintPackageReferences(packagReferences, packageReferenceArgs.Logger);
+
+            return Task.FromResult(0);
+        }
+
+        public void PrintPackageReferences(IEnumerable<ProjectItem> packageReferences, ILogger logger)
+        {
+            foreach(var packageReference in packageReferences)
+            {
+                logger.LogInformation($"{packageReference.EvaluatedInclude}: {packageReference.GetMetadataValue("Version")}");
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
@@ -15,39 +15,51 @@ namespace NuGet.CommandLine.XPlat
              var packagReferences = msBuild.ListPackageReference(packageReferenceArgs.ProjectPath,
                     packageReferenceArgs.PackageDependency, packageReferenceArgs.Frameworks);
 
-            PrintPackageReferences(packagReferences, packageReferenceArgs.Logger, packageReferenceArgs.ProjectPath);
+            PrintPackageReferences(packagReferences, packageReferenceArgs);
 
             return Task.FromResult(0);
         }
 
-        public void PrintPackageReferences(Dictionary<string, IEnumerable<Tuple<string, string>>> packageReferences, ILogger logger, string projectPath)
+        public void PrintPackageReferences(Dictionary<string, IEnumerable<Tuple<string, string>>> packageReferences, PackageReferenceArgs packageReferenceArgs)
         {
+            var logger = packageReferenceArgs.Logger;
+            var projectPath = packageReferenceArgs.ProjectPath;
+            var packageDependency = packageReferenceArgs.PackageDependency;
             if(packageReferences.Keys.Count == 0)
             {
-                logger.LogInformation($"Project '{projectPath}' has no package references.");
+                logger.LogInformation(string.Format(Strings.ListPkg_NoPackageRefsForProject, projectPath));
             }
             else
             {
-                logger.LogInformation($"Project '{projectPath}' has following package references.");
+                logger.LogInformation(string.Format(Strings.ListPkg_References, projectPath));
 
                 foreach (var framework in packageReferences.Keys)
                 {
-                    logger.LogInformation($"Framework '{framework}' - ");
-                    logger.LogInformation($"--------------------------------------------------");
+                    logger.LogInformation(string.Format(Strings.ListPkg_Framework, framework));
+                    logger.LogInformation("--------------------------------------------------");
 
                     if (packageReferences[framework] == null)
                     {
-                        logger.LogInformation($"This poject does not target '{framework}'");
+                        logger.LogInformation(string.Format(Strings.ListPkg_NonTargetedFramework, framework));
                     }
                     else if(!packageReferences[framework].Any())
                     {
-                        logger.LogInformation($"This poject does not reference any package for '{framework}'");
+                        if(packageDependency == null)
+                        {
+                            logger.LogInformation(string.Format(Strings.ListPkg_NoPackageRefsForFramework, framework));
+                        }
+                        else
+                        {
+                            logger.LogInformation(string.Format(Strings.ListPkg_PackageNotReferencedForFramework, 
+                                packageDependency.Id, 
+                                framework));
+                        }
                     }
                     else
                     {
                         foreach (var packageReference in packageReferences[framework])
                         {
-                            logger.LogInformation($"{packageReference.Item1} {packageReference.Item2}");
+                            logger.LogInformation(string.Format(Strings.ListPkg_PackageAndVersion, packageReference.Item1, packageReference.Item2));
                         }
                     }
                     logger.LogInformation($"--------------------------------------------------");

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/ListPackageReferenceCommandRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
@@ -32,19 +33,24 @@ namespace NuGet.CommandLine.XPlat
                 foreach (var framework in packageReferences.Keys)
                 {
                     logger.LogInformation($"Framework '{framework}' - ");
+                    logger.LogInformation($"--------------------------------------------------");
 
-                    if(packageReferences[framework] == null)
+                    if (packageReferences[framework] == null)
                     {
                         logger.LogInformation($"This poject does not target '{framework}'");
                     }
+                    else if(!packageReferences[framework].Any())
+                    {
+                        logger.LogInformation($"This poject does not reference any package for '{framework}'");
+                    }
                     else
                     {
-                        logger.LogInformation($"Package ID \t\t Version");
                         foreach (var packageReference in packageReferences[framework])
                         {
-                            logger.LogInformation($"{packageReference.Item1} \t\t {packageReference.Item2}");
+                            logger.LogInformation($"{packageReference.Item1} {packageReference.Item2}");
                         }
                     }
+                    logger.LogInformation($"--------------------------------------------------");
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/PackageReferenceArgs.cs
@@ -21,6 +21,15 @@ namespace NuGet.CommandLine.XPlat
         public string PackageDirectory { get; set; }
         public bool NoRestore { get; set; }
 
+        public PackageReferenceArgs(string projectPath, ILogger logger)
+        {
+            ValidateArgument(projectPath);
+            ValidateArgument(logger);
+
+            ProjectPath = projectPath;
+            Logger = logger;
+        }
+
         public PackageReferenceArgs(string projectPath, PackageDependency packageDependency, ILogger logger, bool noVersion)
         {
             ValidateArgument(projectPath);

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -18,13 +18,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.1012" />
     <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -84,7 +84,7 @@ namespace NuGet.CommandLine.XPlat
 
             log.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.OutputNuGetVersion, app.FullName, app.LongVersionGetter()));
 
-            int exitCode = 0;
+            var exitCode = 0;
 
             try
             {
@@ -143,6 +143,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 AddPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
                 RemovePackageReferenceCommand.Register(app, () => log, () => new RemovePackageReferenceCommandRunner());
+                ListPackageReferenceCommand.Register(app, () => log, () => new ListPackageReferenceCommandRunner());
             }
             else
             {
@@ -159,7 +160,7 @@ namespace NuGet.CommandLine.XPlat
         /// </summary>
         private static bool TryParseVerbosity(string[] args, CommandOption verbosity, out LogLevel logLevel)
         {
-            bool found = false;
+            var found = false;
 
             for (var index = 0; index < args.Length; index++)
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -141,7 +141,7 @@ namespace NuGet.CommandLine.XPlat
             // Register commands
             if (app.Name == DotnetPackageAppName)
             {
-                ListPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
+                AddPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
                 RemovePackageReferenceCommand.Register(app, () => log, () => new RemovePackageReferenceCommandRunner());
                 ListPackageReferenceCommand.Register(app, () => log, () => new ListPackageReferenceCommandRunner());
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Program.cs
@@ -141,7 +141,7 @@ namespace NuGet.CommandLine.XPlat
             // Register commands
             if (app.Name == DotnetPackageAppName)
             {
-                AddPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
+                ListPackageReferenceCommand.Register(app, () => log, () => new AddPackageReferenceCommandRunner());
                 RemovePackageReferenceCommand.Register(app, () => log, () => new RemovePackageReferenceCommandRunner());
                 ListPackageReferenceCommand.Register(app, () => log, () => new ListPackageReferenceCommandRunner());
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -73,7 +73,7 @@ namespace NuGet.CommandLine.XPlat {
         /// <summary>
         ///   Looks up a localized string similar to Adds a package reference to a project..
         /// </summary>
-        internal static string AddPkg_Description {
+        internal static string ListPkg_Description {
             get {
                 return ResourceManager.GetString("AddPkg_Description", resourceCulture);
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -476,11 +476,29 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All Frameworks.
+        /// </summary>
+        internal static string ListPkg_AllFrameworks {
+            get {
+                return ResourceManager.GetString("ListPkg_AllFrameworks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Lists package references for a project..
         /// </summary>
         internal static string ListPkg_Description {
             get {
                 return ResourceManager.GetString("ListPkg_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Framework &apos;{0}&apos; -.
+        /// </summary>
+        internal static string ListPkg_Framework {
+            get {
+                return ResourceManager.GetString("ListPkg_Framework", resourceCulture);
             }
         }
         
@@ -494,6 +512,42 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This poject does not target framework &apos;{0}&apos;..
+        /// </summary>
+        internal static string ListPkg_NonTargetedFramework {
+            get {
+                return ResourceManager.GetString("ListPkg_NonTargetedFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This poject does not reference any package for framework &apos;{0}&apos;..
+        /// </summary>
+        internal static string ListPkg_NoPackageRefsForFramework {
+            get {
+                return ResourceManager.GetString("ListPkg_NoPackageRefsForFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; has no package references..
+        /// </summary>
+        internal static string ListPkg_NoPackageRefsForProject {
+            get {
+                return ResourceManager.GetString("ListPkg_NoPackageRefsForProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; Version &apos;{1}&apos;..
+        /// </summary>
+        internal static string ListPkg_PackageAndVersion {
+            get {
+                return ResourceManager.GetString("ListPkg_PackageAndVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Id of the package for listing references..
         /// </summary>
         internal static string ListPkg_PackageIdDescription {
@@ -503,11 +557,29 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This poject does not reference package &apos;{0}&apos; for framework &apos;{1}&apos;..
+        /// </summary>
+        internal static string ListPkg_PackageNotReferencedForFramework {
+            get {
+                return ResourceManager.GetString("ListPkg_PackageNotReferencedForFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Path to the project file..
         /// </summary>
         internal static string ListPkg_ProjectPathDescription {
             get {
                 return ResourceManager.GetString("ListPkg_ProjectPathDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; has following package references per framework -.
+        /// </summary>
+        internal static string ListPkg_References {
+            get {
+                return ResourceManager.GetString("ListPkg_References", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -73,7 +73,7 @@ namespace NuGet.CommandLine.XPlat {
         /// <summary>
         ///   Looks up a localized string similar to Adds a package reference to a project..
         /// </summary>
-        internal static string ListPkg_Description {
+        internal static string AddPkg_Description {
             get {
                 return ResourceManager.GetString("AddPkg_Description", resourceCulture);
             }
@@ -472,6 +472,42 @@ namespace NuGet.CommandLine.XPlat {
         internal static string InputFile_Description {
             get {
                 return ResourceManager.GetString("InputFile_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Lists package references for a project..
+        /// </summary>
+        internal static string ListPkg_Description {
+            get {
+                return ResourceManager.GetString("ListPkg_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Frameworks for which the package reference should be listed..
+        /// </summary>
+        internal static string ListPkg_FrameworksDescription {
+            get {
+                return ResourceManager.GetString("ListPkg_FrameworksDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Id of the package for listing references..
+        /// </summary>
+        internal static string ListPkg_PackageIdDescription {
+            get {
+                return ResourceManager.GetString("ListPkg_PackageIdDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to the project file..
+        /// </summary>
+        internal static string ListPkg_ProjectPathDescription {
+            get {
+                return ResourceManager.GetString("ListPkg_ProjectPathDescription", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -492,4 +492,37 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="ListPkg_ProjectPathDescription" xml:space="preserve">
     <value>Path to the project file.</value>
   </data>
+  <data name="ListPkg_AllFrameworks" xml:space="preserve">
+    <value>All Frameworks</value>
+  </data>
+  <data name="ListPkg_Framework" xml:space="preserve">
+    <value>Framework '{0}' -</value>
+    <comment>{0} - Framework Identifier</comment>
+  </data>
+  <data name="ListPkg_NonTargetedFramework" xml:space="preserve">
+    <value>This poject does not target framework '{0}'.</value>
+    <comment>{0} - Framework Identifier</comment>
+  </data>
+  <data name="ListPkg_NoPackageRefsForFramework" xml:space="preserve">
+    <value>This poject does not reference any package for framework '{0}'.</value>
+    <comment>{0} - Framework Identifier</comment>
+  </data>
+  <data name="ListPkg_NoPackageRefsForProject" xml:space="preserve">
+    <value>Project '{0}' has no package references.</value>
+    <comment>{0} - Path to the project file.</comment>
+  </data>
+  <data name="ListPkg_PackageAndVersion" xml:space="preserve">
+    <value>Package '{0}' Version '{1}'.</value>
+    <comment>{0} - Package Identifier
+{1} - Package Version</comment>
+  </data>
+  <data name="ListPkg_PackageNotReferencedForFramework" xml:space="preserve">
+    <value>This poject does not reference package '{0}' for framework '{1}'.</value>
+    <comment>{0} - Package Identifier
+{1} - Framework Identifier</comment>
+  </data>
+  <data name="ListPkg_References" xml:space="preserve">
+    <value>Project '{0}' has following package references per framework -</value>
+    <comment>{0} - Path to the project file.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -458,7 +458,6 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Operation Name
 {1} - project file path</comment>
   </data>
-<<<<<<< HEAD
   <data name="Error_MultipleMatchingSpecs" xml:space="preserve">
     <value>Multiple matching package specs found when attempting to add package '{0}' to project '{1}'. Number of matching package specs found are  '{2}'.</value>
     <comment>{0} - Package ID

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -458,6 +458,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Operation Name
 {1} - project file path</comment>
   </data>
+<<<<<<< HEAD
   <data name="Error_MultipleMatchingSpecs" xml:space="preserve">
     <value>Multiple matching package specs found when attempting to add package '{0}' to project '{1}'. Number of matching package specs found are  '{2}'.</value>
     <comment>{0} - Package ID
@@ -478,5 +479,17 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But no project was found at the project path '{0}'.</value>
     <comment>{0} - Package Id
 {1} - Project path</comment>
+  </data>
+  <data name="ListPkg_Description" xml:space="preserve">
+    <value>Lists package references for a project.</value>
+  </data>
+  <data name="ListPkg_PackageIdDescription" xml:space="preserve">
+    <value>Id of the package for listing references.</value>
+  </data>
+  <data name="ListPkg_FrameworksDescription" xml:space="preserve">
+    <value>Frameworks for which the package reference should be listed.</value>
+  </data>
+  <data name="ListPkg_ProjectPathDescription" xml:space="preserve">
+    <value>Path to the project file.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -152,8 +152,9 @@ namespace NuGet.CommandLine.XPlat
             IEnumerable<string> userInputFrameworks)
         {
             var project = GetProject(projectPath);
-            var packageReferencesPerFramework = new Dictionary<string, IEnumerable<Tuple<string, string>>>();            
-            var projectFrameworks = new HashSet<NuGetFramework>(GetProjectFrameworks(project).Select(f => NuGetFramework.Parse(f)));               
+            var packageReferencesPerFramework = new Dictionary<string, IEnumerable<Tuple<string, string>>>();
+            var projectFrameworkStrings = GetProjectFrameworks(project);
+            var projectFrameworks = new HashSet<NuGetFramework>(GetProjectFrameworks(project).Select(f => NuGetFramework.Parse(f)));
 
             if (!userInputFrameworks.Any())
             {
@@ -162,11 +163,11 @@ namespace NuGet.CommandLine.XPlat
                 packageReferencesPerFramework.Add(Strings.AddPkg_All,
                     unconditionalpackageReferences.Select(i => Tuple.Create(i.EvaluatedInclude, i.GetMetadataValue(VERSION_TAG))));
 
-                foreach (var framework in projectFrameworks)
+                foreach (var framework in projectFrameworkStrings)
                 {
-                    var conditionalpackageReferences = GetPackageReferencesPerFramework(project, packageDependency, framework.ToString());
+                    var conditionalpackageReferences = GetPackageReferencesPerFramework(project, packageDependency, framework);
 
-                    packageReferencesPerFramework.Add(framework.ToString(),
+                    packageReferencesPerFramework.Add(framework,
                         conditionalpackageReferences.Select(i => Tuple.Create(i.EvaluatedInclude, i.GetMetadataValue(VERSION_TAG))));
                 }
             }
@@ -177,7 +178,7 @@ namespace NuGet.CommandLine.XPlat
                     var framework = NuGetFramework.Parse(userInputFramework);
                     if (projectFrameworks.Contains(framework))
                     {
-                        var conditionalpackageReferences = GetPackageReferencesPerFramework(project, packageDependency, framework.ToString());
+                        var conditionalpackageReferences = GetPackageReferencesPerFramework(project, packageDependency, userInputFramework);
 
                         packageReferencesPerFramework.Add(userInputFramework,
                             conditionalpackageReferences.Select(i => Tuple.Create(i.EvaluatedInclude, i.GetMetadataValue(VERSION_TAG))));

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -160,7 +160,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 var unconditionalpackageReferences = GetPackageReferences(project, packageDependency);
 
-                packageReferencesPerFramework.Add(Strings.AddPkg_All,
+                packageReferencesPerFramework.Add(Strings.ListPkg_AllFrameworks,
                     unconditionalpackageReferences.Select(i => Tuple.Create(i.EvaluatedInclude, i.GetMetadataValue(VERSION_TAG))));
 
                 foreach (var framework in projectFrameworkStrings)
@@ -190,6 +190,7 @@ namespace NuGet.CommandLine.XPlat
                 }
             }
 
+            ProjectCollection.GlobalProjectCollection.UnloadProject(project);
             return packageReferencesPerFramework;
         }
 
@@ -404,7 +405,7 @@ namespace NuGet.CommandLine.XPlat
                     .AllEvaluatedProperties
                     .Where(p => p.Name.Equals(FRAMEWORKS_TAG, StringComparison.OrdinalIgnoreCase))
                     .Select(p => p.EvaluatedValue)
-                    .FirstOrDefault();
+                    .LastOrDefault();
                 frameworks = MSBuildStringUtility.Split(frameworksString);
             }
             return frameworks;

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -151,19 +151,20 @@ namespace NuGet.CommandLine.XPlat
         {
             var packageDependencies = new Dictionary<string, Tuple<string, string>>();
             var packageReferences = new List<ProjectItem>();
-            if (frameworks == null)
-            {
-                var project = GetProject(projectPath);
-                packageReferences = GetPackageReferencesForAllFrameworks(project, packageDependency)
-                    .ToList();
-            }
-            else
+            if (frameworks.Any())
             {
                 var project = GetProject(projectPath);
                 foreach (var framework in frameworks)
                 {
                     packageReferences.AddRange(GetPackageReferencesPerFramework(project, packageDependency, framework));
                 }
+
+            }
+            else
+            {
+                var project = GetProject(projectPath);
+                packageReferences = GetPackageReferencesForAllFrameworks(project, packageDependency)
+                    .ToList();
             }
             return packageReferences;
         }
@@ -346,8 +347,7 @@ namespace NuGet.CommandLine.XPlat
         private static IEnumerable<ProjectItem> GetPackageReferences(Project project, PackageDependency packageDependency)
         {
             var packageReferences = project.AllEvaluatedItems
-                .Where(item => item.ItemType.Equals(PACKAGE_REFERENCE_TYPE_TAG, StringComparison.OrdinalIgnoreCase) &&
-                               item.EvaluatedInclude.Equals(packageDependency.Id, StringComparison.OrdinalIgnoreCase));
+                .Where(item => item.ItemType.Equals(PACKAGE_REFERENCE_TYPE_TAG, StringComparison.OrdinalIgnoreCase));
 
             if (packageDependency == null)
             {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -147,6 +147,8 @@ namespace NuGet.CommandLine.XPlat
         /// <param name="projectPath">Path to the csproj file of the project.</param>
         /// <param name="packageDependency">Package Dependency of the package to be added.</param>
         /// <param name="userInputFrameworks">Target Frameworks for which the package reference should be added.</param>
+        /// <returns>Returns a dictionary indexed on target frameworks containing a list of package references.
+        /// The list of package references will be null if the target framework is not targeted by the project.</returns>
         public Dictionary<string, IEnumerable<Tuple<string, string>>> ListPackageReference(string projectPath, 
             PackageDependency packageDependency,
             IEnumerable<string> userInputFrameworks)

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -97,7 +97,7 @@ namespace NuGet.XPlat.FuncTest
                 .ReturnsAsync(0);
 
             testApp.Name = "dotnet nuget_test";
-            AddPackageReferenceCommand.Register(testApp,
+            ListPackageReferenceCommand.Register(testApp,
                 () => logger,
                 () => mockCommandRunner.Object);
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -97,7 +97,7 @@ namespace NuGet.XPlat.FuncTest
                 .ReturnsAsync(0);
 
             testApp.Name = "dotnet nuget_test";
-            ListPackageReferenceCommand.Register(testApp,
+            AddPackageReferenceCommand.Register(testApp,
                 () => logger,
                 () => mockCommandRunner.Object);
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
@@ -1,0 +1,294 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.CommandLineUtils;
+using Moq;
+using NuGet.CommandLine.XPlat;
+using NuGet.Commands;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.XPlat.FuncTest
+{
+    public class XplatListPkgTest
+    {
+
+        private static readonly string projectName = "test_project_listpkg";
+
+        private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());
+        
+        // Argument parsing related tests
+
+        [Theory]
+        [InlineData("--package", "package_foo", "--project", "project_foo.csproj", "", "")]
+        [InlineData("--package", "package_foo", "-p", "project_foo.csproj", "--framework", "net46;netcoreapp1.0")]
+        [InlineData("--package", "package_foo", "-p", "project_foo.csproj", "-f", "net46 ; netcoreapp1.0 ; ")]
+        [InlineData("--package", "package_foo", "-p", "project_foo.csproj", "-f", "net46")]
+        [InlineData("", "", "--project", "project_foo.csproj", "", "")]
+        public void ListPkg_ArgParsing(string packageOption, string packageString,
+        string projectOption, string project, string frameworkOption, string frameworkString)
+        {
+            // Arrange
+            var projectPath = Path.Combine(Path.GetTempPath(), project);
+            File.Create(projectPath).Dispose();
+
+            var argList = new List<string>() {
+                "list",
+                projectOption,
+                projectPath};
+
+            if (!string.IsNullOrEmpty(frameworkOption))
+            {
+                argList.Add(frameworkOption);
+                argList.Add(frameworkString);
+            }
+
+            if (!string.IsNullOrEmpty(packageOption))
+            {
+                argList.Add(packageOption);
+                argList.Add(packageString);
+            }
+
+            var logger = new TestCommandOutputLogger();
+            var testApp = new CommandLineApplication();
+            var mockCommandRunner = new Mock<IPackageReferenceCommandRunner>();
+            mockCommandRunner
+                .Setup(m => m.ExecuteCommand(It.IsAny<PackageReferenceArgs>(), It.IsAny<MSBuildAPIUtility>()))
+                .ReturnsAsync(0);
+
+            testApp.Name = "dotnet nuget_test";
+            ListPackageReferenceCommand.Register(testApp,
+                () => logger,
+                () => mockCommandRunner.Object);
+
+            // Act
+            var result = testApp.Execute(argList.ToArray());
+
+            XPlatTestUtils.DisposeTemporaryFile(projectPath);
+
+            // Assert
+            mockCommandRunner.Verify(m => m.ExecuteCommand(It.Is<PackageReferenceArgs>(p =>
+            p.ProjectPath == projectPath &&
+            (string.IsNullOrEmpty(packageOption) || (!string.IsNullOrEmpty(packageOption) && p.PackageDependency.Id.Equals(packageString))) &&
+            (string.IsNullOrEmpty(frameworkOption) || (!string.IsNullOrEmpty(frameworkOption) && p.Frameworks.SequenceEqual(MSBuildStringUtility.Split(frameworkString))))),
+            It.IsAny<MSBuildAPIUtility>()));
+
+            Assert.Equal(0, result);
+        }
+
+        // List Related Tests
+
+        [Fact]
+        public async void ListPkg_UnconditionalReferences()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage();
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, "netcoreapp1.0");
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath, packageDependency: null, userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(packageReferences.ContainsKey("All Frameworks"));
+                Assert.True(packageReferences["All Frameworks"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_OneConditionalReferences()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString:"netcoreapp1.0");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, 
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath, packageDependency: null, userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(packageReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(packageReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_MultipleConditionalReferences()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
+                var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", frameworkString: "netstandard1.3");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                projectA.AddPackageToFramework("netstandard1.3", packageY);
+
+                projectA.Save();
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+                var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
+
+                Assert.NotNull(itemGroupNetCore);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
+                Assert.NotNull(itemGroupNetStandard);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetStandard, packageY.Id, "1.0.0"));
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath, packageDependency: null, userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(packageReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(packageReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+                Assert.True(packageReferences.ContainsKey("netstandard1.3"));
+                Assert.True(packageReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
+            }
+        }
+
+
+        [Fact]
+        public async void ListPkg_MultipleConditionalWithPackageFilterReferences()
+        {
+            // Arrange
+            //XPlatTestUtils.WaitForDebugger();
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
+                var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", frameworkString: "netstandard1.3");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                projectA.AddPackageToFramework("netstandard1.3", packageY);
+
+                projectA.Save();
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+                var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
+
+                Assert.NotNull(itemGroupNetCore);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
+                Assert.NotNull(itemGroupNetStandard);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetStandard, packageY.Id, "1.0.0"));
+
+                // Act
+                var PackageXReferences = MsBuild.ListPackageReference(projectA.ProjectPath, 
+                    packageDependency: new PackageDependency(packageX.Id, VersionRange.Parse("*")), 
+                    userInputFrameworks: new string[0]);
+
+                var PackageYReferences = MsBuild.ListPackageReference(projectA.ProjectPath, 
+                    packageDependency: new PackageDependency(packageY.Id, VersionRange.Parse("*")), 
+                    userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(PackageXReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(PackageXReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+                Assert.False(PackageXReferences["netstandard1.3"].Any());
+
+                Assert.True(PackageYReferences.ContainsKey("netstandard1.3"));
+                Assert.True(PackageYReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
+                Assert.False(PackageYReferences["netcoreapp1.0"].Any());
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_MultipleConditionalWithFrameworkFilterReferences()
+        {
+            // Arrange
+            //XPlatTestUtils.WaitForDebugger();
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
+                var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", frameworkString: "netstandard1.3");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                projectA.AddPackageToFramework("netstandard1.3", packageY);
+
+                projectA.Save();
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+                var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
+
+                Assert.NotNull(itemGroupNetCore);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
+                Assert.NotNull(itemGroupNetStandard);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetStandard, packageY.Id, "1.0.0"));
+
+                // Act
+                var PackageXReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: new PackageDependency(packageX.Id, VersionRange.Parse("*")),
+                    userInputFrameworks: new string[0]);
+
+                var PackageYReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: new PackageDependency(packageY.Id, VersionRange.Parse("*")),
+                    userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(PackageXReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(PackageXReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+                Assert.True(PackageYReferences.ContainsKey("netstandard1.3"));
+                Assert.True(PackageYReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
+            }
+        }
+    }
+}

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
@@ -16,9 +16,10 @@ using Xunit;
 
 namespace NuGet.XPlat.FuncTest
 {
+
+    [Collection("NuGet XPlat Test Collection")]
     public class XplatListPkgTest
     {
-
         private static readonly string projectName = "test_project_listpkg";
 
         private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatListPkgTest.cs
@@ -22,7 +22,7 @@ namespace NuGet.XPlat.FuncTest
         private static readonly string projectName = "test_project_listpkg";
 
         private static MSBuildAPIUtility MsBuild => new MSBuildAPIUtility(new TestCommandOutputLogger());
-        
+
         // Argument parsing related tests
 
         [Theory]
@@ -99,7 +99,7 @@ namespace NuGet.XPlat.FuncTest
 
                 var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, "netcoreapp1.0");
 
-                // Verify that the package reference exists before removing.
+                // Verify that the package reference exists before listing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
@@ -122,16 +122,16 @@ namespace NuGet.XPlat.FuncTest
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Generate Package
-                var packageX = XPlatTestUtils.CreatePackage(frameworkString:"netcoreapp1.0");
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp1.0");
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
                     packageX);
 
-                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX, 
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
                     projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
 
-                // Verify that the package reference exists before removing.
+                // Verify that the package reference exists before listing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
 
@@ -168,7 +168,7 @@ namespace NuGet.XPlat.FuncTest
 
                 projectA.Save();
 
-                // Verify that the package reference exists before removing.
+                // Verify that the package reference exists before listing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
                 var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
@@ -194,7 +194,6 @@ namespace NuGet.XPlat.FuncTest
         public async void ListPkg_MultipleConditionalWithPackageFilterReferences()
         {
             // Arrange
-            //XPlatTestUtils.WaitForDebugger();
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Generate Package
@@ -212,59 +211,7 @@ namespace NuGet.XPlat.FuncTest
 
                 projectA.Save();
 
-                // Verify that the package reference exists before removing.
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
-                var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
-
-                Assert.NotNull(itemGroupNetCore);
-                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
-                Assert.NotNull(itemGroupNetStandard);
-                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetStandard, packageY.Id, "1.0.0"));
-
-                // Act
-                var PackageXReferences = MsBuild.ListPackageReference(projectA.ProjectPath, 
-                    packageDependency: new PackageDependency(packageX.Id, VersionRange.Parse("*")), 
-                    userInputFrameworks: new string[0]);
-
-                var PackageYReferences = MsBuild.ListPackageReference(projectA.ProjectPath, 
-                    packageDependency: new PackageDependency(packageY.Id, VersionRange.Parse("*")), 
-                    userInputFrameworks: new string[0]);
-
-                // Assert
-                Assert.True(PackageXReferences.ContainsKey("netcoreapp1.0"));
-                Assert.True(PackageXReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
-                Assert.False(PackageXReferences["netstandard1.3"].Any());
-
-                Assert.True(PackageYReferences.ContainsKey("netstandard1.3"));
-                Assert.True(PackageYReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
-                Assert.False(PackageYReferences["netcoreapp1.0"].Any());
-            }
-        }
-
-        [Fact]
-        public async void ListPkg_MultipleConditionalWithFrameworkFilterReferences()
-        {
-            // Arrange
-            //XPlatTestUtils.WaitForDebugger();
-            using (var pathContext = new SimpleTestPathContext())
-            {
-                // Generate Package
-                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
-                var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", frameworkString: "netstandard1.3");
-                await SimpleTestPackageUtility.CreateFolderFeedV3(
-                    pathContext.PackageSource,
-                    PackageSaveMode.Defaultv3,
-                    packageX);
-
-                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
-                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
-
-                projectA.AddPackageToFramework("netstandard1.3", packageY);
-
-                projectA.Save();
-
-                // Verify that the package reference exists before removing.
+                // Verify that the package reference exists before listing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
                 var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
                 var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
@@ -286,8 +233,193 @@ namespace NuGet.XPlat.FuncTest
                 // Assert
                 Assert.True(PackageXReferences.ContainsKey("netcoreapp1.0"));
                 Assert.True(PackageXReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+                Assert.False(PackageXReferences["netstandard1.3"].Any());
+
                 Assert.True(PackageYReferences.ContainsKey("netstandard1.3"));
                 Assert.True(PackageYReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
+                Assert.False(PackageYReferences["netcoreapp1.0"].Any());
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_MultipleConditionalWithPackageAndFrameworkFilterReferences()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                // Verify that the package reference exists before listing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+
+                Assert.NotNull(itemGroupNetCore);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
+
+                // Act
+                var NetCoreReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: new PackageDependency(packageX.Id, VersionRange.Parse("*")),
+                    userInputFrameworks: MSBuildStringUtility.Split("netcoreapp1.0"));
+
+                var NetStandardReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: new PackageDependency(packageX.Id, VersionRange.Parse("*")),
+                    userInputFrameworks: MSBuildStringUtility.Split("netstandard1.3"));
+
+                // Assert
+                Assert.True(NetCoreReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(NetCoreReferences.Keys.Count() == 1);
+                Assert.True(NetCoreReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+
+                Assert.True(NetStandardReferences.ContainsKey("netstandard1.3"));
+                Assert.True(NetStandardReferences.Keys.Count() == 1);
+                Assert.False(NetStandardReferences["netstandard1.3"].Any());
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_MultipleConditionalWithFrameworkFilterReferences()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(packageId: "packageX", frameworkString: "netcoreapp1.0");
+                var packageY = XPlatTestUtils.CreatePackage(packageId: "packageY", frameworkString: "netstandard1.3");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                projectA.AddPackageToFramework("netstandard1.3", packageY);
+
+                projectA.Save();
+
+                // Verify that the package reference exists before listing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroupNetCore = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+                var itemGroupNetStandard = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netstandard1.3");
+
+                Assert.NotNull(itemGroupNetCore);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetCore, packageX.Id, "1.0.0"));
+                Assert.NotNull(itemGroupNetStandard);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroupNetStandard, packageY.Id, "1.0.0"));
+
+                // Act
+                var NetCoreReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: null,
+                    userInputFrameworks: MSBuildStringUtility.Split("netcoreapp1.0"));
+
+                var NetStandardReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: null,
+                    userInputFrameworks: MSBuildStringUtility.Split("netstandard1.3"));
+
+                // Assert
+                Assert.True(NetCoreReferences.ContainsKey("netcoreapp1.0"));
+                Assert.True(NetCoreReferences.Keys.Count() == 1);
+                Assert.True(NetCoreReferences["netcoreapp1.0"].Where(p => p.Item1.Equals(packageX.Id)).Count() == 1);
+
+                Assert.True(NetStandardReferences.ContainsKey("netstandard1.3"));
+                Assert.True(NetStandardReferences.Keys.Count() == 1);
+                Assert.True(NetStandardReferences["netstandard1.3"].Where(p => p.Item1.Equals(packageY.Id)).Count() == 1);
+            }
+        }
+
+        [Fact]
+        public void ListPkg_NonReferencedPackageWithPackageFilter()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    isToolingVersion15: true,
+                    frameworks: MSBuildStringUtility.Split("netcoreapp1.0;netstandard1.3;"));
+
+                projectA.Save();
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: null,
+                    userInputFrameworks: new string[0]);
+
+                // Assert
+                Assert.True(packageReferences.Keys.Count() == 3);
+                foreach (var key in packageReferences.Keys)
+                {
+                    Assert.False(packageReferences[key].Where(p => p.Item1.Equals("packageX")).Any());
+                }
+            }
+        }
+
+        [Fact]
+        public void ListPkg_NonReferencedPackageWithFrameworkFilter()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var projectA = SimpleTestProjectContext.CreateNETCoreWithSDK(
+                    projectName: projectName,
+                    solutionRoot: pathContext.SolutionRoot,
+                    isToolingVersion15: true,
+                    frameworks: MSBuildStringUtility.Split("netcoreapp1.0;netstandard1.3;"));
+
+                projectA.Save();
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath,
+                    packageDependency: null,
+                    userInputFrameworks: MSBuildStringUtility.Split("netstandard1.3"));
+
+                // Assert
+                Assert.True(packageReferences.Keys.Count() == 1);
+                Assert.False(packageReferences["netstandard1.3"].Where(p => p.Item1.Equals("packageX")).Any());
+            }
+        }
+
+        [Fact]
+        public async void ListPkg_ReferencedPackageWithInvalidFrameworkFilter()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate Package
+                var packageX = XPlatTestUtils.CreatePackage(frameworkString: "netcoreapp1.0");
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageX,
+                    projectFrameworks: "netcoreapp1.0;netstandard1.3;", packageFramework: "netcoreapp1.0");
+
+                // Verify that the package reference exists before listing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForFramework(projectXmlRoot, "netcoreapp1.0");
+
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, "1.0.0"));
+
+                // Act
+                var packageReferences = MsBuild.ListPackageReference(projectA.ProjectPath, 
+                    packageDependency: null, 
+                    userInputFrameworks: MSBuildStringUtility.Split("net_foo_bar"));
+
+                // Assert
+                Assert.True(packageReferences.ContainsKey("net_foo_bar"));
+                Assert.True(packageReferences.Keys.Count() == 1);
+                Assert.Null(packageReferences["net_foo_bar"]);
             }
         }
     }


### PR DESCRIPTION
This PR adds support for dotnet list package command in NuGet.  Fixes part of https://github.com/NuGet/Home/issues/4102

# Spec

## Description
The command is used to list the package references for a project. The command allows filtering on package id and framework.

## -help
```
F:\validation\test> & 'E:\nuget.client\artifacts\NuGet.CommandLine.XPlat\15.0\bin\Debug\net46\win7-x86\NuGet.CommandLine.XPlat.exe' package list -h


Usage: NuGet.CommandLine.XPlat.dll package list [options]

Options:
  -h|--help               Show help information
  --force-english-output  Forces the application to run using an invariant, English-based culture.
  --package               Id of the package for listing references.
  -p|--project            Path to the project file.
  -f|--framework          Frameworks for which the package reference should be listed.
```

## Usage 
### csproj file -
 
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFrameworks>netstandard2.0;netcoreapp1.0</TargetFrameworks>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="nuget.versioning" Version="4.0.0" />
  </ItemGroup>  
  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
    <PackageReference Include="newtonsoft.json" Version="9.0.1" />
  </ItemGroup>
  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
    <PackageReference Include="newtonsoft.json" Version="10.0.2" />
  </ItemGroup>
</Project>
```


### Example 1 
Unconditional to print all references.

```
F:\validation\test> & 'E:\nuget.client\artifacts\NuGet.CommandLine.XPlat\15.0\bin\Debug\net46\win7-x86\NuGet.CommandLine.XPlat.exe' package list --project .\test.csproj
info : Project '.\test.csproj' has following package references per framework -
info : Framework 'All Frameworks' -
info : --------------------------------------------------
info : Package 'nuget.versioning' Version '4.0.0'.
info : --------------------------------------------------
info : Framework 'netstandard2.0' -
info : --------------------------------------------------
info : Package 'NETStandard.Library' Version '1.6.1'.
info : Package 'nuget.versioning' Version '4.0.0'.
info : Package 'newtonsoft.json' Version '10.0.2'.
info : --------------------------------------------------
info : Framework 'netcoreapp1.0' -
info : --------------------------------------------------
info : Package 'Microsoft.NETCore.App' Version '1.0.4'.
info : Package 'nuget.versioning' Version '4.0.0'.
info : Package 'newtonsoft.json' Version '9.0.1'.
info : --------------------------------------------------
```

### Example 2 
References for a framework.

```
F:\validation\test> & 'E:\nuget.client\artifacts\NuGet.CommandLine.XPlat\15.0\bin\Debug\net46\win7-x86\NuGet.CommandLine.XPlat.exe' package list --project .\test.csproj --framework netcoreapp1.0
info : Project '.\test.csproj' has following package references per framework -
info : Framework 'netcoreapp1.0' -
info : --------------------------------------------------
info : Package 'Microsoft.NETCore.App' Version '1.0.4'.
info : Package 'nuget.versioning' Version '4.0.0'.
info : Package 'newtonsoft.json' Version '9.0.1'.
info : --------------------------------------------------
```

### Example 3
References for a package.

```
F:\validation\test> & 'E:\nuget.client\artifacts\NuGet.CommandLine.XPlat\15.0\bin\Debug\net46\win7-x86\NuGet.CommandLine.XPlat.exe' package list --project .\test.csproj --package newtonsoft.json
info : Project '.\test.csproj' has following package references per framework -
info : Framework 'All Frameworks' -
info : --------------------------------------------------
info : This poject does not reference package 'newtonsoft.json' for framework 'All Frameworks'.
info : --------------------------------------------------
info : Framework 'netstandard2.0' -
info : --------------------------------------------------
info : Package 'newtonsoft.json' Version '10.0.2'.
info : --------------------------------------------------
info : Framework 'netcoreapp1.0' -
info : --------------------------------------------------
info : Package 'newtonsoft.json' Version '9.0.1'.
info : --------------------------------------------------
```

### Example 4 
Random inputs.

```
F:\validation\test> & 'E:\nuget.client\artifacts\NuGet.CommandLine.XPlat\15.0\bin\Debug\net46\win7-x86\NuGet.CommandLine.XPlat.exe' package list --project .\test.csproj --framework random_framework
info : Project '.\test.csproj' has following package references per framework -
info : Framework 'random_framework' -
info : --------------------------------------------------
info : This poject does not target framework 'random_framework'.
info : --------------------------------------------------
```