### PR TITLE
Add support for ILogger.LogAsync in RestoreOperationLogger

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggerBase.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System.Threading.Tasks;
 
 namespace NuGet.Common
@@ -40,37 +40,37 @@ namespace NuGet.Common
             return Task.FromResult(true);
         }
 
-        public void LogDebug(string data)
+        public virtual void LogDebug(string data)
         {
             Log(LogLevel.Debug, data);
         }
 
-        public void LogError(string data)
+        public virtual void LogError(string data)
         {
             Log(LogLevel.Error, data);
         }
 
-        public void LogInformation(string data)
+        public virtual void LogInformation(string data)
         {
             Log(LogLevel.Information, data);
         }
 
-        public void LogInformationSummary(string data)
+        public virtual void LogInformationSummary(string data)
         {
             Log(LogLevel.Information, data);
         }
 
-        public void LogMinimal(string data)
+        public virtual void LogMinimal(string data)
         {
             Log(LogLevel.Minimal, data);
         }
 
-        public void LogVerbose(string data)
+        public virtual void LogVerbose(string data)
         {
             Log(LogLevel.Verbose, data);
         }
 
-        public void LogWarning(string data)
+        public virtual void LogWarning(string data)
         {
             Log(LogLevel.Warning, data);
         }


### PR DESCRIPTION
Adding support for ILogger.LogAsync in VS logger.

Log and LogAsync contain the same logic here, but they need to be kept separate to avoid making unneeded JTF calls.