### PR TITLE
Adding HideWarningsAndErrors option to RestoreTask

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -38,6 +38,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <IsRestoreTargetsFileLoaded>true</IsRestoreTargetsFileLoaded>
     <!-- Load NuGet.Build.Tasks.dll, this can be overridden to use a different version with $(RestoreTaskAssemblyFile) -->
     <RestoreTaskAssemblyFile Condition=" '$(RestoreTaskAssemblyFile)' == '' ">NuGet.Build.Tasks.dll</RestoreTaskAssemblyFile>
+    <!-- Do not hide errors and warnings by default -->
+    <HideWarningsAndErrors Condition=" '$(HideWarningsAndErrors)' == '' ">false</HideWarningsAndErrors>
     <!-- Recurse by default -->
     <RestoreRecursive Condition=" '$(RestoreRecursive)' == '' ">true</RestoreRecursive>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -45,7 +47,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ValidateRuntimeIdentifierCompatibility Condition=" '$(ValidateRuntimeIdentifierCompatibility)' == '' ">false</ValidateRuntimeIdentifierCompatibility>
     <!-- Error handling while walking projects -->
     <RestoreContinueOnError Condition=" '$(RestoreContinueOnError)' == '' ">WarnAndContinue</RestoreContinueOnError>
-  </PropertyGroup>
+  
+
+</PropertyGroup>
 
   <PropertyGroup>
     <!-- Generate a restore graph for each entry point project. -->
@@ -103,7 +107,8 @@ Copyright (c) .NET Foundation. All rights reserved.
       RestoreConfigFile="$(RestoreConfigFile)"
       RestoreNoCache="$(RestoreNoCache)"
       RestoreIgnoreFailedSources="$(RestoreIgnoreFailedSources)"
-      RestoreRecursive="$(RestoreRecursive)" />
+      RestoreRecursive="$(RestoreRecursive)"
+      HideWarningsAndErrors="$(HideWarningsAndErrors)"/>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/RestoreTask.cs
@@ -71,6 +71,12 @@ namespace NuGet.Build.Tasks
         /// </summary>
         public bool RestoreRecursive { get; set; }
 
+        /// <summary>
+        /// Do not display Errors and Warnings to the user. 
+        /// The Warnings and Errors are written into the assets file and will be read by an sdk target.
+        /// </summary>
+        public bool HideWarningsAndErrors { get; set; }
+
         public override bool Execute()
         {
             var log = new MSBuildLogger(Log);
@@ -85,6 +91,7 @@ namespace NuGet.Build.Tasks
             log.LogDebug($"(in) RestoreNoCache '{RestoreNoCache}'");
             log.LogDebug($"(in) RestoreIgnoreFailedSources '{RestoreIgnoreFailedSources}'");
             log.LogDebug($"(in) RestoreRecursive '{RestoreRecursive}'");
+            log.LogDebug($"(in) HideWarningsAndErrors '{HideWarningsAndErrors}'");
 
             try
             {
@@ -158,7 +165,8 @@ namespace NuGet.Build.Tasks
                     Log = log,
                     MachineWideSettings = new XPlatMachineWideSetting(),
                     PreLoadedRequestProviders = providers,
-                    CachingSourceProvider = sourceProvider
+                    CachingSourceProvider = sourceProvider,
+                    HideWarningsAndErrors = HideWarningsAndErrors
                 };
 
                 if (!string.IsNullOrEmpty(RestoreSources))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -62,7 +62,7 @@ namespace NuGet.Commands
 
         public bool? ValidateRuntimeAssets { get; set; }
 
-        public bool DisplayAllLogs { get; set; } = true;
+        public bool HideErrorsAndWarnings { get; set; } = false;
 
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
@@ -216,7 +216,7 @@ namespace NuGet.Commands
                 request.ValidateRuntimeAssets = ValidateRuntimeAssets.Value;
             }
 
-            request.DisplayAllLogs = DisplayAllLogs;
+            request.HideErrorsAndWarnings = HideErrorsAndWarnings;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -62,7 +62,7 @@ namespace NuGet.Commands
 
         public bool? ValidateRuntimeAssets { get; set; }
 
-        public bool HideErrorsAndWarnings { get; set; } = false;
+        public bool HideWarningsAndErrors { get; set; } = false;
 
         // Cache directory -> ISettings
         private ConcurrentDictionary<string, ISettings> _settingsCache
@@ -216,7 +216,7 @@ namespace NuGet.Commands
                 request.ValidateRuntimeAssets = ValidateRuntimeAssets.Value;
             }
 
-            request.HideErrorsAndWarnings = HideErrorsAndWarnings;
+            request.HideWarningsAndErrors = HideWarningsAndErrors;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -47,7 +47,7 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            var collectorLogger = new CollectorLogger(_request.Log, request.HideErrorsAndWarnings);
+            var collectorLogger = new CollectorLogger(_request.Log, request.HideWarningsAndErrors);
             _logger = collectorLogger;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -47,7 +47,7 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            var collectorLogger = new CollectorLogger(_request.Log, request.DisplayAllLogs);
+            var collectorLogger = new CollectorLogger(_request.Log, request.HideErrorsAndWarnings);
             _logger = collectorLogger;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -139,6 +139,6 @@ namespace NuGet.Commands
         /// <summary>
         /// Display Errors and warnings as they occur
         /// </summary>
-        public bool HideErrorsAndWarnings { get; set; } = false;
+        public bool HideWarningsAndErrors { get; set; } = false;
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreRequest.cs
@@ -139,6 +139,6 @@ namespace NuGet.Commands
         /// <summary>
         /// Display Errors and warnings as they occur
         /// </summary>
-        public bool DisplayAllLogs { get; set; } = true;
+        public bool HideErrorsAndWarnings { get; set; } = false;
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -12,7 +12,7 @@ namespace NuGet.Common
     {
         private readonly ILogger _innerLogger;
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
-        private readonly bool _hideErrorsAndWarnings;
+        private readonly bool _hideWarningsAndErrors;
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
 
@@ -22,13 +22,13 @@ namespace NuGet.Common
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
-        /// <param name="hideErrorsAndWarnings">If this is true, then errors and warnings will not be passed to inner logger.</param>
-        public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool hideErrorsAndWarnings)
+        /// <param name="hideWarningsAndErrors">If this is true, then errors and warnings will not be passed to inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool hideWarningsAndErrors)
             : base(verbosity)
         {
             _innerLogger = innerLogger;
             _errors = new ConcurrentQueue<IRestoreLogMessage>();
-            _hideErrorsAndWarnings = hideErrorsAndWarnings;
+            _hideWarningsAndErrors = hideWarningsAndErrors;
         }
 
         /// <summary>
@@ -36,9 +36,9 @@ namespace NuGet.Common
         /// delegating all log messages to the inner logger.
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
-        /// <param name="hideErrorsAndWarnings">If this is false, then errors and warnings will not be passed to inner logger.</param>
-        public CollectorLogger(ILogger innerLogger, bool hideErrorsAndWarnings)
-            : this(innerLogger, LogLevel.Debug, hideErrorsAndWarnings)
+        /// <param name="hideWarningsAndErrors">If this is false, then errors and warnings will not be passed to inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, bool hideWarningsAndErrors)
+            : this(innerLogger, LogLevel.Debug, hideWarningsAndErrors)
         {
         }
 
@@ -49,7 +49,7 @@ namespace NuGet.Common
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
         public CollectorLogger(ILogger innerLogger, LogLevel verbosity)
-            : this(innerLogger, verbosity, hideErrorsAndWarnings: false)
+            : this(innerLogger, verbosity, hideWarningsAndErrors: false)
         {
         }
 
@@ -59,7 +59,7 @@ namespace NuGet.Common
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         public CollectorLogger(ILogger innerLogger)
-            : this(innerLogger, LogLevel.Debug, hideErrorsAndWarnings: false)
+            : this(innerLogger, LogLevel.Debug, hideWarningsAndErrors: false)
         {
         }
 
@@ -112,7 +112,7 @@ namespace NuGet.Common
         {
             if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
             {
-                return ((!_hideErrorsAndWarnings || message.ShouldDisplay) && message.Level >= VerbosityLevel);
+                return ((!_hideWarningsAndErrors || message.ShouldDisplay) && message.Level >= VerbosityLevel);
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/CollectorLogger.cs
@@ -12,7 +12,7 @@ namespace NuGet.Common
     {
         private readonly ILogger _innerLogger;
         private readonly ConcurrentQueue<IRestoreLogMessage> _errors;
-        private readonly bool _displayAllLogs;
+        private readonly bool _hideErrorsAndWarnings;
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
 
@@ -22,13 +22,13 @@ namespace NuGet.Common
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
-        /// <param name="displayAllLogs">If this is false, then errors and warnings will not be passed to inner logger.</param>
-        public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool displayAllLogs)
+        /// <param name="hideErrorsAndWarnings">If this is true, then errors and warnings will not be passed to inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, LogLevel verbosity, bool hideErrorsAndWarnings)
             : base(verbosity)
         {
             _innerLogger = innerLogger;
             _errors = new ConcurrentQueue<IRestoreLogMessage>();
-            _displayAllLogs = displayAllLogs;
+            _hideErrorsAndWarnings = hideErrorsAndWarnings;
         }
 
         /// <summary>
@@ -36,9 +36,9 @@ namespace NuGet.Common
         /// delegating all log messages to the inner logger.
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
-        /// <param name="displayAllLogs">If this is false, then errors and warnings will not be passed to inner logger.</param>
-        public CollectorLogger(ILogger innerLogger, bool displayAllLogs)
-            : this(innerLogger, LogLevel.Debug, displayAllLogs)
+        /// <param name="hideErrorsAndWarnings">If this is false, then errors and warnings will not be passed to inner logger.</param>
+        public CollectorLogger(ILogger innerLogger, bool hideErrorsAndWarnings)
+            : this(innerLogger, LogLevel.Debug, hideErrorsAndWarnings)
         {
         }
 
@@ -49,7 +49,7 @@ namespace NuGet.Common
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         /// <param name="verbosity">Minimum verbosity below which no logs will be passed to the inner logger.</param>
         public CollectorLogger(ILogger innerLogger, LogLevel verbosity)
-            : this(innerLogger, verbosity, true)
+            : this(innerLogger, verbosity, hideErrorsAndWarnings: false)
         {
         }
 
@@ -59,7 +59,7 @@ namespace NuGet.Common
         /// </summary>
         /// <param name="innerLogger">The inner logger used to delegate the logging.</param>
         public CollectorLogger(ILogger innerLogger)
-            : this(innerLogger, LogLevel.Debug, true)
+            : this(innerLogger, LogLevel.Debug, hideErrorsAndWarnings: false)
         {
         }
 
@@ -112,7 +112,7 @@ namespace NuGet.Common
         {
             if (message.Level == LogLevel.Error || message.Level == LogLevel.Warning)
             {
-                return ((_displayAllLogs || message.ShouldDisplay) && message.Level >= VerbosityLevel);
+                return ((!_hideErrorsAndWarnings || message.ShouldDisplay) && message.Level >= VerbosityLevel);
             }
             else
             {

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug"));
@@ -38,7 +38,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: true);
 
             // Act
             collector.Log(LogLevel.Debug, "Debug");
@@ -61,7 +61,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -84,7 +84,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -102,12 +102,12 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithNoShouldDisplayAndHideErrorsAndWarnings()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithNoShouldDisplayAndHideWarningsAndErrors()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -125,12 +125,12 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplayAndHideErrorsAndWarnings()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplayAndHideWarningsAndErrors()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideWarningsAndErrors: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -152,7 +152,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose, hideErrorsAndWarnings: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose, hideWarningsAndErrors: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -174,7 +174,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error, hideErrorsAndWarnings: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error, hideWarningsAndErrors: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/CollectorLoggerTests.cs
@@ -16,7 +16,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug"));
@@ -38,7 +38,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
 
             // Act
             collector.Log(LogLevel.Debug, "Debug");
@@ -61,7 +61,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -84,7 +84,7 @@ namespace NuGet.Common.Test
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -102,12 +102,12 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithNoShouldDisplayAndDisplayAllLogs()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithNoShouldDisplayAndHideErrorsAndWarnings()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -125,12 +125,12 @@ namespace NuGet.Common.Test
         }
 
         [Fact]
-        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplayAndDisplayAllLogs()
+        public void CollectorLogger_PassesLogMessagesToInnerLoggerWithShouldDisplayAndHideErrorsAndWarnings()
         {
 
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, displayAllLogs: true);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Debug, hideErrorsAndWarnings: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -152,7 +152,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Verbose, hideErrorsAndWarnings: true);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });
@@ -174,7 +174,7 @@ namespace NuGet.Common.Test
         {
             // Arrange
             var innerLogger = new Mock<ILogger>();
-            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error, displayAllLogs: false);
+            var collector = new CollectorLogger(innerLogger.Object, LogLevel.Error, hideErrorsAndWarnings: false);
 
             // Act
             collector.Log(new RestoreLogMessage(LogLevel.Debug, "Debug") { ShouldDisplay = true });


### PR DESCRIPTION
1. Rename `DisplayAllLogs` to `HideWarningsAndErrors`
2. Add `HideWarningsAndErrors ` to `RestoreTask`