### PR TITLE
Keep Project.json in sync with TPMinV for UWP Projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
@@ -44,7 +44,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     var platfromMinVersion = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), EnvDTEProjectInfoUtility.TargetPlatformMinVersion);
 
-                    if (platfromMinVersion != null)
+                    if (!string.IsNullOrEmpty(platfromMinVersion))
                     {
                         // Found the TPMinV in csproj, store this as a new target framework to be replaced in project.json
                         var newTargetFramework = new NuGetFramework(jsonTargetFramework.Framework, new Version(platfromMinVersion));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
@@ -36,13 +36,8 @@ namespace NuGet.PackageManagement.VisualStudio
             var projectId = VsHierarchyUtility.GetProjectId(envDTEProject);
             InternalMetadata.Add(NuGetProjectMetadataKeys.ProjectId, projectId);
 
-            // Override the JSON TFM value from the DTE here.
-            var platfromVersion = EnvDTEProjectInfoUtility.GetTargetPlatformVersion(envDTEProject);
-            var platfromMinVersion = EnvDTEProjectInfoUtility.GetTargetPlatformMinVersion(envDTEProject);
-            if (platfromMinVersion == null)
-            {
-                platfromMinVersion = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), "TargetPlatformMinVersion");
-            }
+            // Override the JSON TFM value from the csproj
+            var platfromMinVersion = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), EnvDTEProjectInfoUtility.TargetPlatformMinVersion);
 
             // Found the TPFmV in csproj, replace the json target framework value with this one.
             if (platfromMinVersion != null)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/ProjectJsonBuildIntegratedProjectSystem.cs
@@ -39,14 +39,13 @@ namespace NuGet.PackageManagement.VisualStudio
             // Override the JSON TFM value from the csproj
             var platfromMinVersion = VsHierarchyUtility.GetMSBuildProperty(VsHierarchyUtility.ToVsHierarchy(envDTEProject), EnvDTEProjectInfoUtility.TargetPlatformMinVersion);
 
-            // Found the TPFmV in csproj, replace the json target framework value with this one.
+            // Found the TPMinV in csproj, replace the json target framework value with this one.
             if (platfromMinVersion != null)
             {
-                NuGetFramework newTargetFramework = null;
                 if (InternalMetadata.ContainsKey(NuGetProjectMetadataKeys.TargetFramework))
                 {
                     var jsonTargetFramework = InternalMetadata[NuGetProjectMetadataKeys.TargetFramework] as NuGetFramework;
-                    newTargetFramework = new NuGetFramework(jsonTargetFramework.Framework, new Version(platfromMinVersion));
+                    var newTargetFramework = new NuGetFramework(jsonTargetFramework.Framework, new Version(platfromMinVersion));
                     InternalMetadata[NuGetProjectMetadataKeys.TargetFramework] = newTargetFramework;
                 }
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -24,6 +24,12 @@ namespace NuGet.VisualStudio
 
         public const string WebConfig = "web.config";
         public const string AppConfig = "app.config";
+        public const string FullPath = "FullPath";
+        public const string ProjectDirectory = "ProjectDirectory";
+        public const string TargetPlatformIdentifier = "TargetPlatformIdentifier";
+        public const string TargetPlatformVersion = "TargetPlatformVersion";
+        public const string TargetPlatformMinVersion = "TargetPlatformMinVersion";
+        public const string TargetFrameworkMoniker = "TargetFrameworkMoniker";
 
         #endregion // Constants and Statics
 
@@ -46,7 +52,7 @@ namespace NuGet.VisualStudio
             }
 
             // FullPath
-            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, "FullPath"));
+            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
 
             if (fullPath != null)
             {
@@ -89,7 +95,7 @@ namespace NuGet.VisualStudio
             // until we can find one containing the full path.
 
             // FullPath
-            string fullPath = GetPropertyValue<string>(envDTEProject, "FullPath");
+            string fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
 
             if (!String.IsNullOrEmpty(fullPath))
             {
@@ -104,7 +110,7 @@ namespace NuGet.VisualStudio
             }
 
             // C++ projects do not have FullPath property, but do have ProjectDirectory one.
-            string projectDirectory = GetPropertyValue<string>(envDTEProject, "ProjectDirectory");
+            string projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
 
             if (!String.IsNullOrEmpty(projectDirectory))
             {
@@ -342,10 +348,10 @@ namespace NuGet.VisualStudio
             }
 
             var projectPath = GetFullProjectPath(envDTEProject);
-            var platformIdentifier = GetPropertyValue<string>(envDTEProject, "TargetPlatformIdentifier");
-            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
-            var platformMinVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformMinVersion");
-            var targetFrameworkMoniker = GetPropertyValue<string>(envDTEProject, "TargetFrameworkMoniker");
+            var platformIdentifier = GetPropertyValue<string>(envDTEProject, TargetPlatformIdentifier);
+            var platformVersion = GetPropertyValue<string>(envDTEProject, TargetPlatformVersion);
+            var platformMinVersion = GetPropertyValue<string>(envDTEProject, TargetPlatformMinVersion);
+            var targetFrameworkMoniker = GetPropertyValue<string>(envDTEProject, TargetFrameworkMoniker);
             var isManagementPackProject = IsManagementPackProject(envDTEProject);
             var isXnaWindowsPhoneProject = IsXnaWindowsPhoneProject(envDTEProject);
 
@@ -363,40 +369,6 @@ namespace NuGet.VisualStudio
                 isXnaWindowsPhoneProject: isXnaWindowsPhoneProject);
 
             return frameworkStrings.FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Determine the project's target platform version based on the project properties.
-        /// </summary>
-        public static string GetTargetPlatformVersion(EnvDTE.Project envDTEProject)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (envDTEProject == null)
-            {
-                return null;
-            }
-
-            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
-
-            return platformVersion;
-        }
-
-        /// <summary>
-        /// Determine the project's target platform minimum version based on the project properties.
-        /// </summary>
-        public static string GetTargetPlatformMinVersion(EnvDTE.Project envDTEProject)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            if (envDTEProject == null)
-            {
-                return null;
-            }
-
-            var platformMinVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformMinVersion");
-
-            return platformMinVersion;
         }
 
         // TODO: Return null for library projects

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -365,6 +365,40 @@ namespace NuGet.VisualStudio
             return frameworkStrings.FirstOrDefault();
         }
 
+        /// <summary>
+        /// Determine the project's target platform version based on the project properties.
+        /// </summary>
+        public static string GetTargetPlatformVersion(EnvDTE.Project envDTEProject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (envDTEProject == null)
+            {
+                return null;
+            }
+
+            var platformVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformVersion");
+
+            return platformVersion;
+        }
+
+        /// <summary>
+        /// Determine the project's target platform minimum version based on the project properties.
+        /// </summary>
+        public static string GetTargetPlatformMinVersion(EnvDTE.Project envDTEProject)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (envDTEProject == null)
+            {
+                return null;
+            }
+
+            var platformMinVersion = GetPropertyValue<string>(envDTEProject, "TargetPlatformMinVersion");
+
+            return platformMinVersion;
+        }
+
         // TODO: Return null for library projects
         public static string GetConfigurationFile(EnvDTE.Project envDTEProject)
         {

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -332,9 +332,7 @@ namespace NuGet.ProjectManagement.Projects
             var frameworks = JsonConfigUtility.GetFrameworks(json);
             if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object newTargetFramework))
             {
-                if (IsUAPFramework(newTargetFramework as NuGetFramework) 
-                    && frameworks.Count() == 1
-                    && IsUAPFramework(frameworks.First()))
+                if (IsUAPFramework(newTargetFramework as NuGetFramework) && frameworks.Count() == 1)
                 {
                     // project.json can have only one target framework
                     JsonConfigUtility.ClearFrameworks(json);

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -252,9 +252,29 @@ namespace NuGet.ProjectManagement.Projects
 
             JsonConfigUtility.AddDependency(json, dependency);
 
+            UpdateFramework(json);
+
             await SaveJsonAsync(json);
 
             return true;
+        }
+
+        private void UpdateFramework(JObject json)
+        {
+            var frameworks = JsonConfigUtility.GetFrameworks(json);
+            if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object outFramework))
+            {
+                var targetFramework = outFramework as NuGetFramework;
+                if (!HasFrameWork(frameworks, targetFramework))
+                {
+                    JsonConfigUtility.AddFramework(json, targetFramework);
+                }
+            }
+        }
+
+        private bool HasFrameWork(IEnumerable<NuGetFramework> list, NuGetFramework framework)
+        {
+            return list.Any(item => item.Framework == framework.Framework && item.Version == framework.Version);
         }
 
         /// <summary>
@@ -268,6 +288,8 @@ namespace NuGet.ProjectManagement.Projects
 
             JsonConfigUtility.RemoveDependency(json, packageId);
 
+            UpdateFramework(json);
+
             await SaveJsonAsync(json);
 
             return true;
@@ -277,6 +299,7 @@ namespace NuGet.ProjectManagement.Projects
         {
             return await RemoveDependencyAsync(packageIdentity.Id, nuGetProjectContext, token);
         }
+
         private JObject GetJson()
         {
             try

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -265,8 +265,10 @@ namespace NuGet.ProjectManagement.Projects
             if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object outFramework))
             {
                 var targetFramework = outFramework as NuGetFramework;
+                // Can move the check and update to utilities.
                 if (!HasFrameWork(frameworks, targetFramework))
                 {
+                    JsonConfigUtility.ClearFrameworks(json);
                     JsonConfigUtility.AddFramework(json, targetFramework);
                 }
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -263,7 +263,7 @@ namespace NuGet.ProjectManagement.Projects
         {
             if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object targetFramework))
             {
-                // project.json can have only one framework
+                // UWP projects can have only one target framework
                 JsonConfigUtility.ClearFrameworks(json);
                 JsonConfigUtility.AddFramework(json, targetFramework as NuGetFramework);
             }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -330,13 +330,16 @@ namespace NuGet.ProjectManagement.Projects
         private void UpdateFramework(JObject json)
         {
             var frameworks = JsonConfigUtility.GetFrameworks(json);
-            if (frameworks.Count() == 1
-                && IsUAPFramework(frameworks.First())
-                && InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object newTargetFramework))
+            if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object newTargetFramework))
             {
-                // project.json can have only one target framework
-                JsonConfigUtility.ClearFrameworks(json);
-                JsonConfigUtility.AddFramework(json, newTargetFramework as NuGetFramework);
+                if (IsUAPFramework(newTargetFramework as NuGetFramework) 
+                    && frameworks.Count() == 1
+                    && IsUAPFramework(frameworks.First()))
+                {
+                    // project.json can have only one target framework
+                    JsonConfigUtility.ClearFrameworks(json);
+                    JsonConfigUtility.AddFramework(json, newTargetFramework as NuGetFramework);
+                }
             }
         }
     }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonBuildIntegratedNuGetProject.cs
@@ -74,7 +74,7 @@ namespace NuGet.ProjectManagement.Projects
             }
 
             JObject projectJson;
-            IEnumerable<NuGetFramework> targetFrameworks = Enumerable.Empty<NuGetFramework>();
+            var targetFrameworks = Enumerable.Empty<NuGetFramework>();
 
             try
             {
@@ -261,22 +261,12 @@ namespace NuGet.ProjectManagement.Projects
 
         private void UpdateFramework(JObject json)
         {
-            var frameworks = JsonConfigUtility.GetFrameworks(json);
-            if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object outFramework))
+            if (InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out object targetFramework))
             {
-                var targetFramework = outFramework as NuGetFramework;
-                // Can move the check and update to utilities.
-                if (!HasFrameWork(frameworks, targetFramework))
-                {
-                    JsonConfigUtility.ClearFrameworks(json);
-                    JsonConfigUtility.AddFramework(json, targetFramework);
-                }
+                // project.json can have only one framework
+                JsonConfigUtility.ClearFrameworks(json);
+                JsonConfigUtility.AddFramework(json, targetFramework as NuGetFramework);
             }
-        }
-
-        private bool HasFrameWork(IEnumerable<NuGetFramework> list, NuGetFramework framework)
-        {
-            return list.Any(item => item.Framework == framework.Framework && item.Version == framework.Version);
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -157,7 +157,7 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
-        /// Retrieve the NuGetFrameworks under frameworks
+        /// Add the specified framework to JSON object
         /// </summary>
         public static void AddFramework(JObject json, NuGetFramework framework)
         {
@@ -174,12 +174,21 @@ namespace NuGet.ProjectManagement
                 frameworkSet = new JObject();
             }
 
-            var frameworkProperty = new JProperty(framework.ToString());
+            var frameworkProperty = new JProperty(framework.Framework.ToLower() + framework.Version.ToString(), new JObject());
             frameworkSet.Add(frameworkProperty);
 
             // order dependencies to reduce merge conflicts
             frameworkSet = SortProperties(frameworkSet);
 
+            json["frameworks"] = frameworkSet;
+        }
+
+        /// <summary>
+        ///  Clear all frameworks from the Json object
+        /// </summary>
+        public static void ClearFrameworks(JObject json)
+        {
+            JObject frameworkSet = frameworkSet = new JObject();
             json["frameworks"] = frameworkSet;
         }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -180,7 +180,7 @@ namespace NuGet.ProjectManagement
                 frameworkSet = new JObject();
             }
 
-            var frameworkProperty = new JProperty(framework.Framework.ToLower() + framework.Version.ToString(), new JObject());
+            var frameworkProperty = new JProperty(framework.GetShortFolderName(), new JObject());
             frameworkSet.Add(frameworkProperty);
 
             // order frameworks to reduce merge conflicts
@@ -216,9 +216,10 @@ namespace NuGet.ProjectManagement
 
         private static bool HasFramework(IEnumerable<NuGetFramework> list, NuGetFramework framework)
         {
-            return list.Any(item => 
-                item.Framework == framework.Framework 
-                && item.Version == framework.Version);
+            return list.Any(
+                item =>
+                    string.Equals(item.Framework, framework.Framework, StringComparison.OrdinalIgnoreCase) 
+                    && item.Version == framework.Version);
         }
 
         private static string GetChildKey(JToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -161,6 +161,12 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static void AddFramework(JObject json, NuGetFramework framework)
         {
+            var frameworks = GetFrameworks(json);
+            if (HasFramework(frameworks, framework))
+            {
+                return;
+            }
+
             JObject frameworkSet = null;
 
             JToken node = null;
@@ -188,8 +194,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static void ClearFrameworks(JObject json)
         {
-            JObject frameworkSet = frameworkSet = new JObject();
-            json["frameworks"] = frameworkSet;
+            json["frameworks"] = new JObject();
         }
 
         /// <summary>
@@ -207,6 +212,13 @@ namespace NuGet.ProjectManagement
             }
 
             return sortedParent;
+        }
+
+        private static bool HasFramework(IEnumerable<NuGetFramework> list, NuGetFramework framework)
+        {
+            return list.Any(item => 
+                item.Framework == framework.Framework 
+                && item.Version == framework.Version);
         }
 
         private static string GetChildKey(JToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -183,14 +183,14 @@ namespace NuGet.ProjectManagement
             var frameworkProperty = new JProperty(framework.Framework.ToLower() + framework.Version.ToString(), new JObject());
             frameworkSet.Add(frameworkProperty);
 
-            // order dependencies to reduce merge conflicts
+            // order frameworks to reduce merge conflicts
             frameworkSet = SortProperties(frameworkSet);
 
             json["frameworks"] = frameworkSet;
         }
 
         /// <summary>
-        ///  Clear all frameworks from the Json object
+        ///  Clear all frameworks from the JSON object
         /// </summary>
         public static void ClearFrameworks(JObject json)
         {

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -157,6 +157,33 @@ namespace NuGet.ProjectManagement
         }
 
         /// <summary>
+        /// Retrieve the NuGetFrameworks under frameworks
+        /// </summary>
+        public static void AddFramework(JObject json, NuGetFramework framework)
+        {
+            JObject frameworkSet = null;
+
+            JToken node = null;
+            if (json.TryGetValue("frameworks", out node))
+            {
+                frameworkSet = node as JObject;
+            }
+
+            if (frameworkSet == null)
+            {
+                frameworkSet = new JObject();
+            }
+
+            var frameworkProperty = new JProperty(framework.ToString());
+            frameworkSet.Add(frameworkProperty);
+
+            // order dependencies to reduce merge conflicts
+            frameworkSet = SortProperties(frameworkSet);
+
+            json["frameworks"] = frameworkSet;
+        }
+
+        /// <summary>
         ///  Sort child properties
         /// </summary>
         private static JObject SortProperties(JObject parent)

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/JsonConfigUtility.cs
@@ -18,13 +18,16 @@ namespace NuGet.ProjectManagement
     /// </summary>
     public static class JsonConfigUtility
     {
+        private const string DEPENDENCIES_TAG = "dependencies";
+        private const string FRAMEWORKS_TAG = "frameworks";
+
         /// <summary>
         /// Read dependencies from a project.json file
         /// </summary>
         public static IEnumerable<PackageDependency> GetDependencies(JObject json)
         {
             JToken node = null;
-            if (json.TryGetValue("dependencies", out node))
+            if (json.TryGetValue(DEPENDENCIES_TAG, out node))
             {
                 foreach (var dependency in node)
                 {
@@ -94,7 +97,7 @@ namespace NuGet.ProjectManagement
             JObject dependencySet = null;
 
             JToken node = null;
-            if (json.TryGetValue("dependencies", out node))
+            if (json.TryGetValue(DEPENDENCIES_TAG, out node))
             {
                 dependencySet = node as JObject;
             }
@@ -110,7 +113,7 @@ namespace NuGet.ProjectManagement
             // order dependencies to reduce merge conflicts
             dependencySet = SortProperties(dependencySet);
 
-            json["dependencies"] = dependencySet;
+            json[DEPENDENCIES_TAG] = dependencySet;
         }
 
         /// <summary>
@@ -119,7 +122,7 @@ namespace NuGet.ProjectManagement
         public static void RemoveDependency(JObject json, string packageId)
         {
             JToken node = null;
-            if (json.TryGetValue("dependencies", out node))
+            if (json.TryGetValue(DEPENDENCIES_TAG, out node))
             {
                 foreach (var dependency in node.ToArray())
                 {
@@ -140,7 +143,7 @@ namespace NuGet.ProjectManagement
             var results = new List<NuGetFramework>();
 
             JToken node = null;
-            if (json.TryGetValue("frameworks", out node))
+            if (json.TryGetValue(FRAMEWORKS_TAG, out node))
             {
                 foreach (var frameworkNode in node.ToArray())
                 {
@@ -161,8 +164,8 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static void AddFramework(JObject json, NuGetFramework framework)
         {
-            var frameworks = GetFrameworks(json);
-            if (HasFramework(frameworks, framework))
+            var frameworksList = GetFrameworks(json);
+            if (HasFramework(frameworksList, framework))
             {
                 return;
             }
@@ -170,7 +173,7 @@ namespace NuGet.ProjectManagement
             JObject frameworkSet = null;
 
             JToken node = null;
-            if (json.TryGetValue("frameworks", out node))
+            if (json.TryGetValue(FRAMEWORKS_TAG, out node))
             {
                 frameworkSet = node as JObject;
             }
@@ -186,7 +189,7 @@ namespace NuGet.ProjectManagement
             // order frameworks to reduce merge conflicts
             frameworkSet = SortProperties(frameworkSet);
 
-            json["frameworks"] = frameworkSet;
+            json[FRAMEWORKS_TAG] = frameworkSet;
         }
 
         /// <summary>
@@ -194,7 +197,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static void ClearFrameworks(JObject json)
         {
-            json["frameworks"] = new JObject();
+            json[FRAMEWORKS_TAG] = new JObject();
         }
 
         /// <summary>
@@ -216,10 +219,7 @@ namespace NuGet.ProjectManagement
 
         private static bool HasFramework(IEnumerable<NuGetFramework> list, NuGetFramework framework)
         {
-            return list.Any(
-                item =>
-                    string.Equals(item.Framework, framework.Framework, StringComparison.OrdinalIgnoreCase) 
-                    && item.Version == framework.Version);
+            return list.Contains(framework);
         }
 
         private static string GetChildKey(JToken token)

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
@@ -109,6 +109,40 @@ namespace ProjectManagement.Test
         }
 
         [Fact]
+        public void JsonConfigUtility_AddFramework()
+        {
+            // Arrange
+            var json = BasicConfig;
+
+            // Act
+            var frameworks = JsonConfigUtility.GetFrameworks(json);
+            Assert.Equal(1, frameworks.Count());
+
+            JsonConfigUtility.AddFramework(json, new NuGet.Frameworks.NuGetFramework("uap", new Version("10.0.0")));
+            frameworks = JsonConfigUtility.GetFrameworks(json);
+
+            //Assert
+            Assert.Equal(2, frameworks.Count());
+        }
+
+        [Fact]
+        public void JsonConfigUtility_ClearFrameworks()
+        {
+            // Arrange
+            var json = BasicConfig;
+
+            // Act
+            var frameworks = JsonConfigUtility.GetFrameworks(json);
+            Assert.Equal("netcore50", frameworks.Single().GetShortFolderName());
+
+            JsonConfigUtility.ClearFrameworks(json);
+            frameworks = JsonConfigUtility.GetFrameworks(json);
+
+            //Assert
+            Assert.Equal(0, frameworks.Count());
+        }
+
+        [Fact]
         public void JsonConfigUtility_AddDependencyToNewFile()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
@@ -114,10 +114,10 @@ namespace ProjectManagement.Test
             // Arrange
             var json = BasicConfig;
 
-            // Act
             var frameworks = JsonConfigUtility.GetFrameworks(json);
             Assert.Equal(1, frameworks.Count());
 
+            // Act
             JsonConfigUtility.AddFramework(json, new NuGet.Frameworks.NuGetFramework("uap", new Version("10.0.0")));
             frameworks = JsonConfigUtility.GetFrameworks(json);
 
@@ -131,7 +131,6 @@ namespace ProjectManagement.Test
             // Arrange
             var json = BasicConfig;
 
-            // Act
             var frameworks = JsonConfigUtility.GetFrameworks(json);
             Assert.Equal(1, frameworks.Count());
 
@@ -139,6 +138,7 @@ namespace ProjectManagement.Test
             frameworks = JsonConfigUtility.GetFrameworks(json);
             Assert.Equal(2, frameworks.Count());
 
+            // Act
             JsonConfigUtility.AddFramework(json, new NuGet.Frameworks.NuGetFramework("uap", new Version("10.0.0")));
             frameworks = JsonConfigUtility.GetFrameworks(json);
             Assert.Equal(2, frameworks.Count());
@@ -150,10 +150,10 @@ namespace ProjectManagement.Test
             // Arrange
             var json = BasicConfig;
 
-            // Act
             var frameworks = JsonConfigUtility.GetFrameworks(json);
             Assert.Equal("netcore50", frameworks.Single().GetShortFolderName());
 
+            // Act
             JsonConfigUtility.ClearFrameworks(json);
             frameworks = JsonConfigUtility.GetFrameworks(json);
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/JsonConfigUtilityTests.cs
@@ -126,6 +126,25 @@ namespace ProjectManagement.Test
         }
 
         [Fact]
+        public void JsonConfigUtility_AddFrameworkDoesNotAddDuplicate()
+        {
+            // Arrange
+            var json = BasicConfig;
+
+            // Act
+            var frameworks = JsonConfigUtility.GetFrameworks(json);
+            Assert.Equal(1, frameworks.Count());
+
+            JsonConfigUtility.AddFramework(json, new NuGet.Frameworks.NuGetFramework("uap", new Version("10.0.0")));
+            frameworks = JsonConfigUtility.GetFrameworks(json);
+            Assert.Equal(2, frameworks.Count());
+
+            JsonConfigUtility.AddFramework(json, new NuGet.Frameworks.NuGetFramework("uap", new Version("10.0.0")));
+            frameworks = JsonConfigUtility.GetFrameworks(json);
+            Assert.Equal(2, frameworks.Count());
+        }
+
+        [Fact]
         public void JsonConfigUtility_ClearFrameworks()
         {
             // Arrange


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/4932. 

Replaces the UAP framework in project.json with the TPMinV from csproj for UWP projects. 

Added relevant unit tests. Investigating into adding end to end tests if possible.