### PR TITLE
Fixing RPS regression

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -6,9 +6,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.Protocol.Core.Types;
-using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
 namespace NuGet.SolutionRestoreManager
@@ -35,16 +32,6 @@ namespace NuGet.SolutionRestoreManager
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
-            // Don't use CPS thread helper because of RPS perf regression
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                var dte = (EnvDTE.DTE)await GetServiceAsync(typeof(SDTE));
-
-                UserAgent.SetUserAgentString(
-                    new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
-            });
-
             _handler = await SolutionRestoreBuildHandler.InitializeAsync(this);
 
             await SolutionRestoreCommand.InitializeAsync(this);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -10,7 +10,7 @@ using Microsoft;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using NuGet.PackageManagement;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
@@ -27,7 +27,7 @@ namespace NuGet.SolutionRestoreManager
         private static readonly Guid CommandSet = GuidList.guidNuGetDialogCmdSet;
 
         [Import]
-        private Lazy<ISolutionManager> SolutionManager { get; set; }
+        private Lazy<IVsSolutionManager> SolutionManager { get; set; }
 
         [Import]
         private Lazy<ISolutionRestoreWorker> SolutionRestoreWorker { get; set; }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -81,7 +81,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Common\NuGet.Common.csproj" />
     <ProjectReference Include="..\..\NuGet.Core\NuGet.PackageManagement\NuGet.PackageManagement.csproj" />
-    <ProjectReference Include="..\..\NuGet.Core\NuGet.Packaging\NuGet.Packaging.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">


### PR DESCRIPTION
This change reduces the number of modules loaded upon solution opened.
Necessary to improve RPS test results for total images in memory.
The NuGet.Protocol and NuGet.Packaging won't be loaded until later
initialization phase.

//cc @rrelyea 