### PR TITLE
update assembly version of nuget dlls to 4.3.0.2

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -187,8 +187,7 @@
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <!-- Assembly attributes for net core projects -->
-    <!--AssemblyVersion should have the build number incremented for every milestone. Currently this is 2 to align with 15.3 preview2 -->
-    <AssemblyVersion>$(SemanticVersion).2</AssemblyVersion>
+    <AssemblyVersion>$(SemanticVersion).$(NetCoreAssemblyBuildNumber)</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
     <Company>Microsoft Corporation</Company>

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -187,8 +187,8 @@
 
   <PropertyGroup Condition=" '$(IsNetCoreProject)' == 'true' ">
     <!-- Assembly attributes for net core projects -->
-    <!--AssemblyVersion should not contain the build number as all NuGet.Core projects had the build number as 0 every time -->
-    <AssemblyVersion>$(SemanticVersion).0</AssemblyVersion>
+    <!--AssemblyVersion should have the build number incremented for every milestone. Currently this is 2 to align with 15.3 preview2 -->
+    <AssemblyVersion>$(SemanticVersion).2</AssemblyVersion>
     <FileVersion>$(SemanticVersion).$(PreReleaseVersion)</FileVersion>
     <InformationalVersion>$(SemanticVersion)$(PreReleaseInformationVersion)</InformationalVersion>
     <Company>Microsoft Corporation</Company>

--- a/build/config.props
+++ b/build/config.props
@@ -6,7 +6,7 @@
     <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
-    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview1</ReleaseLabel>
+    <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview$(NetCoreAssemblyBuildNumber)</ReleaseLabel>
   </PropertyGroup>
 
   <!-- Dependency versions -->

--- a/build/config.props
+++ b/build/config.props
@@ -3,6 +3,9 @@
   <!-- Version -->
   <PropertyGroup>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">4.3.0</SemanticVersion>
+    <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
+    changes we might have made-->
+    <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">2</NetCoreAssemblyBuildNumber>
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">preview1</ReleaseLabel>
   </PropertyGroup>
 

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -11,12 +11,27 @@
     {
         $ProgramFilesPath = ${env:ProgramFiles(x86)}
     }
-    $VS15RelativePath = "Microsoft Visual Studio\2017\Enterprise"
-    if(($VSVersion -eq "15.0") -and (Test-Path (Join-Path $ProgramFilesPath $VS15RelativePath))){
-        $VSFolderPath = Join-Path $ProgramFilesPath $VS15RelativePath
-    } else {
+
+    $VS15PreviewRelativePath = "Microsoft Visual Studio\Preview\Enterprise"
+    $VS15StableRelativePath = "Microsoft Visual Studio\2017\Enterprise"
+
+    if ($VSVersion -eq "15.0")
+    {
+        # Give preference to preview installation of VS2017
+        if (Test-Path (Join-Path $ProgramFilesPath $VS15PreviewRelativePath))
+        {
+            $VSFolderPath = Join-Path $ProgramFilesPath $VS15PreviewRelativePath
+        }
+        elseif (Test-Path (Join-Path $ProgramFilesPath $VS15StableRelativePath)) 
+        {
+            $VSFolderPath = Join-Path $ProgramFilesPath $VS15StableRelativePath
+        }
+    } 
+    else 
+    {
         $VSFolderPath = Join-Path $ProgramFilesPath ("Microsoft Visual Studio " + $VSVersion)
     }
+    
     return $VSFolderPath
 }
 


### PR DESCRIPTION
this will take care of the issue VS and VS Code are hitting where msbuild loads the wrong set of DLLs 
For reference: https://github.com/OmniSharp/omnisharp-vscode/issues/1495

this also modifies our e2e scripts to prefer the preview version of VS2017 over the public release for testing.

CC: @rrelyea 