### PR TITLE
add support for packing framework reference assemblies

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/IPackTaskRequest.cs
@@ -16,7 +16,6 @@ namespace NuGet.Build.Tasks.Pack
     public interface IPackTaskRequest<TItem>
     {
         string AssemblyName { get; }
-        TItem[] AssemblyReferences { get; }
         string[] Authors { get; }
         TItem[] BuildOutputInPackage { get; }
         string BuildOutputFolder { get; }
@@ -25,6 +24,7 @@ namespace NuGet.Build.Tasks.Pack
         string Copyright { get; }
         string Description { get; }
         bool DevelopmentDependency { get; }
+        TItem[] FrameworkAssemblyReferences { get; }
         string IconUrl { get; }
         bool IncludeBuildOutput { get; }
         bool IncludeSource { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/Pack.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 NuGet.targets
 
@@ -169,7 +169,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               NoPackageAnalysis="$(NoPackageAnalysis)"
               MinClientVersion="$(MinClientVersion)"
               Serviceable="$(Serviceable)"
-              AssemblyReferences="@(_References)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
               ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
               NuspecOutputPath="$(BaseIntermediateOutputPath)"
               IncludeBuildOutput="$(IncludeBuildOutput)"
@@ -239,6 +239,26 @@ Copyright (c) .NET Foundation. All rights reserved.
           TaskParameter="TargetOutputs"
           ItemName="_SourceFiles" />
     </MSBuild>
+
+    <MSBuild
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetFrameworkAssemblyReferences"
+      Properties="TargetFramework=%(_TargetFrameworks.Identity);
+                  BuildProjectReferences=false;">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_FrameworkAssemblyReferences" />
+    </MSBuild>
+  </Target>
+
+  <Target Name ="_GetFrameworkAssemblyReferences" DependsOnTargets="ResolveReferences" Returns="@(TfmSpecificFrameworkAssemblyReferences)">
+    <ItemGroup>
+      <TfmSpecificFrameworkAssemblyReferences Include="@(ReferencePath->'%(OriginalItemSpec)')" 
+      Condition="'%(ReferencePath.Pack)' != 'false' AND '%(ReferencePath.ResolvedFrom)' == '{TargetFrameworkDirectory}'">
+        <TargetFramework>$(TargetFramework)</TargetFramework>
+      </TfmSpecificFrameworkAssemblyReferences>
+    </ItemGroup>
   </Target>
   
   <Target Name="_GetBuildOutputFilesWithTfm"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -47,7 +47,7 @@ namespace NuGet.Build.Tasks.Pack
         public string NuspecFile { get; set; }
         public string MinClientVersion { get; set; }
         public bool Serviceable { get; set; }
-        public ITaskItem[] AssemblyReferences { get; set; }
+        public ITaskItem[] FrameworkAssemblyReferences { get; set; }
         public bool ContinuePackingAfterGeneratingNuspec { get; set; }
         public string NuspecOutputPath { get; set; }
         public bool IncludeBuildOutput { get; set; }
@@ -120,7 +120,6 @@ namespace NuGet.Build.Tasks.Pack
             return new PackTaskRequest
             {
                 AssemblyName = MSBuildStringUtility.TrimAndGetNullForEmpty(AssemblyName),
-                AssemblyReferences = MSBuildUtility.WrapMSBuildItem(AssemblyReferences),
                 Authors = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Authors),
                 BuildOutputInPackage = MSBuildUtility.WrapMSBuildItem(BuildOutputInPackage),
                 BuildOutputFolder = MSBuildStringUtility.TrimAndGetNullForEmpty(BuildOutputFolder),
@@ -129,6 +128,7 @@ namespace NuGet.Build.Tasks.Pack
                 Copyright = MSBuildStringUtility.TrimAndGetNullForEmpty(Copyright),
                 Description = MSBuildStringUtility.TrimAndGetNullForEmpty(Description),
                 DevelopmentDependency = DevelopmentDependency,
+                FrameworkAssemblyReferences = MSBuildUtility.WrapMSBuildItem(FrameworkAssemblyReferences),
                 IconUrl = MSBuildStringUtility.TrimAndGetNullForEmpty(IconUrl),
                 IncludeBuildOutput = IncludeBuildOutput,
                 IncludeSource = IncludeSource,
@@ -160,7 +160,7 @@ namespace NuGet.Build.Tasks.Pack
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
                 TargetPathsToSymbols = MSBuildUtility.WrapMSBuildItem(TargetPathsToSymbols),
-                Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title),
+                Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title)
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using NuGet.Commands;
 using NuGet.Common;
 
@@ -9,7 +10,6 @@ namespace NuGet.Build.Tasks.Pack
     public class PackTaskRequest : IPackTaskRequest<IMSBuildItem>
     {
         public string AssemblyName { get; set; }
-        public IMSBuildItem[] AssemblyReferences { get; set; }
         public string[] Authors { get; set; }
         public IMSBuildItem[] BuildOutputInPackage { get; set; }
         public string BuildOutputFolder { get; set; }
@@ -18,6 +18,7 @@ namespace NuGet.Build.Tasks.Pack
         public string Copyright { get; set; }
         public string Description { get; set; }
         public bool DevelopmentDependency { get; set; }
+        public IMSBuildItem[] FrameworkAssemblyReferences { get; set; }
         public string IconUrl { get; set; }
         public bool IncludeBuildOutput { get; set; }
         public bool IncludeSource { get; set; }

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1625,7 +1625,6 @@ namespace ClassLibrary
             // Arrange
             using (var testDirectory = TestDirectory.Create())
             {
-                //XPlatTestUtils.WaitForDebugger();
                 var projectName = "ClassLibrary1";
                 var workingDirectory = Path.Combine(testDirectory, projectName);
                 
@@ -1680,6 +1679,79 @@ namespace ClassLibrary
                     {
                         Assert.Contains(path, items);
                     }
+                }
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+
+        [InlineData("PresentationFramework",                      true,                           "netstandard1.4;net461",                      "",                             "net461")]
+        [InlineData("PresentationFramework",                      false,                          "netstandard1.4;net461",                      "",                             "net461")]
+        [InlineData("System.IO",                                  true,                           "netstandard1.4;net46",                       "",                             "net46")]
+        [InlineData("System.IO",                                  true,                           "net46;net461",                               "net461",                       "net461")]
+        [InlineData("System.IO",                                  true,                           "net461",                                     "",                             "net461")]
+        public void PackCommand_PackProject_AddsReferenceAsFrameworkAssemblyReference(string referenceAssembly, bool pack,
+            string targetFrameworks, string conditionalFramework, string expectedTargetFramework)
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+                
+                // Create the subdirectory structure for testing possible source paths for the content file
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    var frameworkProperty = "TargetFrameworks";
+                    if(targetFrameworks.Split(';').Count() == 1)
+                    {
+                        frameworkProperty = "TargetFramework";
+                    }
+                    ProjectFileUtils.SetTargetFrameworkForProject(xml, frameworkProperty, targetFrameworks);
+
+                    var attributes = new Dictionary<string, string>();
+
+                    var properties = new Dictionary<string, string>();
+                    if (!pack)
+                    {
+                        attributes["Pack"] = "false";
+                    }
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        "Reference",
+                        referenceAssembly,
+                        conditionalFramework,
+                        properties,
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                // Assert
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+                //XPlatTestUtils.WaitForDebugger();
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var expectedFrameworks = expectedTargetFramework.Split(';');
+                    var frameworkItems = nupkgReader.GetFrameworkItems();
+                    foreach(var framework in expectedFrameworks)
+                    {
+                        var nugetFramework = NuGetFramework.Parse(framework);
+                        var frameworkSpecificGroup = frameworkItems.Where(t => t.TargetFramework.Equals(nugetFramework)).First();
+                        Assert.True(frameworkSpecificGroup.Items.Contains(referenceAssembly) == pack);
+                    }                    
                 }
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskLogicTests.cs
@@ -406,7 +406,8 @@ namespace NuGet.Build.Tasks.Pack.Test
                         {"FinalOutputPath", dllPath },
                         {"TargetFramework", "net45" }
                     })},
-                    Logger = new TestLogger()
+                    Logger = new TestLogger(),
+                    FrameworkAssemblyReferences = new MSBuildItem[]{}
                 };
             }
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -203,7 +203,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             // Arrange
             var target = new PackTask
             {
-                AssemblyReferences = new[] { null, new Mock<ITaskItem>().Object },
+                FrameworkAssemblyReferences = new[] { null, new Mock<ITaskItem>().Object },
                 PackageFiles = new[] { null, new Mock<ITaskItem>().Object },
                 PackageFilesToExclude = new[] { null, new Mock<ITaskItem>().Object },
                 PackItem = new Mock<ITaskItem>().Object,
@@ -214,7 +214,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var actual = GetRequest(target);
 
             // Assert
-            Assert.Equal(1, actual.AssemblyReferences.OfType<MSBuildTaskItem>().Count());
+            Assert.Equal(1, actual.FrameworkAssemblyReferences.OfType<MSBuildTaskItem>().Count());
             Assert.Equal(1, actual.PackageFiles.OfType<MSBuildTaskItem>().Count());
             Assert.Equal(1, actual.PackageFilesToExclude.OfType<MSBuildTaskItem>().Count());
             Assert.NotNull(actual.PackItem);
@@ -227,7 +227,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             // Arrange
             var target = new PackTask
             {
-                AssemblyReferences = null,
+                FrameworkAssemblyReferences = null,
                 Authors = null,
                 PackageFiles = null,
                 PackageFilesToExclude = null,
@@ -243,7 +243,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var actual = GetRequest(target);
 
             // Assert
-            Assert.Equal(0, actual.AssemblyReferences.Length);
+            Assert.Equal(0, actual.FrameworkAssemblyReferences.Length);
             Assert.Equal(0, actual.Authors.Length);
             Assert.Equal(0, actual.PackageFiles.Length);
             Assert.Equal(0, actual.PackageFilesToExclude.Length);
@@ -262,7 +262,7 @@ namespace NuGet.Build.Tasks.Pack.Test
             var target = new PackTask
             {
                 AssemblyName = "AssemblyName",
-                AssemblyReferences = new ITaskItem[0],
+                FrameworkAssemblyReferences = new ITaskItem[0],
                 Authors = new string[0],
                 BuildOutputFolder = "BuildOutputFolder",
                 ContentTargetFolders = new string[] { "ContentTargetFolders" } ,


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/4853

Here is how this will work:
All ```<Reference>``` items in the csproj will be added by default to the nuspec as a ```frameworkAssemblyReference``` . This behavior can be overridden by specifying ```<Pack>false</Pack>``` on the reference that you dont want to include in your nuspec.

All implicit framework references will also be added by default. For a list of implicit references, see : https://github.com/dotnet/sdk/blob/release/2.0.0/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.Sdk.BeforeCommon.targets#L84-L109 

If you don't want to include implicity framework assembly references, you can set ```DisableImplicitFrameworkReferences``` to true. Doing this will remove all implicit framework assembly references, except ```System.Core``` which is special and added via a different property called ```AdditionalExplicitAssemblyReferences```. You can skip the addition of System.Core by specifying ```AddAdditionalExplicityAssemblyReferences``` to false.

Tests coming soon.