### PR TITLE
Fix vsix installation scripts

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -46,6 +46,11 @@ if($VSVersion -eq '14.0')
 }
 else 
 {
+    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+	if ($success -eq $false)
+	{
+		exit 1
+	}
 	# Clearing MEF cache helps load the right dlls for vsix
 	ClearDev15MEFCache
 }

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -46,11 +46,9 @@ if($VSVersion -eq '14.0')
 }
 else 
 {
+        #We don't care for the downgrade result...we should be able to install on top anyways.
     $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
-	if ($success -eq $false)
-	{
-		exit 1
-	}
+        
 	# Clearing MEF cache helps load the right dlls for vsix
 	ClearDev15MEFCache
 }

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -48,6 +48,7 @@ else
 {
         #We don't care for the downgrade result...we should be able to install on top anyways.
         $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+        
         if ($success -eq $false)
 	{
 		exit 1

--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -47,7 +47,11 @@ if($VSVersion -eq '14.0')
 else 
 {
         #We don't care for the downgrade result...we should be able to install on top anyways.
-    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+        $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+        if ($success -eq $false)
+	{
+		exit 1
+	}
         
 	# Clearing MEF cache helps load the right dlls for vsix
 	ClearDev15MEFCache

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -188,17 +188,8 @@ function DowngradeVSIX
 
     if ($p.ExitCode -ne 0)
     {
-        if($p.ExitCode -eq 1002)
-        {
-            Write-Host "VSIX already downgraded. Moving on to installing the VSIX! Exit code: $($p.ExitCode)" 
-            return $true
-        }
-        else 
-        {
             Write-Error "Error downgrading the VSIX! Exit code: $($p.ExitCode)"
             return $false
-        }
-
     }
 
     start-sleep -Seconds $VSIXInstallerWaitTimeInSecs

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -169,6 +169,45 @@ function UninstallVSIX
     return $true
 }
 
+function DowngradeVSIX
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$vsixID,
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("15.0")]
+        [string]$VSVersion,
+        [Parameter(Mandatory=$true)]
+        [int]$VSIXInstallerWaitTimeInSecs
+    )
+
+    $VSIXInstallerPath = GetVSIXInstallerPath $VSVersion
+
+    Write-Host 'Downgrading VSIX...'
+    $p = start-process "$VSIXInstallerPath" -Wait -PassThru -NoNewWindow -ArgumentList "/q /a /d:$vsixID"
+
+    if ($p.ExitCode -ne 0)
+    {
+        if($p.ExitCode -eq 1002)
+        {
+            Write-Host "VSIX already downgraded. Moving on to installing the VSIX! Exit code: $($p.ExitCode)" 
+            return $true
+        }
+        else 
+        {
+            Write-Error "Error downgrading the VSIX! Exit code: $($p.ExitCode)"
+            return $false
+        }
+
+    }
+
+    start-sleep -Seconds $VSIXInstallerWaitTimeInSecs
+    Write-Host "VSIX has been downgraded successfully."
+    
+    return $true
+}
+
+
 function InstallVSIX
 {
     param(


### PR DESCRIPTION
The latest prerel VS builds now allow us to downgrade to the VS baked-in VSIXs. 
The new option is /d:VsixID

We don't know the error codes when we try to downgrade the vsix. 

@rohit21agrawal Can you check what happens if we try to downgrade when we only have the baked-in VSIX?
