### PR TITLE
Avoid adding project metadata in MSBuild nuget project constructor

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -4,7 +4,9 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
 
@@ -35,28 +37,30 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)
         {
-            // This is a solution event. Should be on the UI thread
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
-                {
-                    // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
-                    // is showing and the user closes the solution; in that case, we want to hide the Update bar.
-                    var solutionDirectory = SolutionManager.SolutionDirectory;
-                    await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
-                });
+            {
+                // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
+                // is showing and the user closes the solution; in that case, we want to hide the Update bar.
+                var solutionDirectory = SolutionManager.SolutionDirectory;
+
+                // go off the UI thread to raise package missing events
+                await TaskScheduler.Default;
+
+                await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
+            });
         }
 
         private void OnNuGetProjectAdded(object sender, NuGetProjectEventArgs e)
         {
-            // This is a solution event. Should be on the UI thread
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
-                {
-                    var solutionDirectory = SolutionManager.SolutionDirectory;
-                    await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
-                });
+            {
+                var solutionDirectory = SolutionManager.SolutionDirectory;
+
+                // go off the UI thread to raise package missing events
+                await TaskScheduler.Default;
+
+                await RaisePackagesMissingEventForSolutionAsync(solutionDirectory, CancellationToken.None);
+            });
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/MSBuildNuGetProject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -104,10 +104,14 @@ namespace NuGet.ProjectManagement
             ProjectSystem = msbuildNuGetProjectSystem ?? throw new ArgumentNullException(nameof(msbuildNuGetProjectSystem));
             FolderNuGetProject = new FolderNuGetProject(folderNuGetProjectPath);
             InternalMetadata.Add(NuGetProjectMetadataKeys.Name, ProjectSystem.ProjectName);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.TargetFramework, ProjectSystem.TargetFramework);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, msbuildNuGetProjectSystem.ProjectFullPath);
-            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, msbuildNuGetProjectSystem.ProjectUniqueName);
             PackagesConfigNuGetProject = new PackagesConfigNuGetProject(packagesConfigFolderPath, InternalMetadata);
+        }
+
+        protected override void InitializeMetadata()
+        {
+            InternalMetadata.Add(NuGetProjectMetadataKeys.TargetFramework, ProjectSystem.TargetFramework);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.FullPath, ProjectSystem.ProjectFullPath);
+            InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, ProjectSystem.ProjectUniqueName);
         }
 
         public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/NuGetProject.cs
@@ -28,6 +28,10 @@ namespace NuGet.ProjectManagement
 
         public ProjectModel.ProjectStyle ProjectStyle { get; protected set; } = ProjectModel.ProjectStyle.Unknown;
 
+        private bool _initialized;
+
+        private readonly object _lckObj = new object();
+
         /// <summary>
         /// This installs a package into the NuGetProject using the <see cref="Stream"/> passed in
         /// <param name="downloadResourceResult"></param>
@@ -67,12 +71,35 @@ namespace NuGet.ProjectManagement
             return Task.FromResult(0);
         }
 
+        protected virtual void InitializeMetadata()
+        {
+            // do nothing by default.
+        }
+
+        private void EnsureInitialized()
+        {
+            if (!_initialized)
+            {
+                lock (_lckObj)
+                {
+                    if (!_initialized)
+                    {
+                        _initialized = true;
+
+                        InitializeMetadata();
+                    }
+                }
+            }
+        }
+
         public T GetMetadata<T>(string key)
         {
             if (key == null)
             {
                 throw new ArgumentNullException(nameof(key));
             }
+
+            EnsureInitialized();
 
             var value = Metadata[key];
             return (T)value;
@@ -81,6 +108,8 @@ namespace NuGet.ProjectManagement
         public bool TryGetMetadata<T>(string key, out T value)
         {
             value = default(T);
+
+            EnsureInitialized();
 
             object oValue;
             if (Metadata.TryGetValue(key, out oValue))

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/PackagesConfigNuGetProject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -50,8 +50,6 @@ namespace NuGet.ProjectManagement
         /// </summary>
         private string PackagesProjectNameConfigPath { get; }
 
-        private NuGetFramework TargetFramework { get; }
-
         public PackagesConfigNuGetProject(string folderPath, Dictionary<string, object> metadata)
             : base(metadata)
         {
@@ -60,11 +58,12 @@ namespace NuGet.ProjectManagement
                 throw new ArgumentNullException(nameof(folderPath));
             }
 
-            TargetFramework = GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
-
             PackagesConfigPath = Path.Combine(folderPath, "packages.config");
 
-            var projectName = GetMetadata<string>(NuGetProjectMetadataKeys.Name);
+            // Reading project name directly from InternalMetadata instead of using GetMetadata api because
+            // at this time, we don't want to initialize all the project's metadata which also includes target framework
+            // since it impacts project creation performance.
+            var projectName = InternalMetadata[NuGetProjectMetadataKeys.Name];
             PackagesProjectNameConfigPath = Path.Combine(folderPath, "packages." + projectName + ".config");
         }
 
@@ -86,12 +85,8 @@ namespace NuGet.ProjectManagement
             }
 
             var isDevelopmentDependency = await CheckDevelopmentDependencyAsync(downloadResourceResult, token);
-            var newPackageReference = new PackageReference(
-                packageIdentity,
-                TargetFramework,
-                userInstalled: true,
-                developmentDependency: isDevelopmentDependency,
-                requireReinstallation: false);
+            var targetFramework = GetMetadata<NuGetFramework>(NuGetProjectMetadataKeys.TargetFramework);
+            var newPackageReference = new PackageReference(packageIdentity, targetFramework, userInstalled: true, developmentDependency: isDevelopmentDependency, requireReinstallation: false);
             var installedPackagesList = GetInstalledPackagesList();
 
             try


### PR DESCRIPTION
This PR attacks 2 issues with solutions:
1. Added a new EnsureMetadataInitialized() api in NuGetProject which is overridden in MSBuildNuGetProject to initialize project metadata in metadata dictionary which is removed from MSBuildNuGetProject constructor so that it improves performance for CreateNuGetProject.

2. Moved checking for missing packages and then raising event code off the UI thread on solution load or a new NuGet project added event and will be done in a threadpool worker thread which will further improve solution load performance when PMC is default opened.

Fixes https://github.com/NuGet/Home/issues/5276

@rrelyea 