### PR TITLE
Adding codes to all restore warnings/errors

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -92,7 +92,8 @@ namespace NuGet.Commands
                             available);
 
                         issues.Add(issue);
-                        _log.LogError(issue.Format());
+
+                        _log.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1201, issue.Format()));
                     }
 
                     // Skip further checks on projects
@@ -133,7 +134,8 @@ namespace NuGet.Commands
                         available);
 
                     issues.Add(issue);
-                    _log.LogError(issue.Format());
+
+                    _log.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1202, issue.Format()));
                 }
 
                 // Check for matching ref/libs if we're checking a runtime-specific graph
@@ -150,7 +152,7 @@ namespace NuGet.Commands
                             .Where(p => Path.GetExtension(p.Path)
                                 .Equals(".dll", StringComparison.OrdinalIgnoreCase)))
                         {
-                            string name = Path.GetFileNameWithoutExtension(compile.Path);
+                            var name = Path.GetFileNameWithoutExtension(compile.Path);
 
                             // If we haven't already started tracking this compile-time assembly, AND there isn't already a runtime-loadable version
                             if (!compileAssemblies.ContainsKey(name) && !runtimeAssemblies.Contains(name))
@@ -165,7 +167,7 @@ namespace NuGet.Commands
                             .Where(p => Path.GetExtension(p.Path)
                                 .Equals(".dll", StringComparison.OrdinalIgnoreCase)))
                         {
-                            string name = Path.GetFileNameWithoutExtension(runtime.Path);
+                            var name = Path.GetFileNameWithoutExtension(runtime.Path);
 
                             // If there was a compile-time-only assembly under this name...
                             if (compileAssemblies.ContainsKey(name))
@@ -206,7 +208,8 @@ namespace NuGet.Commands
                         graph.RuntimeIdentifier);
 
                     issues.Add(issue);
-                    _log.LogError(issue.Format());
+
+                    _log.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1203, issue.Format()));
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
@@ -52,5 +52,20 @@ namespace NuGet.Commands
 
             return $"{id} {range.MinVersion.ToNormalizedString()}";
         }
+
+        /// <summary>
+        /// Format a graph name with an optional RID.
+        /// </summary>
+        public static string FormatGraphName(RestoreTargetGraph graph)
+        {
+            if (string.IsNullOrEmpty(graph.RuntimeIdentifier))
+            {
+                return $"({graph.Framework.DotNetFrameworkName})";
+            }
+            else
+            {
+                return $"({graph.Framework.DotNetFrameworkName} RuntimeIdentifier: {graph.RuntimeIdentifier})";
+            }
+        }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -103,7 +103,7 @@ namespace NuGet.Commands
                 code = NuGetLogCode.NU1603;
             }
 
-            return RestoreLogMessage.CreateWarning(code, dependency.Child.Name, message, targetGraphs);
+            return RestoreLogMessage.CreateWarning(code, message, dependency.Child.Name, targetGraphs);
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace NuGet.Commands
                                 match.Key.Name,
                                 match.Key.Version);
 
-                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, match.Key.Name, message, graph.Name));
+                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, message, match.Key.Name, graph.Name));
                         }
                     }
                 }
@@ -163,9 +163,9 @@ namespace NuGet.Commands
                    .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
                    .Select(e => RestoreLogMessage.CreateWarning(
                        code: NuGetLogCode.NU1604,
-                       libraryId: e.Name,
                        message: string.Format(CultureInfo.CurrentCulture, Strings.Warning_ProjectDependencyMissingLowerBound,
-                                              DiagnosticUtility.FormatDependency(e.Name, e.LibraryRange.VersionRange))));
+                                              DiagnosticUtility.FormatDependency(e.Name, e.LibraryRange.VersionRange)),
+                       libraryId: e.Name));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -89,7 +89,7 @@ namespace NuGet.Commands
                     dependencyRange,
                     resolvedChild);
 
-                code = NuGetLogCode.NU2502;
+                code = NuGetLogCode.NU1602;
             }
             else
             {
@@ -100,7 +100,7 @@ namespace NuGet.Commands
                     missingChild,
                     resolvedChild);
 
-                code = NuGetLogCode.NU2503;
+                code = NuGetLogCode.NU1603;
             }
 
             return RestoreLogMessage.CreateWarning(code, dependency.Child.Name, message, targetGraphs);
@@ -144,7 +144,7 @@ namespace NuGet.Commands
                                 match.Key.Name,
                                 match.Key.Version);
 
-                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU2501, match.Key.Name, message, graph.Name));
+                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, match.Key.Name, message, graph.Name));
                         }
                     }
                 }
@@ -162,7 +162,7 @@ namespace NuGet.Commands
                    .Where(e => HasMissingLowerBound(e.LibraryRange.VersionRange))
                    .OrderBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
                    .Select(e => RestoreLogMessage.CreateWarning(
-                       code: NuGetLogCode.NU2504,
+                       code: NuGetLogCode.NU1604,
                        libraryId: e.Name,
                        message: string.Format(CultureInfo.CurrentCulture, Strings.Warning_ProjectDependencyMissingLowerBound,
                                               DiagnosticUtility.FormatDependency(e.Name, e.LibraryRange.VersionRange))));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -243,8 +243,21 @@ namespace NuGet.Commands
 
                             if (!targetLibrary.Equals(targetLibraryWithoutFallback))
                             {
-                                var libraryName = $"{library.Name} {library.Version}";
-                                _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_ImportsFallbackWarning, libraryName, String.Join(", ", fallbackFramework.Fallback), nonFallbackFramework));
+                                var libraryName = DiagnosticUtility.FormatIdentity(library);
+
+                                var message = string.Format(CultureInfo.CurrentCulture,
+                                    Strings.Log_ImportsFallbackWarning,
+                                    libraryName,
+                                    string.Join(", ", fallbackFramework.Fallback),
+                                    nonFallbackFramework);
+
+                                var logMessage = RestoreLogMessage.CreateWarning(
+                                    NuGetLogCode.NU1000,
+                                    message,
+                                    library.Name,
+                                    targetGraph.Name);
+
+                                _logger.Log(logMessage);
 
                                 // only log the warning once per library
                                 librariesWithWarnings.Add(library);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -252,7 +252,7 @@ namespace NuGet.Commands
                                     nonFallbackFramework);
 
                                 var logMessage = RestoreLogMessage.CreateWarning(
-                                    NuGetLogCode.NU1000,
+                                    NuGetLogCode.NU1701,
                                     message,
                                     library.Name,
                                     targetGraph.Name);

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -353,7 +353,7 @@ namespace NuGet.Commands
             if (_request.Project.TargetFrameworks.Count == 0)
             {
                 var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectDoesNotSpecifyTargetFrameworks, _request.Project.Name, _request.Project.FilePath);
-                await _logger.LogAsync(new RestoreLogMessage(LogLevel.Error, NuGetLogCode.NU1001, message));
+                await _logger.LogAsync(RestoreLogMessage.CreateError(NuGetLogCode.NU1001, message));
 
                 _success = false;
                 return Enumerable.Empty<RestoreTargetGraph>();

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -255,18 +255,19 @@ namespace NuGet.Commands
             {
                 foreach (var cycle in g.AnalyzeResult.Cycles)
                 {
-                    logger.LogError(Strings.Log_CycleDetected + $" {Environment.NewLine}  {cycle.GetPath()}.");
+                    logger.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1606, Strings.Log_CycleDetected + $" {Environment.NewLine}  {cycle.GetPath()}."));
                     return false;
                 }
 
                 foreach (var versionConflict in g.AnalyzeResult.VersionConflicts)
                 {
-                    logger.LogError(
-                        string.Format(
+                    var message = string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Log_VersionConflict,
                             versionConflict.Selected.Key.Name)
-                        + $" {Environment.NewLine} {versionConflict.Selected.GetPath()} {Environment.NewLine} {versionConflict.Conflicting.GetPath()}.");
+                        + $" {Environment.NewLine} {versionConflict.Selected.GetPath()} {Environment.NewLine} {versionConflict.Conflicting.GetPath()}.";
+
+                    logger.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1607, message));
                     return false;
                 }
 
@@ -279,14 +280,15 @@ namespace NuGet.Commands
                     var fromVersion = downgraded.Key.VersionRange.MinVersion ?? new NuGetVersion(0, 0, 0);
                     var toVersion = downgradedBy.Key.VersionRange.MinVersion ?? new NuGetVersion(0, 0, 0);
 
-                    logger.LogWarning(
-                        string.Format(
+                    var message = string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Log_DowngradeWarning,
                             downgraded.Key.Name,
                             fromVersion,
                             toVersion)
-                        + $" {Environment.NewLine} {downgraded.GetPath()} {Environment.NewLine} {downgradedBy.GetPath()}");
+                        + $" {Environment.NewLine} {downgraded.GetPath()} {Environment.NewLine} {downgradedBy.GetPath()}";
+
+                    logger.Log(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1605, message, downgraded.Key.Name, g.Name));
                 }
             }
 
@@ -328,21 +330,11 @@ namespace NuGet.Commands
                         // Log a summary with compatibility error counts
                         if (projectCount > 0)
                         {
-                            logger.LogError(
-                                string.Format(CultureInfo.CurrentCulture,
-                                    Strings.Log_ProjectsIncompatible,
-                                    graph.Name));
-
                             logger.LogDebug($"Incompatible projects: {projectCount}");
                         }
 
                         if (packageCount > 0)
                         {
-                            logger.LogError(
-                                string.Format(CultureInfo.CurrentCulture,
-                                    Strings.Log_PackagesIncompatible,
-                                    graph.Name));
-
                             logger.LogDebug($"Incompatible packages: {packageCount}");
                         }
                     }
@@ -360,7 +352,9 @@ namespace NuGet.Commands
         {
             if (_request.Project.TargetFrameworks.Count == 0)
             {
-                _logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectDoesNotSpecifyTargetFrameworks, _request.Project.Name, _request.Project.FilePath));
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_ProjectDoesNotSpecifyTargetFrameworks, _request.Project.Name, _request.Project.FilePath);
+                await _logger.LogAsync(new RestoreLogMessage(LogLevel.Error, NuGetLogCode.NU1001, message));
+
                 _success = false;
                 return Enumerable.Empty<RestoreTargetGraph>();
             }
@@ -436,7 +430,9 @@ namespace NuGet.Commands
                 else if (!runtimes.Supports.TryGetValue(profile.Value.Name, out compatProfile))
                 {
                     // No definition of this profile found, so just continue to the next one
-                    _logger.LogWarning(string.Format(CultureInfo.CurrentCulture, Strings.Log_UnknownCompatibilityProfile, profile.Key));
+                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_UnknownCompatibilityProfile, profile.Key);
+
+                    await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1502, message));
                     continue;
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -197,10 +197,12 @@ namespace NuGet.Commands
                 {
                     // No need to throw here - the situation is harmless, and we want to report all possible
                     // inputs that don't resolve to a project.
-                    restoreContext.Log.LogWarning(string.Format(
+                    var message = string.Format(
                             CultureInfo.CurrentCulture,
                             Strings.Error_UnableToLocateRestoreTarget,
-                            Path.GetFullPath(input)));
+                            Path.GetFullPath(input));
+
+                    await restoreContext.Log.LogAsync(new RestoreLogMessage(LogLevel.Warning, NuGetLogCode.NU1501, message));
                 }
                 foreach (var request in inputRequests)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -202,7 +202,7 @@ namespace NuGet.Commands
                             Strings.Error_UnableToLocateRestoreTarget,
                             Path.GetFullPath(input));
 
-                    await restoreContext.Log.LogAsync(new RestoreLogMessage(LogLevel.Warning, NuGetLogCode.NU1501, message));
+                    await restoreContext.Log.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1501, message));
                 }
                 foreach (var request in inputRequests)
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -174,7 +174,7 @@ namespace NuGet.Commands
             {
                 if (!_ignoreWarning)
                 {
-                    _logger.LogWarning(e.Message);
+                    await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1801, e.Message, match.Name));
                 }
             }
             finally
@@ -233,7 +233,7 @@ namespace NuGet.Commands
             {
                 if (!_ignoreWarning)
                 {
-                    _logger.LogWarning(e.Message);
+                    await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1801, e.Message, identity.Name));
                 }
             }
             finally
@@ -308,7 +308,7 @@ namespace NuGet.Commands
             {
                 if (!_ignoreWarning)
                 {
-                    _logger.LogWarning(e.Message);
+                    await _logger.LogAsync(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1801, e.Message, id));
                 }
                 return null;
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -729,7 +729,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to satisfy conflicting requests for &apos;{0}&apos;: {1}.
+        ///   Looks up a localized string similar to Unable to satisfy conflicting requests for &apos;{0}&apos;: {1} Framework: {2}.
         /// </summary>
         internal static string Log_ResolverConflict {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -182,7 +182,8 @@
     <value>Packages containing MSBuild targets and props files cannot be fully installed in projects targeting multiple frameworks. The MSBuild targets and props files have been ignored.</value>
   </data>
   <data name="Log_ResolverConflict" xml:space="preserve">
-    <value>Unable to satisfy conflicting requests for '{0}': {1}</value>
+    <value>Unable to satisfy conflicting requests for '{0}': {1} Framework: {2}</value>
+    <comment>0 - package id, 1 - comma delimited list of conflicts, 2 - framework</comment>
   </data>
   <data name="ResolverRequest_ToStringFormat" xml:space="preserve">
     <value>{0} (via {1})</value>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -22,30 +22,36 @@ namespace NuGet.Common
     /// 
     public enum NuGetLogCode
     {
-        NU1000 = 1000, // For cases do not fit into the cases below.
+        /// <summary>
+        /// Undefined error
+        /// </summary>
+        NU1000 = 1000,
         NU1001, // Actual errors start here
         NU1002,
 
+        /// <summary>
+        /// Undefined warning
+        /// </summary>
         NU1500 = 1500,
 
         /// <summary>
         /// Dependency bumped up
         /// </summary>
-        NU2501 = 2501,
+        NU1601 = 2501,
 
         /// <summary>
         /// Non-exact match on dependency range due to non inclusive minimum bound.
         /// </summary>
-        NU2502,
+        NU1602,
 
         /// <summary>
         /// Non-exact match on dependency range due to missing package version.
         /// </summary>
-        NU2503,
+        NU1603,
 
         /// <summary>
         /// Project dependency does not include a lower bound.
         /// </summary>
-        NU2504
+        NU1604
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -18,21 +18,78 @@ namespace NuGet.Common
     ///         
     ///     zw - 'zw' are the least two digit.
     ///         These could be used for different errors or warnings within the broad categories set by digits 'xy'.
-    /// </summary>
+    ///         
+    /// Groups:
+    /// 1000 - Restore
     /// 
+    /// Sub groups:
+    /// 1000/1500 Input
+    /// 1100/1600 Resolver
+    /// 1200/1700 Compat
+    /// 1300/1800 Feed
+    /// 1400/1900 Package
+    /// </summary>
     public enum NuGetLogCode
     {
         /// <summary>
         /// Undefined error
         /// </summary>
         NU1000 = 1000,
-        NU1001, // Actual errors start here
-        NU1002,
+
+        /// <summary>
+        /// Project has zero target frameworks.
+        /// </summary>
+        NU1001 = 1001,
+
+        /// <summary>
+        /// 
+        /// </summary>
+        NU1002 = 1002,
+
+        /// <summary>
+        /// Unable to resolve package
+        /// TODO split this up into the following errors.
+        /// </summary>
+        NU1101 = 1101,
+        NU1102 = 1102,
+        NU1103 = 1103,
+        NU1104 = 1104,
+        NU1105 = 1105,
+
+        /// <summary>
+        /// Resolver conflict
+        /// </summary>
+        NU1106 = 1106,
+
+        /// <summary>
+        /// Dependency project has an incompatible framework.
+        /// </summary>
+        NU1201 = 1201,
+
+        /// <summary>
+        /// Dependency package does not contain assets for the current framework.
+        /// </summary>
+        NU1202 = 1202,
+
+        /// <summary>
+        /// un-matched reference assemblies
+        /// </summary>
+        NU1203 = 1203,
 
         /// <summary>
         /// Undefined warning
         /// </summary>
         NU1500 = 1500,
+
+        /// <summary>
+        /// Missing restore target.
+        /// </summary>
+        NU1501 = 1501,
+
+        /// <summary>
+        /// Unknown compatibility profile
+        /// </summary>
+        NU1502 = 1502,
 
         /// <summary>
         /// Dependency bumped up
@@ -52,6 +109,31 @@ namespace NuGet.Common
         /// <summary>
         /// Project dependency does not include a lower bound.
         /// </summary>
-        NU1604
+        NU1604,
+
+        /// <summary>
+        /// Package dependency downgraded.
+        /// </summary>
+        NU1605 = 1605,
+
+        /// <summary>
+        /// Circular dependency.
+        /// </summary>
+        NU1606 = 1606,
+
+        /// <summary>
+        /// Version conflict.
+        /// </summary>
+        NU1607 = 1607,
+
+        /// <summary>
+        /// Fallback framework used.
+        /// </summary>
+        NU1701,
+
+        /// <summary>
+        /// Feed error converted to a warning when ignoreFailedSources is true.
+        /// </summary>
+        NU1801,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -99,17 +99,17 @@ namespace NuGet.Common
         /// <summary>
         /// Non-exact match on dependency range due to non inclusive minimum bound.
         /// </summary>
-        NU1602,
+        NU1602 = 1602,
 
         /// <summary>
         /// Non-exact match on dependency range due to missing package version.
         /// </summary>
-        NU1603,
+        NU1603 = 1603,
 
         /// <summary>
         /// Project dependency does not include a lower bound.
         /// </summary>
-        NU1604,
+        NU1604 = 1604,
 
         /// <summary>
         /// Package dependency downgraded.
@@ -129,11 +129,11 @@ namespace NuGet.Common
         /// <summary>
         /// Fallback framework used.
         /// </summary>
-        NU1701,
+        NU1701 = 1701,
 
         /// <summary>
         /// Feed error converted to a warning when ignoreFailedSources is true.
         /// </summary>
-        NU1801,
+        NU1801 = 1801,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -72,8 +72,8 @@ namespace NuGet.Common
         /// </summary>
         public static RestoreLogMessage CreateWarning(
             NuGetLogCode code,
-            string libraryId,
             string message,
+            string libraryId,
             params string[] targetGraphs)
         {
             return new RestoreLogMessage(LogLevel.Warning, message)
@@ -82,6 +82,38 @@ namespace NuGet.Common
                 LibraryId = libraryId,
                 TargetGraphs = targetGraphs.ToList()
             };
+        }
+
+        /// <summary>
+        /// Create a warning log message.
+        /// </summary>
+        public static RestoreLogMessage CreateWarning(
+            NuGetLogCode code,
+            string message)
+        {
+            return new RestoreLogMessage(LogLevel.Warning, code, message);
+        }
+
+        /// <summary>
+        /// Create an error log message.
+        /// </summary>
+        public static RestoreLogMessage CreateError(
+            NuGetLogCode code,
+            string message)
+        {
+            return new RestoreLogMessage(LogLevel.Error, code, message);
+        }
+
+        /// <summary>
+        /// Create an error log message for a target graph.
+        /// </summary>
+        public static RestoreLogMessage CreateError(
+            NuGetLogCode code,
+            string message,
+            string libraryId,
+            params string[] targetGraphs)
+        {
+            return new RestoreLogMessage(LogLevel.Error, code, message);
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1453,7 +1453,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
-                Assert.Contains("NU2503: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
+                Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
 
@@ -1489,7 +1489,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
-                Assert.Contains("NU2503: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
+                Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1577,7 +1577,7 @@ namespace NuGet.Commands.FuncTest
 
                 Assert.Contains(expectedIssue, result.CompatibilityCheckResults.SelectMany(c => c.Issues).ToArray());
                 Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
-                Assert.Contains($"NU1000: {expectedIssue.Format()}", logger.Messages);
+                Assert.Contains(expectedIssue.Format(), logger.Messages);
 
                 Assert.Equal(9, logger.Errors);
                 Assert.Equal(2, installed.Count);

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -741,7 +741,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
-                var warning = "NU1500: Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
+                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
 
                 // Act
                 var result = await command.ExecuteAsync();
@@ -753,7 +753,7 @@ namespace NuGet.Commands.FuncTest
                 Assert.Equal(1, result.GetAllInstalled().Count);
                 Assert.Equal(0, logger.Errors);
                 Assert.Equal(1, logger.Warnings);
-                Assert.Equal(1, logger.Messages.Where(message => message.Equals(warning)).Count());
+                Assert.Equal(1, logger.Messages.Where(message => message.Contains(warning)).Count());
             }
         }
 
@@ -1577,7 +1577,7 @@ namespace NuGet.Commands.FuncTest
 
                 Assert.Contains(expectedIssue, result.CompatibilityCheckResults.SelectMany(c => c.Issues).ToArray());
                 Assert.False(result.CompatibilityCheckResults.Any(c => c.Success));
-                Assert.Contains(expectedIssue.Format(), logger.Messages);
+                Assert.True(logger.Messages.Any(e => e.Contains(expectedIssue.Format())));
 
                 Assert.Equal(9, logger.Errors);
                 Assert.Equal(2, installed.Count);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -199,10 +199,9 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, result.GetAllUnresolved().Count);
                 Assert.NotNull(project2Lib);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
-                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal(1, logger.ErrorMessages.Count());
 
-                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
-                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+                Assert.Equal("NU1201: Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
 
                 // Incompatible projects are marked as Unsupported
                 Assert.Equal(NuGetFramework.UnsupportedFramework.DotNetFrameworkName, project2Lib.Framework);
@@ -295,10 +294,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal(0, result.GetAllUnresolved().Count);
                 Assert.NotNull(project2Lib);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports:\n  - net46 (.NETFramework,Version=v4.6)\n  - win81 (Windows,Version=v8.1)".Replace("\n", Environment.NewLine), issue.Format());
-                Assert.Equal(2, logger.ErrorMessages.Count());
-
-                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
-                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+                Assert.Equal(1, logger.ErrorMessages.Count());
             }
         }
 
@@ -385,10 +381,9 @@ namespace NuGet.Commands.Test
                 Assert.False(result.Success);
                 Assert.Equal(0, result.GetAllUnresolved().Count);
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
-                Assert.Equal(2, logger.ErrorMessages.Count());
+                Assert.Equal(1, logger.ErrorMessages.Count());
 
-                //TODO change NU1000 to a meaningful code once Justin starts throwing correct errors
-                Assert.Equal("NU1000: One or more projects are incompatible with .NETFramework,Version=v4.5.", logger.ErrorMessages.Last());
+                Assert.Equal("NU1201: Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1055,7 +1055,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(result.Success);
                 Assert.Equal(1, result.GetAllUnresolved().Count);
-                Assert.True(logger.ErrorMessages.Contains("NU1000: Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
+                Assert.True(logger.ErrorMessages.Contains("NU1101: Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
@@ -103,10 +103,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().NotContain("NU2504");
-            testLogger.ShowMessages().Should().Contain("NU2501");
-            testLogger.ShowMessages().Should().NotContain("NU2502");
-            testLogger.ShowMessages().Should().NotContain("NU2503");
+            testLogger.ShowMessages().Should().NotContain("NU1604");
+            testLogger.ShowMessages().Should().Contain("NU1601");
+            testLogger.ShowMessages().Should().NotContain("NU1602");
+            testLogger.ShowMessages().Should().NotContain("NU1603");
         }
 
         [Fact]
@@ -137,10 +137,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().NotContain("NU2504");
-            testLogger.ShowMessages().Should().NotContain("NU2501");
-            testLogger.ShowMessages().Should().Contain("NU2502");
-            testLogger.ShowMessages().Should().NotContain("NU2503");
+            testLogger.ShowMessages().Should().NotContain("NU1604");
+            testLogger.ShowMessages().Should().NotContain("NU1601");
+            testLogger.ShowMessages().Should().Contain("NU1602");
+            testLogger.ShowMessages().Should().NotContain("NU1603");
         }
 
         [Fact]
@@ -171,10 +171,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().Contain("NU2504");
-            testLogger.ShowMessages().Should().NotContain("NU2501");
-            testLogger.ShowMessages().Should().NotContain("NU2502");
-            testLogger.ShowMessages().Should().NotContain("NU2503");
+            testLogger.ShowMessages().Should().Contain("NU1604");
+            testLogger.ShowMessages().Should().NotContain("NU1601");
+            testLogger.ShowMessages().Should().NotContain("NU1602");
+            testLogger.ShowMessages().Should().NotContain("NU1603");
         }
 
         [Fact]
@@ -268,7 +268,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetBumpedUpDependencies(targetGraphs, project, ignore).Single();
 
-            log.Code.Should().Be(NuGetLogCode.NU2501);
+            log.Code.Should().Be(NuGetLogCode.NU1601);
             log.TargetGraphs.ShouldBeEquivalentTo(new[] { "net46/win10" });
             log.Message.Should().Be("Dependency specified was x (>= 1.0.0) but ended up with X 2.0.0.");
         }
@@ -309,7 +309,7 @@ namespace NuGet.Commands.Test
             var log = UnexpectedDependencyMessages.GetMissingLowerBounds(targetGraphs, ignore).Single();
 
             log.TargetGraphs.ShouldBeEquivalentTo(new[] { "net46/win10" });
-            log.Code.Should().Be(NuGetLogCode.NU2502);
+            log.Code.Should().Be(NuGetLogCode.NU1602);
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace NuGet.Commands.Test
 
             var logs = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project);
 
-            logs.Select(e => e.Code).ShouldAllBeEquivalentTo(NuGetLogCode.NU2504);
+            logs.Select(e => e.Code).ShouldAllBeEquivalentTo(NuGetLogCode.NU1604);
             logs.Select(e => e.Level).ShouldAllBeEquivalentTo(LogLevel.Warning);
             logs.Select(e => e.Message)
                 .ShouldBeEquivalentTo(new[]
@@ -378,7 +378,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
 
-            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Code.Should().Be(NuGetLogCode.NU1604);
             log.Message.Should().Be("Project dependency x does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
         }
 
@@ -394,7 +394,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
 
-            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Code.Should().Be(NuGetLogCode.NU1604);
             log.Message.Should().Be("Project dependency x (< 2.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
         }
 
@@ -410,7 +410,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetProjectDependenciesMissingLowerBounds(project).Single();
 
-            log.Code.Should().Be(NuGetLogCode.NU2504);
+            log.Code.Should().Be(NuGetLogCode.NU1604);
             log.Message.Should().Be("Project dependency x (> 1.0.0 && < 2.0.0) does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.");
         }
 
@@ -464,7 +464,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
 
-            log.Code.Should().Be(NuGetLogCode.NU2502);
+            log.Code.Should().Be(NuGetLogCode.NU1602);
             log.Message.Should().Be("a 9.0.0 does not provide an inclusive lower bound for dependency b (> 1.0.0). An approximate best match of b 2.0.0 was resolved.");
         }
 
@@ -478,7 +478,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
 
-            log.Code.Should().Be(NuGetLogCode.NU2502);
+            log.Code.Should().Be(NuGetLogCode.NU1602);
             log.Message.Should().Be("a 9.0.0 does not provide an inclusive lower bound for dependency b (<= 5.0.0). An approximate best match of b 2.0.0 was resolved.");
         }
 
@@ -492,7 +492,7 @@ namespace NuGet.Commands.Test
 
             var log = UnexpectedDependencyMessages.GetMissingLowerBoundMessage(dependency);
 
-            log.Code.Should().Be(NuGetLogCode.NU2503);
+            log.Code.Should().Be(NuGetLogCode.NU1603);
             log.Message.Should().Be("a 9.0.0 depends on b (>= 1.0.0) but b 1.0.0 was not found. An approximate best match of b 2.0.0 was resolved.");
         }
 


### PR DESCRIPTION
This covers all scenarios were LogWarning and LogError was being called for restore and adds codes for those.

In a few places I removed summary errors, these weren't contributing anything and it didn't make sense for them to have their own code or even to be logged as NU1000.

