### PR TITLE
Fixing TargetFrameworks declarations

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.Build.Tasks.csproj
@@ -3,14 +3,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework/>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
     <PackProject>true</PackProject>
     <Description>NuGet restore for dotnet CLI</Description>    
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -4,13 +4,17 @@
   <PropertyGroup>
     <Description>Complete commands common to command-line and GUI NuGet clients</Description>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1584;CS1658</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <IncludeInVSIX>true</IncludeInVSIX>
     <Shipping>true</Shipping>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
+++ b/src/NuGet.Core/NuGet.Commands/NuGet.Commands.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>Complete commands common to command-line and GUI NuGet clients</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1584;CS1658</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -3,13 +3,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -38,5 +42,5 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
 </Project>

--- a/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
+++ b/src/NuGet.Core/NuGet.Common/NuGet.Common.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -3,16 +3,20 @@
 
   <PropertyGroup>
     <Description>NuGet's client configuration settings implementation.</Description>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFramework />
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
   </PropertyGroup>
-
+  
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Common\NuGet.Common.csproj" />
   </ItemGroup>
@@ -43,5 +47,5 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Import Project="$(BuildCommonDirectory)common.targets"/>
+  <Import Project="$(BuildCommonDirectory)common.targets" />
 </Project>

--- a/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
+++ b/src/NuGet.Core/NuGet.Configuration/NuGet.Configuration.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>NuGet's client configuration settings implementation.</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -3,14 +3,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <RootNamespace>NuGet.DependencyResolver</RootNamespace>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>The understanding of target frameworks for NuGet.Packaging</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45;net40</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <LangVersion>5</LangVersion>

--- a/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
+++ b/src/NuGet.Core/NuGet.Frameworks/NuGet.Frameworks.csproj
@@ -4,8 +4,7 @@
   <PropertyGroup>
     <Description>The understanding of target frameworks for NuGet.Packaging</Description>
     <TargetFrameworks>netstandard1.3;net45;net40</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573</NoWarn>
     <LangVersion>5</LangVersion>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -14,6 +13,11 @@
     <IncludeInVSIX>true</IncludeInVSIX>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <DefineConstants>$(DefineConstants);IS_DESKTOP;IS_NET40_CLIENT</DefineConstants>
   </PropertyGroup>

--- a/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -3,13 +3,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
+++ b/src/NuGet.Core/NuGet.LibraryModel/NuGet.LibraryModel.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
@@ -4,13 +4,17 @@
   <PropertyGroup>
     <Description>The core data structures for NuGet.Packaging</Description>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
+++ b/src/NuGet.Core/NuGet.Packaging.Core/NuGet.Packaging.Core.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>The core data structures for NuGet.Packaging</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>NuGet's implementation for reading nupkg package and nuspec package specification files.</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
+++ b/src/NuGet.Core/NuGet.Packaging/NuGet.Packaging.csproj
@@ -4,8 +4,7 @@
   <PropertyGroup>
     <Description>NuGet's implementation for reading nupkg package and nuspec package specification files.</Description>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1574;CS1573;CS1572</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
@@ -13,6 +12,11 @@
     <IncludeInVSIX>true</IncludeInVSIX>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\NuGet.Common\NuGet.Common.csproj" />
     <ProjectReference Include="..\NuGet.Packaging.Core\NuGet.Packaging.Core.csproj" />

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -2,14 +2,18 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>`
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
+++ b/src/NuGet.Core/NuGet.ProjectModel/NuGet.ProjectModel.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -3,14 +3,18 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1573;CS0012</NoWarn>
     <PackageTags>nuget protocol</PackageTags>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
+++ b/src/NuGet.Core/NuGet.Protocol/NuGet.Protocol.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1573;CS0012</NoWarn>
     <PackageTags>nuget protocol</PackageTags>

--- a/src/NuGet.Core/NuGet.Resolver/NuGet.Resolver.csproj
+++ b/src/NuGet.Core/NuGet.Resolver/NuGet.Resolver.csproj
@@ -4,13 +4,17 @@
   <PropertyGroup>
     <Description>NuGet's dependency resolver within the NuGet.Packaging package</Description>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
     <PackProject>true</PackProject>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NuGet.Core/NuGet.Resolver/NuGet.Resolver.csproj
+++ b/src/NuGet.Core/NuGet.Resolver/NuGet.Resolver.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <Description>NuGet's dependency resolver within the NuGet.Packaging package</Description>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>

--- a/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
+++ b/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' != 'true'">netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
     <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
     <Description>NuGet's implementation of Semantic Versioning.</Description>
     <PackageTags>semver;semantic versioning</PackageTags>

--- a/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
+++ b/src/NuGet.Core/NuGet.Versioning/NuGet.Versioning.csproj
@@ -3,8 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IsVsixBuild)' == 'true'"></TargetFrameworks>
-    <TargetFramework Condition="'$(IsVsixBuild)' == 'true'">net45</TargetFramework>
+    <TargetFramework />
     <Description>NuGet's implementation of Semantic Versioning.</Description>
     <PackageTags>semver;semantic versioning</PackageTags>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(NetStandardPackageVersion)</NetStandardImplicitPackageVersion>
@@ -13,6 +12,11 @@
     <IncludeInVSIX>true</IncludeInVSIX>
   </PropertyGroup>
   
+  <PropertyGroup Condition=" '$(IsVsixBuild)' == 'true' ">
+    <TargetFrameworks />
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Fixes an issue from: https://github.com/NuGet/NuGet.Client/commit/a15fd847eb1a764db1cce17e1858f24c0421e0c0

In that commit the frameworks were conditionally declared. But it seems that that cannot be done unless both `TargetFrameworks` and `TargetFramework` both are overwritten.

