### PR TITLE
Removing unneeded caching from dependency walker

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -87,13 +87,6 @@ namespace NuGet.DependencyResolver
             };
 
             Debug.Assert(node.Item != null, "FindLibraryCached should return an unresolved item instead of null");
-            if (node.Key.VersionRange != null &&
-                node.Key.VersionRange.IsFloating)
-            {
-                var cacheKey = new LibraryRangeCacheKey(node.Key, framework);
-
-                _context.FindLibraryEntryCache.TryAdd(cacheKey, Task.FromResult(node.Item));
-            }
 
             var tasks = new List<Task<GraphNode<RemoteResolveResult>>>();
 


### PR DESCRIPTION
Removing unneeded code that tries to add floating version ranges into the dependency cache. All ranges and the results are cached regardless of if they are floating or not right before this code is called: https://github.com/NuGet/NuGet.Client/blob/d6636ba54aa107066c9d15e94700f2799f2f4b25/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs#L80

The check to avoid this code was fast so there is no real perf benefit here, this is just removing dead code.