### PR TITLE
Plumbing Collector logger into restore and adding partial APIs for assets file read/write

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -377,7 +377,7 @@ namespace NuGet.CommandLine
                     Settings.Priority.Select(x => Path.Combine(x.Root, x.FileName)),
                     packageSources.Select(x => x.Source),
                     installCount,
-                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message, string.Empty, string.Empty))));
+                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message))));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -377,7 +377,7 @@ namespace NuGet.CommandLine
                     Settings.Priority.Select(x => Path.Combine(x.Root, x.FileName)),
                     packageSources.Select(x => x.Source),
                     installCount,
-                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message))));
+                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, e.Exception.Message))));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -377,7 +377,7 @@ namespace NuGet.CommandLine
                     Settings.Priority.Select(x => Path.Combine(x.Root, x.FileName)),
                     packageSources.Select(x => x.Source),
                     installCount,
-                    collectorLogger.Errors.Concat(failedEvents.Select(e => e.Exception.Message)));
+                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message, string.Empty, string.Empty))));
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -71,7 +71,7 @@ namespace NuGet.Commands
                 if (library.Type == LibraryType.Project || library.Type == LibraryType.ExternalProject)
                 {
                     // Project
-                    var localMatch = item.Data.Match as LocalMatch;
+                    var localMatch = (LocalMatch)item.Data.Match;
 
                     var projectLib = new LockFileLibrary()
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -25,23 +25,26 @@ namespace NuGet.Commands
         private readonly ILogger _logger;
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs;
 
-        public LockFileBuilder(int lockFileVersion, ILogger logger, Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs)
+        public LockFileBuilder(int lockFileVersion, 
+            ILogger logger, 
+            Dictionary<RestoreTargetGraph, 
+            Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs)
         {
             _lockFileVersion = lockFileVersion;
             _logger = logger;
             _includeFlagGraphs = includeFlagGraphs;
         }
 
-        public LockFile CreateLockFile(
-            LockFile previousLockFile,
+        public LockFile CreateLockFile(LockFile previousLockFile,
             PackageSpec project,
             IEnumerable<RestoreTargetGraph> targetGraphs,
             IReadOnlyList<NuGetv3LocalRepository> localRepositories,
             RemoteWalkContext context)
         {
-            var lockFile = new LockFile();
-            lockFile.Version = _lockFileVersion;
-
+            var lockFile = new LockFile()
+            {
+                Version = _lockFileVersion
+            };
             var previousLibraries = previousLockFile?.Libraries.ToDictionary(l => Tuple.Create(l.Name, l.Version));
 
             if (project.RestoreMetadata?.ProjectStyle == ProjectStyle.PackageReference)
@@ -68,7 +71,7 @@ namespace NuGet.Commands
                 if (library.Type == LibraryType.Project || library.Type == LibraryType.ExternalProject)
                 {
                     // Project
-                    LocalMatch localMatch = (LocalMatch)item.Data.Match;
+                    var localMatch = item.Data.Match as LocalMatch;
 
                     var projectLib = new LockFileLibrary()
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -45,7 +45,7 @@ namespace NuGet.Commands
         {
             var requests = GetRequestsFromItems(restoreContext, _dgFile);
 
-            return Task.FromResult<IReadOnlyList<RestoreSummaryRequest>>(requests);
+            return Task.FromResult(requests);
         }
 
         private IReadOnlyList<RestoreSummaryRequest> GetRequestsFromItems(RestoreArgs restoreContext, DependencyGraphSpec dgFile)
@@ -158,11 +158,14 @@ namespace NuGet.Commands
                 project.PackageSpec,
                 sharedCache,
                 restoreContext.CacheContext,
-                restoreContext.Log);
+                restoreContext.Log)
+            {
 
-            // Set properties from the restore metadata
-            request.ProjectStyle = project.PackageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown;
-            request.RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath;
+                // Set properties from the restore metadata
+                ProjectStyle = project.PackageSpec?.RestoreMetadata?.ProjectStyle ?? ProjectStyle.Unknown,
+                RestoreOutputPath = project.PackageSpec?.RestoreMetadata?.OutputPath ?? rootPath
+            };
+
             var restoreLegacyPackagesDirectory = project.PackageSpec?.RestoreMetadata?.LegacyPackagesDirectory
                 ?? DefaultRestoreLegacyPackagesDirectory;
             request.IsLowercasePackagesDirectory = !restoreLegacyPackagesDirectory;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -86,7 +86,10 @@ namespace NuGet.Commands
                 localRepositories,
                 contextForProject);
 
-            _success &= ValidateRestoreGraphs(graphs, _logger);
+            if (!ValidateRestoreGraphs(graphs, _logger))
+            {
+                _success = false;
+            }
 
             // Check package compatibility
             var checkResults = VerifyCompatibility(
@@ -98,7 +101,11 @@ namespace NuGet.Commands
                 _request.ValidateRuntimeAssets,
                 _logger);
 
-            _success &= checkResults.All(r => r.Success);
+            if (checkResults.Any(r => !r.Success))
+            {
+                _success = false;
+            }
+
 
             // Determine the lock file output path
             var assetsFilePath = GetAssetsFilePath(assetsFile);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -86,7 +86,7 @@ namespace NuGet.Commands
                 localRepositories,
                 contextForProject);
 
-            _success = ValidateRestoreGraphs(graphs, _logger);
+            _success &= ValidateRestoreGraphs(graphs, _logger);
 
             // Check package compatibility
             var checkResults = VerifyCompatibility(
@@ -98,7 +98,7 @@ namespace NuGet.Commands
                 _request.ValidateRuntimeAssets,
                 _logger);
 
-            _success = checkResults.All(r => r.Success);
+            _success &= checkResults.All(r => r.Success);
 
             // Determine the lock file output path
             var assetsFilePath = GetAssetsFilePath(assetsFile);
@@ -132,14 +132,12 @@ namespace NuGet.Commands
             // Revert to the original case if needed
             await FixCaseForLegacyReaders(graphs, assetsFile, token);
 
-            if(_logger is CollectorLogger)
-            {
-                var logs = (_logger as CollectorLogger).Errors
-                    .Select(l => l as IAssetsLogMessage)
-                    .ToList();
+            // Write the logs into the assets file
+            var logs = (_logger as CollectorLogger).Errors
+                .Select(l => l as IAssetsLogMessage)
+                .ToList();
 
-                assetsFile.LogMessages = logs;
-            }
+            assetsFile.LogMessages = logs;
 
             restoreTime.Stop();
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -35,33 +35,9 @@ namespace NuGet.Commands
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs
             = new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>();
 
-        public RestoreCommand(RestoreRequest request)
+        public RestoreCommand(RestoreRequest request, ICollectorLogger collectorLogger = null)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            // Validate the lock file version requested
-            if (request.LockFileVersion < 1 || request.LockFileVersion > LockFileFormat.Version)
-            {
-                Debug.Fail($"Lock file version {_request.LockFileVersion} is not supported.");
-                throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
-            }
-
-            _logger = request.Log;
-            _request = request;
-        }
-
-        public RestoreCommand(RestoreSummaryRequest summaryRequest)
-        {
-            if (summaryRequest == null)
-            {
-                throw new ArgumentNullException(nameof(summaryRequest));
-            }
-
-            _request = summaryRequest.Request ?? throw new ArgumentNullException(nameof(summaryRequest.Request));
-
+            _request = request ?? throw new ArgumentNullException(nameof(request));
 
             // Validate the lock file version requested
             if (_request.LockFileVersion < 1 || _request.LockFileVersion > LockFileFormat.Version)
@@ -70,7 +46,8 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            _logger = summaryRequest.CollectorLogger;
+            _logger = collectorLogger ?? _request.Log;
+
         }
 
         public Task<RestoreResult> ExecuteAsync()

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -63,8 +63,11 @@ namespace NuGet.Commands
             var restoreTime = Stopwatch.StartNew();
 
             // Local package folders (non-sources)
-            var localRepositories = new List<NuGetv3LocalRepository>();
-            localRepositories.Add(_request.DependencyProviders.GlobalPackages);
+            var localRepositories = new List<NuGetv3LocalRepository>
+            {
+                _request.DependencyProviders.GlobalPackages
+            };
+
             localRepositories.AddRange(_request.DependencyProviders.FallbackPackageFolders);
 
             var contextForProject = CreateRemoteWalkContext(_request);
@@ -84,10 +87,7 @@ namespace NuGet.Commands
                 localRepositories,
                 contextForProject);
 
-            if (!ValidateRestoreGraphs(graphs, _logger))
-            {
-                _success = false;
-            }
+            _success = ValidateRestoreGraphs(graphs, _logger);
 
             // Check package compatibility
             var checkResults = VerifyCompatibility(
@@ -99,10 +99,7 @@ namespace NuGet.Commands
                 _request.ValidateRuntimeAssets,
                 _logger);
 
-            if (checkResults.Any(r => !r.Success))
-            {
-                _success = false;
-            }
+            _success = checkResults.All(r => r.Success);
 
             // Determine the lock file output path
             var assetsFilePath = GetAssetsFilePath(assetsFile);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -35,7 +35,7 @@ namespace NuGet.Commands
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs
             = new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>();
 
-        public RestoreCommand(RestoreRequest request, ICollectorLogger collectorLogger = null)
+        public RestoreCommand(RestoreRequest request)
         {
             _request = request ?? throw new ArgumentNullException(nameof(request));
 
@@ -46,7 +46,9 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            _logger = collectorLogger ?? _request.Log;
+            var collectorLogger = new CollectorLogger(_request.Log);
+            _logger = collectorLogger;
+            _request.Log = collectorLogger;
 
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -23,40 +23,16 @@ namespace NuGet.Commands
             SourceCacheContext cacheContext,
             ILogger log)
         {
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
 
-            if (dependencyProviders == null)
-            {
-                throw new ArgumentNullException(nameof(dependencyProviders));
-            }
-
-            if (cacheContext == null)
-            {
-                throw new ArgumentNullException(nameof(cacheContext));
-            }
-
-            if (log == null)
-            {
-                throw new ArgumentNullException(nameof(log));
-            }
-
-            Project = project;
+            CacheContext = cacheContext ?? throw new ArgumentNullException(nameof(cacheContext));
+            Log = log ?? throw new ArgumentNullException(nameof(log));
+            Project = project ?? throw new ArgumentNullException(nameof(project));
+            DependencyProviders = dependencyProviders ?? throw new ArgumentNullException(nameof(dependencyProviders));
 
             ExternalProjects = new List<ExternalProjectReference>();
             CompatibilityProfiles = new HashSet<FrameworkRuntimePair>();
-
             PackagesDirectory = dependencyProviders.GlobalPackages.RepositoryRoot;
             IsLowercasePackagesDirectory = true;
-
-            CacheContext = cacheContext;
-            Log = log;
-
-            DependencyProviders = dependencyProviders;
-
-            // Default to the project folder
 
             // Default to the project folder
             RestoreOutputPath = Path.GetDirectoryName(Project.FilePath);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -250,6 +250,7 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
+            var collectoreLogger = summaryRequest.CollectorLogger;
 
             // Read the existing lock file, this is needed to support IsLocked=true
             // This is done on the thread and not as part of creating the request due to
@@ -259,7 +260,7 @@ namespace NuGet.Commands
                 request.ExistingLockFile = LockFileUtilities.GetLockFile(request.LockFilePath, log);
             }
 
-            var command = new RestoreCommand(request);
+            var command = new RestoreCommand(summaryRequest);
             var result = await command.ExecuteAsync(token);
 
             return new RestoreResultPair(summaryRequest, result);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -51,7 +51,7 @@ namespace NuGet.Commands
             RestoreArgs restoreContext,
             CancellationToken token)
         {
-            int maxTasks = GetMaxTaskCount(restoreContext);
+            var maxTasks = GetMaxTaskCount(restoreContext);
 
             var log = restoreContext.Log;
 
@@ -106,7 +106,7 @@ namespace NuGet.Commands
             IEnumerable<RestoreSummaryRequest> restoreRequests,
             RestoreArgs restoreContext)
         {
-            int maxTasks = GetMaxTaskCount(restoreContext);
+            var maxTasks = GetMaxTaskCount(restoreContext);
 
             var log = restoreContext.Log;
 
@@ -299,7 +299,7 @@ namespace NuGet.Commands
                 summaryRequest.InputPath,
                 summaryRequest.Settings,
                 summaryRequest.Sources,
-                summaryRequest.CollectorLogger.Errors);
+                summaryRequest.CollectorLogger.Errors.Select(e => e as RestoreLogMessage));
         }
 
         private static async Task<RestoreSummary> CompleteTaskAsync(List<Task<RestoreSummary>> restoreTasks)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -250,7 +250,6 @@ namespace NuGet.Commands
 
             // Run the restore
             var request = summaryRequest.Request;
-            var collectoreLogger = summaryRequest.CollectorLogger;
 
             // Read the existing lock file, this is needed to support IsLocked=true
             // This is done on the thread and not as part of creating the request due to
@@ -260,7 +259,7 @@ namespace NuGet.Commands
                 request.ExistingLockFile = LockFileUtilities.GetLockFile(request.LockFilePath, log);
             }
 
-            var command = new RestoreCommand(summaryRequest);
+            var command = new RestoreCommand(request, summaryRequest.CollectorLogger);
             var result = await command.ExecuteAsync(token);
 
             return new RestoreResultPair(summaryRequest, result);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -259,7 +259,7 @@ namespace NuGet.Commands
                 request.ExistingLockFile = LockFileUtilities.GetLockFile(request.LockFilePath, log);
             }
 
-            var command = new RestoreCommand(request, summaryRequest.CollectorLogger);
+            var command = new RestoreCommand(request);
             var result = await command.ExecuteAsync(token);
 
             return new RestoreResultPair(summaryRequest, result);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -23,7 +23,7 @@ namespace NuGet.Commands
 
         public int InstallCount { get; }
 
-        public IList<RestoreLogMessage> Errors { get; }
+        public IList<ILogMessage> Errors { get; }
 
         public RestoreSummary(bool success)
         {
@@ -32,7 +32,7 @@ namespace NuGet.Commands
             ConfigFiles = new List<string>().AsReadOnly();
             FeedsUsed = new List<string>().AsReadOnly();
             InstallCount = 0;
-            Errors = new List<RestoreLogMessage>().AsReadOnly();
+            Errors = new List<ILogMessage>().AsReadOnly();
         }
 
         public RestoreSummary(
@@ -63,7 +63,7 @@ namespace NuGet.Commands
             IEnumerable<string> configFiles,
             IEnumerable<string> feedsUsed,
             int installCount,
-            IEnumerable<RestoreLogMessage> errors)
+            IEnumerable<ILogMessage> errors)
         {
             Success = success;
             InputPath = inputPath;
@@ -92,7 +92,7 @@ namespace NuGet.Commands
                 logger.LogErrorSummary(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
                 foreach (var error in restoreSummary.Errors)
                 {
-                    foreach (var line in IndentLines(error.ToString()))
+                    foreach (var line in IndentLines(error.FormatMessage()))
                     {
                         logger.LogErrorSummary(line);
                     }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -23,7 +23,7 @@ namespace NuGet.Commands
 
         public int InstallCount { get; }
 
-        public IList<string> Errors { get; }
+        public IList<RestoreLogMessage> Errors { get; }
 
         public RestoreSummary(bool success)
         {
@@ -32,7 +32,7 @@ namespace NuGet.Commands
             ConfigFiles = new List<string>().AsReadOnly();
             FeedsUsed = new List<string>().AsReadOnly();
             InstallCount = 0;
-            Errors = new List<string>().AsReadOnly();
+            Errors = new List<RestoreLogMessage>().AsReadOnly();
         }
 
         public RestoreSummary(
@@ -40,7 +40,7 @@ namespace NuGet.Commands
             string inputPath,
             ISettings settings,
             IEnumerable<SourceRepository> sourceRepositories,
-            IEnumerable<string> errors)
+            IEnumerable<RestoreLogMessage> errors)
         {
             Success = result.Success;
             InputPath = inputPath;
@@ -63,7 +63,7 @@ namespace NuGet.Commands
             IEnumerable<string> configFiles,
             IEnumerable<string> feedsUsed,
             int installCount,
-            IEnumerable<string> errors)
+            IEnumerable<RestoreLogMessage> errors)
         {
             Success = success;
             InputPath = inputPath;
@@ -92,7 +92,7 @@ namespace NuGet.Commands
                 logger.LogErrorSummary(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
                 foreach (var error in restoreSummary.Errors)
                 {
-                    foreach (var line in IndentLines(error))
+                    foreach (var line in IndentLines(error.ToString()))
                     {
                         logger.LogErrorSummary(line);
                     }

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
@@ -7,12 +7,12 @@ namespace NuGet.Common
     public class LogMessageProperties
     {
 
-        public const string LOG_LEVEL_PROPERTY = "level";
+        public const string LEVEL = "level";
 
-        public const string LOG_CODE_PROPERTY = "code";
+        public const string CODE = "code";
 
-        public const string MESSAGE_PROPERTY = "message";
+        public const string MESSAGE = "message";
 
-        public const string TARGET_GRAPH_PROPERTY = "targetGraph";
+        public const string TARGET_GRAPH = "targetGraph";
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace NuGet.Common
 {
-    class LogMessageProperties
+    public class LogMessageProperties
     {
 
         public const string LOG_LEVEL_PROPERTY = "level";

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessageProperties.cs
@@ -6,16 +6,13 @@ namespace NuGet.Common
 {
     class LogMessageProperties
     {
-        public const string PROJECT_PATH_PROPERTY = "Project";
 
-        public const string LOG_LEVEL_PROPERTY = "LogLevel";
+        public const string LOG_LEVEL_PROPERTY = "level";
 
-        public const string LOG_CODE_PROPERTY = "LogCode";
+        public const string LOG_CODE_PROPERTY = "code";
 
-        public const string MESSAGE_PROPERTY = "Message";
+        public const string MESSAGE_PROPERTY = "message";
 
-        public const string TIME_PROPERTY = "Time";
-
-        public const string TARGET_GRAPH_PROPERTY = "TargetGraph";
+        public const string TARGET_GRAPH_PROPERTY = "targetGraph";
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -6,8 +6,8 @@ namespace NuGet.Common
 {
     public enum NuGetLogCode
     {
-        Undefined = 0, // For cases do not fit into the cases below.
-        NU1001 = 1001, // start with 1001
+        NU1000 = 1000, // For cases do not fit into the cases below.
+        NU1001, // Actual errors start here
         NU1002
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -38,6 +38,12 @@ namespace NuGet.Common
 
         }
 
+        public RestoreLogMessage(LogLevel logLevel, string errorString)
+            : this(logLevel, NuGetLogCode.NU1000, errorString, string.Empty)
+        {
+
+        }
+
         public IDictionary<string, object> ToDictionary()
         {
             var errorDictionary = new Dictionary<string, object>
@@ -69,7 +75,7 @@ namespace NuGet.Common
         {
             var errorString = new StringBuilder();
 
-            errorString.Append($"{Enum.GetName(typeof(NuGetLogCode), Code)}:{Message}");
+            errorString.Append($"{Enum.GetName(typeof(NuGetLogCode), Code)}: {Message}");
 
             return errorString.ToString();
         }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -11,17 +11,16 @@ namespace NuGet.Common
         public LogLevel Level { get; set; }
         public NuGetLogCode Code { get; set; }
         public string Message { get; set; }
-        public string ProjectPath { get; set; }
         public IReadOnlyList<string> TargetGraphs { get; set; }
         public DateTimeOffset Time { get; set; }
+        public string ProjectPath { get; set; }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 
-            string errorString, string projectPath, string targetGraph)
+            string errorString, string targetGraph)
         {
             Level = logLevel;
             Code = errorCode;
             Message = errorString;
-            ProjectPath = projectPath;
             Time = DateTimeOffset.Now;
 
             if (!string.IsNullOrEmpty(targetGraph))
@@ -33,27 +32,10 @@ namespace NuGet.Common
             }
         }
 
-        public bool Equals(RestoreLogMessage other)
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString)
+            : this (logLevel, errorCode, errorString, string.Empty)
         {
-            if(other == null)
-            {
-                return false;
-            }
-            else if(ReferenceEquals(this, other))
-            {
-                return true;
-            }
-            else if(Level == other.Level 
-                && ProjectPath.Equals(other.ProjectPath) 
-                && Level == other.Level
-                && TargetGraphs.SequenceEqual(other.TargetGraphs))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+
         }
 
         public IDictionary<string, object> ToDictionary()

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -22,10 +22,15 @@ namespace NuGet.Common
             Code = errorCode;
             Message = errorString;
             ProjectPath = projectPath;
-            TargetGraphs = new List<string>
+            Time = DateTimeOffset.Now;
+
+            if (!string.IsNullOrEmpty(targetGraph))
             {
-                targetGraph
-            };
+                TargetGraphs = new List<string>
+                {
+                    targetGraph
+                };
+            }
         }
 
         public bool Equals(RestoreLogMessage other)
@@ -55,25 +60,18 @@ namespace NuGet.Common
         {
             var errorDictionary = new Dictionary<string, object>
             {
-                [LogMessageProperties.LOG_CODE_PROPERTY] = Code,
-                [LogMessageProperties.LOG_LEVEL_PROPERTY] = Level  //TODO write an adapter for converting into msbuild style levels
+                [LogMessageProperties.LOG_CODE_PROPERTY] = Enum.GetName(typeof(NuGetLogCode), Code),
+                [LogMessageProperties.LOG_LEVEL_PROPERTY] = Enum.GetName(typeof(LogLevel), Level)
             };
 
             if(Message != null)
             {
                 errorDictionary[LogMessageProperties.MESSAGE_PROPERTY] = Message;
             }
-            if(ProjectPath != null)
-            {
-                errorDictionary[LogMessageProperties.PROJECT_PATH_PROPERTY] = ProjectPath;
-            }
-            if(TargetGraphs != null && TargetGraphs.Any())
+
+            if(TargetGraphs != null && TargetGraphs.Any() && TargetGraphs.All(l => !string.IsNullOrEmpty(l)))
             {
                 errorDictionary[LogMessageProperties.TARGET_GRAPH_PROPERTY] = TargetGraphs;
-            }
-            if(Time != null)
-            {
-                errorDictionary[LogMessageProperties.TIME_PROPERTY] = Time;
             }
 
             return errorDictionary;
@@ -89,7 +87,7 @@ namespace NuGet.Common
         {
             var errorString = new StringBuilder();
 
-            errorString.Append($"{nameof(Code)}:{Message}");
+            errorString.Append($"{Enum.GetName(typeof(NuGetLogCode), Code)}:{Message}");
 
             return errorString.ToString();
         }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -60,18 +60,18 @@ namespace NuGet.Common
         {
             var errorDictionary = new Dictionary<string, object>
             {
-                [LogMessageProperties.LOG_CODE_PROPERTY] = Enum.GetName(typeof(NuGetLogCode), Code),
-                [LogMessageProperties.LOG_LEVEL_PROPERTY] = Enum.GetName(typeof(LogLevel), Level)
+                [LogMessageProperties.CODE] = Enum.GetName(typeof(NuGetLogCode), Code),
+                [LogMessageProperties.LEVEL] = Enum.GetName(typeof(LogLevel), Level)
             };
 
             if(Message != null)
             {
-                errorDictionary[LogMessageProperties.MESSAGE_PROPERTY] = Message;
+                errorDictionary[LogMessageProperties.MESSAGE] = Message;
             }
 
             if(TargetGraphs != null && TargetGraphs.Any() && TargetGraphs.All(l => !string.IsNullOrEmpty(l)))
             {
-                errorDictionary[LogMessageProperties.TARGET_GRAPH_PROPERTY] = TargetGraphs;
+                errorDictionary[LogMessageProperties.TARGET_GRAPH] = TargetGraphs;
             }
 
             return errorDictionary;

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -25,14 +25,14 @@ namespace NuGet.Common
 
         public override void Log(ILogMessage message)
         {
-            _innerLogger.Log(message);
             _errors.Enqueue(message);
+            _innerLogger.Log(message);
         }
 
-        public async override Task LogAsync(ILogMessage message)
+        public override Task LogAsync(ILogMessage message)
         {
-            _innerLogger.Log(message);
             _errors.Enqueue(message);
+            return _innerLogger.LogAsync(message);
         }
 
         public new void LogDebug(string data)

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -25,13 +25,21 @@ namespace NuGet.Common
 
         public override void Log(ILogMessage message)
         {
-            _errors.Enqueue(message);
+            if (CollectMessage(message.Level))
+            {
+                _errors.Enqueue(message);
+            }
+
             _innerLogger.Log(message);
         }
 
         public override Task LogAsync(ILogMessage message)
         {
-            _errors.Enqueue(message);
+            if (CollectMessage(message.Level))
+            {
+                _errors.Enqueue(message);
+            }
+
             return _innerLogger.LogAsync(message);
         }
 

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -35,26 +35,6 @@ namespace NuGet.Common
             return _innerLogger.LogAsync(message);
         }
 
-        public new void LogDebug(string data)
-        {
-            _innerLogger.LogDebug(data);
-        }
-
-        public new void LogVerbose(string data)
-        {
-            _innerLogger.LogVerbose(data);
-        }
-
-        public new void LogInformation(string data)
-        {
-            _innerLogger.LogInformation(data);
-        }
-
-        public new void LogMinimal(string data)
-        {
-            _innerLogger.LogMinimal(data);
-        }
-
         public IEnumerable<ILogMessage> Errors => _errors.ToArray();
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -20,78 +20,39 @@ namespace NuGet.Common
         public CollectorLogger(ILogger innerLogger)
         {
             _innerLogger = innerLogger;
-            _errors = new ConcurrentQueue<string>();
-        }
-
-        public void Log(LogLevel level, string data)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task LogAsync(LogLevel level, string data)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Log(ILogMessage message)
-        {
-            _innerLogger.LogError(message.FormatMessage());
-            _errors.Enqueue(message.FormatMessage());
-        }
-
-        public async Task LogAsync(ILogMessage message)
-        {
-            var messageString = await message.FormatMessageAsync();
-            _innerLogger.LogError(messageString);
-            _errors.Enqueue(message.FormatMessage());
-        }
-
-        public void LogDebug(string data)
-        {
-            _innerLogger.LogDebug(data);
-        }
-
-        public void LogVerbose(string data)
-        {
-            _innerLogger.LogVerbose(data);
-        }
-
-        public void LogInformation(string data)
-        {
-            _innerLogger.LogInformation(data);
-        }
-
-        public void LogMinimal(string data)
-        {
-            _innerLogger.LogMinimal(data);
+            _errors = new ConcurrentQueue<ILogMessage>();
         }
 
         public override void Log(ILogMessage message)
         {
-            _errors.Enqueue(message);
             _innerLogger.Log(message);
-        }
-
-        public override Task LogAsync(ILogMessage message)
-        {            
             _errors.Enqueue(message);
-            return _innerLogger.LogAsync(message);
         }
 
-        public override void Log(LogLevel level, string data)
+        public async override Task LogAsync(ILogMessage message)
         {
-            //TODO clean this
-            var message = new RestoreLogMessage(level, NuGetLogCode.Undefined, data, string.Empty, string.Empty);
+            _innerLogger.Log(message);
             _errors.Enqueue(message);
-            _innerLogger.Log(level, data);
         }
 
-        public override Task LogAsync(LogLevel level, string data)
+        public new void LogDebug(string data)
         {
-            //TODO clean this
-            var message = new RestoreLogMessage(level, NuGetLogCode.Undefined, data, string.Empty, string.Empty);
-            _errors.Enqueue(message);
-            return _innerLogger.LogAsync(level, data);
+            _innerLogger.LogDebug(data);
+        }
+
+        public new void LogVerbose(string data)
+        {
+            _innerLogger.LogVerbose(data);
+        }
+
+        public new void LogInformation(string data)
+        {
+            _innerLogger.LogInformation(data);
+        }
+
+        public new void LogMinimal(string data)
+        {
+            _innerLogger.LogMinimal(data);
         }
 
         public IEnumerable<ILogMessage> Errors => _errors.ToArray();

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -23,6 +23,18 @@ namespace NuGet.Common
             _errors = new ConcurrentQueue<ILogMessage>();
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
+        /// delegating all log messages to the <param name="innerLogger" />
+        /// based on the <param name="verbosity" />
+        /// </summary>
+        public CollectorLogger(ILogger innerLogger, LogLevel verbosity)
+            : base(verbosity)
+        {
+            _innerLogger = innerLogger;
+            _errors = new ConcurrentQueue<ILogMessage>();
+        }
+
         public override void Log(ILogMessage message)
         {
             if (CollectMessage(message.Level))

--- a/src/NuGet.Core/NuGet.Common/Logging/ICollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/ICollectorLogger.cs
@@ -11,6 +11,6 @@ namespace NuGet.Common
         /// Fetch all of the errors logged so far. This method is useful when error log messages
         /// should be redisplayed after the initial log message is emitted.
         /// </summary>
-        IEnumerable<string> Errors { get; }
+        IEnumerable<ILogMessage> Errors { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -52,7 +52,6 @@ namespace NuGet.Common
 
         public void LogErrorSummary(string data)
         {
-            //TODO remove summaries
             Log(LogLevel.Error, data);
         }
 

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -7,6 +7,7 @@ namespace NuGet.Common
 {
     public abstract class LoggerBase : ILogger
     {
+<<<<<<< HEAD
         public LogLevel VerbosityLevel { get; private set; } = LogLevel.Debug;
 
         public LoggerBase()
@@ -39,6 +40,15 @@ namespace NuGet.Common
 
             return Task.FromResult(true);
         }
+=======
+        public abstract void Log(ILogMessage message);
+
+        public abstract void Log(LogLevel level, string data);
+
+        public abstract Task LogAsync(ILogMessage message);
+
+        public abstract Task LogAsync(LogLevel level, string data);
+>>>>>>> dev-restore-errors
 
         public void LogDebug(string data)
         {
@@ -88,5 +98,6 @@ namespace NuGet.Common
         {
             return (messageLevel >= VerbosityLevel);
         }
+
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -26,7 +26,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                Log(new RestoreLogMessage(level, NuGetLogCode.Undefined, data, string.Empty, string.Empty));
+                Log(new RestoreLogMessage(level, NuGetLogCode.Undefined, data));
             }
         }
 
@@ -34,7 +34,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                return LogAsync(new RestoreLogMessage(level, NuGetLogCode.Undefined, data, string.Empty, string.Empty));
+                return LogAsync(new RestoreLogMessage(level, NuGetLogCode.Undefined, data));
             }
 
             return Task.FromResult(true);

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -26,7 +26,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                Log(new RestoreLogMessage(level, NuGetLogCode.Undefined, data));
+                Log(new RestoreLogMessage(level, data));
             }
         }
 
@@ -34,7 +34,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                return LogAsync(new RestoreLogMessage(level, NuGetLogCode.Undefined, data));
+                return LogAsync(new RestoreLogMessage(level, data));
             }
 
             return Task.FromResult(true);
@@ -86,6 +86,14 @@ namespace NuGet.Common
         protected virtual bool DisplayMessage(LogLevel messageLevel)
         {
             return (messageLevel >= VerbosityLevel);
+        }
+
+        /// <summary>
+        /// True if the message meets the verbosity level.
+        /// </summary>
+        protected virtual bool CollectMessage(LogLevel messageLevel)
+        {
+            return (messageLevel >= LogLevel.Warning);
         }
 
     }

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -7,7 +7,6 @@ namespace NuGet.Common
 {
     public abstract class LoggerBase : ILogger
     {
-<<<<<<< HEAD
         public LogLevel VerbosityLevel { get; private set; } = LogLevel.Debug;
 
         public LoggerBase()
@@ -40,15 +39,6 @@ namespace NuGet.Common
 
             return Task.FromResult(true);
         }
-=======
-        public abstract void Log(ILogMessage message);
-
-        public abstract void Log(LogLevel level, string data);
-
-        public abstract Task LogAsync(ILogMessage message);
-
-        public abstract Task LogAsync(LogLevel level, string data);
->>>>>>> dev-restore-errors
 
         public void LogDebug(string data)
         {

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFile.cs
@@ -1,9 +1,10 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Shared;
 using NuGet.Versioning;
@@ -24,6 +25,7 @@ namespace NuGet.ProjectModel
         public IList<LockFileLibrary> Libraries { get; set; } = new List<LockFileLibrary>();
         public IList<LockFileTarget> Targets { get; set; } = new List<LockFileTarget>();
         public IList<LockFileItem> PackageFolders { get; set; } = new List<LockFileItem>();
+        public IList<IAssetsLogMessage> LogMessages { get; set; } = new List<IAssetsLogMessage>();
         public PackageSpec PackageSpec { get; set; }
 
         public bool IsValidForPackageSpec(PackageSpec spec)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -326,11 +326,12 @@ namespace NuGet.ProjectModel
             return logMessageArray;
         }
 
-        private static IAssetsLogMessage ReadLogMessages(string property, JToken json)
+        private static IEnumerable<IAssetsLogMessage> ReadLogMessages(string property, JToken json)
         {
             //TODO
+            var logMessages = new List<IAssetsLogMessage>();
 
-            return null;
+            return logMessages;
         }
 
         private static LockFileTargetLibrary ReadTargetLibrary(string property, JToken json)

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -183,7 +183,8 @@ namespace NuGet.ProjectModel
                 Targets = ReadObject(cursor[TargetsProperty] as JObject, ReadTarget),
                 ProjectFileDependencyGroups = ReadObject(cursor[ProjectFileDependencyGroupsProperty] as JObject, ReadProjectFileDependencyGroup),
                 PackageFolders = ReadObject(cursor[PackageFoldersProperty] as JObject, ReadFileItem),
-                PackageSpec = ReadPackageSpec(cursor[PackageSpecProperty] as JObject)
+                PackageSpec = ReadPackageSpec(cursor[PackageSpecProperty] as JObject),
+                LogMessages = ReadArray(cursor[LogsProperty] as JArray, ReadLogMessage)
             };
             return lockFile;
         }
@@ -309,11 +310,23 @@ namespace NuGet.ProjectModel
             return JObject.FromObject(messageDictionary);
         }
 
-        private static IAssetsLogMessage ReadLogMessage(string property, JToken json)
+        private static IAssetsLogMessage ReadLogMessage(JToken json)
         {
-            //TODO
+            if (json == null)
+            {
+                return null;
+            }
+            else
+            {
+                IAssetsLogMessage logMessage = null;
 
-            return null;
+                var level = json[LogMessageProperties.LOG_LEVEL_PROPERTY];
+                var code = json[LogMessageProperties.LOG_LEVEL_PROPERTY];
+                var message = json[LogMessageProperties.MESSAGE_PROPERTY];
+                var targetGraphs = ReadArray(json[LogMessageProperties.TARGET_GRAPH_PROPERTY] as JArray, ReadString);
+
+                return logMessage;
+            }
         }
 
         private static JArray WriteLogMessages(IEnumerable<IAssetsLogMessage> logMessages)
@@ -324,14 +337,6 @@ namespace NuGet.ProjectModel
                 logMessageArray.Add(WriteLogMessage(logMessage));
             }
             return logMessageArray;
-        }
-
-        private static IEnumerable<IAssetsLogMessage> ReadLogMessages(string property, JToken json)
-        {
-            //TODO
-            var logMessages = new List<IAssetsLogMessage>();
-
-            return logMessages;
         }
 
         private static LockFileTargetLibrary ReadTargetLibrary(string property, JToken json)
@@ -563,7 +568,11 @@ namespace NuGet.ProjectModel
             var items = new List<TItem>();
             foreach (var child in json)
             {
-                items.Add(readItem(child));
+                var item = readItem(child);
+                if(item != null)
+                {
+                    items.Add(item);
+                }
             }
             return items;
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -320,10 +320,10 @@ namespace NuGet.ProjectModel
             {
                 IAssetsLogMessage logMessage = null;
 
-                var level = json[LogMessageProperties.LOG_LEVEL_PROPERTY];
-                var code = json[LogMessageProperties.LOG_LEVEL_PROPERTY];
-                var message = json[LogMessageProperties.MESSAGE_PROPERTY];
-                var targetGraphs = ReadArray(json[LogMessageProperties.TARGET_GRAPH_PROPERTY] as JArray, ReadString);
+                var level = json[LogMessageProperties.LEVEL];
+                var code = json[LogMessageProperties.LEVEL];
+                var message = json[LogMessageProperties.MESSAGE];
+                var targetGraphs = ReadArray(json[LogMessageProperties.TARGET_GRAPH] as JArray, ReadString);
 
                 return logMessage;
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileFormat.cs
@@ -19,7 +19,7 @@ namespace NuGet.ProjectModel
 {
     public class LockFileFormat
     {
-        public static readonly int Version = 3;
+        public static readonly int Version = 2;
         public static readonly string LockFileName = "project.lock.json";
         public static readonly string AssetsFileName = "project.assets.json";
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -131,8 +132,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_CannotFindProjectReferenceWithDifferentNameCase()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -262,8 +265,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_VerifyMinClientVersionV2Source()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -304,8 +309,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_VerifyMinClientVersionV3Source()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://api.nuget.org/v3/index.json"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://api.nuget.org/v3/index.json")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -470,8 +477,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_FrameworkImportRulesAreApplied()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -524,8 +533,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_FrameworkImportArray()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -580,8 +591,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_FrameworkImportRulesAreApplied_Noop()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -635,8 +648,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_LeftOverNupkg_Overwritten()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -694,8 +709,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_FrameworkImport_WarnOn()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -724,7 +741,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
-                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
+                var warning = "NU1000: Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
 
                 // Act
                 var result = await command.ExecuteAsync();
@@ -1227,7 +1244,7 @@ namespace NuGet.Commands.FuncTest
                 var packages = new List<SimpleTestPackageContext>();
                 var dependencies = new List<SimpleTestPackageContext>();
 
-                for (int i = 0; i < 500; i++)
+                for (var i = 0; i < 500; i++)
                 {
                     var package = new SimpleTestPackageContext()
                     {
@@ -1436,7 +1453,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
-                Assert.Contains("Dependency specified was Newtonsoft.Json (>= 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
+                Assert.Contains("NU1000: Dependency specified was Newtonsoft.Json (>= 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
             }
         }
 
@@ -1472,7 +1489,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
-                Assert.Contains("Dependency specified was Newtonsoft.Json (>= 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
+                Assert.Contains("NU1000: Dependency specified was Newtonsoft.Json (>= 7.0.0) but ended up with Newtonsoft.Json 7.0.1.", logger.Messages);
             }
         }
 
@@ -1523,9 +1540,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_NoCompatibleRuntimeAssembliesForProject()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
-
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
             {
@@ -1556,9 +1574,10 @@ namespace NuGet.Commands.FuncTest
                     FrameworkConstants.CommonFrameworks.NetCore50,
                     null,
                     new[] { NuGetFramework.Parse("net40-client") });
+
                 Assert.Contains(expectedIssue, result.CompatibilityCheckResults.SelectMany(c => c.Issues).ToArray());
                 Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
-                Assert.Contains(expectedIssue.Format(), logger.Messages);
+                Assert.Contains($"NU1000: {expectedIssue.Format()}", logger.Messages);
 
                 Assert.Equal(9, logger.Errors);
                 Assert.Equal(2, installed.Count);
@@ -1571,8 +1590,10 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_CorrectlyIdentifiesUnresolvedPackages()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -1835,9 +1856,11 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_RestoreExactVersionWithFailingSource()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://failingSource"));
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://failingSource"),
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -1876,9 +1899,11 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_RestoreFloatingVersionWithFailingHttpSource()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://failingSource"));
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://failingSource"),
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -1915,9 +1940,11 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_RestoreFloatingVersionWithFailingLocalSource()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("\\failingSource"));
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("\\failingSource"),
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -1953,9 +1980,11 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_RestoreFloatingVersionWithIgnoreFailingLocalSource()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("\\failingSource"));
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("\\failingSource"),
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -2000,9 +2029,11 @@ namespace NuGet.Commands.FuncTest
         public async Task RestoreCommand_RestoreFloatingVersionWithIgnoreFailingHttpSource()
         {
             // Arrange
-            var sources = new List<PackageSource>();
-            sources.Add(new PackageSource("https://failingSource"));
-            sources.Add(new PackageSource("https://www.nuget.org/api/v2/"));
+            var sources = new List<PackageSource>
+            {
+                new PackageSource("https://failingSource"),
+                new PackageSource("https://www.nuget.org/api/v2/")
+            };
 
             using (var packagesDir = TestDirectory.Create())
             using (var projectDir = TestDirectory.Create())
@@ -2091,14 +2122,19 @@ namespace NuGet.Commands.FuncTest
         {
             get
             {
-                var json = new JObject();
 
-                var frameworks = new JObject();
-                frameworks["netcore50"] = new JObject();
 
-                json["dependencies"] = new JObject();
+                var frameworks = new JObject
+                {
+                    ["netcore50"] = new JObject()
+                };
 
-                json["frameworks"] = frameworks;
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject(),
+
+                    ["frameworks"] = frameworks
+                };
 
                 json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
 
@@ -2110,14 +2146,19 @@ namespace NuGet.Commands.FuncTest
         {
             get
             {
-                var json = new JObject();
 
-                var frameworks = new JObject();
-                frameworks["net46"] = new JObject();
 
-                json["dependencies"] = new JObject();
+                var frameworks = new JObject
+                {
+                    ["net46"] = new JObject()
+                };
 
-                json["frameworks"] = frameworks;
+                var json = new JObject
+                {
+                    ["dependencies"] = new JObject(),
+
+                    ["frameworks"] = frameworks
+                };
 
                 json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -200,7 +200,9 @@ namespace NuGet.Commands.Test
                 Assert.NotNull(project2Lib);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
                 Assert.Equal(2, logger.ErrorMessages.Count());
-                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+
+                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
+                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
 
                 // Incompatible projects are marked as Unsupported
                 Assert.Equal(NuGetFramework.UnsupportedFramework.DotNetFrameworkName, project2Lib.Framework);
@@ -294,7 +296,9 @@ namespace NuGet.Commands.Test
                 Assert.NotNull(project2Lib);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports:\n  - net46 (.NETFramework,Version=v4.6)\n  - win81 (Windows,Version=v8.1)".Replace("\n", Environment.NewLine), issue.Format());
                 Assert.Equal(2, logger.ErrorMessages.Count());
-                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+
+                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
+                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
             }
         }
 
@@ -382,7 +386,9 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, result.GetAllUnresolved().Count);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
                 Assert.Equal(2, logger.ErrorMessages.Count());
-                Assert.Equal("One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+
+                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
+                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1055,7 +1055,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(result.Success);
                 Assert.Equal(1, result.GetAllUnresolved().Count);
-                Assert.True(logger.ErrorMessages.Contains("Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
+                Assert.True(logger.ErrorMessages.Contains("NU1000: Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RuntimeTargetsTests.cs
@@ -55,9 +55,10 @@ namespace NuGet.Commands.Test
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
                 var logger = new TestLogger();
-                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
-
-                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger)
+                {
+                    LockFilePath = Path.Combine(project1.FullName, "project.lock.json")
+                };
 
                 var packageA = new SimpleTestPackageContext()
                 {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -49,13 +49,13 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.Empty(errorsStart);
-            Assert.Equal(new[] { "ErrorA" }, errorsA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "NU1000: ErrorA" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsA.Select(e => e.FormatMessage()));
         }
 
         [Fact]
-        public void CollectorLogger_DoesNotCollectNonError()
+        public void CollectorLogger_DoesNotCollectNonErrorAndNonWarnings()
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
@@ -65,7 +65,6 @@ namespace NuGet.Common.Test
             collector.LogDebug("Debug");
             collector.LogVerbose("Verbose");
             collector.LogInformation("Information");
-            collector.LogWarning("Warning");
             var errors = collector.Errors.ToArray();
 
             // Assert

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
 
             // Act
             collector.LogDebug("Debug");
@@ -25,6 +25,28 @@ namespace NuGet.Common.Test
 
             // Assert
             innerLogger.Verify(x => x.LogDebug("Debug"), Times.Once);
+            innerLogger.Verify(x => x.LogVerbose("Verbose"), Times.Once);
+            innerLogger.Verify(x => x.LogInformation("Information"), Times.Once);
+            innerLogger.Verify(x => x.LogWarning("Warning"), Times.Once);
+            innerLogger.Verify(x => x.LogError("Error"), Times.Once);
+        }
+
+        [Fact]
+        public void CollectorLogger_PassesToInnerLoggerWithDefaultVerbosity()
+        {
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object);
+
+            // Act
+            collector.LogDebug("Debug");
+            collector.LogVerbose("Verbose");
+            collector.LogInformation("Information");
+            collector.LogWarning("Warning");
+            collector.LogError("Error");
+
+            // Assert
+            innerLogger.Verify(x => x.LogDebug("Debug"), Times.Never);
             innerLogger.Verify(x => x.LogVerbose("Verbose"), Times.Once);
             innerLogger.Verify(x => x.LogInformation("Information"), Times.Once);
             innerLogger.Verify(x => x.LogWarning("Warning"), Times.Once);
@@ -50,8 +72,8 @@ namespace NuGet.Common.Test
             // Assert
             Assert.Empty(errorsStart);
             Assert.Equal(new[] { "NU1000: ErrorA" }, errorsA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsAbc.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errordEnd.Select(e => e.FormatMessage()));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -49,9 +49,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.Empty(errorsStart);
-            Assert.Equal(new[] { "ErrorA" }, errorsA);
-            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsAbc);
-            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errordEnd);
+            Assert.Equal(new[] { "ErrorA" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsA.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsA.Select(e => e.FormatMessage()));
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileFormatTests.cs
@@ -164,7 +164,7 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void LockFileFormat_ReadsLockFileWithNoTools()
         {
-            string lockFileContent = @"{
+            var lockFileContent = @"{
   ""version"": 1,
   ""targets"": {
     "".NETPlatform,Version=v5.0"": {
@@ -243,7 +243,7 @@ namespace NuGet.ProjectModel.Test
         public void LockFileFormat_WritesLockFile()
         {
             // Arrange
-            string lockFileContent = @"{
+            var lockFileContent = @"{
   ""version"": 2,
   ""targets"": {
     "".NETPlatform,Version=v5.0"": {
@@ -321,7 +321,7 @@ namespace NuGet.ProjectModel.Test
         public void LockFileFormat_WritesPackageSpec()
         {
             // Arrange
-            string lockFileContent = @"{
+            var lockFileContent = @"{
   ""version"": 2,
   ""targets"": {},
   ""libraries"": {},
@@ -356,7 +356,7 @@ namespace NuGet.ProjectModel.Test
         public void LockFileFormat_ReadsPackageSpec()
         {
             // Arrange
-            string lockFileContent = @"{
+            var lockFileContent = @"{
   ""version"": 2,
   ""targets"": {},
   ""libraries"": {},
@@ -395,10 +395,11 @@ namespace NuGet.ProjectModel.Test
     }
   }
 }";
-            var lockFile = new LockFile();
-            lockFile.Version = 2;
+            var lockFile = new LockFile()
+            {
+                Version = 2,
 
-            lockFile.PackageSpec = new PackageSpec(new[]
+                PackageSpec = new PackageSpec(new[]
             {
                 new TargetFrameworkInformation
                 {
@@ -427,19 +428,20 @@ namespace NuGet.ProjectModel.Test
                     }
                 }
             })
-            {
-                Version = new NuGetVersion("1.0.0"),
-                RestoreMetadata = new ProjectRestoreMetadata
                 {
-                    ProjectUniqueName = @"X:\ProjectPath\ProjectPath.csproj",
-                    ProjectName = "ProjectPath",
-                    ProjectPath = @"X:\ProjectPath\ProjectPath.csproj",
-                    OutputPath = @"X:\ProjectPath\obj\",
-                    ProjectStyle = ProjectStyle.PackageReference,
-                    OriginalTargetFrameworks = new[] { "netcoreapp1.0" },
-                    TargetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>
+                    Version = new NuGetVersion("1.0.0"),
+                    RestoreMetadata = new ProjectRestoreMetadata
+                    {
+                        ProjectUniqueName = @"X:\ProjectPath\ProjectPath.csproj",
+                        ProjectName = "ProjectPath",
+                        ProjectPath = @"X:\ProjectPath\ProjectPath.csproj",
+                        OutputPath = @"X:\ProjectPath\obj\",
+                        ProjectStyle = ProjectStyle.PackageReference,
+                        OriginalTargetFrameworks = new[] { "netcoreapp1.0" },
+                        TargetFrameworks = new List<ProjectRestoreMetadataFrameworkInfo>
                     {
                         new ProjectRestoreMetadataFrameworkInfo(NuGetFramework.Parse("netcoreapp1.0"))
+                    }
                     }
                 }
             };


### PR DESCRIPTION
Goal -
 Write restore errors and warnings into assets file.

Work Done [Work in Progress]-
1. Altered Collector logger to collect `IEnumerable<ILogMessage>`
2. Added APIs in `LockFileFormat` to write the errors into assets file.

Notes -
1. This has changes from others due to rebasing from dev.
2. The API for reading the new assets file is still not in yet.
3. Investigating the possibility for having warning levels.
4. The format might change after talking to the sdk folks who will be consuming this.

Sample - 

```
...
  "logs": [
    {
      "code": "NU1001",
      "level": "Error",
      "message": "Test error message"
    },
    {
      "code": "NU1002",
      "level": "Warning",
      "message": "Second Test message"
    },
    {
      "code": "NU1002",
      "level": "Warning",
      "message": "Third Test message",
      "targetGraph": [
        "net46"
      ]
    }
  ]
...
```