### PR TITLE
get the exact list of DLLs and PDBs that need to be indexed

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -26,6 +26,7 @@
   </ImportGroup>
   <PropertyGroup Condition="'$(Shipping)' == 'true'">
     <SignTargetsForRealSigning>GetBuildOutputWithSigningMetadata</SignTargetsForRealSigning>
+    <SymbolTargetsToGetPdbs>GetDebugSymbolsProjectOutput</SymbolTargetsToGetPdbs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IncludeInVSIX)' == 'true'">
     <LocTargets>GetBuildOutputWithLocMetadata</LocTargets>
@@ -97,6 +98,25 @@
 
   <!--
     ============================================================
+    GetSymbolsToIndex - gets the list of DLLs,EXEs and PDBs that 
+    need to be indexed on the symbol server
+    ============================================================
+  -->
+  <Target Name="GetSymbolsToIndex" DependsOnTargets="GetTargetFrameworkSet" Returns="@(SymbolFilesToIndex)" Condition=" '$(Shipping)' == 'true' ">
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="$(SignTargetsForRealSigning);$(SymbolTargetsToGetPdbs)"
+      Properties="TargetFramework=%(ProjectTargetFrameworkEntries.Identity);
+                  BuildProjectReferences=false;">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="SymbolFilesToIndex" />
+    </MSBuild>
+  </Target>
+  
+  <!--
+    ============================================================
     GetSigningInputs - gets the list of DLLs that need to
     be signed from each project
     ============================================================
@@ -138,6 +158,12 @@
         <StrongName>$(StrongNameCert)</StrongName>
         <Authenticode>Microsoft</Authenticode>
       </DllsToSignWithMetadata>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GetDebugSymbolsProjectOutput" DependsOnTargets="DebugSymbolsProjectOutputGroup" Returns="@(PdbsToIndex)">
+    <ItemGroup>
+      <PdbsToIndex Include="@(DebugSymbolsProjectOutputGroupOutput->'%(FinalOutputPath)')"/>
     </ItemGroup>
   </Target>
 

--- a/build/symbols.proj
+++ b/build/symbols.proj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="GetSymbolsAndAssembliesToIndex" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+  
+  <!-- Configuration/global properties -->
+  <PropertyGroup>
+    <CommonMSBuildProperties>
+      Configuration=$(Configuration);
+      ReleaseLabel=$(ReleaseLabel);
+      BuildNumber=$(BuildNumber);
+      BuildRTM=$(BuildRTM);
+    </CommonMSBuildProperties>
+  </PropertyGroup>
+
+  <Target Name="GetSymbolsAndAssembliesToIndex">
+    <MSBuild
+      Projects="@(SolutionProjectsWithoutVSIX)"
+      Targets="GetSymbolsToIndex">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="SymbolsToIndex" />
+    </MSBuild>
+    <ItemGroup>
+      <FilteredSymbolsToIndex Include="@(SymbolsToIndex)" Condition="'%(SymbolsToIndex.Extension)' == '.dll' OR '%(SymbolsToIndex.Extension)' == '.exe'
+                                                          OR   '%(SymbolsToIndex.Extension)' == '.pdb'">
+          <DestinationDir>$(ArtifactsDirectory)symbolstoindex\$([MSBuild]::MakeRelative($(ArtifactsDirectory), %(SymbolsToIndex.Identity)))</DestinationDir>
+      </FilteredSymbolsToIndex>
+    </ItemGroup>
+    <Copy SourceFiles="@(FilteredSymbolsToIndex->'%(Identity)')" DestinationFiles="@(FilteredSymbolsToIndex->'%(DestinationDir)')"/>
+    <Message Text="SymbolsToIndex: @(FilteredSymbolsToIndex, '%0a')" Importance="High"/>
+  </Target>
+</Project>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -107,4 +107,11 @@
     </DllsToSign>
   </ItemGroup>
   </Target>
+
+  <Target Name="GetSymbolsToIndex" Returns="@(SymbolsToIndex)">
+    <ItemGroup>
+      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"/>
+      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -18,6 +18,8 @@
     <CreateVsixContainer>false</CreateVsixContainer>
     <DeployExtension>false</DeployExtension>
     <IncludeInVSIX>true</IncludeInVSIX>
+    <Shipping>true</Shipping>
+    <PackProject>false</PackProject>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.Library.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/NuGet.Build.Tasks.Pack.Library.csproj
@@ -77,6 +77,7 @@
   
   <PropertyGroup>
     <SignTargetsForRealSigning>GetIlmergeBuildOutput</SignTargetsForRealSigning>
+    <SymbolTargetsToGetPdbs>GetIlmergeSymbolOutput</SymbolTargetsToGetPdbs>
   </PropertyGroup>
   
   <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
@@ -92,6 +93,13 @@
         <StrongName>MsSharedLib72</StrongName>
         <Authenticode>Microsoft</Authenticode>
       </DllsInOutputDir>
+    </ItemGroup>
+  </Target>
+
+  <!--These targets help get all the DLLs that are packed in the nuspec to be sent for signing.-->
+  <Target Name="GetIlmergeSymbolOutput" Returns="@(SymbolsToIndex)">
+    <ItemGroup>
+      <SymbolsToIndex Include="$(OutputPath)ilmerge\*.pdb" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
   


### PR DESCRIPTION
the current method used to get DLLs and PDBs out of artifacts directory leads to VSTS pulling out 900+ files . it takes a lot of time to index all those files (and it is repetitive). this pulls the exact list of DLLs and PDBs that needs to be indexed.