### PR TITLE
Fix RestoreSummary to not display error summary for only warnings in nuget.exe

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -87,14 +87,19 @@ namespace NuGet.Commands
                 // Display the errors summary
                 foreach (var restoreSummary in restoreSummaries)
                 {
-                    if (restoreSummary.Errors.Count == 0)
+                    var errors = restoreSummary
+                        .Errors
+                        .Where(m => m.Level == LogLevel.Error)
+                        .ToList();
+
+                    if (errors.Count == 0)
                     {
                         continue;
                     }
 
                     logger.LogError(string.Empty);
                     logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
-                    foreach (var error in restoreSummary.Errors.Where(m => m.Level == LogLevel.Error))
+                    foreach (var error in errors)
                     {
                         foreach (var line in IndentLines(error.Message))
                         {


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5289

Improved logs - 

```
C:\Users\anmishr\Desktop\temp\demo_restore> C:\Users\anmishr\Documents\GitHub\NuGet.Client\artifacts\VS15\NuGet.exe restore .\demo_restore.csproj
MSBuild auto-detection: using msbuild version '15.1.1012.6693' from 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\bin'.
Restoring packages for C:\Users\anmishr\Desktop\temp\demo_restore\demo_restore.csproj...
  CACHE https://api.nuget.org/v3-flatcontainer/newtonsoft.json/index.json
  CACHE https://dotnetmyget.blob.core.windows.net/artifacts/cli-deps/nuget/v3/flatcontainer/newtonsoft.json/index.json
WARNING: NU1603: demo_restore depends on Newtonsoft.Json (>= 1.0.0) but Newtonsoft.Json 1.0.0 was not found. An approximate best match of Newtonsoft.Json 3.5.8 was resolved.
Committing restore...
Writing lock file to disk. Path: C:\Users\anmishr\Desktop\temp\demo_restore\obj\project.assets.json
Restore completed in 516.29 ms for C:\Users\anmishr\Desktop\temp\demo_restore\demo_restore.csproj.

NuGet Config files used:
    C:\Users\anmishr\AppData\Roaming\NuGet\NuGet.Config
    C:\Program Files (x86)\NuGet\Config\Microsoft.VisualStudio.Offline.config

Feeds used:
    https://api.nuget.org/v3/index.json
    https://dotnet.myget.org/F/cli-deps/api/v3/index.json
    C:\Users\anmishr\.dotnet\NuGetFallbackFolder
    C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\
```