### PR TITLE
Changing default behavior in collector logger to not log to the inner logger

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -161,7 +161,7 @@ namespace NuGet.CommandLine
                     }
 
                     // Run restore
-                    var v3Summaries = await RestoreRunner.Run(restoreContext);
+                    var v3Summaries = await RestoreRunner.RunAsync(restoreContext);
                     restoreSummaries.AddRange(v3Summaries);
                 }
             }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -123,6 +123,9 @@ namespace NuGet.CommandLine
                     restoreContext.Log = Console;
                     restoreContext.CachingSourceProvider = GetSourceRepositoryProvider();
 
+                    // Restore errors and warnings will be displayed through sdk/msbuild target
+                    restoreContext.DisplayAllLogs = false;
+
                     var packageSaveMode = EffectivePackageSaveMode;
                     if (packageSaveMode != Packaging.PackageSaveMode.None)
                     {

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -158,7 +158,8 @@ namespace NuGet.Build.Tasks
                     Log = log,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider
+                    CachingSourceProvider = sourceProvider,
+                    DisplayAllLogs = false
                 };
 
                 if (!string.IsNullOrEmpty(RestoreSources))

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -185,7 +185,7 @@ namespace NuGet.CommandLine.XPlat
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     GlobalPackagesFolder = packageReferenceArgs.PackageDirectory,
                     PreLoadedRequestProviders = providers,
-                    Sources = packageReferenceArgs.Sources?.ToList()
+                    Sources = packageReferenceArgs.Sources?.ToList()                    
                 };
 
                 // Generate Restore Requests. There will always be 1 request here since we are restoring for 1 project.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreRequest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
@@ -20,10 +20,11 @@ namespace NuGet.Commands
             PackageSpec packageSpec,
             LockFile existingLockFile,
             Dictionary<NuGetFramework, RuntimeGraph> runtimeGraphCache,
-            ConcurrentDictionary<PackageIdentity, RuntimeGraph> runtimeGraphCacheByPackage)
+            ConcurrentDictionary<PackageIdentity, RuntimeGraph> runtimeGraphCacheByPackage,
+            ILogger log)
         {
             CacheContext = request.CacheContext;
-            Log = request.Log;
+            Log = log;
             PackagesDirectory = request.PackagesDirectory;
             ExistingLockFile = existingLockFile;
             RuntimeGraphCache = runtimeGraphCache;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -62,6 +62,8 @@ namespace NuGet.Commands
 
         public bool? ValidateRuntimeAssets { get; set; }
 
+        public bool DisplayAllLogs { get; set; } = true;
+
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
             = new ConcurrentDictionary<string, ISettings>(StringComparer.Ordinal);
@@ -213,6 +215,8 @@ namespace NuGet.Commands
             {
                 request.ValidateRuntimeAssets = ValidateRuntimeAssets.Value;
             }
+
+            request.DisplayAllLogs = DisplayAllLogs;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -28,9 +28,9 @@ namespace NuGet.Commands
         private readonly RestoreRequest _request;
 
         private bool _success = true;
-
         private readonly Dictionary<NuGetFramework, RuntimeGraph> _runtimeGraphCache = new Dictionary<NuGetFramework, RuntimeGraph>();
         private readonly ConcurrentDictionary<PackageIdentity, RuntimeGraph> _runtimeGraphCacheByPackage
+
             = new ConcurrentDictionary<PackageIdentity, RuntimeGraph>(PackageIdentity.Comparer);
         private readonly Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> _includeFlagGraphs
             = new Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>>();
@@ -48,8 +48,6 @@ namespace NuGet.Commands
 
             var collectorLogger = new CollectorLogger(_request.Log);
             _logger = collectorLogger;
-            _request.Log = collectorLogger;
-
         }
 
         public Task<RestoreResult> ExecuteAsync()
@@ -142,6 +140,7 @@ namespace NuGet.Commands
                 .ToList();
 
             assetsFile.LogMessages = logs;
+
 
             restoreTime.Stop();
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -137,8 +137,8 @@ namespace NuGet.Commands
         public bool ValidateRuntimeAssets { get; set; } = true;
 
         /// <summary>
-        /// Display Logs to user
+        /// Display Errors and warnings as they occur
         /// </summary>
-        public bool DisplayLogs { get; set; } = true;
+        public bool DisplayAllLogs { get; set; } = true;
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -135,5 +135,10 @@ namespace NuGet.Commands
         /// Compatibility options
         /// </summary>
         public bool ValidateRuntimeAssets { get; set; } = true;
+
+        /// <summary>
+        /// Display Logs to user
+        /// </summary>
+        public bool DisplayLogs { get; set; } = true;
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -292,14 +292,16 @@ namespace NuGet.Commands
                     summaryRequest.InputPath));
             }
 
+            // Remote the summary messages from the assets file. This will be removed later.
+            var messages = restoreResult.Result.LockFile.LogMessages.Select(e => new RestoreLogMessage(e.Level, e.Code, e.Message));
+
             // Build the summary
             return new RestoreSummary(
                 result,
                 summaryRequest.InputPath,
                 summaryRequest.Settings,
                 summaryRequest.Sources,
-                summaryRequest.CollectorLogger.Errors.Select(e => e as RestoreLogMessage)
-                    .Where(e => e.Level == LogLevel.Error || e.Level == LogLevel.Warning));
+                messages);
         }
 
         private static async Task<RestoreSummary> CompleteTaskAsync(List<Task<RestoreSummary>> restoreTasks)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRunner.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,13 +34,10 @@ namespace NuGet.Commands
         /// <summary>
         /// Create requests, execute requests, and commit restore results.
         /// </summary>
-        public static async Task<IReadOnlyList<RestoreSummary>> Run(RestoreArgs restoreContext)
+        public static async Task<IReadOnlyList<RestoreSummary>> RunAsync(RestoreArgs restoreContext)
         {
-            // Create requests
-            var requests = await GetRequests(restoreContext);
-
             // Run requests
-            return await RunAsync(requests, restoreContext, CancellationToken.None);
+            return await RunAsync(restoreContext, CancellationToken.None);
         }
 
         /// <summary>
@@ -301,7 +298,8 @@ namespace NuGet.Commands
                 summaryRequest.InputPath,
                 summaryRequest.Settings,
                 summaryRequest.Sources,
-                summaryRequest.CollectorLogger.Errors.Select(e => e as RestoreLogMessage).Where(e => e.Level == LogLevel.Error));
+                summaryRequest.CollectorLogger.Errors.Select(e => e as RestoreLogMessage)
+                    .Where(e => e.Level == LogLevel.Error || e.Level == LogLevel.Warning));
         }
 
         private static async Task<RestoreSummary> CompleteTaskAsync(List<Task<RestoreSummary>> restoreTasks)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -92,9 +93,9 @@ namespace NuGet.Commands
                 logger.LogErrorSummary(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
                 foreach (var error in restoreSummary.Errors)
                 {
-                    foreach (var line in IndentLines(error.Message))
+                    foreach (var line in IndentLines($"{Enum.GetName(typeof(NuGetLogCode), error.Code)}: {error.Message}"))
                     {
-                        logger.LogErrorSummary(line);
+                        logger.LogError(line);
                     }
                 }
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummaryRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummaryRequest.cs
@@ -21,8 +21,6 @@ namespace NuGet.Commands
 
         public string InputPath { get; }
 
-        public CollectorLogger CollectorLogger {get; }
-
         public RestoreSummaryRequest(
             RestoreRequest request,
             string inputPath,
@@ -33,9 +31,6 @@ namespace NuGet.Commands
             Settings = settings;
             Sources = sources;
             InputPath = inputPath;
-
-            CollectorLogger = new CollectorLogger(request.Log);
-            request.Log = CollectorLogger;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
@@ -20,6 +20,6 @@ namespace NuGet.Common
         /// <summary>
         /// Bool indicating if this message needs to be logged to the inner logger.
         /// </summary>
-        bool DisplayToUser { get; set; }
+        bool ShouldDisplay { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
@@ -20,6 +20,6 @@ namespace NuGet.Common
         /// <summary>
         /// Bool indicating if this message needs to be logged to the inner logger.
         /// </summary>
-        bool LogToInnerLogger { get; set; }
+        bool DisplayToUser { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/IRestoreLogMessage.cs
@@ -8,13 +8,18 @@ namespace NuGet.Common
     public interface IRestoreLogMessage : ILogMessage, ILogFileContext
     {
         /// <summary>
-        /// Project or Package Id
+        /// Project or Package Id.
         /// </summary>
         string LibraryId { get; set; }
 
         /// <summary>
-        /// List of TargetGraphs
+        /// List of TargetGraphs.
         /// </summary>
         IReadOnlyList<string> TargetGraphs { get; set; }
+
+        /// <summary>
+        /// Bool indicating if this message needs to be logged to the inner logger.
+        /// </summary>
+        bool LogToInnerLogger { get; set; }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -23,7 +23,7 @@ namespace NuGet.Common
         public int EndColumnNumber { get; set; } = -1;
         public string LibraryId { get; set; }
         public IReadOnlyList<string> TargetGraphs { get; set; }
-        public bool LogToInnerLogger { get; set; }
+        public bool DisplayToUser { get; set; }
 
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode,
@@ -42,7 +42,7 @@ namespace NuGet.Common
             }
 
             TargetGraphs = graphList;
-            LogToInnerLogger = logToInnerLogger;
+            DisplayToUser = logToInnerLogger;
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -23,7 +23,7 @@ namespace NuGet.Common
         public int EndColumnNumber { get; set; } = -1;
         public string LibraryId { get; set; }
         public IReadOnlyList<string> TargetGraphs { get; set; }
-        public bool DisplayToUser { get; set; }
+        public bool ShouldDisplay { get; set; }
 
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode,
@@ -42,7 +42,7 @@ namespace NuGet.Common
             }
 
             TargetGraphs = graphList;
-            DisplayToUser = logToInnerLogger;
+            ShouldDisplay = logToInnerLogger;
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -23,9 +23,11 @@ namespace NuGet.Common
         public int EndColumnNumber { get; set; } = -1;
         public string LibraryId { get; set; }
         public IReadOnlyList<string> TargetGraphs { get; set; }
+        public bool LogToInnerLogger { get; set; }
 
-        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 
-            string errorString, string targetGraph)
+
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode,
+            string errorString, string targetGraph, bool logToInnerLogger)
         {
             Level = logLevel;
             Code = errorCode;
@@ -40,15 +42,27 @@ namespace NuGet.Common
             }
 
             TargetGraphs = graphList;
+            LogToInnerLogger = logToInnerLogger;
+        }
+
+        public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 
+            string errorString, string targetGraph)
+            : this(logLevel, errorCode, errorString, targetGraph, false)
+        {
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString)
-            : this(logLevel, errorCode, errorString, string.Empty)
+            : this(logLevel, errorCode, errorString, string.Empty, false)
         {
         }
 
         public RestoreLogMessage(LogLevel logLevel, string errorString)
-            : this(logLevel, LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500, errorString, string.Empty)
+            : this(logLevel, LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500, errorString, string.Empty, false)
+        {
+        }
+
+        public RestoreLogMessage(LogLevel logLevel, string errorString, bool logToInnerLogger)
+            : this(logLevel, LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500, errorString, string.Empty, logToInnerLogger)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -12,6 +12,7 @@ namespace NuGet.Common
     {
         private readonly ILogger _innerLogger;
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
+        private readonly bool _emitLogs = true;
 
         /// <summary>
         /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
@@ -83,11 +84,11 @@ namespace NuGet.Common
         {
             if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
             {
-                return message.DisplayToUser && message.Level >= VerbosityLevel;
+                return ((_emitLogs || message.DisplayToUser) && message.Level >= VerbosityLevel);
             }
             else
             {
-                return message.Level >= VerbosityLevel;
+                return (message.Level >= VerbosityLevel);
             }   
         }
 

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -66,12 +66,12 @@ namespace NuGet.Common
         }
         public override void Log(ILogMessage message)
         {
-            Log(new RestoreLogMessage(message.Level, message.Code, message.Message));
+            Log(ToRestoreLogMessage(message));
         }
 
         public override Task LogAsync(ILogMessage message)
         {
-            return LogAsync(new RestoreLogMessage(message.Level, message.Code, message.Message));
+            return LogAsync(ToRestoreLogMessage(message));
         }
 
         /// <summary>
@@ -83,12 +83,24 @@ namespace NuGet.Common
         {
             if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
             {
-                return message.LogToInnerLogger && message.Level >= VerbosityLevel;
+                return message.DisplayToUser && message.Level >= VerbosityLevel;
             }
             else
             {
                 return message.Level >= VerbosityLevel;
             }   
+        }
+
+        private static IRestoreLogMessage ToRestoreLogMessage(ILogMessage message)
+        {
+            var restoreLogMessage = message as IRestoreLogMessage;
+
+            if (restoreLogMessage == null)
+            {
+                restoreLogMessage = new RestoreLogMessage(message.Level, message.Code, message.Message);
+            }
+
+            return restoreLogMessage;
         }
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -12,29 +12,30 @@ namespace NuGet.Common
     {
         private readonly ILogger _innerLogger;
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
-        private readonly bool _emitLogs = true;
-
-        /// <summary>
-        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
-        /// delegating all log messages to the <param name="innerLogger" />.
-        /// </summary>
-        public CollectorLogger(ILogger innerLogger)
-        {
-            _innerLogger = innerLogger;
-            _errors = new ConcurrentQueue<IRestoreLogMessage>();
-        }
+        private readonly bool _displayAllLogs;
 
         /// <summary>
         /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
         /// delegating all log messages to the <param name="innerLogger" />
         /// based on the <param name="verbosity" />
         /// </summary>
-        public CollectorLogger(ILogger innerLogger, LogLevel verbosity)
+        public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool displayAllLogs)
             : base(verbosity)
         {
             _innerLogger = innerLogger;
             _errors = new ConcurrentQueue<IRestoreLogMessage>();
+            _displayAllLogs = displayAllLogs;
         }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
+        /// delegating all log messages to the <param name="innerLogger" />.
+        /// </summary>
+        public CollectorLogger(ILogger innerLogger)
+            : this(innerLogger, LogLevel.Verbose, true)
+        {
+        }
+
 
         public void Log(IRestoreLogMessage message)
         {
@@ -84,7 +85,7 @@ namespace NuGet.Common
         {
             if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
             {
-                return ((_emitLogs || message.DisplayToUser) && message.Level >= VerbosityLevel);
+                return ((_displayAllLogs || message.ShouldDisplay) && message.Level >= VerbosityLevel);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -81,7 +81,14 @@ namespace NuGet.Common
         /// <returns>bool indicating if this message should be logged.</returns>
         protected bool DisplayMessage(IRestoreLogMessage message)
         {
-            return (message.LogToInnerLogger && message.Level >= VerbosityLevel);
+            if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
+            {
+                return message.LogToInnerLogger && message.Level >= VerbosityLevel;
+            }
+            else
+            {
+                return message.Level >= VerbosityLevel;
+            }   
         }
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -14,11 +14,15 @@ namespace NuGet.Common
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
         private readonly bool _displayAllLogs;
 
+        public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
+
         /// <summary>
         /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
-        /// delegating all log messages to the <param name="innerLogger" />
-        /// based on the <param name="verbosity" />
+        /// delegating all log messages to the inner logger.
         /// </summary>
+        /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
+        /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
+        /// <param name="displayAllLogs">If this is false, then errors and warnings will not be passed to inner logger.</param>
         public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool displayAllLogs)
             : base(verbosity)
         {
@@ -29,13 +33,35 @@ namespace NuGet.Common
 
         /// <summary>
         /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
-        /// delegating all log messages to the <param name="innerLogger" />.
+        /// delegating all log messages to the inner logger.
         /// </summary>
-        public CollectorLogger(ILogger innerLogger)
-            : this(innerLogger, LogLevel.Verbose, true)
+        /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
+        /// <param name="displayAllLogs">If this is false, then errors and warnings will not be passed to inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, bool displayAllLogs)
+            : this(innerLogger, LogLevel.Debug, displayAllLogs)
         {
         }
 
+        /// <summary>
+        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
+        /// delegating all log messages to the inner logger.
+        /// </summary>
+        /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
+        /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, LogLevel verbosity)
+            : this(innerLogger, verbosity, true)
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the <see cref="CollectorLogger"/>, while still
+        /// delegating all log messages to the inner logger.
+        /// </summary>
+        /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
+        public CollectorLogger(ILogger innerLogger)
+            : this(innerLogger, LogLevel.Debug, true)
+        {
+        }
 
         public void Log(IRestoreLogMessage message)
         {
@@ -66,6 +92,7 @@ namespace NuGet.Common
                 return Task.FromResult(0);
             }
         }
+
         public override void Log(ILogMessage message)
         {
             Log(ToRestoreLogMessage(message));
@@ -105,6 +132,5 @@ namespace NuGet.Common
             return restoreLogMessage;
         }
 
-        public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -95,6 +95,5 @@ namespace NuGet.Common
         {
             return (messageLevel >= LogLevel.Warning);
         }
-
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2021,7 +2021,6 @@ EndProject");
         [Fact]
         public void RestoreCommand_SourceLoggingFileSource()
         {
-            DebuggerUtils.WaitForDebugger();
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
             var identity = new Packaging.Core.PackageIdentity("packageA", new Versioning.NuGetVersion("1.1.0"));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -19,6 +19,7 @@ using System.Text.RegularExpressions;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol;
 using NuGet.Common;
+using Test.Utility;
 
 namespace NuGet.CommandLine.Test
 {
@@ -2020,6 +2021,7 @@ EndProject");
         [Fact]
         public void RestoreCommand_SourceLoggingFileSource()
         {
+            DebuggerUtils.WaitForDebugger();
             // Arrange
             var nugetexe = Util.GetNuGetExePath();
             var identity = new Packaging.Core.PackageIdentity("packageA", new Versioning.NuGetVersion("1.1.0"));

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreMessageTest.cs
@@ -99,8 +99,12 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.NotNull(lockFileObj);
                 Assert.Equal(1, lockFileObj.LogMessages.Count());
-                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", lockFileObj.LogMessages.First().Message, StringComparison.OrdinalIgnoreCase);
-                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", output, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", 
+                    lockFileObj.LogMessages.First().Message, 
+                    StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", 
+                    output, 
+                    StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -134,8 +138,12 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.NotNull(lockFileObj);
                 Assert.Equal(1, lockFileObj.LogMessages.Count());
-                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", lockFileObj.LogMessages.First().Message, StringComparison.OrdinalIgnoreCase);
-                Assert.Contains("Detected package downgrade: i from 9.0.0 to 1.0.0", output, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Unable to find package b. No packages exist with this id in source(s): source", 
+                    lockFileObj.LogMessages.First().Message, 
+                    StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("Unable to find package b. No packages exist with this id in source(s): source", 
+                    output, 
+                    StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -832,10 +832,11 @@ namespace NuGet.CommandLine.Test
 
                 // Act
                 var r = Util.RestoreSolution(pathContext);
+                var output = r.Item2 + r.Item3;
 
                 // Assert
-                Assert.True(File.Exists(projectA.AssetsFileOutputPath), r.Item2);
-                Assert.Contains($"Compatibility Profile: {guid}", r.Item2);
+                Assert.True(File.Exists(projectA.AssetsFileOutputPath), output);
+                Assert.Contains($"Compatibility Profile: {guid}", output);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CommandsTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CommandsTestUtility.cs
@@ -49,7 +49,7 @@ namespace NuGet.Commands.Test
                     }
                 };
 
-                var summaries = await RestoreRunner.Run(restoreContext);
+                var summaries = await RestoreRunner.RunAsync(restoreContext);
                 return summaries.ToList();
             }
         }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/NETCoreRestoreTestUtility.cs
@@ -57,7 +57,7 @@ namespace NuGet.Commands.Test
                 }
             };
 
-            return await RestoreRunner.Run(restoreContext);
+            return await RestoreRunner.RunAsync(restoreContext);
         }
 
         public static PackageSpec GetProject(string projectName, string framework)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreBuildTargetsAndPropsTests.cs
@@ -440,7 +440,7 @@ namespace NuGet.Commands.Test
                 }
             };
 
-            return await RestoreRunner.Run(restoreContext);
+            return await RestoreRunner.RunAsync(restoreContext);
         }
 
         private static PackageSpec GetProject(string projectName, params string[] frameworks)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -80,7 +80,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var summary = summaries.Single();
 
                     // Assert
@@ -176,7 +176,7 @@ namespace NuGet.Commands.Test
                     var propsPath = Path.Combine(project1.FullName, "project1.nuget.props");
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var summary = summaries.Single();
 
                     var targets = TargetsUtility.GetMSBuildPackageImports(targetsPath);
@@ -266,7 +266,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var summary = summaries.Single();
 
                     // Assert
@@ -346,7 +346,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var summary = summaries.Single();
 
                     // Assert
@@ -479,7 +479,7 @@ namespace NuGet.Commands.Test
                 restoreContext.Inputs.Add(dgPath);
 
                 // Act
-                var summaries = await RestoreRunner.Run(restoreContext);
+                var summaries = await RestoreRunner.RunAsync(restoreContext);
                 var success = summaries.All(s => s.Success);
 
                 var lockFormat = new LockFileFormat();
@@ -616,7 +616,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var success = summaries.All(s => s.Success);
 
                     var lockFormat = new LockFileFormat();
@@ -714,7 +714,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var success = summaries.All(s => s.Success);
 
                     // Assert
@@ -787,7 +787,7 @@ namespace NuGet.Commands.Test
                     restoreContext.Runtimes.Add("linux-x86");
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
                     var success = summaries.All(s => s.Success);
 
                     var lockFormat = new LockFileFormat();
@@ -826,7 +826,7 @@ namespace NuGet.Commands.Test
                     };
 
                     // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
+                    var summaries = await RestoreRunner.RunAsync(restoreContext);
 
                     // Assert
                     Assert.Equal(0, summaries.Count);

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -29,9 +29,9 @@ namespace NuGet.Common.Test
             collector.Log(new RestoreLogMessage(LogLevel.Error, "Error"));
 
             // Assert
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Never());
         }
@@ -51,9 +51,9 @@ namespace NuGet.Common.Test
             collector.Log(LogLevel.Error, "Error");
 
             // Assert
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Never());
         }
@@ -70,14 +70,14 @@ namespace NuGet.Common.Test
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
             collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = false });
             collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = false });
             collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using Moq;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.Common.Test
@@ -13,7 +14,7 @@ namespace NuGet.Common.Test
     {
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLogger()
+        public void CollectorLogger_DoesNotPassLogMessagesToInnerLoggerByDefault()
         {
 
             // Arrange
@@ -28,17 +29,16 @@ namespace NuGet.Common.Test
             collector.Log(new RestoreLogMessage(LogLevel.Error, "Error"));
 
             // Assert
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Never());
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogCallsToInnerLogger()
+        public void CollectorLogger_DoesNotPassLogCallsToInnerLoggerByDefault()
         {
-
             // Arrange
             var innerLogger = new Mock<ILogger>();
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
@@ -51,15 +51,15 @@ namespace NuGet.Common.Test
             collector.Log(LogLevel.Error, "Error");
 
             // Assert
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
-            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Never());
         }
 
         [Fact]
-        public void CollectorLogger_PassesToInnerLogger()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerOnlyWithLogToInnerLogger()
         {
 
             // Arrange
@@ -67,11 +67,34 @@ namespace NuGet.Common.Test
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
 
             // Act
-            collector.LogDebug("Debug");
-            collector.LogVerbose("Verbose");
-            collector.LogInformation("Information");
-            collector.LogWarning("Warning");
-            collector.LogError("Error");
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
+
+            // Assert
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Never());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
+        }
+
+        [Fact]
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithLogToInnerLogger()
+        {
+
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
+
+            // Act
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
@@ -82,18 +105,18 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesToInnerLoggerWithLessVerbosity()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithLessVerbosity()
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose);
 
             // Act
-            collector.LogDebug("Debug");
-            collector.LogVerbose("Verbose");
-            collector.LogInformation("Information");
-            collector.LogWarning("Warning");
-            collector.LogError("Error");
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
@@ -104,18 +127,18 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesToInnerLoggerWithLeastVerbosity()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithLeastVerbosity()
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error);
 
             // Act
-            collector.LogDebug("Debug");
-            collector.LogVerbose("Verbose");
-            collector.LogInformation("Information");
-            collector.LogWarning("Warning");
-            collector.LogError("Error");
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
@@ -124,6 +147,7 @@ namespace NuGet.Common.Test
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Never());
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
         }
+
 
         [Fact]
         public void CollectorLogger_CollectsErrors()

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -67,11 +67,11 @@ namespace NuGet.Common.Test
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
@@ -90,11 +90,11 @@ namespace NuGet.Common.Test
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
@@ -112,11 +112,11 @@ namespace NuGet.Common.Test
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
@@ -134,11 +134,11 @@ namespace NuGet.Common.Test
             var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { LogToInnerLogger = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { LogToInnerLogger = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
 using System.Linq;
 using Moq;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.Common.Test
@@ -19,7 +16,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug"));
@@ -41,7 +38,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
 
             // Act
             collector.Log(LogLevel.Debug, "Debug");
@@ -59,19 +56,19 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerOnlyWithLogToInnerLogger()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerOnlyWithShouldDisplay()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = false });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
@@ -82,19 +79,65 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithLogToInnerLogger()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplay()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = true });
+
+            // Assert
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
+        }
+
+        [Fact]
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithNoShouldDisplayAndDisplayAllLogs()
+        {
+
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: true);
+
+            // Act
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = false });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = false });
+
+            // Assert
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Verbose, "Verbose", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Information, "Information", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Warning, "Warning", Times.Once());
+            VerifyInnerLoggerCalls(innerLogger, LogLevel.Error, "Error", Times.Once());
+        }
+
+        [Fact]
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplayAndDisplayAllLogs()
+        {
+
+            // Arrange
+            var innerLogger = new Mock<ILogger>();
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: true);
+
+            // Act
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Once());
@@ -109,14 +152,14 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose, displayAllLogs: false);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());
@@ -131,14 +174,14 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error, displayAllLogs: false);
 
             // Act
-            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { DisplayToUser = true });
-            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { DisplayToUser = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Verbose, "Verbose") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Information, "Information") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Warning, "Warning") { ShouldDisplay = true });
+            collector.Log(new RestoreLogMessage(LogLevel.Error, "Error") { ShouldDisplay = true });
 
             // Assert
             VerifyInnerLoggerCalls(innerLogger, LogLevel.Debug, "Debug", Times.Never());

--- a/test/TestUtilities/Test.Utility/DebuggerUtils.cs
+++ b/test/TestUtilities/Test.Utility/DebuggerUtils.cs
@@ -2,18 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Test.Utility
 {
-    public class DebuggerUtils
+    public static class DebuggerUtils
     {
         public static void WaitForDebugger()
         {
+#if IS_CORECLR
             Console.WriteLine("Waiting for debugger to attach.");
             Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
 
@@ -22,6 +19,9 @@ namespace Test.Utility
                 System.Threading.Thread.Sleep(100);
             }
             Debugger.Break();
+#else
+            Debugger.Launch();
+#endif
         }
     }
 }

--- a/test/TestUtilities/Test.Utility/DebuggerUtils.cs
+++ b/test/TestUtilities/Test.Utility/DebuggerUtils.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.Utility
+{
+    public class DebuggerUtils
+    {
+        public static void WaitForDebugger()
+        {
+            Console.WriteLine("Waiting for debugger to attach.");
+            Console.WriteLine($"Process ID: {Process.GetCurrentProcess().Id}");
+
+            while (!Debugger.IsAttached)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+            Debugger.Break();
+        }
+    }
+}


### PR DESCRIPTION
This is part of the on going work for restore warnings and errors. This should only affect restore logs since no other code path uses collector logger.

I have added a bool `LogToInnerLogger` into `IRestoreLogMessage` to ensure that the collector logger selectively passes logs to the inner logger. But this only applies to errors and warnings because other logs should still be passed to the inner logger.