### PR TITLE
Get last known good credentials from credentials cache

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/CredentialService.cs
@@ -47,7 +47,7 @@ namespace NuGet.Credentials
             {
                 throw new ArgumentNullException(nameof(providers));
             }
-            
+
             _nonInteractive = nonInteractive;
             Providers = new List<ICredentialProvider>(providers);
             HandlesDefaultCredentials = Providers.Any(provider => provider is DefaultCredentialsCredentialProvider);
@@ -146,6 +146,47 @@ namespace NuGet.Credentials
         }
 
         /// <summary>
+        /// Attempts to retrieve last known good credentials for a URI from a credentials cache.
+        /// </summary>
+        /// <remarks>
+        /// When the return value is <c>true</c>, <paramref name="credentials" /> will have last known
+        /// good credentials from the credentials cache.  These credentials may have become invalid
+        /// since their last use, so there is no guarantee that the credentials are currently valid.
+        /// </remarks>
+        /// <param name="uri">The URI for which cached credentials should be retrieved.</param>
+        /// <param name="isProxy"><c>true</c> for proxy credentials; otherwise, <c>false</c>.</param>
+        /// <param name="credentials">Cached credentials or <c>null</c>.</param>
+        /// <returns><c>true</c> if a result is returned from the cache; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        public bool TryGetLastKnownGoodCredentialsFromCache(
+            Uri uri,
+            bool isProxy,
+            out ICredentials credentials)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            credentials = null;
+
+            var rootUri = GetRootUri(uri);
+            var ending = $"_{isProxy}_{rootUri}";
+
+            foreach (var entry in _providerCredentialCache)
+            {
+                if (entry.Value.Status == CredentialStatus.Success && entry.Key.EndsWith(ending))
+                {
+                    credentials = entry.Value.Credentials;
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets the currently configured providers.
         /// </summary>
         private IEnumerable<ICredentialProvider> Providers { get; }
@@ -179,8 +220,13 @@ namespace NuGet.Credentials
 
         private static string CredentialCacheKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)
         {
-            var rootUri =new Uri(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
+            var rootUri = GetRootUri(uri);
             return GetUriKey(rootUri, type, provider);
+        }
+
+        private static Uri GetRootUri(Uri uri)
+        {
+            return new Uri(uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped));
         }
 
         private static string GetUriKey(Uri uri, CredentialRequestType type, ICredentialProvider provider)

--- a/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Credential/ICredentialService.cs
@@ -8,14 +8,48 @@ using System.Threading.Tasks;
 
 namespace NuGet.Configuration
 {
+    /// <summary>
+    /// A credentials service.
+    /// </summary>
     public interface ICredentialService
     {
+        /// <summary>
+        /// Asynchronously gets credentials.
+        /// </summary>
+        /// <param name="uri">The URI for which credentials should be retrieved.</param>
+        /// <param name="proxy">A web proxy.</param>
+        /// <param name="type">The credential request type.</param>
+        /// <param name="message">A message to display when prompting for credentials.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="ICredentials" />.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
+        /// is cancelled.</exception>
         Task<ICredentials> GetCredentialsAsync(
             Uri uri,
             IWebProxy proxy,
             CredentialRequestType type,
             string message,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Attempts to retrieve last known good credentials for a URI from a credentials cache.
+        /// </summary>
+        /// <remarks>
+        /// When the return value is <c>true</c>, <paramref name="credentials" /> will have last known
+        /// good credentials from the credentials cache.  These credentials may have become invalid
+        /// since their last use, so there is no guarantee that the credentials are currently valid.
+        /// </remarks>
+        /// <param name="uri">The URI for which cached credentials should be retrieved.</param>
+        /// <param name="isProxy"><c>true</c> for proxy credentials; otherwise, <c>false</c>.</param>
+        /// <param name="credentials">Cached credentials or <c>null</c>.</param>
+        /// <returns><c>true</c> if a result is returned from the cache; otherwise, false.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="uri" /> is <c>null</c>.</exception>
+        bool TryGetLastKnownGoodCredentialsFromCache(
+            Uri uri,
+            bool isProxy,
+            out ICredentials credentials);
 
         /// <summary>
         /// Gets a value indicating whether this credential service wants to handle "default credentials" specially,


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/5142.

This method will be used to return last known good credentials from the credentials cache to a plugin.  It is fine to return stale (invalid) credentials or even no credentials if none are available as plugins have a mechanism for requesting newer credentials on demand.  To avoid unnecessary credential prompts, NuGet will pass a plugin LKG credentials it currently has in its cache.

CC @jmyersmsft, @cajonemsft, @zjrunner