### PR TITLE
Fixes add package command to work well with DotnetCliToolsReferences

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -50,16 +50,20 @@ namespace NuGet.CommandLine.XPlat
             var matchingPackageSpecs = dgSpec
                 .Projects
                 .Where(p => p.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference && 
-                PathUtility.GetStringComparerBasedOnOS().Equals(Path.GetFullPath(p.RestoreMetadata.ProjectPath), projectFullPath));
+                PathUtility.GetStringComparerBasedOnOS().Equals(Path.GetFullPath(p.RestoreMetadata.ProjectPath), projectFullPath))
+                .ToArray();
 
             // This ensures that the DG specs generated in previous steps contain exactly 1 project with the same path as the project requesting add package.
+            // Throw otherwise since we cannot proceed further.
             if (!matchingPackageSpecs.Any())
             {
-                throw new Exception(Strings.Error_NoMatchingSpecs);
+                packageReferenceArgs.Logger.LogDebug(Strings.Error_NoMatchingSpecs);
+                throw new Exception(Strings.Error_NoProjectFound);
             }
             else if (matchingPackageSpecs.Count() > 1)
             {
-                throw new Exception(Strings.Error_MultipleMatchingSpecs);
+                packageReferenceArgs.Logger.LogDebug(Strings.Error_MultipleMatchingSpecs);
+                throw new Exception(Strings.Error_MultipleProjectsFound);
             }
 
             var originalPackageSpec = matchingPackageSpecs.FirstOrDefault();

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/NuGet.CommandLine.XPlat.csproj
@@ -21,7 +21,8 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.1012" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -314,6 +314,15 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But multiple projects were found at the project path &apos;{1}&apos;..
+        /// </summary>
+        internal static string Error_MultipleProjectsFound {
+            get {
+                return ResourceManager.GetString("Error_MultipleProjectsFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None or invalid DgSpec was passed to NuGet add package command..
         /// </summary>
         internal static string Error_NoDgSpec {
@@ -328,6 +337,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_NoMatchingSpecs {
             get {
                 return ResourceManager.GetString("Error_NoMatchingSpecs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But no project was found at the project path &apos;{0}&apos;..
+        /// </summary>
+        internal static string Error_NoProjectFound {
+            get {
+                return ResourceManager.GetString("Error_NoProjectFound", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -305,11 +305,29 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Multiple matching package specs found when attempting to add package &apos;{0}&apos; to project &apos;{1}&apos;. Number of matching package specs found are  &apos;{2}&apos;..
+        /// </summary>
+        internal static string Error_MultipleMatchingSpecs {
+            get {
+                return ResourceManager.GetString("Error_MultipleMatchingSpecs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None or invalid DgSpec was passed to NuGet add package command..
         /// </summary>
         internal static string Error_NoDgSpec {
             get {
                 return ResourceManager.GetString("Error_NoDgSpec", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No matching package specs found when attempting to add package &apos;{0}&apos; to project &apos;{1}&apos;..
+        /// </summary>
+        internal static string Error_NoMatchingSpecs {
+            get {
+                return ResourceManager.GetString("Error_NoMatchingSpecs", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -456,4 +456,15 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Operation Name
 {1} - project file path</comment>
   </data>
+  <data name="Error_MultipleMatchingSpecs" xml:space="preserve">
+    <value>Multiple matching package specs found when attempting to add package '{0}' to project '{1}'. Number of matching package specs found are  '{2}'.</value>
+    <comment>{0} - Package ID
+{1} - Project path
+{2} -  NUmber of matching package specs found</comment>
+  </data>
+  <data name="Error_NoMatchingSpecs" xml:space="preserve">
+    <value>No matching package specs found when attempting to add package '{0}' to project '{1}'.</value>
+    <comment>{0} - Package ID
+{1} - Project path</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -467,4 +467,14 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Package ID
 {1} - Project path</comment>
   </data>
+  <data name="Error_MultipleProjectsFound" xml:space="preserve">
+    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But multiple projects were found at the project path '{1}'.</value>
+    <comment>{0} - Package Id
+{1} - Project path</comment>
+  </data>
+  <data name="Error_NoProjectFound" xml:space="preserve">
+    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But no project was found at the project path '{0}'.</value>
+    <comment>{0} - Package Id
+{1} - Project path</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -173,7 +173,11 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageY);
 
-                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageDotnetCliToolX, "net46");
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+
+                projectA.DotnetCLIToolReferences.Add(packageDotnetCliToolX);
+
+                projectA.Save();
 
                 // Verify that the package reference exists before removing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
@@ -246,7 +250,7 @@ namespace NuGet.XPlat.FuncTest
         [InlineData("net46; netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
         [InlineData("net46", "net46; netcoreapp1.0", "1.*")]
         [InlineData("netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
-        public async void AddPkg_UnconditionalAddWithDotnetCliToolReferenceAndNoRestore_Success(string packageFrameworks,
+        public async void AddPkg_UnconditionalAddWithDotnetCliToolAndNoRestore_Success(string packageFrameworks,
             string projectFrameworks,
             string userInputVersion)
         {
@@ -270,7 +274,11 @@ namespace NuGet.XPlat.FuncTest
                     PackageSaveMode.Defaultv3,
                     packageY);
 
-                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageDotnetCliToolX, "net46");
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
+
+                projectA.DotnetCLIToolReferences.Add(packageDotnetCliToolX);
+
+                projectA.Save();
 
                 // Verify that the package reference exists before removing.
                 var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -10,6 +10,7 @@ using Moq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Commands;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
 using Xunit;
 
@@ -153,30 +154,46 @@ namespace NuGet.XPlat.FuncTest
         public async void AddPkg_UnconditionalAddWithDotnetCliTool_Success(string userInputVersion)
         {
             // Arrange
-
             using (var pathContext = new SimpleTestPathContext())
             {
-                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, "net46");
-                var packageX = XPlatTestUtils.CreatePackage();
+                // Generate DotNetCliToolReference Package
+                var packageDotnetCliToolX = XPlatTestUtils.CreatePackage(packageId: "PackageDotnetCliToolX", 
+                    packageType: PackageType.DotnetCliTool);
 
-                // Generate Package
                 await SimpleTestPackageUtility.CreateFolderFeedV3(
                     pathContext.PackageSource,
                     PackageSaveMode.Defaultv3,
-                    packageX);
+                    packageDotnetCliToolX);
 
-                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageX.Id, userInputVersion, projectA);
+                // Generate test package
+                var packageY = XPlatTestUtils.CreatePackage(packageId:"PackageY");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageY);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageDotnetCliToolX, "net46");
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot, packageType: PackageType.DotnetCliTool);
+
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageDotnetCliToolX.Id, "1.0.0", PackageType.DotnetCliTool));
+
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageY.Id, userInputVersion, projectA, noRestore: false);
                 var commandRunner = new AddPackageReferenceCommandRunner();
 
                 // Act
                 var result = commandRunner.ExecuteCommand(packageArgs, MsBuild).Result;
-                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
-                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
 
                 // Assert
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
-                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageY.Id, userInputVersion));
             }
         }
 
@@ -220,6 +237,60 @@ namespace NuGet.XPlat.FuncTest
                 Assert.Equal(0, result);
                 Assert.NotNull(itemGroup);
                 Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageX.Id, userInputVersion));
+            }
+        }
+
+        [Theory]
+        [InlineData("net46", "net46; netcoreapp1.0", "1.*")]
+        [InlineData("net46; netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
+        [InlineData("net46; netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
+        [InlineData("net46", "net46; netcoreapp1.0", "1.*")]
+        [InlineData("netcoreapp1.0", "net46; netcoreapp1.0", "1.*")]
+        public async void AddPkg_UnconditionalAddWithDotnetCliToolReferenceAndNoRestore_Success(string packageFrameworks,
+            string projectFrameworks,
+            string userInputVersion)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Generate DotNetCliToolReference Package
+                var packageDotnetCliToolX = XPlatTestUtils.CreatePackage(packageId: "PackageDotnetCliToolX",
+                    packageType: PackageType.DotnetCliTool);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageDotnetCliToolX);
+
+                // Generate test package
+                var packageY = XPlatTestUtils.CreatePackage(packageId: "PackageY");
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    PackageSaveMode.Defaultv3,
+                    packageY);
+
+                var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, packageDotnetCliToolX, "net46");
+
+                // Verify that the package reference exists before removing.
+                var projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                var itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot, packageType: PackageType.DotnetCliTool);
+
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageDotnetCliToolX.Id, "1.0.0", PackageType.DotnetCliTool));
+
+                var packageArgs = XPlatTestUtils.GetPackageReferenceArgs(packageY.Id, userInputVersion, projectA, noRestore: true);
+                var commandRunner = new AddPackageReferenceCommandRunner();
+
+                // Act
+                var result = commandRunner.ExecuteCommand(packageArgs, MsBuild).Result;
+                projectXmlRoot = XPlatTestUtils.LoadCSProj(projectA.ProjectPath).Root;
+                itemGroup = XPlatTestUtils.GetItemGroupForAllFrameworks(projectXmlRoot);
+
+                // Assert
+                Assert.Equal(0, result);
+                Assert.NotNull(itemGroup);
+                Assert.True(XPlatTestUtils.ValidateReference(itemGroup, packageY.Id, userInputVersion));
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -307,9 +307,13 @@ namespace NuGet.XPlat.FuncTest
         public static XElement GetItemGroupForAllFrameworks(XElement root, PackageType packageType = null)
         {
             var itemGroups = root.Descendants("ItemGroup");
-
+            var referenceType = GetReferenceType(packageType);
+            foreach(var i in itemGroups)
+            {
+                var x = i.Descendants(referenceType);
+            }
             return itemGroups
-                    .Where(i => i.Descendants(GetReferenceType(packageType)).Count() > 0 &&
+                    .Where(i => i.Descendants(referenceType).Count() > 0 &&
                                 i.FirstAttribute == null)
                      .First();
         }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -40,8 +40,10 @@ namespace NuGet.XPlat.FuncTest
             {
                 var json = new JObject();
 
-                var frameworks = new JObject();
-                frameworks["netcoreapp1.0"] = new JObject();
+                var frameworks = new JObject
+                {
+                    ["netcoreapp1.0"] = new JObject()
+                };
 
                 json["dependencies"] = new JObject();
 
@@ -75,7 +77,7 @@ namespace NuGet.XPlat.FuncTest
         {
             get
             {
-                string fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+                var fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
 
                 return Path.Combine(fullPath, CoreConfigFileName);
             }
@@ -97,7 +99,7 @@ namespace NuGet.XPlat.FuncTest
         {
             get
             {
-                string fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+                var fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
 
                 return Path.Combine(fullPath, ProtocolConfigFileName);
             }
@@ -105,7 +107,7 @@ namespace NuGet.XPlat.FuncTest
 
         public static string ReadApiKey(string feedName)
         {
-            string fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            var fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
             using (Stream configStream = File.OpenRead(ProtocolConfigPath))
             {
                 var doc = XDocument.Load(XmlReader.Create(configStream));
@@ -190,7 +192,8 @@ namespace NuGet.XPlat.FuncTest
 
         public static SimpleTestPackageContext CreatePackage(string packageId = "packageX",
             string packageVersion = "1.0.0",
-            string frameworkString = null)
+            string frameworkString = null,
+            PackageType packageType = null)
         {
             var package = new SimpleTestPackageContext()
             {
@@ -198,6 +201,11 @@ namespace NuGet.XPlat.FuncTest
                 Version = packageVersion
             };
             var frameworks = MSBuildStringUtility.Split(frameworkString);
+
+            if (packageType != null)
+            {
+                package.PackageType = packageType;
+            }
 
             // Make the package Compatible with specific frameworks
             frameworks?
@@ -252,10 +260,11 @@ namespace NuGet.XPlat.FuncTest
 
         // Assert Helper Methods
 
-        public static bool ValidateReference(XElement root, string packageId, string version)
+        public static bool ValidateReference(XElement root, string packageId, string version, PackageType packageType = null)
         {
+
             var packageReferences = root
-                    .Descendants("PackageReference")
+                    .Descendants(GetReferenceType(packageType))
                     .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
 
             if (packageReferences.Count() != 1)
@@ -275,32 +284,32 @@ namespace NuGet.XPlat.FuncTest
             return true;
         }
 
-        public static bool ValidateNoReference(XElement root, string packageId)
+        public static bool ValidateNoReference(XElement root, string packageId, PackageType packageType = null)
         {
             var packageReferences = root
-                    .Descendants("PackageReference")
+                    .Descendants(GetReferenceType(packageType))
                     .Where(d => d.FirstAttribute.Value.Equals(packageId, StringComparison.OrdinalIgnoreCase));
 
             return !(packageReferences.Count() > 0);
         }
 
-        public static XElement GetItemGroupForFramework(XElement root, string framework)
+        public static XElement GetItemGroupForFramework(XElement root, string framework, PackageType packageType = null)
         {
             var itemGroups = root.Descendants("ItemGroup");
             return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Any() &&
+                    .Where(i => i.Descendants(GetReferenceType(packageType)).Any() &&
                                 i.FirstAttribute != null &&
                                 i.FirstAttribute.Name.LocalName.Equals("Condition", StringComparison.OrdinalIgnoreCase) &&
                                 i.FirstAttribute.Value.Trim().Equals(GetTargetFrameworkCondition(framework), StringComparison.OrdinalIgnoreCase))
                      .First();
         }
 
-        public static XElement GetItemGroupForAllFrameworks(XElement root)
+        public static XElement GetItemGroupForAllFrameworks(XElement root, PackageType packageType = null)
         {
             var itemGroups = root.Descendants("ItemGroup");
 
             return itemGroups
-                    .Where(i => i.Descendants("PackageReference").Count() > 0 &&
+                    .Where(i => i.Descendants(GetReferenceType(packageType)).Count() > 0 &&
                                 i.FirstAttribute == null)
                      .First();
         }
@@ -365,6 +374,18 @@ namespace NuGet.XPlat.FuncTest
             {
                 File.Delete(filePath);
             }
+        }
+
+        public static string GetReferenceType(PackageType packageType)
+        {
+            var referenceType = "PackageReference";
+
+            if (packageType == PackageType.DotnetCliTool)
+            {
+                referenceType = "DotNetCliToolReference";
+            }
+
+            return referenceType;
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XplatRemovePkgTests.cs
@@ -138,7 +138,6 @@ namespace NuGet.XPlat.FuncTest
         public async void RemovePkg_ConditionalRemove_Success(string packageframework)
         {
             // Arrange
-
             using (var pathContext = new SimpleTestPathContext())
             {
                 // Generate Package

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
@@ -43,6 +43,7 @@ namespace NuGet.Test.Utility
         public List<KeyValuePair<string, byte[]>> Files { get; set; } = new List<KeyValuePair<string, byte[]>>();
         public XDocument Nuspec { get; set; }
         public List<PackageType> PackageTypes { get; set; } = new List<PackageType>();
+        public PackageType PackageType { get; set; }
 
         /// <summary>
         /// runtime.json
@@ -51,13 +52,7 @@ namespace NuGet.Test.Utility
 
         public bool IsSymbolPackage { get; set; }
 
-        public PackageIdentity Identity
-        {
-            get
-            {
-                return new PackageIdentity(Id, NuGetVersion.Parse(Version));
-            }
-        }
+        public PackageIdentity Identity => new PackageIdentity(Id, NuGetVersion.Parse(Version));
 
         /// <summary>
         /// Add a file to the zip. Ex: lib/net45/a.dll

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -442,9 +442,16 @@ namespace NuGet.Test.Utility
                             props.Add("PrivateAssets", package.PrivateAssets);
                         }
 
+                        var referenceType = "PackageReference";
+
+                        if(package.PackageType == PackageType.DotnetCliTool)
+                        {
+                            referenceType = "DotNetCliToolReference";
+                        }
+
                         ProjectFileUtils.AddItem(
                             xml,
-                            "PackageReference",
+                            referenceType,
                             package.Id,
                             referenceFramework,
                             props,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -256,13 +256,7 @@ namespace NuGet.Test.Utility
         /// <summary>
         /// Project references from all TFMs
         /// </summary>
-        public List<SimpleTestProjectContext> AllProjectReferences
-        {
-            get
-            {
-                return Frameworks.SelectMany(f => f.ProjectReferences).Distinct().ToList();
-            }
-        }
+        public List<SimpleTestProjectContext> AllProjectReferences => Frameworks.SelectMany(f => f.ProjectReferences).Distinct().ToList();
 
         public void Save()
         {
@@ -444,7 +438,7 @@ namespace NuGet.Test.Utility
 
                         ProjectFileUtils.AddItem(
                             xml,
-                            "PackageReferences",
+                            "PackageReference",
                             package.Id,
                             referenceFramework,
                             props,

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -442,16 +442,9 @@ namespace NuGet.Test.Utility
                             props.Add("PrivateAssets", package.PrivateAssets);
                         }
 
-                        var referenceType = "PackageReference";
-
-                        if(package.PackageType == PackageType.DotnetCliTool)
-                        {
-                            referenceType = "DotNetCliToolReference";
-                        }
-
                         ProjectFileUtils.AddItem(
                             xml,
-                            referenceType,
+                            "PackageReferences",
                             package.Id,
                             referenceFramework,
                             props,
@@ -474,9 +467,11 @@ namespace NuGet.Test.Utility
                             }
                         }
 
-                        var props = new Dictionary<string, string>();
-                        props.Add("Name", project.ProjectName);
-                        props.Add("Project", project.ProjectGuid.ToString());
+                        var props = new Dictionary<string, string>
+                        {
+                            { "Name", project.ProjectName },
+                            { "Project", project.ProjectGuid.ToString() }
+                        };
 
                         if (!string.IsNullOrEmpty(project.ExcludeAssets))
                         {
@@ -507,15 +502,24 @@ namespace NuGet.Test.Utility
                 foreach (var tool in DotnetCLIToolReferences)
                 {
                     var props = new Dictionary<string, string>();
-                    props.Add("Version", tool.Version.ToString());
+                    var attributes = new Dictionary<string, string>();
+
+                    if (ToolingVersion15)
+                    {
+                        attributes.Add("Version", tool.Version.ToString());
+                    }
+                    else
+                    {
+                        props.Add("Version", tool.Version.ToString());
+                    }
 
                     ProjectFileUtils.AddItem(
                         xml,
-                        "DotnetCLIToolReference",
+                        "DotNetCliToolReference",
                         $"{tool.Id}",
                         NuGetFramework.AnyFramework,
                         props,
-                        new Dictionary<string, string>());
+                        attributes);
                 }
             }
             else
@@ -523,9 +527,11 @@ namespace NuGet.Test.Utility
                 // Add all project references directly
                 foreach (var project in Frameworks.SelectMany(f => f.ProjectReferences).Distinct())
                 {
-                    var props = new Dictionary<string, string>();
-                    props.Add("Name", project.ProjectName);
-                    props.Add("Project", project.ProjectGuid.ToString());
+                    var props = new Dictionary<string, string>
+                    {
+                        { "Name", project.ProjectName },
+                        { "Project", project.ProjectGuid.ToString() }
+                    };
 
                     if (!string.IsNullOrEmpty(project.ExcludeAssets))
                     {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4771

If a project has `DotnetCliToolsReferences` then a dgSpec will contain multiple projects for restore. Currently we get the project name by doing `FirstOrDefault()`. Added a fix so that we filter the projects based on their `ProjectStyle `and then pick the project that matches the `ProjectFullPath`.

Added some tests to catch this and did some test plumbing that allows `DotnetCliToolsReference `in `SimplePackageTestContext`.