### PR TITLE
RestoreTask support for ICancelableTask

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Newtonsoft.Json;
@@ -20,8 +21,10 @@ namespace NuGet.Build.Tasks
     /// <summary>
     /// .NET Core compatible restore task for PackageReference and UWP project.json projects.
     /// </summary>
-    public class RestoreTask : Microsoft.Build.Utilities.Task
+    public class RestoreTask : Microsoft.Build.Utilities.Task, ICancelableTask, IDisposable
     {
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+
         /// <summary>
         /// DG file entries
         /// </summary>
@@ -86,6 +89,12 @@ namespace NuGet.Build.Tasks
             try
             {
                 return ExecuteAsync(log).Result;
+            }
+            catch (AggregateException ex) when (_cts.Token.IsCancellationRequested && ex.InnerException is TaskCanceledException)
+            {
+                // Canceled by user
+                log.LogError(Strings.RestoreCanceled);
+                return false;
             }
             catch (Exception e)
             {
@@ -163,7 +172,9 @@ namespace NuGet.Build.Tasks
                     HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
                 }
 
-                var restoreSummaries = await RestoreRunner.Run(restoreContext);
+                _cts.Token.ThrowIfCancellationRequested();
+
+                var restoreSummaries = await RestoreRunner.RunAsync(restoreContext, _cts.Token);
 
                 // Summary
                 RestoreSummary.Log(log, restoreSummaries);
@@ -195,6 +206,16 @@ namespace NuGet.Build.Tasks
             // OS description is set by default on Desktop
             UserAgent.SetUserAgentString(new UserAgentStringBuilder(agent));
 #endif
+        }
+
+        public void Cancel()
+        {
+            _cts.Cancel();
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.Designer.cs
@@ -78,5 +78,14 @@ namespace NuGet.Build.Tasks {
                 return ResourceManager.GetString("NoProjectsToRestore", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore canceled!.
+        /// </summary>
+        internal static string RestoreCanceled {
+            get {
+                return ResourceManager.GetString("RestoreCanceled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Strings.resx
@@ -123,4 +123,7 @@
   <data name="NoProjectsToRestore" xml:space="preserve">
     <value>Nothing to do. None of the projects specified contain packages to restore.</value>
   </data>
+  <data name="RestoreCanceled" xml:space="preserve">
+    <value>Restore canceled!</value>
+  </data>
 </root>


### PR DESCRIPTION
*ICancelableTask* allows restore to be canceled from the command line using *ctrl+c*. This is important for large restores and scenarios where package downloads are taking a long time. Using the cancellation token this will gracefully stop in the same way Visual Studio allows canceling restore.

Fixes https://github.com/NuGet/Home/issues/4517