### PR TITLE
Change the Vsix Name to NuGet.Tools.vsix, fixes #5131

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Client/NuGet.VisualStudio.Client.csproj
@@ -20,6 +20,7 @@
     <DeployExtension>false</DeployExtension>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <AssemblyName>NuGet.VisualStudio.Client</AssemblyName>
+    <TargetVsixContainerName>NuGet.Tools.vsix</TargetVsixContainerName>
     <VSSDKTargetPlatformRegRootSuffix>Exp</VSSDKTargetPlatformRegRootSuffix>
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <FileUpgradeFlags />


### PR DESCRIPTION
Change the Vsix Name to NuGet.Tools.vsix so that the packageid.json manifest file has the correct file name

Fixes https://github.com/NuGet/Home/issues/5131