### PR TITLE
ILogException support for logging exceptions with error codes

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -104,7 +104,7 @@ namespace NuGet.Build.Tasks.Pack
             }
             catch (Exception ex)
             {
-                ExceptionUtilities.HandleException(ex, Logger);
+                ExceptionUtilities.LogException(ex, Logger);
                 return false;
             }
             

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -98,7 +98,7 @@ namespace NuGet.Build.Tasks
             }
             catch (Exception e)
             {
-                ExceptionUtilities.HandleException(e, log);
+                ExceptionUtilities.LogException(e, log);
                 return false;
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -92,7 +92,7 @@ namespace NuGet.Commands
                 logger.LogErrorSummary(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
                 foreach (var error in restoreSummary.Errors)
                 {
-                    foreach (var line in IndentLines(error.FormatMessage()))
+                    foreach (var line in IndentLines(error.Message))
                     {
                         logger.LogErrorSummary(line);
                     }

--- a/src/NuGet.Core/NuGet.Common/Errors/ILogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/ILogMessage.cs
@@ -1,8 +1,7 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 
 namespace NuGet.Common
 {
@@ -38,17 +37,5 @@ namespace NuGet.Common
         /// Indicates the date time at which the error occurred.
         /// </summary>
         DateTimeOffset Time { get; set; }
-
-        /// <summary>
-        /// Converts the ILogMessage into a string that can be logged as-is into a Console.
-        /// </summary>
-        /// <returns>The string representation of the ILogMessage.</returns>
-        string FormatMessage();
-
-        /// <summary>
-        /// Converts the ILogMessage into a string that can be logged as-is into a Console.
-        /// </summary>
-        /// <returns>The string representation of the ILogMessage.</returns>
-        Task<string> FormatMessageAsync();
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/ILogMessageException.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/ILogMessageException.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace NuGet.Common
+{
+    /// <summary>
+    /// Allows converting an Exception to an ILogMessage.
+    /// </summary>
+    public interface ILogMessageException
+    {
+        /// <summary>
+        /// Retrieve the exception as a log message.
+        /// </summary>
+        ILogMessage AsLogMessage();
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
@@ -32,15 +32,7 @@ namespace NuGet.Common
 
         public string FormatMessage()
         {
-            // Only errors and warnings need codes. informational do not need codes.
-            if (Level >= LogLevel.Warning)
-            {
-                return $"{Enum.GetName(typeof(NuGetLogCode), Code)}: {Message}";
-            }
-            else
-            {
-                return Message;
-            }
+            return Message;
         }
 
         public Task<string> FormatMessageAsync()

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace NuGet.Common
+{
+    /// <summary>
+    /// Basic log message.
+    /// </summary>
+    public class LogMessage : ILogMessage
+    {
+        public LogLevel Level { get; set; }
+        public WarningLevel WarningLevel { get; set; }
+        public NuGetLogCode Code { get; set; }
+        public string Message { get; set; }
+        public string ProjectPath { get; set; }
+        public DateTimeOffset Time { get; set; } = DateTimeOffset.UtcNow;
+
+        public LogMessage(LogLevel level, string message, NuGetLogCode code)
+            : this(level, message)
+        {
+            Code = code;
+        }
+
+        public LogMessage(LogLevel level, string message)
+        {
+            Level = level;
+            Message = message;
+        }
+
+        public string FormatMessage()
+        {
+            // Only errors and warnings need codes. informational do not need codes.
+            if (Level >= LogLevel.Warning)
+            {
+                return $"{Enum.GetName(typeof(NuGetLogCode), Code)}: {Message}";
+            }
+            else
+            {
+                return Message;
+            }
+        }
+
+        public Task<string> FormatMessageAsync()
+        {
+            return Task.FromResult(FormatMessage());
+        }
+
+        public override string ToString()
+        {
+            return FormatMessage();
+        }
+
+        public static LogMessage CreateError(NuGetLogCode code, string message)
+        {
+            return new LogMessage(LogLevel.Error, message, code);
+        }
+
+        public static LogMessage CreateWarning(NuGetLogCode code, string message)
+        {
+            return new LogMessage(LogLevel.Warning, message, code);
+        }
+
+        public static LogMessage Create(LogLevel level, string message)
+        {
+            return new LogMessage(level, message);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 
 namespace NuGet.Common
 {
@@ -30,19 +29,9 @@ namespace NuGet.Common
             Message = message;
         }
 
-        public string FormatMessage()
-        {
-            return Message;
-        }
-
-        public Task<string> FormatMessageAsync()
-        {
-            return Task.FromResult(FormatMessage());
-        }
-
         public override string ToString()
         {
-            return FormatMessage();
+            return Message;
         }
 
         public static LogMessage CreateError(NuGetLogCode code, string message)

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -156,5 +156,10 @@ namespace NuGet.Common
         /// Feed error converted to a warning when ignoreFailedSources is true.
         /// </summary>
         NU1801 = 1801,
+
+        /// <summary>
+        /// Package MinClientVersion did not match.
+        /// </summary>
+        NU1901 = 1901,
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -32,6 +32,11 @@ namespace NuGet.Common
     public enum NuGetLogCode
     {
         /// <summary>
+        /// Do not display the code.
+        /// </summary>
+        Undefined = 0,
+
+        /// <summary>
         /// Undefined error
         /// </summary>
         NU1000 = 1000,

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -52,24 +52,6 @@ namespace NuGet.Common
         {
         }
 
-        public string FormatMessage()
-        {
-            // Only errors and warnings need codes. informational do not need codes.
-            if(Level >= LogLevel.Warning)
-            {
-                return $"{Enum.GetName(typeof(NuGetLogCode), Code)}: {Message}";
-            }
-            else
-            {
-                return Message;
-            }
-        }
-
-        public Task<string> FormatMessageAsync()
-        {
-            return Task.FromResult(FormatMessage());
-        }
-
         /// <summary>
         /// Create a log message for a target graph library.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
@@ -14,20 +14,42 @@ namespace NuGet.Common
     /// </summary>
     public static class ExceptionUtilities
     {
-        public static void HandleException(Exception ex, ILogger logger)
+        /// <summary>
+        /// Log an exception to an ILogger.
+        /// This will log using NU1000 if the exception does not contain a code.
+        /// </summary>
+        public static void LogException(Exception ex, ILogger logger)
         {
+            LogException(ex, logger, logStackAsError: false);
+        }
+
+        /// <summary>
+        /// Log an exception to an ILogger.
+        /// This will log using NU1000 if the exception does not contain a code.
+        /// </summary>
+        public static void LogException(Exception ex, ILogger logger, bool logStackAsError)
+        {
+            // Unwrap aggregate exceptions.
+            var unwrappedException = Unwrap(ex);
+
             // Log the error
-            if (ExceptionLogger.Instance.ShowStack)
+            var logExceptionMessage = unwrappedException as ILogMessageException;
+            if (logExceptionMessage != null)
             {
-                logger.LogError(ex.ToString());
+                // Log the log message itself.
+                var logMessage = logExceptionMessage.AsLogMessage();
+                logger.Log(logMessage);
             }
             else
             {
-                logger.LogError(ExceptionUtilities.DisplayMessage(ex));
+                // Create a string from the exception.
+                logger.Log(new LogMessage(LogLevel.Error, DisplayMessage(unwrappedException)));
             }
 
-            // Log the stack trace as verbose output.
-            logger.LogVerbose(ex.ToString());
+            // Log the stack as an error if ShowStack is set.
+            var stackLevel = (logStackAsError || ExceptionLogger.Instance.ShowStack) ? LogLevel.Error : LogLevel.Verbose;
+
+            logger.Log(LogMessage.Create(stackLevel, unwrappedException.StackTrace.ToString()));
         }
 
         public static string DisplayMessage(Exception exception, bool indent)

--- a/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
+++ b/src/NuGet.Core/NuGet.Common/ExceptionUtilities.cs
@@ -49,7 +49,7 @@ namespace NuGet.Common
             // Log the stack as an error if ShowStack is set.
             var stackLevel = (logStackAsError || ExceptionLogger.Instance.ShowStack) ? LogLevel.Error : LogLevel.Verbose;
 
-            logger.Log(LogMessage.Create(stackLevel, unwrappedException.StackTrace.ToString()));
+            logger.Log(LogMessage.Create(stackLevel, unwrappedException.ToString()));
         }
 
         public static string DisplayMessage(Exception exception, bool indent)

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -39,7 +39,7 @@ namespace NuGet.Common
         {
             if (CollectMessage(message.Level))
             {
-                _errors.Enqueue(message as RestoreLogMessage);
+                _errors.Enqueue(new RestoreLogMessage(message.Level, message.Code, message.Message));
             }
 
             _innerLogger.Log(message);
@@ -49,7 +49,7 @@ namespace NuGet.Common
         {
             if (CollectMessage(message.Level))
             {
-                _errors.Enqueue(message as RestoreLogMessage);
+                _errors.Enqueue(new RestoreLogMessage(message.Level, message.Code, message.Message));
             }
 
             return _innerLogger.LogAsync(message);

--- a/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LegacyLoggerAdapter.cs
@@ -63,14 +63,12 @@ namespace NuGet.Common
 
         public void Log(ILogMessage message)
         {
-            Log(message.Level, message.FormatMessage());
+            Log(message.Level, message.Message);
         }
 
         public async Task LogAsync(ILogMessage message)
         {
-            var data = await message.FormatMessageAsync();
-
-            await LogAsync(message.Level, data);
+            await LogAsync(message.Level, message.Message);
         }
 
         public abstract void LogDebug(string data);

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -7,7 +7,7 @@ namespace NuGet.Common
 {
     public abstract class LoggerBase : ILogger
     {
-        public LogLevel VerbosityLevel { get; private set; } = LogLevel.Debug;
+        public LogLevel VerbosityLevel { get; set; } = LogLevel.Debug;
 
         public LoggerBase()
         {
@@ -26,7 +26,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                Log(new RestoreLogMessage(level, data));
+                Log(new LogMessage(level, data));
             }
         }
 
@@ -34,7 +34,7 @@ namespace NuGet.Common
         {
             if (DisplayMessage(level))
             {
-                return LogAsync(new RestoreLogMessage(level, data));
+                return LogAsync(new LogMessage(level, data));
             }
 
             return Task.FromResult(true);

--- a/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/ProjectContextLogger.cs
@@ -23,19 +23,20 @@ namespace NuGet.PackageManagement
             {
                 var messageLevel = LogLevelToMessageLevel(message.Level);
 
-                _projectContext.Log(messageLevel, message.FormatMessage());
+                _projectContext.Log(messageLevel, message.Message);
             }
         }
 
-        public override async Task LogAsync(ILogMessage message)
+        public override Task LogAsync(ILogMessage message)
         {
             if (DisplayMessage(message.Level))
             {
                 var messageLevel = LogLevelToMessageLevel(message.Level);
-                var text = await message.FormatMessageAsync();
 
-                _projectContext.Log(messageLevel, text);
+                _projectContext.Log(messageLevel, message.Message);
             }
+
+            return Task.FromResult(0);
         }
 
         private static MessageLevel LogLevelToMessageLevel(LogLevel level)

--- a/src/NuGet.Core/NuGet.Packaging/Exceptions/MinClientVersionException.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Exceptions/MinClientVersionException.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 
 namespace NuGet.Packaging
@@ -9,11 +9,16 @@ namespace NuGet.Packaging
     /// <summary>
     /// Custom exception type for a package that has a higher minClientVersion than the current client.
     /// </summary>
-    public class MinClientVersionException : PackagingException
+    public class MinClientVersionException : PackagingException, ILogMessageException
     {
         public MinClientVersionException(string message)
             : base(message)
         {
+        }
+
+        public ILogMessage AsLogMessage()
+        {
+            return LogMessage.CreateError(NuGetLogCode.NU1901, Message);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -62,8 +62,7 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
             var hostName = Guid.NewGuid().ToString();
             var fullHostName = "https://" + hostName + "/";
-            var expected = "System.AggregateException: One or more errors occurred. ---> " +
-                           "NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load the service index for source " +
+            var expected = "NuGet.Protocol.Core.Types.FatalProtocolException: Unable to load the service index for source " +
                            $"{fullHostName}";
 
             var args = new[] { "list", "-Source", fullHostName };
@@ -80,7 +79,7 @@ namespace NuGet.CommandLine.Test
                 });
 
             // Assert
-            Assert.Contains(expected, result.Item3);
+            Assert.Contains(expected, result.Item2 + " " + result.Item3);
             Assert.NotEqual(0, result.Item1);
         }
 
@@ -110,7 +109,7 @@ namespace NuGet.CommandLine.Test
                 });
 
             // Assert
-            Assert.Contains(expected, result.Item3);
+            Assert.Contains(expected, result.Item2 + " " + result.Item3);
             Assert.NotEqual(0, result.Item1);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1280,10 +1280,12 @@ namespace NuGet.CommandLine.Test
                         });
                     server.Stop();
 
+                    var output = r1.Item2 + " " + r1.Item3;
+
                     // Assert
-                    Assert.True(1 == r1.Item1, r1.Item2 + " " + r1.Item3);
-                    Assert.Contains("401 (Unauthorized)", r1.Item3);
-                    Assert.Contains($"Credential plugin {pluginPath} timed out", r1.Item2);
+                    Assert.True(1 == r1.Item1, output);
+                    Assert.Contains("401 (Unauthorized)", output);
+                    Assert.Contains($"Credential plugin {pluginPath} timed out", output);
                     // ensure the process was killed
                     Assert.Equal(0, System.Diagnostics.Process.GetProcessesByName(Path.GetFileNameWithoutExtension(pluginPath)).Length);
                     // No requests hit server, since abort during credential acquisition

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1210,8 +1210,8 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.Equal(1, r1.Item1);
-                    Assert.Contains("401 (Unauthorized)", r1.Item3);
-                    Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Item2);
+                    Assert.Contains("401 (Unauthorized)", r1.Item2 + " " + r1.Item3);
+                    Assert.Contains($"Credential plugin {pluginPath} handles this request, but is unable to provide credentials. Testing abort.", r1.Item2 + " " + r1.Item3);
 
                     // No requests hit server, since abort during credential acquisition
                     // and no fallback to console provider

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1453,7 +1453,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(1, logger.Warnings); // Warnings are combined on message
-                Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
+                Assert.Contains("TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
 
@@ -1489,7 +1489,7 @@ namespace NuGet.Commands.FuncTest
 
                 // Assert
                 Assert.Equal(1, logger.Warnings); // Warnings for all graphs are combined
-                Assert.Contains("NU1603: TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
+                Assert.Contains("TestProject depends on Newtonsoft.Json (>= 7.0.0) but Newtonsoft.Json 7.0.0 was not found. An approximate best match of Newtonsoft.Json 7.0.1 was resolved.", logger.Messages);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/ProjectResolutionTests.cs
@@ -201,7 +201,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
                 Assert.Equal(1, logger.ErrorMessages.Count());
 
-                Assert.Equal("NU1201: Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
+                Assert.Contains("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
 
                 // Incompatible projects are marked as Unsupported
                 Assert.Equal(NuGetFramework.UnsupportedFramework.DotNetFrameworkName, project2Lib.Framework);
@@ -383,7 +383,7 @@ namespace NuGet.Commands.Test
                 Assert.Equal("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", issue.Format());
                 Assert.Equal(1, logger.ErrorMessages.Count());
 
-                Assert.Equal("NU1201: Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
+                Assert.Contains("Project project2 is not compatible with net45 (.NETFramework,Version=v4.5). Project project2 supports: net46 (.NETFramework,Version=v4.6)", logger.ErrorMessages.Last());
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnexpectedDependencyMessagesTests.cs
@@ -103,10 +103,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().NotContain("NU1604");
-            testLogger.ShowMessages().Should().Contain("NU1601");
-            testLogger.ShowMessages().Should().NotContain("NU1602");
-            testLogger.ShowMessages().Should().NotContain("NU1603");
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1604);
+            testLogger.LogMessages.Select(e => e.Code).Should().Contain(NuGetLogCode.NU1601);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1602);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1603);
         }
 
         [Fact]
@@ -137,10 +137,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().NotContain("NU1604");
-            testLogger.ShowMessages().Should().NotContain("NU1601");
-            testLogger.ShowMessages().Should().Contain("NU1602");
-            testLogger.ShowMessages().Should().NotContain("NU1603");
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1604);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1601);
+            testLogger.LogMessages.Select(e => e.Code).Should().Contain(NuGetLogCode.NU1602);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1603);
         }
 
         [Fact]
@@ -171,10 +171,10 @@ namespace NuGet.Commands.Test
 
             await UnexpectedDependencyMessages.LogAsync(targetGraphs, project, testLogger);
 
-            testLogger.ShowMessages().Should().Contain("NU1604");
-            testLogger.ShowMessages().Should().NotContain("NU1601");
-            testLogger.ShowMessages().Should().NotContain("NU1602");
-            testLogger.ShowMessages().Should().NotContain("NU1603");
+            testLogger.LogMessages.Select(e => e.Code).Should().Contain(NuGetLogCode.NU1604);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1601);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1602);
+            testLogger.LogMessages.Select(e => e.Code).Should().NotContain(NuGetLogCode.NU1603);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -143,9 +143,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.Empty(errorsStart);
-            Assert.Equal(new[] { "NU1000: ErrorA" }, errorsA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errorsAbc.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1000: ErrorA", "NU1000: ErrorB", "NU1000: ErrorC" }, errordEnd.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "ErrorA" }, errorsA.Select(e => e.Message));
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errorsAbc.Select(e => e.Message));
+            Assert.Equal(new[] { "ErrorA", "ErrorB", "ErrorC" }, errordEnd.Select(e => e.Message));
         }
 
         [Fact]
@@ -166,9 +166,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.Empty(warningsStart);
-            Assert.Equal(new[] { "NU1500: WarningA" }, warningA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1500: WarningA", "NU1500: WarningB", "NU1500: WarningC" }, warningAbc.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1500: WarningA", "NU1500: WarningB", "NU1500: WarningC" }, warningsEnd.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "WarningA" }, warningA.Select(e => e.Message));
+            Assert.Equal(new[] { "WarningA", "WarningB", "WarningC" }, warningAbc.Select(e => e.Message));
+            Assert.Equal(new[] { "WarningA", "WarningB", "WarningC" }, warningsEnd.Select(e => e.Message));
         }
 
         [Fact]
@@ -191,9 +191,9 @@ namespace NuGet.Common.Test
 
             // Assert
             Assert.Empty(warningsStart);
-            Assert.Equal(new[] { "NU1500: WarningA" }, warningA.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1500: WarningA", "NU1500: WarningB", "NU1500: WarningC" }, warningAbc.Select(e => e.FormatMessage()));
-            Assert.Equal(new[] { "NU1500: WarningA", "NU1500: WarningB", "NU1500: WarningC" }, warningsEnd.Select(e => e.FormatMessage()));
+            Assert.Equal(new[] { "WarningA" }, warningA.Select(e => e.Message));
+            Assert.Equal(new[] { "WarningA", "WarningB", "WarningC" }, warningAbc.Select(e => e.Message));
+            Assert.Equal(new[] { "WarningA", "WarningB", "WarningC" }, warningsEnd.Select(e => e.Message));
         }
 
         [Fact]
@@ -215,8 +215,7 @@ namespace NuGet.Common.Test
 
         private void VerifyInnerLoggerCalls(Mock<ILogger> innerLogger, LogLevel messageLevel, string message, Times times)
         {
-            var expectedCode = messageLevel == LogLevel.Error ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500;
-            innerLogger.Verify(x => x.Log(It.Is<RestoreLogMessage>(l => l.Code == expectedCode && 
+            innerLogger.Verify(x => x.Log(It.Is<ILogMessage>(l => 
             l.Level == messageLevel && 
             l.Message == message)), 
             times);

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
@@ -148,23 +148,5 @@ namespace NuGet.Common.Test
             Assert.Equal(-1, logMessage.EndColumnNumber);
             targetGraphs.SequenceEqual(logMessage.TargetGraphs);
         }
-
-        [Theory]
-        [InlineData(LogLevel.Error, "NU1000: Error string", "Error string")]
-        [InlineData(LogLevel.Warning, "NU1500: Warning string", "Warning string")]
-        [InlineData(LogLevel.Debug, "Debug string", "Debug string")]
-        [InlineData(LogLevel.Verbose, "Verbose string", "Verbose string")]
-        [InlineData(LogLevel.Information, "Information string", "Information string")]
-        public void RestoreLogMessage_TestFormatMessage(LogLevel level, string expectedMessage, string message)
-        {
-            // Arrange
-            var logMessage = new RestoreLogMessage(level, message);
-
-            // Act
-            var actualMessage = logMessage.FormatMessage();
-
-            // Assert
-            Assert.Equal(expectedMessage, actualMessage);
-        }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/MinClientVersionUtilityTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Versioning;
 using Xunit;
 
@@ -81,6 +82,29 @@ namespace NuGet.Packaging.Test
             // Act & Assert
             Assert.Throws(typeof(MinClientVersionException),
                 () => MinClientVersionUtility.VerifyMinClientVersion(nuspec));
+        }
+
+        [Fact]
+        public void MinClientVersionUtility_ReadFromNuspecInCompatThrowsVerifyLogMessage()
+        {
+            // Arrange
+            var nuspec = GetNuspec("99.0.0");
+            ILogMessage logMessage = null;
+
+            // Act
+            try
+            {
+                MinClientVersionUtility.VerifyMinClientVersion(nuspec);
+            }
+            catch (MinClientVersionException ex)
+            {
+                logMessage = ex.AsLogMessage();
+            }
+
+            // Assert
+            Assert.Equal(NuGetLogCode.NU1901, logMessage.Code);
+            Assert.Contains("requires NuGet client version", logMessage.Message);
+            Assert.Equal(LogLevel.Error, logMessage.Level);
         }
 
         [Fact]


### PR DESCRIPTION
Adding ``ILogException.AsLogMessage`` for Exceptions. This allows logging the exception to an ILogger with complete metadata.