### PR TITLE
Fail overall restoration when a project is invalid

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -43,8 +43,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <!-- RuntimeIdentifier compatibility check -->
     <ValidateRuntimeIdentifierCompatibility Condition=" '$(ValidateRuntimeIdentifierCompatibility)' == '' ">false</ValidateRuntimeIdentifierCompatibility>
-    <!-- Error handling while walking projects -->
-    <RestoreContinueOnError Condition=" '$(RestoreContinueOnError)' == '' ">WarnAndContinue</RestoreContinueOnError>
+    <!-- Error handling while walking projects: keep going, but fail the overall "build" -->
+    <RestoreContinueOnError Condition=" '$(RestoreContinueOnError)' == '' ">ErrorAndContinue</RestoreContinueOnError>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes NuGet/Home#5284 by changing the default setting for
`$(RestoreContinueOnError)` from `WarnAndContinue` (treat errors as
warnings that do not fail this task nor the overall build) to
`ErrorAndContinue` (continue the build, but mark it as failed if there
are any errors here).