### PR TITLE
Unexpected package version warnings

### DIFF
--- a/build/Shared/SharedExtensions.cs
+++ b/build/Shared/SharedExtensions.cs
@@ -1,15 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
-namespace NuGet.PackageManagement
+namespace NuGet.Shared
 {
-    internal static class CollectionExtensions
+    internal static class Extensions
     {
         /// <summary>
-        /// Return the enumerable as a List of T, copying if required. Optimized for common case where it is an List of T 
-        /// or a ListWrapperCollection of T. Avoid mutating the return value.
+        /// Return the enumerable as a List of T, copying if required. Optimized for common case where it is an List of T.
+        /// Avoid mutating the return value.
         /// </summary>
         /// <remarks>https://aspnetwebstack.codeplex.com/SourceControl/latest#src/Common/CollectionExtensions.cs</remarks>
         public static List<T> AsList<T>(this IEnumerable<T> enumerable)

--- a/build/config.props
+++ b/build/config.props
@@ -14,6 +14,7 @@
     <XunitVersion>2.2.0</XunitVersion>
     <TestSDKVersion>15.0.0</TestSDKVersion>
     <MoqVersion>4.7.1</MoqVersion>
+    <FluentAssertionsVersion>4.19.2</FluentAssertionsVersion>
     <MicrosoftBuildPackageVersion>0.1.0-preview-00038-160914</MicrosoftBuildPackageVersion>
   </PropertyGroup>
   

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Warning and error logging helpers.
+    /// </summary>
+    public static class DiagnosticUtility
+    {
+        /// <summary>
+        /// Format an id and include the version only if it exists.
+        /// Ignore versions for projects.
+        /// </summary>
+        public static string FormatIdentity(LibraryIdentity identity)
+        {
+            // Display the version if it exists
+            // Ignore versions for projects
+            if (identity.Version != null && identity.Type == LibraryType.Package)
+            {
+                return $"{identity.Name} {identity.Version.ToNormalizedString()}";
+            }
+
+            return identity.Name;
+        }
+
+        /// <summary>
+        /// Format an id and include the range only if it has bounds.
+        /// </summary>
+        public static string FormatDependency(string id, VersionRange range)
+        {
+            if (range == null || !(range.HasLowerBound || range.HasUpperBound))
+            {
+                return id;
+            }
+
+            return $"{id} {range.ToNonSnapshotRange().PrettyPrint()}";
+        }
+
+        /// <summary>
+        /// Format an id and include the lower bound only if it has one.
+        /// </summary>
+        public static string FormatExpectedIdentity(string id, VersionRange range)
+        {
+            if (range == null || !range.HasLowerBound || !range.IsMinInclusive)
+            {
+                return id;
+            }
+
+            return $"{id} {range.MinVersion.ToNormalizedString()}";
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Shared;
+using NuGet.Versioning;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Log warnings for packages that did not resolve to the minimum version of the dependency range.
+    /// </summary>
+    public static class UnexpectedDependencyMessages
+    {
+        /// <summary>
+        /// Log warnings for all project issues related to unexpected dependencies.
+        /// </summary>
+        public static async Task LogAsync(IEnumerable<IRestoreTargetGraph> graphs, PackageSpec project, ILogger logger)
+        {
+            var ignoreIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var graphList = graphs.AsList();
+
+            // 1. Detect project dependency authoring issues in the current project.
+            //    The user can fix these themselves.
+            var projectMissingLowerBounds = GetProjectDependenciesMissingLowerBounds(project);
+            ignoreIds.UnionWith(projectMissingLowerBounds.Select(e => e.Id));
+            await logger.LogMessagesAsync(projectMissingLowerBounds);
+
+            // 2. Detect dependency and source issues across the entire graph 
+            //    where the minimum version was not matched exactly.
+            //    Ignore packages already logged by #1
+            var missingMinimums = GetMissingLowerBounds(graphList, ignoreIds);
+            ignoreIds.UnionWith(missingMinimums.Select(e => e.Id));
+            await logger.LogMessagesAsync(missingMinimums);
+
+            // 3. Detect top level dependencies that have a version different from the specified version.
+            //    Ignore packages already logged in #1 and #2 since those errors are more specific.
+            var bumpedUp = GetBumpedUpDependencies(graphList, project, ignoreIds);
+            await logger.LogMessagesAsync(bumpedUp);
+        }
+
+        /// <summary>
+        /// Get warnings for packages that have dependencies on non-existant versions of packages
+        /// and also for packages with ranges that have missing minimum versions.
+        /// </summary>
+        public static IEnumerable<RestoreLogMessage> GetMissingLowerBounds(IEnumerable<IRestoreTargetGraph> graphs, ISet<string> ignoreIds)
+        {
+            var messages = new List<RestoreLogMessage>();
+
+            foreach (var graph in graphs)
+            {
+                messages.AddRange(graph.ResolvedDependencies
+                                            .Distinct()
+                                            .Where(e => !ignoreIds.Contains(e.Child.Name, StringComparer.OrdinalIgnoreCase)
+                                                        && DependencyRangeHasMissingExactMatch(e))
+                                            .OrderBy(e => e.Child.Name, StringComparer.OrdinalIgnoreCase)
+                                            .ThenBy(e => e.Child.Version)
+                                            .ThenBy(e => e.Parent.Name, StringComparer.OrdinalIgnoreCase)
+                                            .Select(e => GetMissingLowerBoundMessage(e, graph.Name)));
+            }
+
+            return messages;
+        }
+
+        /// <summary>
+        /// Get warning message for missing minimum dependencies.
+        /// </summary>
+        public static RestoreLogMessage GetMissingLowerBoundMessage(ResolvedDependencyKey dependency, params string[] targetGraphs)
+        {
+            NuGetLogCode code;
+            var message = string.Empty;
+            var parent = DiagnosticUtility.FormatIdentity(dependency.Parent);
+            var dependencyRange = DiagnosticUtility.FormatDependency(dependency.Child.Name, dependency.Range);
+            var missingChild = DiagnosticUtility.FormatExpectedIdentity(dependency.Child.Name, dependency.Range);
+            var resolvedChild = DiagnosticUtility.FormatIdentity(dependency.Child);
+
+            if (HasMissingLowerBound(dependency.Range))
+            {
+                // Range does not have a lower bound, the best match can only be approximate.
+                message = string.Format(CultureInfo.CurrentCulture, Strings.Warning_MinVersionNonInclusive,
+                    parent,
+                    dependencyRange,
+                    resolvedChild);
+
+                code = NuGetLogCode.NU2502;
+            }
+            else
+            {
+                // The minimum version does not exist.
+                message = string.Format(CultureInfo.CurrentCulture, Strings.Warning_MinVersionDoesNotExist,
+                    parent,
+                    dependencyRange,
+                    missingChild,
+                    resolvedChild);
+
+                code = NuGetLogCode.NU2503;
+            }
+
+            return RestoreLogMessage.CreateWarning(code, dependency.Child.Name, message, targetGraphs);
+        }
+
+        /// <summary>
+        /// Warn for dependencies that have been bumped up.
+        /// </summary>
+        public static IEnumerable<RestoreLogMessage> GetBumpedUpDependencies(
+            IEnumerable<IRestoreTargetGraph> graphs,
+            PackageSpec project,
+            ISet<string> ignoreIds)
+        {
+            var messages = new List<RestoreLogMessage>();
+
+            // Group by framework to get project dependencies, then check each graph.
+            foreach (var frameworkGroup in graphs.GroupBy(e => e.Framework))
+            {
+                // Get dependencies from the project
+                var dependencies = project.GetPackageDependenciesForFramework(frameworkGroup.Key)
+                                              .Where(e => !ignoreIds.Contains(e.Name, StringComparer.OrdinalIgnoreCase))
+                                              .Where(IsNonFloatingPackageDependency);
+
+                foreach (var dependency in dependencies)
+                {
+                    // Graphs may have different versions of the resolved package
+                    foreach (var graph in frameworkGroup)
+                    {
+                        // Ignore floating or version-less (project) dependencies
+                        // Avoid warnings for non-packages
+                        var match = graph.Flattened.GetItemById(dependency.Name);
+
+                        if (match != null
+                            && LibraryType.Package == match.Key.Type
+                            && dependency.LibraryRange.VersionRange.IsMinInclusive
+                            && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
+                        {
+                            var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
+                                dependency.LibraryRange.Name,
+                                dependency.LibraryRange.VersionRange.PrettyPrint(),
+                                match.Key.Name,
+                                match.Key.Version);
+
+                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU2501, match.Key.Name, message, graph.Name));
+                        }
+                    }
+                }
+            }
+
+            return messages;
+        }
+
+        /// <summary>
+        /// Warn for project dependencies that do not include a lower bound on the version range.
+        /// </summary>
+        public static IEnumerable<RestoreLogMessage> GetProjectDependenciesMissingLowerBounds(PackageSpec project)
+        {
+            return project.GetAllPackageDependencies()
+                   .Where(e => HasMissingLowerBound(e.LibraryRange.VersionRange))
+                   .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                   .Select(e => RestoreLogMessage.CreateWarning(
+                       code: NuGetLogCode.NU2504,
+                       id: e.Name,
+                       message: string.Format(CultureInfo.CurrentCulture, Strings.Warning_ProjectDependencyMissingLowerBound,
+                                              DiagnosticUtility.FormatDependency(e.Name, e.LibraryRange.VersionRange))));
+        }
+
+        /// <summary>
+        /// True if the dependency version range has a min version that matches the resolved version.
+        /// </summary>
+        public static bool DependencyRangeHasMissingExactMatch(ResolvedDependencyKey dependency)
+        {
+            // Ignore floating
+            if (dependency.Range.IsFloating)
+            {
+                return false;
+            }
+
+            // Ignore projects
+            if (dependency.Child.Type != LibraryType.Package)
+            {
+                return false;
+            }
+
+            return (!dependency.Range.IsMinInclusive || dependency.Range.MinVersion != dependency.Child.Version);
+        }
+
+        /// <summary>
+        /// True if the range has an obtainable version for the lower bound.
+        /// </summary>
+        public static bool HasMissingLowerBound(VersionRange range)
+        {
+            if (range == null)
+            {
+                return true;
+            }
+
+            // Ignore floating
+            if (range.IsFloating)
+            {
+                return false;
+            }
+
+            return !range.IsMinInclusive || !range.HasLowerBound;
+        }
+
+        private static bool IsNonFloatingPackageDependency(this LibraryDependency dependency)
+        {
+            return (dependency.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                && dependency.LibraryRange.VersionRange != null && !dependency.LibraryRange.VersionRange.IsFloating);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreTargetGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/IRestoreTargetGraph.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using NuGet.Client;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.RuntimeModel;
+
+namespace NuGet.Commands
+{
+    public interface IRestoreTargetGraph
+    {
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the runtime identifier used during the restore operation on this graph
+        /// </summary>
+        string RuntimeIdentifier { get; }
+
+        /// <summary>
+        /// Gets the <see cref="NuGetFramework" /> used during the restore operation on this graph
+        /// </summary>
+        NuGetFramework Framework { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ManagedCodeConventions" /> used to resolve assets from packages in this graph
+        /// </summary>
+        ManagedCodeConventions Conventions { get; }
+
+        /// <summary>
+        /// Gets the <see cref="RuntimeGraph" /> that defines runtimes and their relationships for this graph
+        /// </summary>
+        RuntimeGraph RuntimeGraph { get; }
+
+        /// <summary>
+        /// Gets the resolved dependency graph
+        /// </summary>
+        IEnumerable<GraphNode<RemoteResolveResult>> Graphs { get; }
+
+        ISet<RemoteMatch> Install { get; }
+
+        ISet<GraphItem<RemoteResolveResult>> Flattened { get; }
+
+        ISet<LibraryRange> Unresolved { get; }
+
+        bool InConflict { get; }
+
+        IEnumerable<ResolverConflict> Conflicts { get; }
+
+        AnalyzeResult<RemoteResolveResult> AnalyzeResult { get; }
+
+        ISet<ResolvedDependencyKey> ResolvedDependencies { get; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ResolvedDependencyKey.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ResolvedDependencyKey.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.LibraryModel;
+using NuGet.Shared;
+using NuGet.Versioning;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// ResolvedDependencyKey represents a node in the graph, the edge containing
+    /// the dependency constraint, and the child node that was resolved based 
+    /// on this constraint.
+    /// 
+    /// (Parent Node) --(Range Constraint)--> (Resolved Child Node)
+    /// </summary>
+    public class ResolvedDependencyKey : IEquatable<ResolvedDependencyKey>
+    {
+        /// <summary>
+        /// Parent node.
+        /// </summary>
+        public LibraryIdentity Parent { get; }
+
+        /// <summary>
+        /// Dependency range from the parent on the child.
+        /// </summary>
+        public VersionRange Range { get; }
+
+        /// <summary>
+        /// Child node.
+        /// </summary>
+        public LibraryIdentity Child { get; }
+
+        public ResolvedDependencyKey(LibraryIdentity parent, VersionRange range, LibraryIdentity child)
+        {
+            Parent = parent ?? throw new ArgumentNullException(nameof(parent));
+            Range = range ?? VersionRange.All;
+            Child = child ?? throw new ArgumentNullException(nameof(child));
+        }
+
+        public bool Equals(ResolvedDependencyKey other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Parent.Equals(other.Parent)
+                && Child.Equals(other.Child)
+                && Range.Equals(other.Range);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ResolvedDependencyKey);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCodeCombiner.GetHashCode(Parent, Range, Child);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreTargetGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreTargetGraph.cs
@@ -13,7 +13,7 @@ using NuGet.RuntimeModel;
 
 namespace NuGet.Commands
 {
-    public class RestoreTargetGraph
+    public class RestoreTargetGraph : IRestoreTargetGraph
     {
         /// <summary>
         /// Gets the runtime identifier used during the restore operation on this graph
@@ -52,6 +52,8 @@ namespace NuGet.Commands
 
         public AnalyzeResult<RemoteResolveResult> AnalyzeResult { get; private set; }
 
+        public ISet<ResolvedDependencyKey> ResolvedDependencies { get; }
+
         private RestoreTargetGraph(IEnumerable<ResolverConflict> conflicts,
                                    NuGetFramework framework,
                                    string runtimeIdentifier,
@@ -60,9 +62,10 @@ namespace NuGet.Commands
                                    ISet<RemoteMatch> install,
                                    ISet<GraphItem<RemoteResolveResult>> flattened,
                                    ISet<LibraryRange> unresolved,
-                                   AnalyzeResult<RemoteResolveResult> analyzeResult)
+                                   AnalyzeResult<RemoteResolveResult> analyzeResult,
+                                   ISet<ResolvedDependencyKey> resolvedDependencies)
         {
-            Conflicts = conflicts;
+            Conflicts = conflicts.ToArray();
             RuntimeIdentifier = runtimeIdentifier;
             RuntimeGraph = runtimeGraph;
             Framework = framework;
@@ -75,6 +78,7 @@ namespace NuGet.Commands
             Flattened = flattened;
             AnalyzeResult = analyzeResult;
             Unresolved = unresolved;
+            ResolvedDependencies = resolvedDependencies;
         }
 
         public static RestoreTargetGraph Create(IEnumerable<GraphNode<RemoteResolveResult>> graphs, RemoteWalkContext context, ILogger logger, NuGetFramework framework)
@@ -96,6 +100,7 @@ namespace NuGet.Commands
 
             var conflicts = new Dictionary<string, HashSet<ResolverRequest>>();
             var analyzeResult = new AnalyzeResult<RemoteResolveResult>();
+            var resolvedDependencies = new HashSet<ResolvedDependencyKey>();
 
             foreach (var graph in graphs)
             {
@@ -129,7 +134,7 @@ namespace NuGet.Commands
                             ranges.Add(new ResolverRequest(requestor, node.Key));
                         }
 
-                        if (string.Equals(node?.Item?.Key?.Type, LibraryType.Unresolved))
+                        if (node?.Item?.Key?.Type == LibraryType.Unresolved)
                         {
                             if (node.Key.VersionRange != null)
                             {
@@ -142,6 +147,16 @@ namespace NuGet.Commands
                         // Don't add rejected nodes since we only want to write reduced nodes
                         // to the lock file
                         flattened.Add(node.Item);
+                    }
+
+                    if (node?.OuterNode != null && node.Item.Key.Type != LibraryType.Unresolved)
+                    {
+                        var dependencyKey = new ResolvedDependencyKey(
+                            parent: node.OuterNode.Item.Key,
+                            range: node.Key.VersionRange,
+                            child: node.Item.Key);
+
+                        resolvedDependencies.Add(dependencyKey);
                     }
 
                     // If the package came from a remote library provider, it needs to be installed locally
@@ -163,7 +178,8 @@ namespace NuGet.Commands
                 install,
                 flattened,
                 unresolved,
-                analyzeResult);
+                analyzeResult,
+                resolvedDependencies);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs
@@ -16,6 +16,7 @@ using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -109,7 +110,7 @@ namespace NuGet.Commands
 
                     if (set != null)
                     {
-                        lockFileLib.Dependencies = set.ToList();
+                        lockFileLib.Dependencies = set.AsList();
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1089,6 +1089,24 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved..
+        /// </summary>
+        internal static string Warning_MinVersionDoesNotExist {
+            get {
+                return ResourceManager.GetString("Warning_MinVersionDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} does not provide an inclusive lower bound for dependency {1}. An approximate best match of {2} was resolved..
+        /// </summary>
+        internal static string Warning_MinVersionNonInclusive {
+            get {
+                return ResourceManager.GetString("Warning_MinVersionNonInclusive", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored..
         /// </summary>
         internal static string Warning_MultiTarget {
@@ -1130,6 +1148,15 @@ namespace NuGet.Commands {
         internal static string Warning_PackageCommandPackageIssueSummary {
             get {
                 return ResourceManager.GetString("Warning_PackageCommandPackageIssueSummary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project dependency {0} does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results..
+        /// </summary>
+        internal static string Warning_ProjectDependencyMissingLowerBound {
+            get {
+                return ResourceManager.GetString("Warning_ProjectDependencyMissingLowerBound", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -510,5 +510,14 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="LocalsCommand_ClearingNuGetTempCache" xml:space="preserve">
     <value>Clearing NuGet Temp cache: {0}</value>
     <comment>{0} : Temp cache path</comment>
+  </data>
+  <data name="Warning_MinVersionDoesNotExist" xml:space="preserve">
+    <value>{0} depends on {1} but {2} was not found. An approximate best match of {3} was resolved.</value>
+  </data>
+  <data name="Warning_MinVersionNonInclusive" xml:space="preserve">
+    <value>{0} does not provide an inclusive lower bound for dependency {1}. An approximate best match of {2} was resolved.</value>
+  </data>
+  <data name="Warning_ProjectDependencyMissingLowerBound" xml:space="preserve">
+    <value>Project dependency {0} does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Internal extension helpers for NuGet.Commands
+    /// </summary>
+    internal static class Extensions
+    {
+        public static ISet<LibraryDependency> GetAllPackageDependencies(this PackageSpec project)
+        {
+            // Remove non-package dependencies such as framework assembly references.
+            return new HashSet<LibraryDependency>(
+                project.Dependencies.Concat(project.TargetFrameworks.SelectMany(e => e.Dependencies))
+                                    .Where(e => !e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
+        }
+
+        public static ISet<LibraryDependency> GetPackageDependenciesForFramework(this PackageSpec project, NuGetFramework framework)
+        {
+            // Remove non-package dependencies such as framework assembly references.
+            return new HashSet<LibraryDependency>(
+                project.Dependencies.Concat(project.GetTargetFramework(framework).Dependencies)
+                                    .Where(e => !e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
+        }
+
+        /// <summary>
+        /// Search on Key.Name for the given package/project id.
+        /// </summary>
+        public static GraphItem<RemoteResolveResult> GetItemById(this IEnumerable<GraphItem<RemoteResolveResult>> items, string id)
+        {
+            return items.FirstOrDefault(e => e.Key.Name.Equals(id, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using NuGet.Common;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -21,7 +23,7 @@ namespace NuGet.Commands
             // Remove non-package dependencies such as framework assembly references.
             return new HashSet<LibraryDependency>(
                 project.Dependencies.Concat(project.TargetFrameworks.SelectMany(e => e.Dependencies))
-                                    .Where(e => !e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
+                                    .Where(e => e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
         }
 
         public static ISet<LibraryDependency> GetPackageDependenciesForFramework(this PackageSpec project, NuGetFramework framework)
@@ -29,7 +31,7 @@ namespace NuGet.Commands
             // Remove non-package dependencies such as framework assembly references.
             return new HashSet<LibraryDependency>(
                 project.Dependencies.Concat(project.GetTargetFramework(framework).Dependencies)
-                                    .Where(e => !e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
+                                    .Where(e => e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
         }
 
         /// <summary>
@@ -38,6 +40,25 @@ namespace NuGet.Commands
         public static GraphItem<RemoteResolveResult> GetItemById(this IEnumerable<GraphItem<RemoteResolveResult>> items, string id)
         {
             return items.FirstOrDefault(e => e.Key.Name.Equals(id, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Log all messages.
+        /// </summary>
+        public static Task LogMessagesAsync(this ILogger logger, params ILogMessage[] messages)
+        {
+            return logger.LogMessagesAsync(messages);
+        }
+
+        /// <summary>
+        /// Log all messages.
+        /// </summary>
+        public static async Task LogMessagesAsync(this ILogger logger, IEnumerable<ILogMessage> messages)
+        {
+            foreach (var message in messages)
+            {
+                await logger.LogAsync(message);
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Common
 {
@@ -8,6 +7,26 @@ namespace NuGet.Common
     {
         NU1000 = 1000, // For cases do not fit into the cases below.
         NU1001, // Actual errors start here
-        NU1002
+        NU1002,
+
+        /// <summary>
+        /// Dependency bumped up
+        /// </summary>
+        NU2501 = 2501,
+
+        /// <summary>
+        /// Non-exact match on dependency range due to non inclusive minimum bound.
+        /// </summary>
+        NU2502,
+
+        /// <summary>
+        /// Non-exact match on dependency range due to missing package version.
+        /// </summary>
+        NU2503,
+
+        /// <summary>
+        /// Project dependency does not include a lower bound.
+        /// </summary>
+        NU2504,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -15,6 +15,11 @@ namespace NuGet.Common
         public DateTimeOffset Time { get; set; }
         public string ProjectPath { get; set; }
 
+        /// <summary>
+        /// Project or Package Id
+        /// </summary>
+        public string Id { get; set; }
+
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 
             string errorString, string targetGraph)
         {
@@ -83,6 +88,23 @@ namespace NuGet.Common
         public Task<string> FormatMessageAsync()
         {
             return Task.FromResult(FormatMessage());
+        }
+
+        /// <summary>
+        /// Create a log message for a target graph library.
+        /// </summary>
+        public static RestoreLogMessage CreateWarning(
+            NuGetLogCode code,
+            string id,
+            string message,
+            params string[] targetGraphs)
+        {
+            return new RestoreLogMessage(LogLevel.Warning, message)
+            {
+                Code = code,
+                Id = id,
+                TargetGraphs = targetGraphs.ToList()
+            };
         }
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-using NuGet.Versioning;
 using NuGet.LibraryModel;
+using NuGet.Shared;
 
 namespace NuGet.DependencyResolver
 {
@@ -144,7 +144,7 @@ namespace NuGet.DependencyResolver
         {
             foreach (var item in path)
             {
-                var childNode = node.InnerNodes.FirstOrDefault(n => 
+                var childNode = node.InnerNodes.FirstOrDefault(n =>
                     StringComparer.OrdinalIgnoreCase.Equals(n.Key.Name, item));
 
                 if (childNode == null)
@@ -322,7 +322,7 @@ namespace NuGet.DependencyResolver
 
                 // avoid Foreach here since it's inside 3 layer nested loops which might make it to
                 // be called 100 of 1000 times so GetEnumerator() might end up taking lot of memory space.
-                for (int i = 0; i < work.Item1.InnerNodes.Count; i++)
+                for (var i = 0; i < work.Item1.InnerNodes.Count; i++)
                 {
                     var innerNode = work.Item1.InnerNodes[i];
                     queue.Enqueue(Tuple.Create(innerNode, innerState));
@@ -332,8 +332,8 @@ namespace NuGet.DependencyResolver
 
         public static void ForEach<TItem>(this IEnumerable<GraphNode<TItem>> roots, Action<GraphNode<TItem>> visitor)
         {
-            var graphNodes = roots.ToList();
-            for (int i = 0; i < graphNodes.Count; i++)
+            var graphNodes = roots.AsList();
+            for (var i = 0; i < graphNodes.Count; i++)
             {
                 graphNodes[i].ForEach(visitor);
             }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DiagnosticUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DiagnosticUtilityTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class DiagnosticUtilityTests
+    {
+        [Fact]
+        public void GivenIFormatAnExpectedIdentityVerifyOutputString()
+        {
+            var range = VersionRange.Parse("1.0");
+
+            DiagnosticUtility.FormatExpectedIdentity("A", range).Should().Be("A 1.0.0");
+        }
+
+        [Fact]
+        public void GivenIFormatAnExpectedIdentityWithNoBoundsVerifyIdOnly()
+        {
+            DiagnosticUtility.FormatExpectedIdentity("A", VersionRange.All).Should().Be("A");
+        }
+
+        [Fact]
+        public void GivenIFormatAnExpectedIdentityWithNoLowerBoundVerifyIdOnly()
+        {
+            var range = VersionRange.Parse("(1.0.0, 2.0.0]");
+
+            DiagnosticUtility.FormatExpectedIdentity("A", range).Should().Be("A");
+        }
+
+        [Fact]
+        public void GivenIFormatADependencyVerifyOutputString()
+        {
+            var range = VersionRange.Parse("1.0.0");
+
+            DiagnosticUtility.FormatDependency("A", range).Should().Be("A (>= 1.0.0)");
+        }
+
+        [Fact]
+        public void GivenIFormatADependencyWithNoBoundsVerifyRangeNotShown()
+        {
+            var range = VersionRange.All;
+
+            DiagnosticUtility.FormatDependency("A", range).Should().Be("A");
+        }
+
+        [Fact]
+        public void GivenIFormatADependencyWithANullRangeVerifyRangeNotShown()
+        {
+            DiagnosticUtility.FormatDependency("A", range: null).Should().Be("A");
+        }
+
+        [Fact]
+        public void GivenAProjectLibraryVerifyFormatDoesNotIncludeTheVersion()
+        {
+            var library = new LibraryIdentity("A", NuGetVersion.Parse("1.0.0"), LibraryType.Project);
+
+            DiagnosticUtility.FormatIdentity(library).Should().Be("A", "the version is not needed for projects");
+        }
+
+        [Fact]
+        public void GivenAPackageLibraryVerifyFormatDoesIncludeTheVersion()
+        {
+            var library = new LibraryIdentity("A", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+
+            DiagnosticUtility.FormatIdentity(library).Should().Be("A 1.0.0", "the version is shown for packages");
+        }
+
+        [Fact]
+        public void GivenAnUnresolvedLibraryVerifyFormatDoesNotIncludeTheVersion()
+        {
+            var library = new LibraryIdentity("A", null, LibraryType.Unresolved);
+
+            DiagnosticUtility.FormatIdentity(library).Should().Be("A", "the version is not used for non-projects");
+        }
+
+        [Fact]
+        public void GivenAPackageLibraryVerifyFormatNormalizesTheVersion()
+        {
+            var library = new LibraryIdentity("A", NuGetVersion.Parse("1.0+abc"), LibraryType.Package);
+
+            DiagnosticUtility.FormatIdentity(library).Should().Be("A 1.0.0");
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NuGet.Commands.Test.csproj
@@ -12,6 +12,10 @@
     <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
   </ItemGroup>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
@@ -1,0 +1,592 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class UnexpectedDependencyMessagesTests
+    {
+        [Fact]
+        public void GivenAGraphWithMultipleIssuesForTheSamePackageVerifyBothMessagesLogged()
+        {
+            var parent1 = new LibraryIdentity("x", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var parent2 = new LibraryIdentity("y", NuGetVersion.Parse("8.0.0"), LibraryType.Package);
+            var child1 = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var child2 = new LibraryIdentity("b", NuGetVersion.Parse("3.0.0"), LibraryType.Package);
+            var dependency1 = new ResolvedDependencyKey(parent1, VersionRange.Parse("(, 5.0.0]"), child1);
+            var dependency2 = new ResolvedDependencyKey(parent2, VersionRange.Parse("(1.0.0, 6.0.0]"), child2);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency1, dependency2 };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            var logs = UnexpectedDependencyMessages.GetMissingLowerBounds(targetGraphs, ignore).ToList();
+
+            logs.Select(e => e.Message).ShouldBeEquivalentTo(new[]
+            {
+                "x 9.0.0 does not provide an inclusive lower bound for dependency b (<= 5.0.0). An approximate best match of b 2.0.0 was resolved.",
+                "y 8.0.0 does not provide an inclusive lower bound for dependency b (> 1.0.0 && <= 6.0.0). An approximate best match of b 3.0.0 was resolved."
+            });
+        }
+
+        [Fact]
+        public async Task GivenAProjectWithNoIssuesVerifyNoMessagesLogged()
+        {
+            var testLogger = new TestLogger();
+            var range = VersionRange.Parse("[1.0.0, 3.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("X", NuGetVersion.Parse("1.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("x", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("[1.0.0, 3.0.0)"), child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
+
+            testLogger.Warnings.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task GivenAProjectWithMultipleWarningsForXVerifyOnlyFinalBumpedMessageIsShown()
+        {
+            var testLogger = new TestLogger();
+            var range = VersionRange.Parse("[1.0.0, 3.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("X", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("x", NuGetVersion.Parse("1.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("[1.0.0, 3.0.0)"), child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
+
+            testLogger.ShowMessages().Should().NotContain("NU2504");
+            testLogger.ShowMessages().Should().Contain("NU2501");
+            testLogger.ShowMessages().Should().NotContain("NU2502");
+            testLogger.ShowMessages().Should().NotContain("NU2503");
+        }
+
+        [Fact]
+        public async Task GivenAProjectWithMultipleWarningsForXVerifyOnlyOneIsLogged()
+        {
+            var testLogger = new TestLogger();
+            var range = VersionRange.Parse("[1.0.0, 3.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("X", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("x", NuGetVersion.Parse("2.5.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, VersionRange.Parse("(, 3.0.0)"), child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
+
+            testLogger.ShowMessages().Should().NotContain("NU2504");
+            testLogger.ShowMessages().Should().NotContain("NU2501");
+            testLogger.ShowMessages().Should().Contain("NU2502");
+            testLogger.ShowMessages().Should().NotContain("NU2503");
+        }
+
+        [Fact]
+        public async Task GivenAProjectWithMultipleWarningsForXVerifyOnlyTheFirstIsLogged()
+        {
+            var testLogger = new TestLogger();
+            var range = VersionRange.Parse("(, 3.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("X", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var parent = new LibraryIdentity("z", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("x", NuGetVersion.Parse("2.5.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
+
+            testLogger.ShowMessages().Should().Contain("NU2504");
+            testLogger.ShowMessages().Should().NotContain("NU2501");
+            testLogger.ShowMessages().Should().NotContain("NU2502");
+            testLogger.ShowMessages().Should().NotContain("NU2503");
+        }
+
+        [Fact]
+        public void GivenAProjectWithABumpedNonInclusiveDependencyVerifyNoMessage()
+        {
+            var range = VersionRange.Parse("(1.0.0, 2.0.0]");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Reference));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Reference))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            UnexpectedDependencyMessages.GetBumpedUpDependencies(targetGraphs, project, ignore).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenAProjectWithABumpedReferenceDependencyVerifyNoMessage()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Reference));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Reference))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            UnexpectedDependencyMessages.GetBumpedUpDependencies(targetGraphs, project, ignore).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenAProjectWithABumpedDependencyThatIsIgnoredVerifyNoMessage()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("x", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>() { "X" };
+
+            UnexpectedDependencyMessages.GetBumpedUpDependencies(targetGraphs, project, ignore).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenAProjectWithABumpedDependencyVerifyMessage()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+            var flattened = new HashSet<GraphItem<RemoteResolveResult>>
+            {
+                new GraphItem<RemoteResolveResult>(new LibraryIdentity("X", NuGetVersion.Parse("2.0.0"), LibraryType.Package))
+            };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.Flattened).Returns(flattened);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            targetGraph.SetupGet(e => e.Framework).Returns(NuGetFramework.Parse("net46"));
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            var log = UnexpectedDependencyMessages.GetBumpedUpDependencies(targetGraphs, project, ignore).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU2501);
+            log.TargetGraphs.ShouldBeEquivalentTo(new[] { "net46/win10" });
+            log.Message.Should().Be("Dependency specified was x (>= 1.0.0) but ended up with X 2.0.0.");
+        }
+
+        [Fact]
+        public void GivenAGraphIsMissingALowerBoundAndIdIsIgnoredVerifyWarningSkipped()
+        {
+            var range = VersionRange.Parse("(, 5.0.0]");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>() { "B" };
+
+            var logs = UnexpectedDependencyMessages.GetMissingLowerBounds(targetGraphs, ignore);
+
+            logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenAGraphIsMissingALowerBoundVerifyWarningIncludesGraphName()
+        {
+            var range = VersionRange.Parse("(, 5.0.0]");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+            var dependencySet = new HashSet<ResolvedDependencyKey>() { dependency };
+            var targetGraph = new Mock<IRestoreTargetGraph>();
+            targetGraph.SetupGet(e => e.ResolvedDependencies).Returns(dependencySet);
+            targetGraph.SetupGet(e => e.Name).Returns("net46/win10");
+            var targetGraphs = new[] { targetGraph.Object };
+            var ignore = new HashSet<string>();
+
+            var log = UnexpectedDependencyMessages.GetMissingLowerBounds(targetGraphs, ignore).Single();
+
+            log.TargetGraphs.ShouldBeEquivalentTo(new[] { "net46/win10" });
+            log.Code.Should().Be(NuGetLogCode.NU2502);
+        }
+
+        [Fact]
+        public void GivenAProjectWithMultipleDependencyBoundIssuesVerifyWarnings()
+        {
+            var tfi = new List<TargetFrameworkInformation>();
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", VersionRange.Parse("(, 2.0.0)"), LibraryDependencyTarget.Package)));
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("netstandard1.3"), new LibraryRange("y", VersionRange.Parse("(, 3.0.0)"), LibraryDependencyTarget.Package)));
+
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            var logs = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project);
+
+            logs.Select(e => e.Code).ShouldAllBeEquivalentTo(NuGetLogCode.NU2504);
+            logs.Select(e => e.Level).ShouldAllBeEquivalentTo(LogLevel.Warning);
+            logs.Select(e => e.Message)
+                .ShouldBeEquivalentTo(new[]
+                {
+                    "Project dependency x (< 2.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.",
+                    "Project dependency y (< 3.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results."
+                });
+        }
+
+        [Fact]
+        public void GivenAProjectWithMultipleFrameworksAndDifferentRangesVerifyDifferentWarningsPerPackage()
+        {
+            var tfi = new List<TargetFrameworkInformation>();
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", VersionRange.Parse("(, 2.0.0)"), LibraryDependencyTarget.Package)));
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("netstandard1.3"), new LibraryRange("x", VersionRange.Parse("(, 2.0.0]"), LibraryDependencyTarget.Package)));
+
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void GivenAProjectWithMultipleFrameworksAndSameDependenciesVerifyASingleWarningPerPackage()
+        {
+            var range = VersionRange.Parse("(, 2.0.0)");
+            var tfi = new List<TargetFrameworkInformation>();
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package)));
+            tfi.AddRange(GetTFI(NuGetFramework.Parse("netstandard1.3"), new LibraryRange("x", range, LibraryDependencyTarget.Package)));
+
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void GivenAProjectWithADependencyOnAPackageWithANullRanageVerifyWarningMessage()
+        {
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", null, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Message.Should().Be("Project dependency x does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
+        }
+
+        [Fact]
+        public void GivenAProjectWithADependencyOnAPackageWithNoLowerBoundVerifyWarningMessage()
+        {
+            var range = VersionRange.Parse("(, 2.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Message.Should().Be("Project dependency x (< 2.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
+        }
+
+        [Fact]
+        public void GivenAProjectWithADependencyOnAPackageWithANonInclusiveLowerBoundVerifyWarningMessage()
+        {
+            var range = VersionRange.Parse("(1.0.0, 2.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("x", range, LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj"
+            };
+
+            var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
+
+            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Message.Should().Be("Project dependency x (> 1.0.0 && < 2.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
+        }
+
+        [Fact]
+        public void GivenAProjectWithNullRangesForNonPackageDependenciesVersionNoWarnings()
+        {
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("a", null, LibraryDependencyTarget.Project));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj",
+                Dependencies = GetDependencyList(new LibraryRange("b", null, LibraryDependencyTarget.Reference))
+            };
+
+            UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Should().BeEmpty("non-project references should be ignored");
+        }
+
+        [Fact]
+        public void GivenAProjectWithNonPackageDependenciesVersionNoWarnings()
+        {
+            var badRange = VersionRange.Parse("(, 2.0.0)");
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("a", badRange, LibraryDependencyTarget.Project));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj",
+                Dependencies = GetDependencyList(new LibraryRange("b", badRange, LibraryDependencyTarget.Reference))
+            };
+
+            UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Should().BeEmpty("non-project references should be ignored");
+        }
+
+        [Fact]
+        public void GivenAProjectWithCorrectDependenciesVerifyNoMissingLowerBoundWarnings()
+        {
+            var tfi = GetTFI(NuGetFramework.Parse("net46"), new LibraryRange("a", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package));
+            var project = new PackageSpec(tfi)
+            {
+                Name = "proj",
+                Dependencies = GetDependencyList(new LibraryRange("b", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.Package))
+            };
+
+            UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Should().BeEmpty("all dependencies are valid");
+        }
+
+        [Fact]
+        public void GivenADependencyHasANonInclusiveLowerBoundVerifyMessage()
+        {
+            var range = VersionRange.Parse("(1.0.0, )");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
+
+            log.Code.Should().Be(NuGetLogCode.NU2502);
+            log.Message.Should().Be("a 9.0.0 does not provide an inclusive lower bound for dependency b (> 1.0.0). An approximate best match of b 2.0.0 was resolved.");
+        }
+
+        [Fact]
+        public void GivenADependencyHasNoLowerBoundVerifyMessage()
+        {
+            var range = VersionRange.Parse("(, 5.0.0]");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
+
+            log.Code.Should().Be(NuGetLogCode.NU2502);
+            log.Message.Should().Be("a 9.0.0 does not provide an inclusive lower bound for dependency b (<= 5.0.0). An approximate best match of b 2.0.0 was resolved.");
+        }
+
+        [Fact]
+        public void GivenAPackageDidNotResolveToTheMinimumVerifyMessage()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
+
+            log.Code.Should().Be(NuGetLogCode.NU2503);
+            log.Message.Should().Be("a 9.0.0 depends on b (>= 1.0.0) but b 1.0.0 was not found. An approximate best match of b 2.0.0 was resolved.");
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "1.0.0")]
+        [InlineData("1.0.0", "1.0.0+abc")]
+        [InlineData("[1.0.0, ]", "1.0.0")]
+        [InlineData("[1.0.0]", "1.0.0")]
+        [InlineData("[1.0.0-beta, ]", "1.0.0-beta")]
+        [InlineData("[1.0.0-beta, 2.0.0)", "1.0.0-beta")]
+        public void GivenARangeVerifyItHasAnExactMatch(string rangeString, string childVersion)
+        {
+            var range = VersionRange.Parse(rangeString);
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse(childVersion), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            UnexpectedDependencyMessages.DependencyRangeHasMissingExactMatch(dependency).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("1.0.0", "2.0.0")]
+        [InlineData("[1.0.0, ]", "1.0.0-beta")]
+        [InlineData("[1.0.0-beta, ]", "1.0.1-beta")]
+        [InlineData("(1.0.0-beta, 2.0.0)", "1.0.0-beta")]
+        [InlineData("(,9.0.0)", "1.0.0")]
+        [InlineData("[,9.0.0)", "1.0.0")]
+        public void GivenARangeVerifyItDoesNotHaveAnExactMatch(string rangeString, string childVersion)
+        {
+            var range = VersionRange.Parse(rangeString);
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Package);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse(childVersion), LibraryType.Package);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            UnexpectedDependencyMessages.DependencyRangeHasMissingExactMatch(dependency).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenARangeVerifyProjectsCountAsExactMatches()
+        {
+            var range = VersionRange.Parse("( , 1.0.0]");
+            var parent = new LibraryIdentity("a", NuGetVersion.Parse("9.0.0"), LibraryType.Project);
+            var child = new LibraryIdentity("b", NuGetVersion.Parse("2.0.0"), LibraryType.Project);
+            var dependency = new ResolvedDependencyKey(parent, range, child);
+
+            UnexpectedDependencyMessages.DependencyRangeHasMissingExactMatch(dependency).Should().BeFalse("Project type should return false, regardless of the range.");
+        }
+
+        [Theory]
+        [InlineData("(1.0.0, )")]
+        [InlineData("(, 1.0.0]")]
+        [InlineData("(1.0.0, 1.0.0)")]
+        [InlineData("(1.0.0, 2.0.0)")]
+        public void GivenARangeVerifyLowerBoundMissingIsTrue(string s)
+        {
+            UnexpectedDependencyMessages.HasMissingLowerBound(VersionRange.Parse(s)).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("[1.0.0, )")]
+        [InlineData("[1.0.0]")]
+        [InlineData("[1.0.0, 2.0.0)")]
+        [InlineData("[1.0.0-beta.*, 2.0.0)")]
+        [InlineData("1.0.0-*")]
+        public void GivenARangeVerifyLowerBoundMissingIsFalse(string s)
+        {
+            UnexpectedDependencyMessages.HasMissingLowerBound(VersionRange.Parse(s)).Should().BeFalse();
+        }
+
+        public void GivenANullRangeVerifyLowerBoundMissingIsTrue()
+        {
+            UnexpectedDependencyMessages.HasMissingLowerBound(range: null).Should().BeTrue();
+        }
+
+        public void GivenTheAllRangeVerifyLowerBoundMissingIsTrue()
+        {
+            UnexpectedDependencyMessages.HasMissingLowerBound(VersionRange.All).Should().BeTrue();
+        }
+
+        private static List<LibraryDependency> GetDependencyList(LibraryRange range)
+        {
+            return new List<LibraryDependency>() { new LibraryDependency() { LibraryRange = range } };
+        }
+
+        private static List<TargetFrameworkInformation> GetTFI(NuGetFramework framework, params LibraryRange[] dependencies)
+        {
+            return new List<TargetFrameworkInformation>()
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = framework,
+                    Dependencies = dependencies.Select(e => new LibraryDependency(){ LibraryRange = e }).ToList()
+                }
+            };
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionFormatterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionFormatterTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Xunit;
 
 namespace NuGet.Versioning.Test
@@ -21,7 +20,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:F}", version);
+            var s = string.Format(formatter, "{0:F}", version);
             var s2 = version.ToString("F", formatter);
 
             // assert
@@ -42,7 +41,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:N}", version);
+            var s = string.Format(formatter, "{0:N}", version);
             var s2 = version.ToString("N", formatter);
 
             // assert
@@ -61,7 +60,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:M}", version);
+            var s = string.Format(formatter, "{0:M}", version);
             var s2 = version.ToString("M", formatter);
 
             // assert
@@ -81,7 +80,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:R}", version);
+            var s = string.Format(formatter, "{0:R}", version);
             var s2 = version.ToString("R", formatter);
 
             // assert
@@ -101,7 +100,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:V}", version);
+            var s = string.Format(formatter, "{0:V}", version);
             var s2 = version.ToString("V", formatter);
 
             // assert
@@ -121,7 +120,7 @@ namespace NuGet.Versioning.Test
             var version = NuGetVersion.Parse(versionString);
 
             // act
-            var s = String.Format(formatter, "{0:x}.{0:x}.{0:y}.{0:z}.{0:r}({0:M})*{0:R}: {0:V}", version, version, version, version, version, version, version, version);
+            var s = string.Format(formatter, "{0:x}.{0:x}.{0:y}.{0:z}.{0:r}({0:M})*{0:R}: {0:V}", version, version, version, version, version, version, version, version);
             var s2 = version.ToString("x.x.y.z.r(M)*R: V", formatter);
 
             // assert

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -10,6 +10,61 @@ namespace NuGet.Versioning.Test
     public class VersionRangeTests
     {
         [Theory]
+        [InlineData("1.0.0", "(>= 1.0.0)")]
+        [InlineData("[1.0.0]", "(= 1.0.0)")]
+        [InlineData("[1.0.0, ]", "(>= 1.0.0)")]
+        [InlineData("[1.0.0, )", "(>= 1.0.0)")]
+        [InlineData("(1.0.0, )", "(> 1.0.0)")]
+        [InlineData("(1.0.0, ]", "(> 1.0.0)")]
+        [InlineData("(1.0.0, 2.0.0)", "(> 1.0.0 && < 2.0.0)")]
+        [InlineData("[1.0.0, 2.0.0]", "(>= 1.0.0 && <= 2.0.0)")]
+        [InlineData("[1.0.0, 2.0.0)", "(>= 1.0.0 && < 2.0.0)")]
+        [InlineData("(1.0.0, 2.0.0]", "(> 1.0.0 && <= 2.0.0)")]
+        [InlineData("(, 2.0.0]", "(<= 2.0.0)")]
+        [InlineData("(, 2.0.0)", "(< 2.0.0)")]
+        [InlineData("[, 2.0.0)", "(< 2.0.0)")]
+        [InlineData("[, 2.0.0]", "(<= 2.0.0)")]
+        [InlineData("1.0.0-beta*", "(>= 1.0.0-beta)")]
+        [InlineData("[1.0.0-beta*, 2.0.0)", "(>= 1.0.0-beta && < 2.0.0)")]
+        [InlineData("[1.0.0-beta.1, 2.0.0-alpha.2]", "(>= 1.0.0-beta.1 && <= 2.0.0-alpha.2)")]
+        [InlineData("[1.0.0+beta.1, 2.0.0+alpha.2]", "(>= 1.0.0 && <= 2.0.0)")]
+        [InlineData("[1.0, 2.0]", "(>= 1.0.0 && <= 2.0.0)")]
+        public void VersionRange_PrettyPrintTests(string versionString, string expected)
+        {
+            // Arrange
+            var formatter = new VersionRangeFormatter();
+            var range = VersionRange.Parse(versionString);
+
+            // Act
+            var s = string.Format(formatter, "{0:P}", range);
+            var s2 = range.ToString("P", formatter);
+            var s3 = range.PrettyPrint();
+
+            // Assert
+            Assert.Equal(expected, s);
+            Assert.Equal(expected, s2);
+            Assert.Equal(expected, s3);
+        }
+
+        [Fact]
+        public void VersionRange_PrettyPrintAllRange()
+        {
+            // Arrange
+            var formatter = new VersionRangeFormatter();
+            var range = VersionRange.All;
+
+            // Act
+            var s = string.Format(formatter, "{0:P}", range);
+            var s2 = range.ToString("P", formatter);
+            var s3 = range.PrettyPrint();
+
+            // Assert
+            Assert.Equal("", s);
+            Assert.Equal("", s2);
+            Assert.Equal("", s3);
+        }
+
+        [Theory]
         [InlineData("1.0.0", "1.0.1-beta", false)]
         [InlineData("1.0.0", "1.0.1", true)]
         [InlineData("1.0.0-*", "1.0.0-beta", true)]


### PR DESCRIPTION
This improves the experience around unexpected package versions and provides helpful warnings around scenarios where the package or project is authored incorrectly without a minimum version on the dependency range, which leads to *floating downwards* and the result is subject to whatever is available on the sources.

I've done some perf testing on this after the changes it looks to be the same with and without the additional checks.

* Fixed a bug in VersionRange.PrettyPrint
* Added AsList extension method to shared extension methods, this is an optimization that was previously under PackageManagement only. 
* FluentAssertions for tests, I've had much better results with using this on top of Xunit, it simplifies comparisions and provides much better messages when failures happen. As part of this I've added new tests using this with names that follow those guidelines. CLI/SDK are using this also.
* Added IRestoreTargetGraph for Mock support
* Minor optimizations/perf improvements around the code changed

Fixes https://github.com/NuGet/Home/issues/5145
Fixes https://github.com/NuGet/Home/issues/5137