### PR TITLE
Exclude project references with ReferenceOutputAssembly=false

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -340,6 +340,7 @@ namespace NuGet.SolutionRestoreManager
                 tfi.ProjectReferences.AddRange(
                     targetFrameworkInfo.ProjectReferences
                         .Cast<IVsReferenceItem>()
+                        .Where(IsReferenceOutputAssemblyTrueOrEmpty)
                         .Select(item => ToProjectRestoreReference(item, projectDirectory)));
             }
 
@@ -451,6 +452,17 @@ namespace NuGet.SolutionRestoreManager
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// True if ReferenceOutputAssembly is true or empty.
+        /// All other values will be false.
+        /// </summary>
+        private static bool IsReferenceOutputAssemblyTrueOrEmpty(IVsReferenceItem item)
+        {
+            var value = GetPropertyValueOrNull(item, "ReferenceOutputAssembly");
+
+            return MSBuildStringUtility.IsTrueOrEmpty(value);
         }
     }
 }


### PR DESCRIPTION
Exclude project references with ReferenceOutputAssembly=false from Visual Studio restore

Projects with ReferenceOutputAssembly=false should be ignored during restore in Visual Studio. Transitive dependencies should not flow from these projects to the parent project.

I've tested this manually. I don't see a clear way to add unit tests for this without refactoring or making these private methods public which doesn't appear to go with the current design.

Fixes https://github.com/NuGet/Home/issues/4992