### PR TITLE
Updated MS.VS.ComponentModelHost package version specific for Dev14 vs Dev15

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Interop/NuGet.VisualStudio.Interop.csproj
@@ -21,11 +21,10 @@
   </ItemGroup>
   <ItemGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.2.25123" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost.NuGet" Version="14.0.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26201" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Earlier Microsoft.VisualStudio.ComponentModelHost package version 15.0.26201 was added outside visual studio version check which made it a dependency for all visual studio versions. Where as this package only apply for Dev15. So added right version of this package for Dev14 and Dev15.

Fixes https://github.com/NuGet/Home/issues/5206

@rrelyea 