### PR TITLE
Fixed static resource reference

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Styles.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources/Styles.cs
@@ -1,28 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using Microsoft.VisualStudio.Shell;
 
 namespace NuGet.PackageManagement.UI
 {
-    public class Styles
+    public static class Styles
     {
-        public static void LoadVsStyles()
-        {
-            var assembly = AppDomain.CurrentDomain.Load(
-                "Microsoft.VisualStudio.ExtensionsExplorer.UI");
-            var comboBoxType = assembly.GetType(
-                "Microsoft.VisualStudio.ExtensionsExplorer.UI.AutomationComboBox");
-            ThemedComboStyleKey = new ComponentResourceKey(comboBoxType, "ThemedComboBoxStyle");
-        }
-
         [Browsable(false)]
-        public static object ThemedComboStyleKey { get; private set; } = typeof(ComboBox);
+        public static object ThemedComboStyleKey => VsResourceKeys.ThemedDialogComboBoxStyleKey ?? typeof(ComboBox);
 
         [Browsable(false)]
         public static object ScrollBarStyleKey => VsResourceKeys.ScrollBarStyleKey ?? typeof(ScrollBar);

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -147,7 +147,6 @@ namespace NuGetVSExtension
 
             SolutionManager.AfterNuGetProjectRenamed += SolutionManager_NuGetProjectRenamed;
 
-            Styles.LoadVsStyles();
             Brushes.LoadVsBrushes();
 
             // Add our command handlers for menu (commands must exist in the .vsct file)

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +13,6 @@ using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using System.Windows.Media;
 using EnvDTE;
 using Microsoft.VisualStudio.Threading;


### PR DESCRIPTION
Resolves NuGet/Home#5232.

NuGet implicitly referenced a resource in VS platform module
`Microsoft.VisualStudio.ExtensionsExplorer.UI.dll`.

Due to recent changes in VS platform API the module owners decided to remove
the `ThemedComboBoxStyle` resource. As a result of this missing resource
reference broke "Manage NuGet packages..." dialog.

This change replaces `ThemedComboBoxStyleKey` with shell's
`VsResourceKeys.ThemedDialogComboBoxStyleKey`.

//cc @rrelyea @sbanni 