### PR TITLE
add logic to detect if installation of helper pacakge is required

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/FrameworkConstants.cs
@@ -87,6 +87,7 @@ namespace NuGet.Frameworks
             public static readonly NuGetFramework Net461 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 1, 0));
             public static readonly NuGetFramework Net462 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 2, 0));
             public static readonly NuGetFramework Net463 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 6, 3, 0));
+            public static readonly NuGetFramework Net47 = new NuGetFramework(FrameworkIdentifiers.Net, new Version(4, 7, 0, 0));
 
             public static readonly NuGetFramework NetCore45 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 0, 0));
             public static readonly NuGetFramework NetCore451 = new NuGetFramework(FrameworkIdentifiers.NetCore, new Version(4, 5, 1, 0));

--- a/src/NuGet.Core/NuGet.PackageManagement/NetStandard20CompatibilityUtil.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NetStandard20CompatibilityUtil.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Frameworks;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol.Core.Types;
+using NuGet.Resolver;
+
+namespace NuGet.PackageManagement
+{
+    internal static class NetStandard20CompatibilityUtil
+    {
+        internal const string CompatibilityPackageId = "NETStandard.Library.NetFramework";
+
+        /// <summary>
+        /// This function is used to determine whether package "NETStandard.Library.NetFramework" 
+        /// needs to be installed to the project to make NETStandard2.0 compatible
+        /// with net461/net462/net47.
+        /// </summary>
+        internal static bool IsCompatibilityPackageNeededForProjectFramework(NuGetFramework currentProjectFramework)
+        {
+            if(currentProjectFramework == null)
+            {
+                throw new ArgumentNullException(nameof(currentProjectFramework));
+            }
+
+            if(currentProjectFramework.IsDesktop() 
+                && currentProjectFramework.Version >= FrameworkConstants.CommonFrameworks.Net461.Version
+                && currentProjectFramework.Version <= FrameworkConstants.CommonFrameworks.Net47.Version)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// If the install actions include the compatibility package itself, then we mark the boolean as false
+        /// to avoid running into a recursive loop (since installing the compatibility package does need netstandard2.0 assets).
+        /// </summary>
+        /// <param name="actionsList"></param>
+        internal static bool IsCompatibilityPackageBeingInstalled(IEnumerable<NuGetProjectAction> actionsList)
+        {
+            if (actionsList.Where(action => action.NuGetProjectActionType == NuGetProjectActionType.Install)
+                            .Where(t => string.Equals(t.PackageIdentity.Id, CompatibilityPackageId, StringComparison.OrdinalIgnoreCase))
+                            .Any())
+            {
+                return false;
+            }
+
+            return true;
+        }
+        internal static bool IsNearestFrameworkNetStandard20OrGreater(NuGetFramework currentProjectFramework,
+            IEnumerable<NuGetFramework> supportedFrameworks)
+        {
+            // we look at target frameworks supported by the package and determine if the nearest framework is netstandard2.0,
+            // then we do need to install the compatibility package. We only do it once for the whole list of actions -
+            // hence the !needsNetstandard20Assets condition.
+            var frameworkReducer = new FrameworkReducer();
+            var nearestFramework = frameworkReducer.GetNearest(currentProjectFramework, supportedFrameworks);
+            if (string.Equals(nearestFramework.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard, StringComparison.OrdinalIgnoreCase)
+                    && nearestFramework.Version >= FrameworkConstants.CommonFrameworks.NetStandard20.Version)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static async Task InstallNetStandard20CompatibilityPackage(NuGetProject nuGetProject,
+            INuGetProjectContext nuGetProjectContext,
+            NuGetPackageManager packageManager,
+            ISourceRepositoryProvider sourceRepositoryProvider,
+            CancellationToken token)
+        {
+            // First check if the compatibility package is already installed.
+            var projectInstalledPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
+
+            var installedPackageReference = projectInstalledPackageReferences
+                .Where(pr => StringComparer.OrdinalIgnoreCase.Equals(pr.PackageIdentity.Id, CompatibilityPackageId))
+                .FirstOrDefault();
+
+            if (installedPackageReference != null)
+            {
+                return;
+            }
+
+            nuGetProjectContext.Log(
+                    ProjectManagement.MessageLevel.Info,
+                    Strings.InstallingNetstandard20CompatibilityPackage);
+
+            var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest,
+            includePrelease: false,
+            includeUnlisted: false,
+            versionConstraints: VersionConstraints.None);
+
+            var primarySources = sourceRepositoryProvider.GetRepositories()
+                .Where(e => e.PackageSource.IsEnabled);
+
+            var log = new LoggerAdapter(nuGetProjectContext);
+
+            // Check for latest stable version of the package.
+            var resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(CompatibilityPackageId,
+                nuGetProject,
+                resolutionContext,
+                primarySources,
+                log,
+                token);
+
+            if (resolvedPackage?.LatestVersion == null)
+            {
+                // If no stable version of the package could be found, then look for latest pre-release.
+                resolutionContext = new ResolutionContext(DependencyBehavior.Lowest,
+                    includePrelease: true,
+                    includeUnlisted: false,
+                    versionConstraints: VersionConstraints.None);
+
+                resolvedPackage = await NuGetPackageManager.GetLatestVersionAsync(CompatibilityPackageId,
+                    nuGetProject,
+                    resolutionContext,
+                    primarySources,
+                    log,
+                    token);
+
+                if (resolvedPackage == null || resolvedPackage.LatestVersion == null)
+                {
+                    throw new InvalidOperationException(string.Format(Strings.NoLatestVersionFound, CompatibilityPackageId));
+                }
+
+            }
+
+            await packageManager.InstallPackageAsync(nuGetProject,
+                new PackageIdentity(CompatibilityPackageId, resolvedPackage.LatestVersion),
+                resolutionContext,
+                nuGetProjectContext,
+                primarySources,
+                Enumerable.Empty<SourceRepository>(),
+                token);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2047,22 +2047,15 @@ namespace NuGet.PackageManagement
                 // Set the original packages config if it exists
                 var msbuildProject = nuGetProject as MSBuildNuGetProject;
                 var mightNeedHelperNetstandardPackage = false;
-                var needsNetstandard20Assets = false;
+                var needsNetstandard20OrGreaterAssets = false;
                 NuGetFramework projectTargetFramework = null;
                 if (msbuildProject != null)
                 {
                     nuGetProjectContext.OriginalPackagesConfig =
                         msbuildProject.PackagesConfigNuGetProject?.GetPackagesConfig();
                     projectTargetFramework = msbuildProject.PackagesConfigNuGetProject?.TargetFramework;
-                    if(projectTargetFramework != null)
-                    {
-                        // This boolean is used to narrow down the condition to determine whether package 
-                        // "NETStandard.Library.NetFramework" needs to be installed to this project to make
-                        // NETStandard2.0 compatible with net461/net462/net47.
-                        mightNeedHelperNetstandardPackage = projectTargetFramework == FrameworkConstants.CommonFrameworks.Net461
-                            || projectTargetFramework == FrameworkConstants.CommonFrameworks.Net462
-                            || projectTargetFramework == FrameworkConstants.CommonFrameworks.Net47;
-                    }
+                    mightNeedHelperNetstandardPackage =
+                        NetStandard20CompatibilityUtil.IsCompatibilityPackageNeededForProjectFramework(projectTargetFramework);
                 }
 
                 var executedNuGetProjectActions = new Stack<NuGetProjectAction>();
@@ -2092,15 +2085,8 @@ namespace NuGet.PackageManagement
 
                     if (hasInstalls)
                     {
-                        // If the install actions include the compatibility package itself, then we mark the boolean as false
-                        // to avoid running into a recursive loop (since installing the compatibility package does need netstandard2.0 assets).
-                        if(actionsList.Where(action => action.NuGetProjectActionType == NuGetProjectActionType.Install)
-                            .Where(t => string.Equals(t.PackageIdentity.Id, "NETStandard.Library.NETFramework", StringComparison.OrdinalIgnoreCase))
-                            .Any())
-                        {
-                            mightNeedHelperNetstandardPackage = false;
-                        }
-
+                        mightNeedHelperNetstandardPackage = 
+                            NetStandard20CompatibilityUtil.IsCompatibilityPackageBeingInstalled(actionsList);
                         // Make this independently cancelable.
                         downloadTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
 
@@ -2158,18 +2144,16 @@ namespace NuGet.PackageManagement
 
                                 // use the version exactly as specified in the nuspec file
                                 var packageIdentity = downloadPackageResult.PackageReader.GetIdentity();
-                                if(!needsNetstandard20Assets && mightNeedHelperNetstandardPackage && projectTargetFramework != null)
+
+                                // Check to see if the hack to install make net461/net462/net47 compatibile with netstandard20 or greater
+                                // is required.
+                                if(!needsNetstandard20OrGreaterAssets && mightNeedHelperNetstandardPackage && projectTargetFramework != null)
                                 {
-                                    // we look at target frameworks supported by the package and determine if the nearest framework is netstandard2.0,
-                                    // then we do need to install the compatibility package. We only do it once for the whole list of actions -
-                                    // hence the !needsNetstandard20Assets condition.
-                                    var frameworkReducer = new FrameworkReducer();
-                                    var nearestFramework = frameworkReducer.GetNearest(projectTargetFramework, downloadPackageResult.PackageReader.GetSupportedFrameworks());
-                                    if(nearestFramework == FrameworkConstants.CommonFrameworks.NetStandard20)
-                                    {
-                                        needsNetstandard20Assets = true;
-                                    }
+                                    needsNetstandard20OrGreaterAssets =
+                                        NetStandard20CompatibilityUtil.IsNearestFrameworkNetStandard20OrGreater(projectTargetFramework,
+                                            downloadPackageResult.PackageReader.GetSupportedFrameworks());
                                 }
+
                                 await ExecuteInstallAsync(
                                     nuGetProject,
                                     packageIdentity,
@@ -2191,10 +2175,14 @@ namespace NuGet.PackageManagement
                         }
                     }
 
-                    if(needsNetstandard20Assets)
+                    if(needsNetstandard20OrGreaterAssets)
                     {
                         // Install the compatibility package
-                        await InstallNetStandard20CompatibilityPackage(nuGetProject, nuGetProjectContext, token);
+                        await NetStandard20CompatibilityUtil.InstallNetStandard20CompatibilityPackage(nuGetProject,
+                            nuGetProjectContext,
+                            this,
+                            SourceRepositoryProvider,
+                            token);
                     }
 
                     // Post process
@@ -2295,72 +2283,6 @@ namespace NuGet.PackageManagement
                 exceptionInfo.Throw();
             }
 
-        }
-
-        private async Task InstallNetStandard20CompatibilityPackage(NuGetProject nuGetProject, 
-            INuGetProjectContext nuGetProjectContext, 
-            CancellationToken token)
-        {
-            try
-            {
-                nuGetProjectContext.Log(
-                        ProjectManagement.MessageLevel.Info,
-                        Strings.InstallingNetstandard20CompatibilityPackage);
-
-                var resolutionContext = new ResolutionContext(DependencyBehavior.Lowest,
-                includePrelease: false,
-                includeUnlisted: false,
-                versionConstraints: VersionConstraints.None);
-
-                var primarySources = SourceRepositoryProvider.GetRepositories()
-                    .Where(e => e.PackageSource.IsEnabled);
-
-                var log = new LoggerAdapter(nuGetProjectContext);
-
-                // First check for latest stable version of the package.
-                var resolvedPackage = await GetLatestVersionAsync("NETStandard.Library.NETFramework",
-                    nuGetProject,
-                    resolutionContext,
-                    primarySources,
-                    log,
-                    token);
-
-                if (resolvedPackage == null || resolvedPackage.LatestVersion == null)
-                {
-                    // If no stable version of the package could be found, then look for latest pre-release.
-                    resolutionContext = new ResolutionContext(DependencyBehavior.Lowest,
-                        includePrelease: true,
-                        includeUnlisted: false,
-                        versionConstraints: VersionConstraints.None);
-
-                    resolvedPackage = await GetLatestVersionAsync("NETStandard.Library.NETFramework",
-                        nuGetProject,
-                        resolutionContext,
-                        primarySources,
-                        log,
-                        token);
-
-                    if (resolvedPackage == null || resolvedPackage.LatestVersion == null)
-                    {
-                        throw new InvalidOperationException(string.Format(Strings.NoLatestVersionFound, "NETStandard.Library.NETFramework"));
-                    }
-
-                }
-
-                await InstallPackageAsync(nuGetProject,
-                    new PackageIdentity("NETStandard.Library.NETFramework", resolvedPackage.LatestVersion),
-                    resolutionContext,
-                    nuGetProjectContext,
-                    primarySources,
-                    Enumerable.Empty<SourceRepository>(),
-                    token);
-            }
-            catch (InvalidOperationException e) when (e.InnerException.GetType() == typeof(PackageAlreadyInstalledException))
-            {
-                nuGetProjectContext.Log(
-                        ProjectManagement.MessageLevel.Info,
-                        Strings.Netstandard20CompatibilityPackageAlreadyInstalled);
-            }
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -2053,7 +2053,7 @@ namespace NuGet.PackageManagement
                 {
                     nuGetProjectContext.OriginalPackagesConfig =
                         msbuildProject.PackagesConfigNuGetProject?.GetPackagesConfig();
-                    projectTargetFramework = msbuildProject.PackagesConfigNuGetProject?.TargetFramework;
+                    projectTargetFramework = nuGetProject.GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
                     mightNeedHelperNetstandardPackage =
                         NetStandard20CompatibilityUtil.IsCompatibilityPackageNeededForProjectFramework(projectTargetFramework);
                 }
@@ -2147,7 +2147,9 @@ namespace NuGet.PackageManagement
 
                                 // Check to see if the hack to install make net461/net462/net47 compatibile with netstandard20 or greater
                                 // is required.
-                                if(!needsNetstandard20OrGreaterAssets && mightNeedHelperNetstandardPackage && projectTargetFramework != null)
+                                if (!needsNetstandard20OrGreaterAssets 
+                                        && mightNeedHelperNetstandardPackage 
+                                            && projectTargetFramework != null)
                                 {
                                     needsNetstandard20OrGreaterAssets =
                                         NetStandard20CompatibilityUtil.IsNearestFrameworkNetStandard20OrGreater(projectTargetFramework,
@@ -2175,10 +2177,10 @@ namespace NuGet.PackageManagement
                         }
                     }
 
-                    if(needsNetstandard20OrGreaterAssets)
+                    if (needsNetstandard20OrGreaterAssets)
                     {
                         // Install the compatibility package
-                        await NetStandard20CompatibilityUtil.InstallNetStandard20CompatibilityPackage(nuGetProject,
+                        await NetStandard20CompatibilityUtil.InstallNetStandard20CompatibilityPackageAsync(nuGetProject,
                             nuGetProjectContext,
                             this,
                             SourceRepositoryProvider,

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
@@ -50,7 +50,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         private string PackagesProjectNameConfigPath { get; }
 
-        private NuGetFramework TargetFramework { get; }
+        internal NuGetFramework TargetFramework { get; }
 
         public PackagesConfigNuGetProject(string folderPath, Dictionary<string, object> metadata)
             : base(metadata)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
@@ -50,7 +50,7 @@ namespace NuGet.ProjectManagement
         /// </summary>
         private string PackagesProjectNameConfigPath { get; }
 
-        internal NuGetFramework TargetFramework { get; }
+        private NuGetFramework TargetFramework { get; }
 
         public PackagesConfigNuGetProject(string folderPath, Dictionary<string, object> metadata)
             : base(metadata)

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -457,7 +457,7 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installing &quot;NETStandard.Library.NETFramework&quot; for compatibilty between NETStandard 2.0 and current project&apos;s target framework..
+        ///   Looks up a localized string similar to One or more packages target NETStandard 2.0 or higher and require an additional dependency. Automatically installing NETStandard.Library.NETFramework..
         /// </summary>
         internal static string InstallingNetstandard20CompatibilityPackage {
             get {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace NuGet.PackageManagement {
     using System;
-    using System.Reflection;
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -39,7 +39,7 @@ namespace NuGet.PackageManagement {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.PackageManagement.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("NuGet.PackageManagement.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -457,6 +457,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installing &quot;NETStandard.Library.NETFramework&quot; for compatibilty between NETStandard 2.0 and current project&apos;s target framework..
+        /// </summary>
+        internal static string InstallingNetstandard20CompatibilityPackage {
+            get {
+                return ResourceManager.GetString("InstallingNetstandard20CompatibilityPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installing package &apos;{0}&apos; to project.
         /// </summary>
         internal static string InstallingPackage {
@@ -498,6 +507,15 @@ namespace NuGet.PackageManagement {
         internal static string MultiplePackageTypesNotSupported {
             get {
                 return ResourceManager.GetString("MultiplePackageTypesNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Compatibility package &quot;NETStandard.Library.NETFramework&quot; is already installed and no updates available..
+        /// </summary>
+        internal static string Netstandard20CompatibilityPackageAlreadyInstalled {
+            get {
+                return ResourceManager.GetString("Netstandard20CompatibilityPackageAlreadyInstalled", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -511,11 +511,11 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Compatibility package &quot;NETStandard.Library.NETFramework&quot; is already installed and no updates available..
+        ///   Looks up a localized string similar to Unable to find package NETStandard.Library.NetFramework in an enabled source. Install the package manually to prevent any build errors..
         /// </summary>
-        internal static string Netstandard20CompatibilityPackageAlreadyInstalled {
+        internal static string NetStandardCompatibilityPackageNotFound {
             get {
-                return ResourceManager.GetString("Netstandard20CompatibilityPackageAlreadyInstalled", resourceCulture);
+                return ResourceManager.GetString("NetStandardCompatibilityPackageNotFound", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -486,7 +486,7 @@
     <value>An error occurred while applying transformation to '{0}' in project '{1}'</value>
   </data>
   <data name="InstallingNetstandard20CompatibilityPackage" xml:space="preserve">
-    <value>Installing "NETStandard.Library.NETFramework" for compatibilty between NETStandard 2.0 and current project's target framework.</value>
+    <value>One or more packages target NETStandard 2.0 or higher and require an additional dependency. Automatically installing NETStandard.Library.NETFramework.</value>
   </data>
   <data name="Netstandard20CompatibilityPackageAlreadyInstalled" xml:space="preserve">
     <value>Compatibility package "NETStandard.Library.NETFramework" is already installed and no updates available.</value>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -426,7 +485,10 @@
   <data name="XdtError" xml:space="preserve">
     <value>An error occurred while applying transformation to '{0}' in project '{1}'</value>
   </data>
-  <data name="PackageAlreadyExistsInProject" xml:space="preserve">
-    <value>Package '{0}' already exists in project '{1}'</value>
+  <data name="InstallingNetstandard20CompatibilityPackage" xml:space="preserve">
+    <value>Installing "NETStandard.Library.NETFramework" for compatibilty between NETStandard 2.0 and current project's target framework.</value>
+  </data>
+  <data name="Netstandard20CompatibilityPackageAlreadyInstalled" xml:space="preserve">
+    <value>Compatibility package "NETStandard.Library.NETFramework" is already installed and no updates available.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -488,7 +488,7 @@
   <data name="InstallingNetstandard20CompatibilityPackage" xml:space="preserve">
     <value>One or more packages target NETStandard 2.0 or higher and require an additional dependency. Automatically installing NETStandard.Library.NETFramework.</value>
   </data>
-  <data name="Netstandard20CompatibilityPackageAlreadyInstalled" xml:space="preserve">
-    <value>Compatibility package "NETStandard.Library.NETFramework" is already installed and no updates available.</value>
+  <data name="NetStandardCompatibilityPackageNotFound" xml:space="preserve">
+    <value>Unable to find package NETStandard.Library.NetFramework in an enabled source. Install the package manually to prevent any build errors.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5187

This PR adds logic to detect if there is a need of installing the helper NETStandard.Library.NETFramework package, and if there is, it installs it.

I have already manually tested that it works for install/update scenarios from the VS UI and PMC.

I am working on adding automation tests. Will update this PR when they are ready.