### PR TITLE
Fix tests broken by No-Op changes

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -482,8 +482,7 @@ namespace NuGet.CommandLine
                 {
                     dgFileOutput = await GetDependencyGraphSpecAsync(projectsWithPotentialP2PReferences,
                         GetSolutionDirectory(packageRestoreInputs),
-                        ConfigFile,
-                        CurrentDirectory);
+                        ConfigFile);
                 }
                 catch (Exception ex)
                 {
@@ -591,7 +590,7 @@ namespace NuGet.CommandLine
         /// <summary>
         ///  Create a dg v2 file using msbuild.
         /// </summary>
-        private async Task<DependencyGraphSpec> GetDependencyGraphSpecAsync(string[] projectsWithPotentialP2PReferences, string solutionDirectory, string configFile, string restoreDirectory)
+        private async Task<DependencyGraphSpec> GetDependencyGraphSpecAsync(string[] projectsWithPotentialP2PReferences, string solutionDirectory, string configFile)
         {
             // Create requests based on the solution directory if a solution was used read settings for the solution.
             // If the solution directory is null, then use config file if present
@@ -621,7 +620,6 @@ namespace NuGet.CommandLine
                 Recursive,
                 solutionDirectory,
                 configFile,
-                restoreDirectory,
                 Source.ToArray(),
                 PackagesDirectory
                 );

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -74,7 +74,6 @@ namespace NuGet.CommandLine
             bool recursive,
             string solutionDirectory,
             string restoreConfigFile,
-            string restoreDirectory,
             string[] sources,
             string packagesDirectory)
         {
@@ -156,11 +155,6 @@ namespace NuGet.CommandLine
                 {
                     argumentBuilder.Append(" /p:RestoreConfigFile=");
                     argumentBuilder.Append(EscapeQuoted(restoreConfigFile));
-                }
-
-                if (!string.IsNullOrEmpty(restoreDirectory)) {
-                    argumentBuilder.Append(" /p:RestoreDirectory=");
-                    argumentBuilder.Append(EscapeQuoted(restoreDirectory));
                 }
 
                 var isMono = RuntimeEnvironmentHelper.IsMono && !RuntimeEnvironmentHelper.IsWindows;

--- a/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/BuildTasksUtility.cs
@@ -65,6 +65,14 @@ namespace NuGet.Build.Tasks
             }
         }
 
+        public static void AddPropertyIfExists(IDictionary<string, string> properties, string key, string[] value)
+        {
+            if (value!=null && !properties.ContainsKey(key))
+            {
+                properties.Add(key, string.Concat(value.Select(e => e + ";")));
+            }
+        }
+
         private static HashSet<ProjectStyle> RestorableTypes = new HashSet<ProjectStyle>()
         {
             ProjectStyle.DotnetCliTool,

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -33,19 +33,24 @@ namespace NuGet.Build.Tasks
         public string ToolFramework { get; set; }
 
         /// <summary>
-        /// NuGet sources, ; delimited
+        /// NuGet sources
         /// </summary>
-        public string RestoreSources { get; set; }
+        public string[] RestoreSources { get; set; }
 
         /// <summary>
         /// NuGet fallback folders
         /// </summary>
-        public string RestoreFallbackFolders { get; set; }
+        public string[] RestoreFallbackFolders { get; set; }
 
         /// <summary>
         /// User packages folder
         /// </summary>
         public string RestorePackagesPath { get; set; }
+
+        /// <summary>
+        /// Config File Paths used
+        /// </summary>
+        public string[] RestoreConfigFilePaths { get; set; }
 
         [Required]
         public ITaskItem[] DotnetCliToolReferences { get; set; }
@@ -55,6 +60,22 @@ namespace NuGet.Build.Tasks
             var log = new MSBuildLogger(Log);
             log.LogDebug($"(in) ProjectPath '{ProjectPath}'");
             log.LogDebug($"(in) DotnetCliToolReferences '{string.Join(";", DotnetCliToolReferences.Select(p => p.ItemSpec))}'");
+            if (RestoreSources != null)
+            {
+                log.LogDebug($"(in) RestoreSources '{string.Join(";", RestoreSources.Select(p => p))}'");
+            }
+            if (RestorePackagesPath != null)
+            {
+                log.LogDebug($"(in) RestorePackagesPath '{RestorePackagesPath}'");
+            }
+            if (RestoreFallbackFolders != null)
+            {
+                log.LogDebug($"(in) RestoreFallbackFolders '{string.Join(";", RestoreFallbackFolders.Select(p => p))}'");
+            }
+            if (RestoreConfigFilePaths != null)
+            {
+                log.LogDebug($"(in) RestoreConfigFilePaths '{string.Join(";", RestoreConfigFilePaths.Select(p => p))}'");
+            }
 
             var entries = new List<ITaskItem>();
 
@@ -75,6 +96,7 @@ namespace NuGet.Build.Tasks
                 properties.Add("ProjectName", $"DotnetCliToolReference-{msbuildItem.ItemSpec}");
                 BuildTasksUtility.AddPropertyIfExists(properties, "Sources", RestoreSources);
                 BuildTasksUtility.AddPropertyIfExists(properties, "FallbackFolders", RestoreFallbackFolders);
+                BuildTasksUtility.AddPropertyIfExists(properties, "ConfigFilePaths", RestoreConfigFilePaths);
                 BuildTasksUtility.AddPropertyIfExists(properties, "PackagesPath", RestorePackagesPath);
                 properties.Add("TargetFrameworks", ToolFramework);
                 properties.Add("ProjectStyle", ProjectStyle.DotnetCliTool.ToString());

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -35,8 +35,6 @@ namespace NuGet.Build.Tasks
 
         public string RestoreSolutionDirectory { get; set; }
 
-        public string RestoreDirectory { get; set; }
-
         /// <summary>
         /// Output items
         /// </summary>
@@ -132,17 +130,12 @@ namespace NuGet.Build.Tasks
                 log.LogDebug($"(in) RestoreConfigFile '{RestoreConfigFile}'");
             }
 
-            if (RestoreDirectory != null)
-            {
-                log.LogDebug($"(in) RestoreDirectory '{RestoreDirectory}'");
-            }
-
             if (RestoreSolutionDirectory != null)
             {
                 log.LogDebug($"(in) RestoreSolutionDirectory '{RestoreSolutionDirectory}'");
             }
 
-            var settings = ReadSettings(RestoreSolutionDirectory, string.IsNullOrEmpty(RestoreDirectory) ? Path.GetDirectoryName(ProjectUniqueName) : RestoreDirectory, RestoreConfigFile);
+            var settings = ReadSettings(RestoreSolutionDirectory, Path.GetDirectoryName(ProjectUniqueName) , RestoreConfigFile);
 
             if (string.IsNullOrEmpty(RestorePackagesPath))
             {

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -432,7 +432,6 @@ Copyright (c) .NET Foundation. All rights reserved.
      RestoreFallbackFolders="$(RestoreFallbackFolders)"
      RestoreConfigFile="$(RestoreConfigFile)"
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
-     RestoreDirectory="$(RestoreDirectory)"
      >
       <Output
         TaskParameter="OutputSources"

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -301,6 +301,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GenerateDotnetCliToolReferenceSpecs"
+      DependsOnTargets="_GetRestoreSettings"
       Returns="@(_RestoreGraphEntry)">
 
     <PropertyGroup>
@@ -312,12 +313,17 @@ Copyright (c) .NET Foundation. All rights reserved.
       Condition=" '$(RestoreDotnetCliToolReferences)' == '' OR '$(RestoreDotnetCliToolReferences)' == 'true' "
       ProjectPath="$(MSBuildProjectFullPath)"
       ToolFramework="$(DotnetCliToolTargetFramework)"
+      RestorePackagesPath="$(_OutputPackagesPath)"
+      RestoreFallbackFolders="$(_OutputFallbackFolders)"
+      RestoreSources="$(_OutputSources)"
+      RestoreConfigFilePaths="$(_OutputConfigFilePaths)"
       DotnetCliToolReferences="@(DotnetCliToolReference)">
 
       <Output
         TaskParameter="RestoreGraphItems"
         ItemName="_RestoreGraphEntry" />
     </GetRestoreDotnetCliToolsTask>
+    
   </Target>
 
   <!--
@@ -414,12 +420,43 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+    _GetRestoreSettings
+    ============================================================
+  -->
+  <Target Name="_GetRestoreSettings" DependsOnTargets="_GetRestoreProjectStyle" Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
+    <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
+    <GetRestoreSettingsTask Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' "
+     ProjectUniqueName="$(MSBuildProjectFullPath)"
+     RestoreSources="$(RestoreSources)"
+     RestorePackagesPath="$(RestorePackagesPath)"
+     RestoreFallbackFolders="$(RestoreFallbackFolders)"
+     RestoreConfigFile="$(RestoreConfigFile)"
+     RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
+     RestoreDirectory="$(RestoreDirectory)"
+     >
+      <Output
+        TaskParameter="OutputSources"
+        PropertyName="_OutputSources" />
+      <Output
+        TaskParameter="OutputPackagesPath"
+        PropertyName="_OutputPackagesPath" />
+      <Output
+        TaskParameter="OutputFallbackFolders"
+        PropertyName="_OutputFallbackFolders" />
+      <Output
+        TaskParameter="OutputConfigFilePaths"
+        PropertyName="_OutputConfigFilePaths" />
+    </GetRestoreSettingsTask>
+  </Target>
+
+  <!--
+    ============================================================
     _GenerateRestoreProjectSpec
     Generate a restore project spec for the current project.
     ============================================================
   -->
   <Target Name="_GenerateRestoreProjectSpec"
-    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworksOutput"
+    DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreTargetFrameworksOutput;_GetRestoreSettings"
     Returns="@(_RestoreGraphEntry)">
 
     <!-- Determine the restore output path -->
@@ -467,29 +504,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RestoreSkipContentFileWrite Condition=" '$(TargetFrameworks)' == '' AND '$(TargetFramework)' == '' ">true</_RestoreSkipContentFileWrite>
     </PropertyGroup>
     
-    <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
-    <GetRestoreSettingsTask Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' "
-     ProjectUniqueName="$(MSBuildProjectFullPath)"
-     RestoreSources="$(RestoreSources)"
-     RestorePackagesPath="$(RestorePackagesPath)"
-     RestoreFallbackFolders="$(RestoreFallbackFolders)"
-     RestoreConfigFile="$(RestoreConfigFile)"
-     RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
-     RestoreDirectory="$(RestoreDirectory)"
-     >
-      <Output
-        TaskParameter="OutputSources"
-        PropertyName="_OutputSources" />
-      <Output
-        TaskParameter="OutputPackagesPath"
-        PropertyName="_OutputPackagesPath" />
-      <Output
-        TaskParameter="OutputFallbackFolders"
-        PropertyName="_OutputFallbackFolders" />
-      <Output
-        TaskParameter="OutputConfigFilePaths"
-        PropertyName="_OutputConfigFilePaths" />
-    </GetRestoreSettingsTask>
+
 
 
     <!-- Write properties for the top level entry point -->

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -528,6 +528,7 @@ Copyright (c) .NET Foundation. All rights reserved.
         <PackagesPath>$(_OutputPackagesPath)</PackagesPath>
         <ProjectJsonPath>$(_CurrentProjectJsonPath)</ProjectJsonPath>
         <ProjectStyle>$(RestoreProjectStyle)</ProjectStyle>
+        <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/DependencyGraphSpecRequestProvider.cs
@@ -176,7 +176,7 @@ namespace NuGet.Commands
 
         private string GetPackagesPath(RestoreArgs restoreArgs, ExternalProjectReference project)
         {
-            if (restoreArgs.GlobalPackagesFolder != null)
+            if (!string.IsNullOrEmpty(restoreArgs.GlobalPackagesFolder))
             {
                 project.PackageSpec.RestoreMetadata.PackagesPath = restoreArgs.GlobalPackagesFolder;
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -166,21 +166,17 @@ namespace NuGet.Commands
                 // Read project references for all
                 AddProjectReferences(result, items);
 
-                // Read package references for netcore, tools, and standalone
                 if (restoreType == ProjectStyle.PackageReference
                     || restoreType == ProjectStyle.Standalone
-                    || restoreType == ProjectStyle.DotnetCliTool)
-                {
-                    AddFrameworkAssemblies(result, items);
-                    AddPackageReferences(result, items);
-                    result.RestoreMetadata.OutputPath = specItem.GetProperty("OutputPath");
+                    || restoreType == ProjectStyle.DotnetCliTool
+                    || restoreType == ProjectStyle.ProjectJson) {
 
                     foreach (var source in MSBuildStringUtility.Split(specItem.GetProperty("Sources")))
                     {
                         result.RestoreMetadata.Sources.Add(new PackageSource(source));
                     }
 
-                    foreach( var configFilePath in MSBuildStringUtility.Split(specItem.GetProperty("ConfigFilePaths")))
+                    foreach (var configFilePath in MSBuildStringUtility.Split(specItem.GetProperty("ConfigFilePaths")))
                     {
                         result.RestoreMetadata.ConfigFilePaths.Add(configFilePath);
                     }
@@ -191,6 +187,16 @@ namespace NuGet.Commands
                     }
 
                     result.RestoreMetadata.PackagesPath = specItem.GetProperty("PackagesPath");
+                }
+
+                // Read package references for netcore, tools, and standalone
+                if (restoreType == ProjectStyle.PackageReference
+                    || restoreType == ProjectStyle.Standalone
+                    || restoreType == ProjectStyle.DotnetCliTool)
+                {
+                    AddFrameworkAssemblies(result, items);
+                    AddPackageReferences(result, items);
+                    result.RestoreMetadata.OutputPath = specItem.GetProperty("OutputPath");
 
                     // Store the original framework strings for msbuild conditionals
                     foreach (var originalFramework in GetFrameworksStrings(specItem))

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -232,9 +232,9 @@ namespace NuGet.Configuration
             {
                 return NullSettings.Instance;
             }
-            foreach(var configPath in configFilePaths)
+            foreach(var configFile in configFilePaths)
             {
-                settings.Add(LoadSettings(configPath));
+                settings.Add(LoadSettings(configFile));
             }
 
             return LoadSettingsForSpecificConfigs(settings.First().Root, settings.First().FileName, settings, null, true, false);

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -303,9 +303,16 @@ namespace NuGet.PackageManagement
         {
             var specs = await project.GetPackageSpecsAsync(context);
 
-            return specs.Where(e => e.RestoreMetadata.ProjectStyle != ProjectStyle.Standalone
+            var projectSpec =  specs.Where(e => e.RestoreMetadata.ProjectStyle != ProjectStyle.Standalone
                 && e.RestoreMetadata.ProjectStyle != ProjectStyle.DotnetCliTool)
                 .FirstOrDefault();
+
+            var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(context.Settings);
+            var fallbackFolders = SettingsUtility.GetFallbackPackageFolders(context.Settings);
+            projectSpec.RestoreMetadata.FallbackFolders = projectSpec.RestoreMetadata.FallbackFolders ?? fallbackFolders.AsList();
+            projectSpec.RestoreMetadata.PackagesPath = projectSpec.RestoreMetadata.PackagesPath ?? globalPackagesFolder;
+
+            return projectSpec;
         }
 
         public static async Task<DependencyGraphSpec> GetSolutionRestoreSpec(

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -331,8 +331,8 @@ namespace NuGet.PackageManagement
             foreach (var packageSpec in context.DeferredPackageSpecs)
             {
                 //TODO NK - Does this really make sense? Anything unforeseen here? 
-                packageSpec.RestoreMetadata.FallbackFolders = packageSpec.RestoreMetadata.FallbackFolders ?? fallbackFolders.AsList();
-                packageSpec.RestoreMetadata.PackagesPath = packageSpec.RestoreMetadata.PackagesPath ?? globalPackagesFolder;
+                packageSpec.RestoreMetadata.FallbackFolders = fallbackFolders.AsList();
+                packageSpec.RestoreMetadata.PackagesPath = globalPackagesFolder;
 
                 dgSpec.AddProject(packageSpec);
 
@@ -353,7 +353,7 @@ namespace NuGet.PackageManagement
 
                 foreach (var packageSpec in packageSpecs)
                 {
-                    packageSpec.RestoreMetadata.FallbackFolders = (IList<string>)fallbackFolders;
+                    packageSpec.RestoreMetadata.FallbackFolders = fallbackFolders.AsList();
                     packageSpec.RestoreMetadata.PackagesPath = globalPackagesFolder;
 
                     dgSpec.AddProject(packageSpec);

--- a/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/BuildIntegration/DependencyGraphRestoreUtility.cs
@@ -222,6 +222,11 @@ namespace NuGet.PackageManagement
             var spec = specs.Single(e => e.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference
                 || e.RestoreMetadata.ProjectStyle == ProjectStyle.ProjectJson);
 
+            var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(context.Settings);
+            var fallbackFolders = SettingsUtility.GetFallbackPackageFolders(context.Settings);
+            spec.RestoreMetadata.FallbackFolders = spec.RestoreMetadata.FallbackFolders ?? fallbackFolders.AsList();
+            spec.RestoreMetadata.PackagesPath = spec.RestoreMetadata.PackagesPath ?? globalPackagesFolder;
+
             var result = await PreviewRestoreAsync(
                 solutionManager,
                 project,
@@ -325,6 +330,7 @@ namespace NuGet.PackageManagement
 
             foreach (var packageSpec in context.DeferredPackageSpecs)
             {
+                //TODO NK - Does this really make sense? Anything unforeseen here? 
                 packageSpec.RestoreMetadata.FallbackFolders = packageSpec.RestoreMetadata.FallbackFolders ?? fallbackFolders.AsList();
                 packageSpec.RestoreMetadata.PackagesPath = packageSpec.RestoreMetadata.PackagesPath ?? globalPackagesFolder;
 

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatAddPkgTests.cs
@@ -575,7 +575,6 @@ namespace NuGet.XPlat.FuncTest
         public async void AddPkg_ConditionalAddTwoPackages_Success(string packageFrameworks, string projectFrameworks, string userInputFrameworks)
         {
             // Arrange
-
             using (var pathContext = new SimpleTestPathContext())
             {
                 var projectA = XPlatTestUtils.CreateProject(projectName, pathContext, projectFrameworks);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -12,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using NuGet.CommandLine.XPlat;
 using NuGet.Commands;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
@@ -180,11 +182,17 @@ namespace NuGet.XPlat.FuncTest
             SimpleTestPathContext pathContext,
             string projectFrameworks)
         {
+            var settings = Settings.LoadDefaultSettings(Path.GetDirectoryName(pathContext.NuGetConfig), Path.GetFileName(pathContext.NuGetConfig), null);
             var project = SimpleTestProjectContext.CreateNETCoreWithSDK(
                     projectName: projectName,
                     solutionRoot: pathContext.SolutionRoot,
                     isToolingVersion15: true,
                     frameworks: MSBuildStringUtility.Split(projectFrameworks));
+
+            project.FallbackFolders = (IList<string>) SettingsUtility.GetFallbackPackageFolders(settings);
+            project.GlobalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+            var packageSourceProvider = new PackageSourceProvider(settings);
+            project.Sources = packageSourceProvider.LoadPackageSources();
 
             project.Save();
             return project;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
@@ -70,7 +70,7 @@ namespace NuGet.Commands.Test
             // Arrange
             var cache = new RestoreCommandProvidersCache();
             var provider = new DependencyGraphFileRequestProvider(cache);
-            //Debugger.Launch();
+
             using (var workingDir = TestDirectory.Create())
             {
                 var dgSpec = Path.Combine(workingDir, "project.dg");

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RequestFactoryTests.cs
@@ -65,7 +65,7 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public async Task RequestFactory_FindProjectJsonFilesInDirectory()
+        public async Task RequestFactory_ReadDGSpec()
         {
             // Arrange
             var cache = new RestoreCommandProvidersCache();
@@ -112,8 +112,6 @@ namespace NuGet.Commands.Test
         ""outputPath"": ""C:\\Users\\Documents\\Visual Studio 2017\\Projects\\ConsoleApp7\\ConsoleApp1\\obj\\"",
         ""projectStyle"": ""PackageReference"",
         ""configFilePaths"": [
-          ""C:\\Users\\AppData\\Roaming\\NuGetNuGet.Config"",
-          ""C:\\Program Files (x86)\\NuGet\\ConfigMicrosoft.VisualStudio.Offline.config""
         ],
         ""fallbackFolders"": [
           ""C:\\Users\\.dotnet\\NuGetFallbackFolder""

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -42,26 +43,36 @@ namespace NuGet.Commands.Test
 
             using (var workingDir = TestDirectory.Create())
             {
+                var projectName = "project1";
                 var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
                 var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
-                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", projectName));
+                
                 packagesDir.Create();
                 packageSource.Create();
                 project1.Create();
                 sources.Add(new PackageSource(packageSource.FullName));
 
-                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
-
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                var dgPath = Path.Combine(project1.FullName, "project.dg");
+
+                File.WriteAllText(specPath1, project1Json);
+
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, projectName , specPath1);
+
+                spec1 = spec1.EnsureRestoreMetadata();
+                spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
+                spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(spec1);
+                dgSpec.AddRestore(projectName);
 
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.lock.json");
+                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
                 var providerCache = new RestoreCommandProvidersCache();
-
                 using (var cacheContext = new SourceCacheContext())
                 {
                     var restoreContext = new RestoreArgs()
@@ -70,12 +81,11 @@ namespace NuGet.Commands.Test
                         DisableParallel = true,
                         GlobalPackagesFolder = packagesDir.FullName,
                         Sources = new List<string>() { packageSource.FullName },
-                        Inputs = new List<string>() { specPath1 },
                         Log = logger,
                         CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                        RequestProviders = new List<IRestoreRequestProvider>()
+                        PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
                         {
-                            new ProjectJsonRestoreRequestProvider(providerCache)
+                            new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
                         }
                     };
 
@@ -87,8 +97,9 @@ namespace NuGet.Commands.Test
                     Assert.True(summary.Success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
                     Assert.Equal(1, summary.FeedsUsed.Count);
                     Assert.True(File.Exists(lockPath), lockPath);
-                    Assert.False(File.Exists(Path.Combine(project1.FullName, "project1.nuget.targets")));
+                    Assert.False(File.Exists(Path.Combine(project1.FullName, "project1.nuget.targets"))); // TODO NK - Why are we doing this? The name of the targets has changed!
                     Assert.False(File.Exists(Path.Combine(project1.FullName, "project1.nuget.props")));
+                    Debugger.Launch();
                 }
             }
         }
@@ -320,11 +331,19 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-
                 var configPath = Path.Combine(workingDir, "NuGet.Config");
 
+                var dgFile = new DependencyGraphSpec();
+                spec1 = spec1.EnsureRestoreMetadata();
+                spec1.RestoreMetadata.ConfigFilePaths = new List<string> { configPath };
+                spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
+                spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
+
+                dgFile.AddProject(spec1);
+                dgFile.AddRestore("project1");
+
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.lock.json");
+                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
 
                 var providerCache = new RestoreCommandProvidersCache();
 
@@ -334,14 +353,13 @@ namespace NuGet.Commands.Test
                     {
                         CacheContext = cacheContext,
                         DisableParallel = true,
-                        GlobalPackagesFolder = packagesDir.FullName,
+                        GlobalPackagesFolder = spec1.RestoreMetadata.PackagesPath,
                         ConfigFile = configPath,
-                        Inputs = new List<string>() { specPath1 },
                         Log = logger,
                         CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(new List<PackageSource>())),
-                        RequestProviders = new List<IRestoreRequestProvider>()
+                        PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>
                         {
-                            new ProjectJsonRestoreRequestProvider(providerCache)
+                            new DependencyGraphSpecRequestProvider(providerCache, dgFile)
                         }
                     };
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/RestoreRunnerTests.cs
@@ -99,7 +99,6 @@ namespace NuGet.Commands.Test
                     Assert.True(File.Exists(lockPath), lockPath);
                     Assert.False(File.Exists(Path.Combine(project1.FullName, "project1.nuget.targets"))); // TODO NK - Why are we doing this? The name of the targets has changed!
                     Assert.False(File.Exists(Path.Combine(project1.FullName, "project1.nuget.props")));
-                    Debugger.Launch();
                 }
             }
         }
@@ -141,9 +140,15 @@ namespace NuGet.Commands.Test
 
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+                spec1 = spec1.EnsureRestoreMetadata();
+                spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
+                spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
+                var dgFile = new DependencyGraphSpec();
+                dgFile.AddProject(spec1);
+                dgFile.AddRestore("project1");
 
                 var logger = new TestLogger();
-                var lockPath = Path.Combine(project1.FullName, "project.lock.json");
+                var lockPath = Path.Combine(project1.FullName, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
@@ -174,16 +179,15 @@ namespace NuGet.Commands.Test
                         DisableParallel = true,
                         GlobalPackagesFolder = packagesDir.FullName,
                         Sources = new List<string>() { packageSource.FullName },
-                        Inputs = new List<string>() { specPath1 },
                         Log = logger,
                         CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                        RequestProviders = new List<IRestoreRequestProvider>()
+                        PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
                         {
-                            new ProjectJsonRestoreRequestProvider(providerCache)
+                            new DependencyGraphSpecRequestProvider(providerCache, dgFile)
                         }
                     };
 
-                    var targetsPath = Path.Combine(project1.FullName, "project1.nuget.targets");
+                    var targetsPath = Path.Combine(project1.FullName, "project1.csproj.nuget.g.targets");
                     var propsPath = Path.Combine(project1.FullName, "project1.nuget.props");
 
                     // Act
@@ -651,99 +655,6 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public async Task RestoreRunner_RestoreFolder()
-        {
-            // Arrange
-            var sources = new List<PackageSource>();
-
-            var project1Json = @"
-            {
-              ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""frameworks"": {
-                ""net45"": {
-                }
-              }
-            }";
-
-            var project2Json = @"
-            {
-              ""version"": ""1.0.0"",
-              ""description"": """",
-              ""authors"": [ ""author"" ],
-              ""tags"": [ """" ],
-              ""projectUrl"": """",
-              ""licenseUrl"": """",
-              ""frameworks"": {
-                ""net45"": {
-                }
-              }
-            }";
-
-            using (var workingDir = TestDirectory.Create())
-            {
-                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
-                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
-                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
-                var project2 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project2"));
-                packagesDir.Create();
-                packageSource.Create();
-                project1.Create();
-                project2.Create();
-                sources.Add(new PackageSource(packageSource.FullName));
-
-                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
-                File.WriteAllText(Path.Combine(project2.FullName, "project.json"), project1Json);
-
-                var specPath1 = Path.Combine(project1.FullName, "project.json");
-                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
-
-                var specPath2 = Path.Combine(project2.FullName, "project.json");
-                var spec2 = JsonPackageSpecReader.GetPackageSpec(project2Json, "project2", specPath2);
-
-                var logger = new TestLogger();
-                var lockPath1 = Path.Combine(project1.FullName, "project.lock.json");
-                var lockPath2 = Path.Combine(project2.FullName, "project.lock.json");
-
-                var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
-
-                var providerCache = new RestoreCommandProvidersCache();
-
-                using (var cacheContext = new SourceCacheContext())
-                {
-                    var restoreContext = new RestoreArgs()
-                    {
-                        CacheContext = cacheContext,
-                        DisableParallel = true,
-                        GlobalPackagesFolder = packagesDir.FullName,
-                        Sources = new List<string>() { packageSource.FullName },
-                        Inputs = new List<string>() { workingDir },
-                        Log = logger,
-                        CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                        RequestProviders = new List<IRestoreRequestProvider>()
-                        {
-                        new DependencyGraphFileRequestProvider(providerCache),
-                            new ProjectJsonRestoreRequestProvider(providerCache)
-                        }
-                    };
-
-                    // Act
-                    var summaries = await RestoreRunner.Run(restoreContext);
-                    var success = summaries.All(s => s.Success);
-
-                    // Assert
-                    Assert.True(success, "Failed: " + string.Join(Environment.NewLine, logger.Messages));
-                    Assert.True(File.Exists(lockPath1), lockPath1);
-                    Assert.True(File.Exists(lockPath2), lockPath2);
-                }
-            }
-        }
-
-        [Fact]
         public async Task RestoreRunner_RestoreWithRuntime()
         {
             // Arrange
@@ -778,8 +689,15 @@ namespace NuGet.Commands.Test
                 var specPath1 = Path.Combine(project1.FullName, "project.json");
                 var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
 
+                spec1 = spec1.EnsureRestoreMetadata();
+                spec1.RestoreMetadata.Sources = new List<PackageSource> { new PackageSource(packageSource.FullName) };
+                spec1.RestoreMetadata.PackagesPath = packagesDir.FullName;
+                var dgSpec = new DependencyGraphSpec();
+                dgSpec.AddProject(spec1);
+                dgSpec.AddRestore("project1");
+
                 var logger = new TestLogger();
-                var lockPath1 = Path.Combine(project1.FullName, "project.lock.json");
+                var lockPath1 = Path.Combine(project1.FullName, "project.assets.json");
 
                 var sourceRepos = sources.Select(source => Repository.Factory.GetCoreV3(source.Source)).ToList();
 
@@ -791,14 +709,13 @@ namespace NuGet.Commands.Test
                     {
                         CacheContext = cacheContext,
                         DisableParallel = true,
-                        GlobalPackagesFolder = packagesDir.FullName,
+                        GlobalPackagesFolder = spec1.RestoreMetadata.PackagesPath,
                         Sources = new List<string>() { packageSource.FullName },
-                        Inputs = new List<string>() { specPath1 },
                         Log = logger,
                         CachingSourceProvider = new CachingSourceProvider(new TestPackageSourceProvider(sources)),
-                        RequestProviders = new List<IRestoreRequestProvider>()
+                        PreLoadedRequestProviders = new List<IPreLoadedRestoreRequestProvider>()
                         {
-                             new ProjectJsonRestoreRequestProvider(providerCache)
+                             new DependencyGraphSpecRequestProvider(providerCache, dgSpec)
                         }
                     };
 

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedRestoreUtilityTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -170,7 +170,7 @@ namespace NuGet.Test
 
                 var testLogger = new TestLogger();
 
-                var restoreContext = new DependencyGraphCacheContext(testLogger, NullSettings.Instance);
+                var restoreContext = new DependencyGraphCacheContext(testLogger, settings);
 
                 // Act
                 await DependencyGraphRestoreUtility.RestoreAsync(
@@ -178,7 +178,7 @@ namespace NuGet.Test
                     restoreContext,
                     new RestoreCommandProvidersCache(),
                     (c) => { },
-                    sources, //TODO NK - settings removed
+                    sources,
                     testLogger,
                     CancellationToken.None);
 

--- a/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
+++ b/test/TestUtilities/Test.Utility/Commands/ProjectJsonTestHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -107,6 +108,7 @@ namespace NuGet.Commands.Test
             updated.RestoreMetadata.ProjectName = spec.Name;
             updated.RestoreMetadata.ProjectUniqueName = spec.Name;
             updated.RestoreMetadata.ProjectPath = projectPath;
+            updated.RestoreMetadata.ConfigFilePaths = new List<string>();
 
             foreach (var framework in updated.TargetFrameworks.Select(e => e.FrameworkName))
             {

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Xml.Linq;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
@@ -110,6 +111,12 @@ namespace NuGet.Test.Utility
 
         public bool ToolingVersion15 { get; set; } = false;
 
+        public IEnumerable<PackageSource> Sources { get; set; }
+
+        public IList<string> FallbackFolders { get; set; }
+
+        public string GlobalPackagesFolder { get; set; }
+
         /// <summary>
         /// project.lock.json or project.assets.json
         /// </summary>
@@ -204,6 +211,9 @@ namespace NuGet.Test.Utility
                     _packageSpec.RestoreMetadata.TargetFrameworks = Frameworks
                         .Select(f => new ProjectRestoreMetadataFrameworkInfo(f.Framework))
                         .ToList();
+                    _packageSpec.RestoreMetadata.Sources = Sources.ToList();
+                    _packageSpec.RestoreMetadata.PackagesPath = GlobalPackagesFolder;
+                    _packageSpec.RestoreMetadata.FallbackFolders = FallbackFolders;
                     if (Type == ProjectStyle.ProjectJson)
                     {
                         _packageSpec.RestoreMetadata.ProjectJsonPath = Path.Combine(Path.GetDirectoryName(ProjectPath), "project.json");


### PR DESCRIPTION
Fixing the old tests that got broken by the source plumbing in changes.  There's initial VS work done here too, where we set the globalpackages/fallback folders.