### PR TITLE
Improve error messages for unresolved packages and projects

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NuGet.Common;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 
@@ -66,6 +71,77 @@ namespace NuGet.Commands
             {
                 return $"({graph.Framework.DotNetFrameworkName} RuntimeIdentifier: {graph.RuntimeIdentifier})";
             }
+        }
+
+        /// <summary>
+        /// Format a message as:
+        /// 
+        /// First line
+        ///   - second
+        ///   - third
+        /// </summary>
+        public static string GetMultiLineMessage(IEnumerable<string> lines)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var line in lines)
+            {
+                if (sb.Length == 0)
+                {
+                    sb.Append(line);
+                }
+                else
+                {
+                    sb.Append(Environment.NewLine);
+                    sb.Append($"  - {line}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Merge messages with the same code and message, combining the target graphs.
+        /// </summary>
+        public static IEnumerable<RestoreLogMessage> MergeOnTargetGraph(IEnumerable<RestoreLogMessage> messages)
+        {
+            var output = new List<RestoreLogMessage>();
+
+            foreach (var codeGroup in messages.GroupBy(e => e.Code))
+            {
+                foreach (var messageGroup in codeGroup.GroupBy(e => e.Message, StringComparer.Ordinal))
+                {
+                    var group = messageGroup.ToArray();
+
+                    if (group.Length == 1)
+                    {
+                        output.AddRange(group);
+                    }
+                    else
+                    {
+                        var message = new RestoreLogMessage(group[0].Level, group[0].Code, group[0].Message)
+                        {
+                            Time = group[0].Time,
+                            WarningLevel = group[0].WarningLevel,
+                            LibraryId = group[0].LibraryId,
+                            FilePath = group[0].FilePath,
+                            EndColumnNumber = group[0].EndColumnNumber,
+                            ProjectPath = group[0].ProjectPath,
+                            StartLineNumber = group[0].StartLineNumber,
+                            StartColumnNumber = group[0].StartColumnNumber,
+                            EndLineNumber = group[0].EndLineNumber,
+                            TargetGraphs = group.SelectMany(e => e.TargetGraphs)
+                                .OrderBy(e => e, StringComparer.Ordinal)
+                                .Distinct()
+                                .ToList()
+                        };
+
+                        output.Add(message);
+                    }
+                }
+            }
+
+            return output.OrderBy(e => e.Time).ToList();
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -31,19 +31,19 @@ namespace NuGet.Commands
             //    The user can fix these themselves.
             var projectMissingLowerBounds = GetProjectDependenciesMissingLowerBounds(project);
             ignoreIds.UnionWith(projectMissingLowerBounds.Select(e => e.LibraryId));
-            await logger.LogMessagesAsync(projectMissingLowerBounds);
+            await logger.LogMessagesAsync(DiagnosticUtility.MergeOnTargetGraph(projectMissingLowerBounds));
 
             // 2. Detect dependency and source issues across the entire graph 
             //    where the minimum version was not matched exactly.
             //    Ignore packages already logged by #1
             var missingMinimums = GetMissingLowerBounds(graphList, ignoreIds);
             ignoreIds.UnionWith(missingMinimums.Select(e => e.LibraryId));
-            await logger.LogMessagesAsync(missingMinimums);
+            await logger.LogMessagesAsync(DiagnosticUtility.MergeOnTargetGraph(missingMinimums));
 
             // 3. Detect top level dependencies that have a version different from the specified version.
             //    Ignore packages already logged in #1 and #2 since those errors are more specific.
             var bumpedUp = GetBumpedUpDependencies(graphList, project, ignoreIds);
-            await logger.LogMessagesAsync(bumpedUp);
+            await logger.LogMessagesAsync(DiagnosticUtility.MergeOnTargetGraph(bumpedUp));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.DependencyResolver;
+using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Log errors for packages and projects that were missing.
+    /// </summary>
+    public static class UnresolvedMessages
+    {
+        /// <summary>
+        /// Log errors for missing dependencies.
+        /// </summary>
+        public static async Task LogAsync(IEnumerable<IRestoreTargetGraph> graphs, RemoteWalkContext context, ILogger logger, CancellationToken token)
+        {
+            var tasks = graphs.SelectMany(graph => graph.Unresolved.Select(e => GetMessageAsync(graph, e, context, logger, token))).ToArray();
+            var messages = await Task.WhenAll(tasks);
+
+            await logger.LogMessagesAsync(DiagnosticUtility.MergeOnTargetGraph(messages));
+        }
+
+        /// <summary>
+        /// Create a specific error message for the unresolved dependency.
+        /// </summary>
+        public static async Task<RestoreLogMessage> GetMessageAsync(IRestoreTargetGraph graph,
+            LibraryRange unresolved,
+            RemoteWalkContext context,
+            ILogger logger,
+            CancellationToken token)
+        {
+            // Default to using the generic unresolved error code, this will be overridden later.
+            var code = NuGetLogCode.NU1100;
+            var message = string.Empty;
+
+            if (unresolved.TypeConstraintAllows(LibraryDependencyTarget.ExternalProject)
+                && !unresolved.TypeConstraintAllows(LibraryDependencyTarget.Package))
+            {
+                // Project
+                // Check if the name is a path and if it exists. All project paths should have been normalized and converted to full paths before this.
+                if (unresolved.Name.IndexOf(Path.DirectorySeparatorChar) > -1 && File.Exists(unresolved.Name))
+                {
+                    // File exists but the dg spec did not contain the spec
+                    code = NuGetLogCode.NU1105;
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Error_UnableToFindProjectInfo, unresolved.Name);
+                }
+                else
+                {
+                    // Generic missing project error
+                    code = NuGetLogCode.NU1104;
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Error_ProjectDoesNotExist, unresolved.Name);
+                }
+            }
+            else if (unresolved.TypeConstraintAllows(LibraryDependencyTarget.Package)
+                        && context.RemoteLibraryProviders.Count > 0)
+            {
+                // Package
+                var range = unresolved.VersionRange ?? VersionRange.All;
+                var sourceInfo = await GetSourceInfosForIdAsync(unresolved.Name, range, context, logger, token);
+                var allVersions = new SortedSet<NuGetVersion>(sourceInfo.SelectMany(e => e.Value));
+
+                if (allVersions.Count == 0)
+                {
+                    // No versions found
+                    code = NuGetLogCode.NU1101;
+                    var sourceList = string.Join(", ",
+                                        sourceInfo.Select(e => e.Key.Name)
+                                                  .OrderBy(e => e, StringComparer.OrdinalIgnoreCase));
+
+                    message = string.Format(CultureInfo.CurrentCulture, Strings.Error_NoPackageVersionsExist, unresolved.Name, sourceList);
+                }
+                else
+                {
+                    // At least one version found
+                    var firstLine = string.Empty;
+                    var rangeString = range.ToNonSnapshotRange().PrettyPrint();
+
+                    if (!IsPrereleaseAllowed(range) && HasPrereleaseVersionsOnly(range, allVersions))
+                    {
+                        code = NuGetLogCode.NU1103;
+                        firstLine = string.Format(CultureInfo.CurrentCulture, Strings.Error_NoStablePackageVersionsExist, unresolved.Name, rangeString);
+                    }
+                    else
+                    {
+                        code = NuGetLogCode.NU1102;
+                        firstLine = string.Format(CultureInfo.CurrentCulture, Strings.Error_NoPackageVersionsExistInRange, unresolved.Name, rangeString);
+                    }
+
+                    var lines = new List<string>()
+                    {
+                        firstLine
+                    };
+
+                    lines.AddRange(sourceInfo.Select(e => FormatSourceInfo(e, range)));
+
+                    message = DiagnosticUtility.GetMultiLineMessage(lines);
+                }
+            }
+            else
+            {
+                // Unknown or non-specific.
+                // Also shown when no sources exist.
+                message = string.Format(CultureInfo.CurrentCulture,
+                    Strings.Log_UnresolvedDependency,
+                    unresolved.ToString(),
+                    graph.Name);
+
+                // Set again for clarity
+                code = NuGetLogCode.NU1100;
+            }
+
+            return RestoreLogMessage.CreateError(code, message, unresolved.Name, graph.Name);
+        }
+
+        /// <summary>
+        /// True if no stable versions satisfy the range 
+        /// but a pre-release version is found.
+        /// </summary>
+        public static bool HasPrereleaseVersionsOnly(VersionRange range, IEnumerable<NuGetVersion> versions)
+        {
+            var currentRange = range ?? VersionRange.All;
+            var currentVersions = versions ?? Enumerable.Empty<NuGetVersion>();
+
+            return (versions.Any(e => e.IsPrerelease && currentRange.Satisfies(e))
+                && !versions.Any(e => !e.IsPrerelease && currentRange.Satisfies(e)));
+        }
+
+        /// <summary>
+        /// True if the range allows pre-release versions.
+        /// </summary>
+        public static bool IsPrereleaseAllowed(VersionRange range)
+        {
+            return (range?.MaxVersion?.IsPrerelease == true
+                || range?.MinVersion?.IsPrerelease == true);
+        }
+
+        /// <summary>
+        /// Found 2839 version(s) in nuget-build [ Nearest version: 1.0.0-beta ]
+        /// </summary>
+        public static string FormatSourceInfo(KeyValuePair<PackageSource, SortedSet<NuGetVersion>> sourceInfo, VersionRange range)
+        {
+            var bestMatch = GetBestMatch(sourceInfo.Value, range);
+
+            if (bestMatch != null)
+            {
+                return string.Format(CultureInfo.CurrentCulture,
+                    Strings.FoundVersionsInSource,
+                    sourceInfo.Value.Count,
+                    sourceInfo.Key.Name,
+                    bestMatch.ToNormalizedString());
+            }
+
+            return string.Format(CultureInfo.CurrentCulture,
+                                Strings.FoundVersionsInSourceWithoutMatch,
+                                sourceInfo.Value.Count,
+                                sourceInfo.Key.Name);
+        }
+
+        /// <summary>
+        /// Get the complete set of source info for a package id.
+        /// </summary>
+        public static async Task<List<KeyValuePair<PackageSource, SortedSet<NuGetVersion>>>> GetSourceInfosForIdAsync(
+            string id,
+            VersionRange range,
+            RemoteWalkContext context,
+            ILogger logger,
+            CancellationToken token)
+        {
+            var sources = new List<KeyValuePair<PackageSource, SortedSet<NuGetVersion>>>();
+
+            // Get versions from all sources. These should be cached by the providers already.
+            var tasks = context.RemoteLibraryProviders
+                .Select(e => GetSourceInfoForIdAsync(e, id, context.CacheContext, logger, token))
+                .ToArray();
+
+            foreach (var task in tasks)
+            {
+                sources.Add(await task);
+            }
+
+            // Sort by most package versions, then by source path.
+            return sources.OrderByDescending(e => e.Value.Count)
+                .ThenBy(e => e.Key.Source, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Find all package versions from a source.
+        /// </summary>
+        public static async Task<KeyValuePair<PackageSource, SortedSet<NuGetVersion>>> GetSourceInfoForIdAsync(
+            IRemoteDependencyProvider provider,
+            string id,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            // Find all versions from a source.
+            var versions = await provider.GetAllVersionsAsync(id, cacheContext, logger, token);
+
+            return new KeyValuePair<PackageSource, SortedSet<NuGetVersion>>(
+                provider.Source,
+                new SortedSet<NuGetVersion>(versions));
+        }
+
+        /// <summary>
+        /// Find the best match on the feed.
+        /// </summary>
+        public static NuGetVersion GetBestMatch(SortedSet<NuGetVersion> versions, VersionRange range)
+        {
+            if (versions.Count == 0)
+            {
+                return null;
+            }
+
+            // Find a pivot point
+            var ideal = new NuGetVersion(0, 0, 0);
+
+            if (range != null)
+            {
+                if (range.HasUpperBound)
+                {
+                    ideal = range.MaxVersion;
+                }
+
+                if (range.HasLowerBound)
+                {
+                    ideal = range.MinVersion;
+                }
+            }
+
+            // Take the lowest version higher than the pivot if one exists.
+            var bestMatch = versions.Where(e => e >= ideal).FirstOrDefault();
+
+            if (bestMatch == null)
+            {
+                // Take the highest possible version.
+                bestMatch = versions.Last();
+            }
+
+            return bestMatch;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -101,7 +102,7 @@ namespace NuGet.Commands
             await EnsureResource();
 
             // Discover all versions from the feed
-            var packageVersions = await GetPackageVersionsAsync(libraryRange.Name, cacheContext, logger, cancellationToken);
+            var packageVersions = await GetAllVersionsAsync(libraryRange.Name, cacheContext, logger, cancellationToken);
 
             // Select the best match
             var packageVersion = packageVersions?.FindBestMatch(libraryRange.VersionRange, version => version);
@@ -128,14 +129,14 @@ namespace NuGet.Commands
         {
             AsyncLazy<LibraryDependencyInfo> result = null;
 
-            var action = new AsyncLazy<LibraryDependencyInfo>(async () => 
+            var action = new AsyncLazy<LibraryDependencyInfo>(async () =>
                 await GetDependenciesCoreAsync(match, targetFramework, cacheContext, logger, cancellationToken));
 
             var key = new LibraryRangeCacheKey(match, targetFramework);
 
             if (cacheContext.RefreshMemoryCache)
             {
-                result = _dependencyInfoCache.AddOrUpdate(key, action, (k,v) => action);
+                result = _dependencyInfoCache.AddOrUpdate(key, action, (k, v) => action);
             }
             else
             {
@@ -286,7 +287,7 @@ namespace NuGet.Commands
         /// <summary>
         /// Discover all package versions from a feed.
         /// </summary>
-        private async Task<IEnumerable<NuGetVersion>> GetPackageVersionsAsync(string id,
+        public async Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id,
                                                                     SourceCacheContext cacheContext,
                                                                     ILogger logger,
                                                                     CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -143,6 +143,33 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to find package {0}. No packages exist with this id in source(s): {1}.
+        /// </summary>
+        internal static string Error_NoPackageVersionsExist {
+            get {
+                return ResourceManager.GetString("Error_NoPackageVersionsExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find package {0} with version {1}.
+        /// </summary>
+        internal static string Error_NoPackageVersionsExistInRange {
+            get {
+                return ResourceManager.GetString("Error_NoPackageVersionsExistInRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find a stable package {0} with version {1}.
+        /// </summary>
+        internal static string Error_NoStablePackageVersionsExist {
+            get {
+                return ResourceManager.GetString("Error_NoStablePackageVersionsExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to build package. Ensure &apos;{0}&apos; includes assembly files. For help on building symbols package, visit {1}..
         /// </summary>
         internal static string Error_PackageCommandNoFilesForLibPackage {
@@ -175,6 +202,24 @@ namespace NuGet.Commands {
         internal static string Error_ProcessingNuspecFile {
             get {
                 return ResourceManager.GetString("Error_ProcessingNuspecFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find project &apos;{0}&apos;. Check that the project reference is valid and that the project file exists..
+        /// </summary>
+        internal static string Error_ProjectDoesNotExist {
+            get {
+                return ResourceManager.GetString("Error_ProjectDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to find project information for &apos;{0}&apos;. The project file may be invalid or missing targets required for restore..
+        /// </summary>
+        internal static string Error_UnableToFindProjectInfo {
+            get {
+                return ResourceManager.GetString("Error_UnableToFindProjectInfo", resourceCulture);
             }
         }
         
@@ -238,6 +283,24 @@ namespace NuGet.Commands {
         internal static string FileNotAddedToPackage {
             get {
                 return ResourceManager.GetString("FileNotAddedToPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found {0} version(s) in {1} [ Nearest version: {2} ].
+        /// </summary>
+        internal static string FoundVersionsInSource {
+            get {
+                return ResourceManager.GetString("FoundVersionsInSource", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found {0} version(s) in {1}.
+        /// </summary>
+        internal static string FoundVersionsInSourceWithoutMatch {
+            get {
+                return ResourceManager.GetString("FoundVersionsInSourceWithoutMatch", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -521,4 +521,25 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Warning_ProjectDependencyMissingLowerBound" xml:space="preserve">
     <value>Project dependency {0} does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.</value>
   </data>
+  <data name="Error_NoPackageVersionsExist" xml:space="preserve">
+    <value>Unable to find package {0}. No packages exist with this id in source(s): {1}</value>
+  </data>
+  <data name="Error_NoPackageVersionsExistInRange" xml:space="preserve">
+    <value>Unable to find package {0} with version {1}</value>
+  </data>
+  <data name="Error_NoStablePackageVersionsExist" xml:space="preserve">
+    <value>Unable to find a stable package {0} with version {1}</value>
+  </data>
+  <data name="Error_ProjectDoesNotExist" xml:space="preserve">
+    <value>Unable to find project '{0}'. Check that the project reference is valid and that the project file exists.</value>
+  </data>
+  <data name="Error_UnableToFindProjectInfo" xml:space="preserve">
+    <value>Unable to find project information for '{0}'. The project file may be invalid or missing targets required for restore.</value>
+  </data>
+  <data name="FoundVersionsInSource" xml:space="preserve">
+    <value>Found {0} version(s) in {1} [ Nearest version: {2} ]</value>
+  </data>
+  <data name="FoundVersionsInSourceWithoutMatch" xml:space="preserve">
+    <value>Found {0} version(s) in {1}</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -47,13 +47,34 @@ namespace NuGet.Common
         NU1002 = 1002,
 
         /// <summary>
-        /// Unable to resolve package
-        /// TODO split this up into the following errors.
+        /// Unable to resolve package, generic message for unknown type constraints.
+        /// </summary>
+        NU1100 = 1100,
+        
+        /// <summary>
+        /// No versions of the package exist on any of the sources.
         /// </summary>
         NU1101 = 1101,
+
+        /// <summary>
+        /// Versions of the package exist, but none are in the range.
+        /// </summary>
         NU1102 = 1102,
+
+        /// <summary>
+        /// Range does not allow prerelease packages and only prerelease versions were found
+        /// within the range.
+        /// </summary>
         NU1103 = 1103,
+
+        /// <summary>
+        /// Project path does not exist on disk.
+        /// </summary>
         NU1104 = 1104,
+
+        /// <summary>
+        /// Project reference was not in the dg spec.
+        /// </summary>
         NU1105 = 1105,
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,13 +32,14 @@ namespace NuGet.Common
             Message = errorString;
             Time = DateTimeOffset.UtcNow;
 
+            var graphList = new List<string>();
+
             if (!string.IsNullOrEmpty(targetGraph))
             {
-                TargetGraphs = new List<string>
-                {
-                    targetGraph
-                };
+                graphList.Add(targetGraph);
             }
+
+            TargetGraphs = graphList;
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString)

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/IRemoteDependencyProvider.cs
@@ -11,6 +11,7 @@ using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace NuGet.DependencyResolver
 {
@@ -44,5 +45,11 @@ namespace NuGet.DependencyResolver
             SourceCacheContext cacheContext,
             ILogger logger,
             CancellationToken cancellationToken);
+
+        Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
+            string id,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token);
     }
 }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Providers/LocalDependencyProvider.cs
@@ -11,6 +11,7 @@ using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace NuGet.DependencyResolver
 {
@@ -69,6 +70,15 @@ namespace NuGet.DependencyResolver
             CancellationToken cancellationToken)
         {
             throw new NotSupportedException();
+        }
+
+        public Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(
+            string id,
+            SourceCacheContext cacheContext,
+            ILogger logger,
+            CancellationToken token)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1452,7 +1452,7 @@ namespace NuGet.Commands.FuncTest
                 var runtimeAssembly = runtimeAssemblies.FirstOrDefault();
 
                 // Assert
-                Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
+                Assert.Equal(1, logger.Warnings); // Warnings are combined on message
                 Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
@@ -1488,7 +1488,7 @@ namespace NuGet.Commands.FuncTest
                 var resultB = await commandB.ExecuteAsync();
 
                 // Assert
-                Assert.Equal(3, logger.Warnings); // We'll get the warning for each runtime and for the runtime-less restore.
+                Assert.Equal(1, logger.Warnings); // Warnings for all graphs are combined
                 Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
@@ -1620,7 +1620,7 @@ namespace NuGet.Commands.FuncTest
                 // Assert
                 Assert.False(result.Success);
 
-                Assert.Equal(3, logger.Errors);
+                Assert.Equal(1, logger.Errors);
                 Assert.Empty(result.CompatibilityCheckResults);
                 Assert.DoesNotContain("compatible with", logger.Messages);
                 Assert.Equal(1, unresolved.Count);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreProject2ProjectTests.cs
@@ -467,7 +467,7 @@ namespace NuGet.Commands.Test
 
                 // Assert
                 Assert.False(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                Assert.Contains("Unable to resolve", string.Join(Environment.NewLine, logger.Messages));
+                Assert.Contains("Unable to find project", string.Join(Environment.NewLine, logger.Messages));
                 Assert.Contains(projects[1].ProjectPath, string.Join(Environment.NewLine, logger.Messages));
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreCommandTests.cs
@@ -1055,7 +1055,7 @@ namespace NuGet.Commands.Test
                 // Assert
                 Assert.False(result.Success);
                 Assert.Equal(1, result.GetAllUnresolved().Count);
-                Assert.True(logger.ErrorMessages.Contains("NU1101: Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'."));
+                Assert.True(logger.ErrorMessages.Any(s => s.Contains("Unable to resolve 'project1 (>= 1.0.0)' for '.NETFramework,Version=v4.5'.")));
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -1,0 +1,428 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.DependencyResolver;
+using NuGet.LibraryModel;
+using NuGet.Protocol.Core.Types;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class UnresolvedMessagesTests
+    {
+        [Fact]
+        public async Task GivenAnUnresolvedProjectWithExistingProjectVerifyMessage()
+        {
+            using (var working = TestDirectory.Create())
+            {
+                var path = Path.Combine(working, "project.csproj");
+                File.WriteAllText(path, "test");
+
+                var range = new LibraryRange(path, VersionRange.All, LibraryDependencyTarget.ExternalProject);
+                var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0-beta"), NuGetVersion.Parse("4.4.0-beta.2+test") };
+
+                var message = await GetMessage(range, versions);
+
+                message.Code.Should().Be(NuGetLogCode.NU1105);
+                message.LibraryId.Should().Be(path);
+                message.Message.Should().Contain($"Unable to find project information for '{path}'");
+                message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+                message.Level.Should().Be(LogLevel.Error);
+            }
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedProjectWithNotFoundVerifyMessage()
+        {
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "notfound.csproj");
+            var range = new LibraryRange(path, VersionRange.All, LibraryDependencyTarget.ExternalProject);
+            var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0-beta"), NuGetVersion.Parse("4.4.0-beta.2+test") };
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1104);
+            message.LibraryId.Should().Be(path);
+            message.Message.Should().Contain($"Unable to find project '{path}'");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedReferenceVerifyMessage()
+        {
+            var range = new LibraryRange("x", VersionRange.All, LibraryDependencyTarget.Reference);
+            var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0-beta"), NuGetVersion.Parse("4.4.0-beta.2+test") };
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1100);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Contain("Unable to resolve 'reference/x ' for 'abc'");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedPackageWithPreRelVersionsAndPreRelRangeVerifyMessage()
+        {
+            var range = new LibraryRange("x", VersionRange.Parse("[4.0.0-beta, 5.0.0]"), LibraryDependencyTarget.Package);
+            var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0-beta"), NuGetVersion.Parse("4.4.0-beta.2+test") };
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1102);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Contain("Unable to find package x with version (>= 4.0.0-beta && <= 5.0.0)");
+            message.Message.Should().Contain("Found 2 version(s) in http://nuget.org/a/ [ Nearest version: 4.4.0-beta.2 ]");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedPackageWithPreRelVersionsVerifyMessage()
+        {
+            var range = new LibraryRange("x", VersionRange.Parse("[4.0.0, 5.0.0]"), LibraryDependencyTarget.Package);
+            var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0-beta"), NuGetVersion.Parse("4.4.0-beta.2+test") };
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1103);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Contain("Unable to find a stable package x with version (>= 4.0.0 && <= 5.0.0)");
+            message.Message.Should().Contain("Found 2 version(s) in http://nuget.org/a/ [ Nearest version: 4.4.0-beta.2 ]");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedPackageWithVersionsVerifyMessage()
+        {
+            var range = new LibraryRange("x", VersionRange.Parse("[4.0.0]"), LibraryDependencyTarget.Package);
+            var versions = new List<NuGetVersion>() { NuGetVersion.Parse("1.0.0"), NuGetVersion.Parse("5.0.0") };
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1102);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Contain("Unable to find package x with version (= 4.0.0)");
+            message.Message.Should().Contain("Found 2 version(s) in http://nuget.org/a/ [ Nearest version: 5.0.0 ]");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedPackageWithNoVersionsAndMultipleSourcesVerifyMessage()
+        {
+            var range = new LibraryRange("x", LibraryDependencyTarget.Package);
+            var versions = new List<NuGetVersion>();
+
+            var token = CancellationToken.None;
+            var logger = new TestLogger();
+            var provider1 = GetProvider("http://nuget.org/a/", versions);
+            var provider2 = GetProvider("http://nuget.org/b/", versions);
+            var cacheContext = new Mock<SourceCacheContext>();
+            var remoteWalkContext = new RemoteWalkContext(cacheContext.Object, NullLogger.Instance);
+            remoteWalkContext.RemoteLibraryProviders.Add(provider1.Object);
+            remoteWalkContext.RemoteLibraryProviders.Add(provider2.Object);
+            var graph = new Mock<IRestoreTargetGraph>();
+            graph.SetupGet(e => e.Name).Returns("abc");
+
+            var message = await UnresolvedMessages.GetMessageAsync(graph.Object, range, remoteWalkContext, logger, token);
+
+            message.Code.Should().Be(NuGetLogCode.NU1101);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Be("Unable to find package x. No packages exist with this id in source(s): http://nuget.org/a/, http://nuget.org/b/");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAnUnresolvedPackageWithNoVersionsVerifyMessage()
+        {
+            var range = new LibraryRange("x", LibraryDependencyTarget.Package);
+            var versions = new List<NuGetVersion>();
+
+            var message = await GetMessage(range, versions);
+
+            message.Code.Should().Be(NuGetLogCode.NU1101);
+            message.LibraryId.Should().Be("x");
+            message.Message.Should().Be("Unable to find package x. No packages exist with this id in source(s): http://nuget.org/a/");
+            message.TargetGraphs.ShouldBeEquivalentTo(new[] { "abc" });
+            message.Level.Should().Be(LogLevel.Error);
+        }
+
+        [Fact]
+        public async Task GivenAMultipleSourcesVerifyInfosReturned()
+        {
+            var versions1 = new[]
+            {
+                NuGetVersion.Parse("1.0.0"),
+                NuGetVersion.Parse("2.0.0"),
+                NuGetVersion.Parse("3.0.0-beta"),
+            };
+
+            var versions2 = new[]
+            {
+                NuGetVersion.Parse("1.0.0")
+            };
+
+            var provider1 = GetProvider("http://nuget.org/a/", versions1);
+            var provider2 = GetProvider("http://nuget.org/b/", versions2);
+
+            var cacheContext = new Mock<SourceCacheContext>();
+            var remoteWalkContext = new RemoteWalkContext(cacheContext.Object, NullLogger.Instance);
+            remoteWalkContext.RemoteLibraryProviders.Add(provider1.Object);
+            remoteWalkContext.RemoteLibraryProviders.Add(provider2.Object);
+
+            var infos = await UnresolvedMessages.GetSourceInfosForIdAsync("a", VersionRange.Parse("1.0.0"), remoteWalkContext, NullLogger.Instance, CancellationToken.None);
+
+            infos.Count.Should().Be(2);
+            infos[0].Value.ShouldBeEquivalentTo(versions1);
+            infos[1].Value.ShouldBeEquivalentTo(versions2);
+            infos[0].Key.Source.Should().Be("http://nuget.org/a/");
+            infos[1].Key.Source.Should().Be("http://nuget.org/b/");
+        }
+
+        [Fact]
+        public async Task GivenAnEmptySourceVerifySourceInfoContainsAllVersions()
+        {
+            var versions = new[]
+            {
+                NuGetVersion.Parse("1.0.0"),
+                NuGetVersion.Parse("2.0.0"),
+                NuGetVersion.Parse("3.0.0-beta"),
+            };
+
+            var source = new PackageSource("http://nuget.org/a/");
+            var context = new Mock<SourceCacheContext>();
+            var provider = new Mock<IRemoteDependencyProvider>();
+            provider.Setup(e => e.GetAllVersionsAsync(It.IsAny<string>(), It.IsAny<SourceCacheContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => versions);
+            provider.SetupGet(e => e.Source).Returns(source);
+
+            var info = await UnresolvedMessages.GetSourceInfoForIdAsync(provider.Object, "a", context.Object, NullLogger.Instance, CancellationToken.None);
+
+            info.Value.ShouldBeEquivalentTo(versions);
+            info.Key.Source.Should().Be(source.Source);
+        }
+
+        [Fact]
+        public async Task GivenAnEmptySourceVerifySourceInfoContainsNoVersions()
+        {
+            var source = new PackageSource("http://nuget.org/a/");
+            var context = new Mock<SourceCacheContext>();
+            var provider = new Mock<IRemoteDependencyProvider>();
+            provider.Setup(e => e.GetAllVersionsAsync(It.IsAny<string>(), It.IsAny<SourceCacheContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => Enumerable.Empty<NuGetVersion>());
+            provider.SetupGet(e => e.Source).Returns(source);
+
+            var info = await UnresolvedMessages.GetSourceInfoForIdAsync(provider.Object, "a", context.Object, NullLogger.Instance, CancellationToken.None);
+
+            info.Value.Should().BeEmpty();
+            info.Key.Source.Should().Be(source.Source);
+        }
+
+        [Fact]
+        public void GivenARangeWithExclusiveBoundsVerifyExactMatchesCanStillBeSelected()
+        {
+            var range = VersionRange.Parse("(1.0.0, 2.0.0)");
+            var versions = new SortedSet<NuGetVersion>()
+            {
+                NuGetVersion.Parse("1.0.0"),
+                NuGetVersion.Parse("2.0.0")
+            };
+
+            UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse("1.0.0"));
+        }
+
+        [Fact]
+        public void GivenARangeWithExclusiveBoundsVerifyExactMatchesCanStillBeSelectedForUpper()
+        {
+            var range = VersionRange.Parse("(1.0.0, 2.0.0)");
+            var versions = new SortedSet<NuGetVersion>()
+            {
+                NuGetVersion.Parse("2.0.0")
+            };
+
+            UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse("2.0.0"));
+        }
+
+        [Theory]
+        // in the range first
+        [InlineData("1.0.0", "0.1.0,1.0.0,3.0.0,4.0.0")]
+        // then above the range
+        [InlineData("3.0.0", "0.1.0,0.2.0,3.0.0,4.0.0")]
+        // include prerelease also
+        [InlineData("3.0.0-beta", "0.1.0,0.2.0,3.0.0-beta,3.0.0,4.0.0")]
+        [InlineData("4.0.0", "0.1.0,0.2.0,4.0.0")]
+        // then below the range
+        [InlineData("0.2.0", "0.1.0,0.2.0")]
+        [InlineData("0.1.0-beta", "0.1.0-beta")]
+        public void GivenRangeOf1To2VerifyBestMatch(string expected, string versionStrings)
+        {
+            var range = VersionRange.Parse("[1.0.0, 2.0.0]");
+            var versions = new SortedSet<NuGetVersion>(versionStrings.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(NuGetVersion.Parse));
+
+            UnresolvedMessages.GetBestMatch(versions, range).ShouldBeEquivalentTo(NuGetVersion.Parse(expected));
+        }
+
+        [Fact]
+        public void GivenNoVersionsVerifyBestMatch()
+        {
+            var range = VersionRange.Parse("2.0.0");
+            var versions = new SortedSet<NuGetVersion>();
+
+            UnresolvedMessages.GetBestMatch(versions, range).Should().BeNull();
+        }
+
+        [Fact]
+        public void GivenASourceInfoVerifyFullFormatting()
+        {
+            var range = VersionRange.Parse("2.0.0");
+            var sourceInfo = new KeyValuePair<PackageSource, SortedSet<NuGetVersion>>(
+                key: new PackageSource("http://nuget.org/a/"),
+                value: new SortedSet<NuGetVersion>()
+                {
+                    NuGetVersion.Parse("1.0.0")
+                });
+
+            var s = UnresolvedMessages.FormatSourceInfo(sourceInfo, range);
+
+            s.Should().Be("Found 1 version(s) in http://nuget.org/a/ [ Nearest version: 1.0.0 ]");
+        }
+
+        [Fact]
+        public void GivenASourceInfoWithNoVersionsVerifyOutputString()
+        {
+            var range = VersionRange.Parse("2.0.0");
+            var sourceInfo = new KeyValuePair<PackageSource, SortedSet<NuGetVersion>>(
+                key: new PackageSource("http://nuget.org/a/"),
+                value: new SortedSet<NuGetVersion>());
+
+            var s = UnresolvedMessages.FormatSourceInfo(sourceInfo, range);
+
+            s.Should().Be("Found 0 version(s) in http://nuget.org/a/");
+        }
+
+        [Theory]
+        [InlineData("1.0.0")]
+        [InlineData("[1.0.0]")]
+        [InlineData("(1.0.0, 2.0.0)")]
+        [InlineData("1.0.*")]
+        public void GivenAStableRangeVerifyIsPrereleaseAllowedFalse(string s)
+        {
+            var range = VersionRange.Parse(s);
+
+            UnresolvedMessages.IsPrereleaseAllowed(range).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("1.0.0-a")]
+        [InlineData("[1.0.0-b]")]
+        [InlineData("(1.0.0-a, 2.0.0)")]
+        [InlineData("(1.0.0, 2.0.0-a)")]
+        [InlineData("1.0.0-*")]
+        [InlineData("1.0.0-beta.*")]
+        public void GivenAStableRangeVerifyIsPrereleaseAllowedTrue(string s)
+        {
+            var range = VersionRange.Parse(s);
+
+            UnresolvedMessages.IsPrereleaseAllowed(range).Should().BeTrue();
+        }
+
+        public void GivenANullRangeVerifyIsPrereleaseAllowedFalse(string s)
+        {
+            UnresolvedMessages.IsPrereleaseAllowed(null).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenAPreRelRangeAndAPreRelVersionInRangeVerifyHasPrereleaseVersionsOnlyTrue()
+        {
+            var range = VersionRange.Parse("( , 2.0.0-alpha)");
+            var versions = new[] { NuGetVersion.Parse("1.0.1-beta") };
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, versions).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenAStableRangeAndAPreRelVersionInRangeVerifyHasPrereleaseVersionsOnlyTrue()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var versions = new[] { NuGetVersion.Parse("1.0.1-beta") };
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, versions).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenAStableRangeAndAStableVersionInRangeVerifyHasPrereleaseVersionsOnlyFalse()
+        {
+            var range = VersionRange.Parse("1.0.0");
+            var versions = new[] { NuGetVersion.Parse("1.0.0") };
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, versions).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenAStableRangeAndNoVersionsVerifyHasPrereleaseVersionsOnlyFalse()
+        {
+            var range = VersionRange.Parse("1.0.0");
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, new List<NuGetVersion>()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenAStableRangeAndAStableVersionOutOfRangeVerifyHasPrereleaseVersionsOnlyFalse()
+        {
+            var range = VersionRange.Parse("2.0.0");
+            var versions = new[] { NuGetVersion.Parse("1.0.0") };
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, versions).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenAStableRangeAndAPreRelVersionOutOfRangeVerifyHasPrereleaseVersionsOnlyFalse()
+        {
+            var range = VersionRange.Parse("2.0.0");
+            var versions = new[] { NuGetVersion.Parse("1.0.0-beta") };
+
+            UnresolvedMessages.HasPrereleaseVersionsOnly(range, versions).Should().BeFalse();
+        }
+
+        private static Mock<IRemoteDependencyProvider> GetProvider(string source, IEnumerable<NuGetVersion> versions)
+        {
+            var provider = new Mock<IRemoteDependencyProvider>();
+            provider.Setup(e => e.GetAllVersionsAsync(It.IsAny<string>(), It.IsAny<SourceCacheContext>(), It.IsAny<ILogger>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => versions);
+            provider.SetupGet(e => e.Source).Returns(new PackageSource(source));
+
+            return provider;
+        }
+
+        private static async Task<RestoreLogMessage> GetMessage(LibraryRange range, List<NuGetVersion> versions)
+        {
+            var token = CancellationToken.None;
+            var logger = new TestLogger();
+            var provider = GetProvider("http://nuget.org/a/", versions);
+            var cacheContext = new Mock<SourceCacheContext>();
+            var remoteWalkContext = new RemoteWalkContext(cacheContext.Object, NullLogger.Instance);
+            remoteWalkContext.RemoteLibraryProviders.Add(provider.Object);
+            var graph = new Mock<IRestoreTargetGraph>();
+            graph.SetupGet(e => e.Name).Returns("abc");
+
+            var message = await UnresolvedMessages.GetMessageAsync(graph.Object, range, remoteWalkContext, logger, token);
+            return message;
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -30,7 +30,7 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndColumnNumber);
             if (string.IsNullOrEmpty(targetGraph))
             {
-                Assert.Null(logMessage.TargetGraphs);
+                Assert.Equal(0, logMessage.TargetGraphs.Count);
             }
             else
             {
@@ -87,7 +87,7 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndLineNumber);
             Assert.Equal(-1, logMessage.StartColumnNumber);
             Assert.Equal(-1, logMessage.EndColumnNumber);
-            Assert.Null(logMessage.TargetGraphs);
+            Assert.Equal(0, logMessage.TargetGraphs.Count);
         }
 
         [Theory]
@@ -107,7 +107,7 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndLineNumber);
             Assert.Equal(-1, logMessage.StartColumnNumber);
             Assert.Equal(-1, logMessage.EndColumnNumber);
-            Assert.Null(logMessage.TargetGraphs);
+            Assert.Equal(0, logMessage.TargetGraphs.Count);
         }
 
 
@@ -127,7 +127,6 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndLineNumber);
             Assert.Equal(-1, logMessage.StartColumnNumber);
             Assert.Equal(-1, logMessage.EndColumnNumber);
-            Assert.NotNull(logMessage.TargetGraphs);
             targetGraphs.SequenceEqual(logMessage.TargetGraphs);
         }
 
@@ -147,7 +146,6 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndLineNumber);
             Assert.Equal(-1, logMessage.StartColumnNumber);
             Assert.Equal(-1, logMessage.EndColumnNumber);
-            Assert.NotNull(logMessage.TargetGraphs);
             targetGraphs.SequenceEqual(logMessage.TargetGraphs);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/RemoteDependencyWalkerTests.cs
@@ -853,6 +853,11 @@ namespace NuGet.DependencyResolver.Tests
                 return Task.FromResult(packages.FindBestMatch(libraryRange.VersionRange, i => i?.Version));
             }
 
+            public Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, ILogger logger, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<LibraryDependencyInfo> GetDependenciesAsync(
                 LibraryIdentity match,
                 NuGetFramework targetFramework,

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/ResolverFacts.cs
@@ -153,6 +153,11 @@ namespace NuGet.DependencyResolver.Core.Tests
             {
                 return Task.FromResult(LibraryDependencyInfo.Create(match, targetFramework, Enumerable.Empty<LibraryDependency>()));
             }
+
+            public Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, SourceCacheContext cacheContext, ILogger logger, CancellationToken token)
+            {
+                return Task.FromResult(_libraries.Select(e => e.Version));
+            }
         }
     }
 }


### PR DESCRIPTION
Adding new error codes and text for scenarios where packages cannot be found during restore.
* No versions of a package exist
* No stable versions of a package exist
* No versions fit the dependency range
* The project was not found

### Examples
#### Package does not exist anywhere

```
NU1101: Unable to find package System.Missing. No packages exist with this id in source(s): dotnet-buildtools, dotnet-core, dotnet-roslyn, NuGet.org, NuGetVolatile
```

#### Package version is not within the range
```
NU1102: Unable to find package NuGet.Versioning with version (>= 9.0.1)
  - Found 30 version(s) in NuGet.org [ Nearest version: 4.0.0 ]
  - Found 10 version(s) in dotnet-buildtools [ Nearest version: 4.0.0-rc-2129 ]
  - Found 9 version(s) in NuGetVolatile [ Nearest version: 3.0.0-beta-00032 ]
  - Found 0 version(s) in dotnet-core
  - Found 0 version(s) in dotnet-roslyn
```
Fixes https://github.com/NuGet/Home/issues/2730

//cc @rrelyea @anangaur 