### PR TITLE
Avoid restore errors for projects that cannot be read by restore

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -3049,7 +3049,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public void RestoreNetCore_NETCore_ProjectToProject_MissingProjectReference()
+        public void RestoreNetCore_NETCore_ProjectToProject_IgnoreMissingProjectReference()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -3078,7 +3078,8 @@ namespace NuGet.CommandLine.Test
                 File.Delete(projectB.ProjectPath);
 
                 // Act && Assert
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+                // Missing projects are ignored during restore. These issues are reported at build time.
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
             }
         }
 


### PR DESCRIPTION
Skip projects that could not be read by restore, these are commonly broken projects or projects that do not reference common targets that allow importing the restore task.

NuGet 3.5.0 and NuGet for Visual Studio ignores these projects, this adds the same behavior to msbuild.

Errors due to these invalid projects will be reported at build time. Previous attempts at warning for these scenarios in Visual Studio caused a lot of unneeded noise and had to be removed.

Fixes https://github.com/NuGet/Home/issues/4650