### PR TITLE
Separate VSIX building from the building of the rest of the projects

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -18,7 +18,7 @@
                           Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj"/>
     <VSUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\*\*.csproj"
                         Exclude="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj" />
-    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj;
+    <CoreFuncTestProjects Include="$(RepositoryRootDireftory)test\NuGet.Core.FuncTests\*\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Clients.FuncTests\*\*.csproj" />
@@ -35,6 +35,11 @@
     <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj" />
   </ItemGroup>
 
+  <!-- The project that builds the VSIX -->
+  <PropertyGroup>
+    <VSIXProject>$(RepositoryRootDirectory)src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj</VSIXProject>
+  </PropertyGroup>
+
   <!-- All projects in the repository -->
   <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
     <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
@@ -42,13 +47,22 @@
                       Condition=" '$(ExcludeTestProjects)' != 'true' " />
 
     <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />
+    <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"
+                                Exclude="$(VSIXProject)" />
   </ItemGroup>
+
+  <Target Name="GetSlns">
+    <Message Text="@(SolutionProjectsWithoutVSIX)" Importance="High"/>
+        <Message Text="$(VSIXProject)" Importance="High"/>
+
+  </Target>
 
   <!-- All projects in the repository that support cross platform builds -->
   <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
     <SolutionProjects Include="@(CoreUnitTestProjects)" />
     <SolutionProjects Include="@(CoreFuncTestProjects)" />
   </ItemGroup>
+
 
   <!--
     ============================================================
@@ -179,8 +193,27 @@
   -->
   <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building for VS14" Importance="high" />
+    <CallTarget Targets="BuildVS14NoVSIX;BuildVS14VSIX"/>
+  </Target>
 
-    <MSBuild Projects="@(SolutionProjects)"
+  <!--
+    ============================================================
+    Build for VS15
+    ============================================================
+  -->
+  <Target Name="BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">
+    <Message Text="Building for VS15" Importance="high" />
+    <CallTarget Targets="BuildVS15NoVSIX;BuildVS15VSIX"/>
+  </Target>
+
+    <!--
+    ============================================================
+    Build for VS14
+    ============================================================
+  -->
+  <Target Name="BuildVS14NoVSIX" Condition=" '$(IsXPlat)' != 'true' ">
+    <Message Text="Building for VS14" Importance="high" />
+    <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=14.0;" />
@@ -191,10 +224,38 @@
     Build for VS15
     ============================================================
   -->
-  <Target Name="BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS15NoVSIX" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building for VS15" Importance="high" />
 
-    <MSBuild Projects="@(SolutionProjects)"
+    <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
+             Targets="Build"
+             Properties="$(CommonMSBuildProperties);
+                         VisualStudioVersion=15.0;" />
+  </Target>
+
+  <!--
+    ============================================================
+    Build the VS14 VSIX
+    ============================================================
+  -->
+  <Target Name="BuildVS14VSIX" Condition=" '$(IsXPlat)' != 'true' ">
+    <Message Text="Building the VSIX for VS14" Importance="high" />
+
+    <MSBuild Projects="@(VSIXProject)"
+             Targets="Build"
+             Properties="$(CommonMSBuildProperties);
+                         VisualStudioVersion=14.0;" />
+  </Target>
+
+  <!--
+    ============================================================
+    Build the VS15 VSIX
+    ============================================================
+  -->
+  <Target Name="BuildVS15VSIX" Condition=" '$(IsXPlat)' != 'true' ">
+    <Message Text="Building the VSIX for VS15" Importance="high" />
+
+    <MSBuild Projects="@(VSIXProject)"
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=15.0;" />

--- a/build/build.proj
+++ b/build/build.proj
@@ -35,11 +35,6 @@
     <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj" />
   </ItemGroup>
 
-  <!-- The project that builds the VSIX -->
-  <PropertyGroup>
-    <VSIXProject>$(RepositoryRootDirectory)src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj</VSIXProject>
-  </PropertyGroup>
-
   <!-- All projects in the repository -->
   <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
     <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
@@ -184,9 +179,8 @@
     Build for VS14
     ============================================================
   -->
-  <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' " AfterTargets="BuildVS14NoVSIX;BuildVS14VSIX">
     <Message Text="Building for VS14" Importance="high" />
-    <CallTarget Targets="BuildVS14NoVSIX;BuildVS14VSIX"/>
   </Target>
 
   <!--
@@ -194,9 +188,8 @@
     Build for VS15
     ============================================================
   -->
-  <Target Name="BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS15" Condition=" '$(IsXPlat)' != 'true' " AfterTargets="BuildVS15NoVSIX;BuildVS15VSIX">
     <Message Text="Building for VS15" Importance="high" />
-    <CallTarget Targets="BuildVS15NoVSIX;BuildVS15VSIX"/>
   </Target>
 
     <!--

--- a/build/build.proj
+++ b/build/build.proj
@@ -222,6 +222,8 @@
   <!--
     ============================================================
     Build the VS14 VSIX
+    This target always needs to be below BuildVS14NoVSIX so that
+    BuildVS14 runs the NoVSIX targets before this one.
     ============================================================
   -->
   <Target Name="BuildVS14VSIX" AfterTargets= "BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
@@ -236,6 +238,8 @@
   <!--
     ============================================================
     Build the VS15 VSIX
+    This target always needs to be below BuildVS15NoVSIX so that
+    BuildVS15 runs the NoVSIX targets before this one.
     ============================================================
   -->
   <Target Name="BuildVS15VSIX" AfterTargets= "BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">

--- a/build/build.proj
+++ b/build/build.proj
@@ -18,7 +18,7 @@
                           Exclude="$(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj"/>
     <VSUnitTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\*\*.csproj"
                         Exclude="$(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj" />
-    <CoreFuncTestProjects Include="$(RepositoryRootDireftory)test\NuGet.Core.FuncTests\*\*.csproj;
+    <CoreFuncTestProjects Include="$(RepositoryRootDirectory)test\NuGet.Core.FuncTests\*\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Clients.Tests\NuGet.CommandLine.Test\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Core.Tests\NuGet.PackageManagement.Test\*.csproj;
                                    $(RepositoryRootDirectory)test\NuGet.Clients.FuncTests\*\*.csproj" />
@@ -50,12 +50,6 @@
     <SolutionProjectsWithoutVSIX Include="@(SolutionProjects)"
                                 Exclude="$(VSIXProject)" />
   </ItemGroup>
-
-  <Target Name="GetSlns">
-    <Message Text="@(SolutionProjectsWithoutVSIX)" Importance="High"/>
-        <Message Text="$(VSIXProject)" Importance="High"/>
-
-  </Target>
 
   <!-- All projects in the repository that support cross platform builds -->
   <ItemGroup Condition=" '$(IsXPlat)' == 'true' ">
@@ -241,7 +235,7 @@
   <Target Name="BuildVS14VSIX" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building the VSIX for VS14" Importance="high" />
 
-    <MSBuild Projects="@(VSIXProject)"
+    <MSBuild Projects="$(VSIXProject)"
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=14.0;" />
@@ -255,7 +249,7 @@
   <Target Name="BuildVS15VSIX" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building the VSIX for VS15" Importance="high" />
 
-    <MSBuild Projects="@(VSIXProject)"
+    <MSBuild Projects="$(VSIXProject)"
              Targets="Build"
              Properties="$(CommonMSBuildProperties);
                          VisualStudioVersion=15.0;" />

--- a/build/build.proj
+++ b/build/build.proj
@@ -57,7 +57,6 @@
     <SolutionProjects Include="@(CoreFuncTestProjects)" />
   </ItemGroup>
 
-
   <!--
     ============================================================
     Run core functional tests (non-VS specific)

--- a/build/build.proj
+++ b/build/build.proj
@@ -179,16 +179,16 @@
     Build for VS14
     ============================================================
   -->
-  <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' " AfterTargets="BuildVS14NoVSIX;BuildVS14VSIX">
+  <Target Name="BuildVS14" Condition=" '$(IsXPlat)' != 'true' " >
     <Message Text="Building for VS14" Importance="high" />
   </Target>
 
   <!--
     ============================================================
-    Build for VS15
+    Build for VS15 
     ============================================================
   -->
-  <Target Name="BuildVS15" Condition=" '$(IsXPlat)' != 'true' " AfterTargets="BuildVS15NoVSIX;BuildVS15VSIX">
+  <Target Name="BuildVS15"  Condition=" '$(IsXPlat)' != 'true' " >
     <Message Text="Building for VS15" Importance="high" />
   </Target>
 
@@ -197,7 +197,7 @@
     Build for VS14
     ============================================================
   -->
-  <Target Name="BuildVS14NoVSIX" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS14NoVSIX" AfterTargets="BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building for VS14" Importance="high" />
     <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
              Targets="Build"
@@ -210,7 +210,7 @@
     Build for VS15
     ============================================================
   -->
-  <Target Name="BuildVS15NoVSIX" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS15NoVSIX" AfterTargets="BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building for VS15" Importance="high" />
 
     <MSBuild Projects="@(SolutionProjectsWithoutVSIX)"
@@ -224,7 +224,7 @@
     Build the VS14 VSIX
     ============================================================
   -->
-  <Target Name="BuildVS14VSIX" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS14VSIX" AfterTargets= "BuildVS14" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building the VSIX for VS14" Importance="high" />
 
     <MSBuild Projects="$(VSIXProject)"
@@ -238,7 +238,7 @@
     Build the VS15 VSIX
     ============================================================
   -->
-  <Target Name="BuildVS15VSIX" Condition=" '$(IsXPlat)' != 'true' ">
+  <Target Name="BuildVS15VSIX" AfterTargets= "BuildVS15" Condition=" '$(IsXPlat)' != 'true' ">
     <Message Text="Building the VSIX for VS15" Importance="high" />
 
     <MSBuild Projects="$(VSIXProject)"

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -196,4 +196,9 @@
     <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)' == ''">$(BuildCommonDirectory)NuGet.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <!-- The project that builds the VSIX -->
+  <PropertyGroup>
+    <VSIXProject>$(RepositoryRootDirectory)src\NuGet.Clients\NuGet.VisualStudio.Client\NuGet.VisualStudio.Client.csproj</VSIXProject>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
As part of https://github.com/NuGet/Client.Engineering/issues/6 and https://github.com/NuGet/Client.Engineering/issues/23 we need to separate the packing of the VSIX so that we can do it after we have signed and localized.

The intention here is to preserve the same behavior of the build scripts for the end-user. 