### PR TITLE
Throw a helpful message if HOME is not set

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Common/Strings.Designer.cs
@@ -98,6 +98,15 @@ namespace NuGet.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required environment variable &apos;{0}&apos; is not set. Try setting &apos;{0}&apos; and running the operation again..
+        /// </summary>
+        internal static string MissingRequiredEnvVar {
+            get {
+                return ResourceManager.GetString("MissingRequiredEnvVar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to At least one package folder path must be provided..
         /// </summary>
         internal static string NoPackageFoldersFound {

--- a/src/NuGet.Core/NuGet.Common/Strings.resx
+++ b/src/NuGet.Core/NuGet.Common/Strings.resx
@@ -129,6 +129,9 @@
   <data name="Error_FailedToCreateRandomFile" xml:space="preserve">
     <value>Failed to create random file for dotnet add pkg command.</value>
   </data>
+  <data name="MissingRequiredEnvVar" xml:space="preserve">
+    <value>Required environment variable '{0}' is not set. Try setting '{0}' and running the operation again.</value>
+  </data>
   <data name="NoPackageFoldersFound" xml:space="preserve">
     <value>At least one package folder path must be provided.</value>
   </data>


### PR DESCRIPTION
This change adds a helpful message when the user HOME path cannot be found. Previously CI scenarios which were not running under normal user accounts would throw exceptions around a NRE with Path.Combine when HOME was null, this has been a common source of support requests.

Fixes https://github.com/NuGet/Home/issues/4671