### PR TITLE
add microsoft.web.xmltransform.resources.dll to the list of files to be signed

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -24,6 +24,9 @@
       <FilesToSign Include="$(SolutionPackagesFolder)Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll">
         <Authenticode>3PartySHA2</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
+        <Authenticode>Microsoft</Authenticode>
+      </FilesToSign>
     </ItemGroup>
     <MSBuild
       Projects="@(SolutionProjectsWithoutVSIX)"


### PR DESCRIPTION
just noticed that sign check failed on a VS PR validation build because Microsoft.Web.XmlTransform.resources.dll is not being signed in the vsix. this change fixes that.