### PR TITLE
Don't include install.ps1 for VS14

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio/NuGet.VisualStudio.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <None Update="install.ps1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory Condition=" '$(VisualStudioVersion)' == '15.0' ">PreserveNewest</CopyToOutputDirectory> <!-- TODO: Remove this when we stop building for VS14 -->
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
The install.ps1 from nuget.visualstudio is currently being included in the VS14 VSIX. 
