### PR TITLE
set vsix build number to the insertable version

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -34,4 +34,8 @@
     <Copyright>Copyright .NET Foundation. All rights reserved.</Copyright>
     <Serviceable>true</Serviceable>
   </PropertyGroup>
+
+  <Target Name="GetSemanticVersion">
+    <Message Text="$(SemanticVersion)" Importance="High"/>
+  </Target>
 </Project>

--- a/scripts/cibuild/ConfigureVstsBuild.ps1
+++ b/scripts/cibuild/ConfigureVstsBuild.ps1
@@ -31,6 +31,48 @@ param
     [string]$BuildRTM
 )
 
+Function Get-Version {
+    param(
+        [string]$ProductVersion,
+        [string]$build
+    )
+        Write-Host "Evaluating the new VSIX Version : ProductVersion $ProductVersion, build $build"
+        # Generate the new minor version: 4.0.0 => 40000, 4.11.5 => 41105. 
+        # This assumes we only get to NuGet major/minor 99 at worst, otherwise the logic breaks. 
+        #The final version for NuGet 4.0.0, build number 3128 would be 15.0.40000.3128
+        $finalVersion = "15.0.$((-join ($ProductVersion -split '\.' | %{ '{0:D2}' -f ($_ -as [int]) } )).TrimStart("0")).$build"    
+    
+        Write-Host "The new VSIX Version is: $finalVersion"
+        return $finalVersion    
+}
+
+Function Update-VsixVersion {
+    param(
+        [string]$ReleaseProductVersion,
+        [string]$manifestName,
+        [int]$buildNumber
+    )
+    $vsixManifest = Join-Path $env:BUILD_REPOSITORY_LOCALPATH\src\NuGet.Clients\NuGet.VisualStudio.Client $manifestName
+
+    Write-Host "Updating the VSIX version in manifest $vsixManifest"
+
+    [xml]$xml = get-content $vsixManifest
+    $root = $xml.PackageManifest
+
+    # Reading the current version from the manifest
+    $oldVersion = $root.Metadata.Identity.Version
+    # Evaluate the new version
+    $newVersion = Get-Version $ReleaseProductVersion $buildNumber
+    Write-Host "Updating the VSIX version [$oldVersion] => [$newVersion]"
+    # setting the revision to the new version
+    $root.Metadata.Identity.Version = "$newVersion"
+
+    $xml.Save($vsixManifest)
+
+    Write-Host "Updated the VSIX version [$oldVersion] => [$($root.Metadata.Identity.Version)]"
+}
+
+$msbuildExe = 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin\msbuild.exe'
 if ($BuildRTM -eq 'true')
 {
     # Set the $(NupkgOutputDir) build variable in VSTS build
@@ -41,7 +83,7 @@ if ($BuildRTM -eq 'true')
         $numberOfTries++
         Start-Sleep -s 15
     }
-    until ((Test-Path $BuildInfoJsonFile) -or ($numberOfTries -gt 10))
+    until ((Test-Path $BuildInfoJsonFile) -or ($numberOfTries -gt 50))
     $json = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
     $currentBuild = [System.Decimal]::Parse($json.BuildNumber)
     # Set the $(Revision) build variable in VSTS build
@@ -63,5 +105,12 @@ else
 
     New-Item $BuildInfoJsonFile -Force
     $jsonRepresentation | ConvertTo-Json | Set-Content $BuildInfoJsonFile
-
+    $productVersion = & $msbuildExe $env:BUILD_REPOSITORY_LOCALPATH\build\config.props /v:m /nologo /t:GetSemanticVersion
+    if (-not $?)
+    {
+        Write-Error "Failed to get product version."
+        exit 1
+    }
+    Update-VsixVersion -manifestName source.extension.vs15.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $newBuildCounter
+    Update-VsixVersion -manifestName source.extension.vs15.insertable.vsixmanifest -ReleaseProductVersion $productVersion -buildNumber $newBuildCounter
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.insertable.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.insertable.vsixmanifest
@@ -5,6 +5,7 @@
     <DisplayName>NuGet Package Manager for Visual Studio 2017</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <PackageId>Microsoft.VisualStudio.NuGet.Core</PackageId>
+    <License>eula.rtf</License>
     <Icon>Resources/nuget_96.png</Icon>
     <PreviewImage>Resources/nuget_256.png</PreviewImage>
   </Metadata>

--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.vsixmanifest
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/source.extension.vs15.vsixmanifest
@@ -5,6 +5,7 @@
     <DisplayName>NuGet Package Manager for Visual Studio 2017</DisplayName>
     <Description>A collection of tools to automate the process of downloading, installing, upgrading, configuring, and removing packages from a VS Project.</Description>
     <PackageId>Microsoft.VisualStudio.NuGet.Core</PackageId>
+    <License>eula.rtf</License>
     <Icon>Resources/nuget_96.png</Icon>
     <PreviewImage>Resources/nuget_256.png</PreviewImage>
   </Metadata>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/45

Also makes a number of minor changes:
1) Adds eula.rtf as ```<License>``` in extension.vsixmanifest
2) Increases the number of retries so that if a build is kept waiting longer in the queue, it doesn't die because of it.