### PR TITLE
 add a vsmanproj to generate a vsman file for insertion

### DIFF
--- a/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
+++ b/setup/Microsoft.VisualStudio.NuGet.Core.vsmanproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
+
+    <PropertyGroup>
+        <!-- Define properties that drive the manifest creation here. -->
+        <FinalizeManifest>true</FinalizeManifest>
+        <FinalizeSkipLayout>true</FinalizeSkipLayout>
+        <BuildNumber>$(SemanticVersion).$(BuildNumber)</BuildNumber>
+        <TargetName>$(MSBuildProjectName)</TargetName>
+        <OutputPath>$(VsixPublishDestination)Insertable</OutputPath>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <MergeManifest Include="$(VsixPublishDestination)Microsoft.VisualStudio.NuGet.Core.json" />
+    </ItemGroup>
+
+    <Import Project="$(SolutionPackagesFolder)MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets"/>
+</Project>


### PR DESCRIPTION
This work is to enable a part of : https://github.com/NuGet/Client.Engineering/issues/49

This automates the step where we need to get the vsman file that contains the url we insert into the VS repo.