### PR TITLE
Calling IsSolutionFullyLoaded only after SolutionRetoreWorker is initialized

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -139,14 +139,14 @@ namespace NuGet.SolutionRestoreManager
                     Advise(_vsSolution);
 #endif
                 });
-            }
 
-            // Signal the background job runner solution is loaded
-            // Needed when OnAfterBackgroundSolutionLoadComplete fires before
-            // Advise has been called.
-            if (!_solutionLoadedEvent.IsSet && await IsSolutionFullyLoadedAsync())
-            {
-                _solutionLoadedEvent.Set();
+                // Signal the background job runner solution is loaded
+                // Needed when OnAfterBackgroundSolutionLoadComplete fires before
+                // Advise has been called.
+                if (!_solutionLoadedEvent.IsSet && await IsSolutionFullyLoadedAsync())
+                {
+                    _solutionLoadedEvent.Set();
+                }
             }
         }
 


### PR DESCRIPTION
When there are multiple nominations at the same time, then multiple projects could try to initialize SolutionRestoreWorker at the same time. But since we initialize only once and all other calls still go ahead and calls IsSolutionFullyLoadedAsync, which throws NPE if first thread hasn't completed the initialization.

So the right fix we should always call IsSolutionFullyLoadedAsync inside SolutionRestoreWorker initialization.

Fixes https://github.com/NuGet/Home/issues/5288

@rrelyea 