### PR TITLE
Avoid downgrade warnings for projects

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -504,7 +504,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}.
+        ///   Looks up a localized string similar to Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version..
         /// </summary>
         internal static string Log_DowngradeWarning {
             get {
@@ -927,7 +927,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Version conflict detected for {0}..
+        ///   Looks up a localized string similar to Version conflict detected for {0}. Reference the package directly from the project to resolve this issue..
         /// </summary>
         internal static string Log_VersionConflict {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -204,10 +204,10 @@
     <value>Cycle detected:</value>
   </data>
   <data name="Log_DowngradeWarning" xml:space="preserve">
-    <value>Detected package downgrade: {0} from {1} to {2}</value>
+    <value>Detected package downgrade: {0} from {1} to {2}. Reference the package directly from the project to select a different version.</value>
   </data>
   <data name="Log_VersionConflict" xml:space="preserve">
-    <value>Version conflict detected for {0}.</value>
+    <value>Version conflict detected for {0}. Reference the package directly from the project to resolve this issue.</value>
   </data>
   <data name="Error_UnknownBuildAction" xml:space="preserve">
     <value>Package '{0}' specifies an invalid build action '{1}' for file '{2}'.</value>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Frameworks;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class RestoreMessageTest
+    {
+        [Fact]
+        public void GivenAProjectIsUsedOverAPackageVerifyNoDowngradeWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard1.5"));
+
+                var projectB = SimpleTestProjectContext.CreateNETCore(
+                    "b",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard1.5"));
+
+                // A -> B
+                projectA.AddProjectToAllFrameworks(projectB);
+
+                var packageX = new SimpleTestPackageContext("x", "9.0.0");
+                var packageB = new SimpleTestPackageContext("b", "9.0.0");
+                packageX.Dependencies.Add(packageB);
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageX, packageB);
+
+                // PackageB will be overridden by ProjectB
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Projects.Add(projectB);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.Restore(pathContext, projectA.ProjectPath);
+                var output = r.Item2 + " " + r.Item3;
+
+                // Assert
+                Assert.DoesNotContain("downgrade", output, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void GivenAPackageDowngradeVerifyDowngradeWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("NETStandard1.5"));
+
+                var packageB = new SimpleTestPackageContext("b", "9.0.0");
+                var packageI1 = new SimpleTestPackageContext("i", "9.0.0");
+                var packageI2 = new SimpleTestPackageContext("i", "1.0.0");
+                packageB.Dependencies.Add(packageI1);
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageB, packageI1, packageI2);
+
+                projectA.AddPackageToAllFrameworks(packageB);
+                projectA.AddPackageToAllFrameworks(packageI2);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // Act
+                var r = Util.Restore(pathContext, projectA.ProjectPath);
+                var output = r.Item2 + " " + r.Item3;
+
+                // Assert
+                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", output, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Skip downgrade warnings for non-packages
* Adding text to suggest referencing the package top level for conflicts and downgrade warnings to make these errors actionable
* De-dupe downgrade warnings across graphs when the messages are the same.

Fixes https://github.com/NuGet/Home/issues/4620