### PR TITLE
Fixed :100: functional tests failing on CI

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -15,146 +15,66 @@ namespace NuGet.Build
     {
         private readonly TaskLoggingHelper _taskLogging;
 
-        private delegate void LogMessageWithDetails(string subcategory,
-            string code,
-            string helpKeyword,
-            string file,
-            int lineNumber,
-            int columnNumber,
-            int endLineNumber,
-            int endColumnNumber,
-            MessageImportance importance,
-            string message,
-            params object[] messageArgs);
-
-        private delegate void LogErrorWithDetails(string subcategory,
-            string code,
-            string helpKeyword,
-            string file,
-            int lineNumber,
-            int columnNumber,
-            int endLineNumber,
-            int endColumnNumber,
-            string message,
-            params object[] messageArgs);
-
-        private delegate void LogMessageAsString(MessageImportance importance,
-            string message,
-            params object[] messageArgs);
-
-        private delegate void LogErrorAsString(string message,
-            params object[] messageArgs);
-
-
-
-
         public MSBuildLogger(TaskLoggingHelper taskLogging)
         {
-            _taskLogging = taskLogging;
+            _taskLogging = taskLogging ?? throw new ArgumentNullException(nameof(taskLogging));
         }
 
         public override void Log(ILogMessage message)
         {
             if (DisplayMessage(message.Level))
             {
-                if (RuntimeEnvironmentHelper.IsMono)
-                {
-                    LogForMono(message);
-                    return;
-                }
-                else
-                {
-                    var logMessage = message as IRestoreLogMessage;
+                var logMessage = message as IRestoreLogMessage;
 
-                    if (logMessage == null)
+                if (logMessage == null)
+                {
+                    logMessage = new RestoreLogMessage(message.Level, message.Message)
                     {
-                        logMessage = new RestoreLogMessage(message.Level, message.Message)
-                        {
-                            Code = message.Code,
-                            FilePath = message.ProjectPath,
-                            StartLineNumber = -1,
-                            EndLineNumber = -1,
-                            StartColumnNumber = -1,
-                            EndColumnNumber = -1
-                        };
-                    }
-                    Log(logMessage);
+                        Code = message.Code,
+                        FilePath = message.ProjectPath,
+                        StartLineNumber = -1,
+                        EndLineNumber = -1,
+                        StartColumnNumber = -1,
+                        EndColumnNumber = -1
+                    };
+                }
+
+                switch (message.Level)
+                {
+                    case LogLevel.Error:
+                        LogError(logMessage);
+                        break;
+
+                    case LogLevel.Warning:
+                        LogWarning(logMessage);
+                        break;
+
+                    case LogLevel.Minimal:
+                        LogMessage(MessageImportance.High, logMessage);
+                        break;
+
+                    case LogLevel.Information:
+                        LogMessage(MessageImportance.Normal, logMessage);
+                        break;
+
+                    case LogLevel.Debug:
+                    case LogLevel.Verbose:
+                    default:
+                        // Default to LogLevel.Debug and low importance
+                        LogMessage(MessageImportance.Low, logMessage);
+                        break;
                 }
             }
         }
 
-        private void Log(IRestoreLogMessage message)
-        {
-            switch (message.Level)
-            {
-                case LogLevel.Error:
-                    LogError(message, _taskLogging.LogError, _taskLogging.LogError);
-                    break;
-
-                case LogLevel.Warning:
-                    LogError(message, _taskLogging.LogWarning, _taskLogging.LogWarning);
-                    break;
-
-                case LogLevel.Minimal:
-                    LogMessage(message, MessageImportance.High, _taskLogging.LogMessage, _taskLogging.LogMessage);
-                    break;
-
-                case LogLevel.Information:
-                    LogMessage(message, MessageImportance.Normal, _taskLogging.LogMessage, _taskLogging.LogMessage);
-                    break;
-
-                case LogLevel.Debug:
-                case LogLevel.Verbose:
-                default:
-                    // Default to LogLevel.Debug and low importance
-                    LogMessage(message, MessageImportance.Low, _taskLogging.LogMessage, _taskLogging.LogMessage);
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Log using basic methods to avoid missing methods on mono.
-        /// </summary>
-        private void LogForMono(ILogMessage message)
-        {
-            switch (message.Level)
-            {
-                case LogLevel.Error:
-                    _taskLogging.LogError(message.Message);
-                    break;
-
-                case LogLevel.Warning:
-                    _taskLogging.LogWarning(message.Message);
-                    break;
-
-                case LogLevel.Minimal:
-                    _taskLogging.LogMessage(MessageImportance.High, message.Message);
-                    break;
-
-                case LogLevel.Information:
-                    _taskLogging.LogMessage(MessageImportance.Normal, message.Message);
-                    break;
-
-                case LogLevel.Debug:
-                case LogLevel.Verbose:
-                default:
-                    // Default to LogLevel.Debug and low importance
-                    _taskLogging.LogMessage(MessageImportance.Low, message.Message);
-                    break;
-            }
-
-            return;
-        }
-
-        private void LogMessage(IRestoreLogMessage logMessage,
+        private void LogMessage(
             MessageImportance importance,
-            LogMessageWithDetails logWithDetails,
-            LogMessageAsString logAsString)
+            IRestoreLogMessage logMessage)
         {
             if (logMessage.Code > NuGetLogCode.Undefined)
             {
                 // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
-                logWithDetails(string.Empty,
+                _taskLogging.LogMessage(string.Empty,
                     Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
                     Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
                     logMessage.FilePath,
@@ -167,18 +87,16 @@ namespace NuGet.Build
             }
             else
             {
-                logAsString(importance, logMessage.Message);
+                _taskLogging.LogMessage(importance, logMessage.Message);
             }
         }
 
-        private void LogError(IRestoreLogMessage logMessage,
-            LogErrorWithDetails logWithDetails,
-            LogErrorAsString logAsString)
+        private void LogWarning(IRestoreLogMessage logMessage)
         {
             if (logMessage.Code > NuGetLogCode.Undefined)
             {
                 // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
-                logWithDetails(string.Empty,
+                _taskLogging.LogWarning(string.Empty,
                     Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
                     Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
                     logMessage.FilePath,
@@ -190,7 +108,28 @@ namespace NuGet.Build
             }
             else
             {
-                logAsString(logMessage.Message);
+                _taskLogging.LogWarning(logMessage.Message);
+            }
+        }
+
+        private void LogError(IRestoreLogMessage logMessage)
+        {
+            if (logMessage.Code > NuGetLogCode.Undefined)
+            {
+                // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
+                _taskLogging.LogError(string.Empty,
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    Enum.GetName(typeof(NuGetLogCode), logMessage.Code),
+                    logMessage.FilePath,
+                    logMessage.StartLineNumber,
+                    logMessage.StartColumnNumber,
+                    logMessage.EndLineNumber,
+                    logMessage.EndColumnNumber,
+                    logMessage.Message);
+            }
+            else
+            {
+                _taskLogging.LogError(logMessage.Message);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -83,7 +83,7 @@ namespace NuGet.Build
             }
         }
 
-        private void Log(RestoreLogMessage message)
+        private void Log(IRestoreLogMessage message)
         {
             switch (message.Level)
             {

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -24,7 +24,6 @@ namespace Test.Utility
         private HashSet<string> FilesInProcessing { get; set; }
         public HashSet<string> ProcessedFiles { get; private set; }
         public HashSet<string> Imports { get; }
-        public Dictionary<string, int> ScriptsExecuted { get; }
         public int BindingRedirectsCallCount { get; private set; }
         public INuGetProjectContext NuGetProjectContext { get; set; }
         public int BatchCount { get; private set; }
@@ -45,7 +44,6 @@ namespace Test.Utility
             Imports = new HashSet<string>();
             NuGetProjectContext = nuGetProjectContext;
             ProjectFullPath = string.IsNullOrEmpty(projectFullPath) ? Environment.CurrentDirectory : projectFullPath;
-            ScriptsExecuted = new Dictionary<string, int>();
             ProcessedFiles = new HashSet<string>();
             ProjectName = projectName ?? TestProjectName;
             ProjectFileFullPath = projectFileFullPath ?? Path.Combine(ProjectFullPath, ProjectName);
@@ -158,24 +156,6 @@ namespace Test.Utility
         public void AddBindingRedirects()
         {
             BindingRedirectsCallCount++;
-        }
-
-        public Task ExecuteScriptAsync(PackageIdentity identity, string packageInstallPath, string scriptRelativePath, bool throwOnFailure)
-        {
-            var scriptFullPath = Path.Combine(packageInstallPath, scriptRelativePath);
-            if (!File.Exists(scriptFullPath) && throwOnFailure)
-            {
-                throw new InvalidOperationException(scriptRelativePath + " was not found. Could not execute PS script");
-            }
-
-            int runCount;
-            if (!ScriptsExecuted.TryGetValue(scriptRelativePath, out runCount))
-            {
-                ScriptsExecuted.Add(scriptRelativePath, 0);
-            }
-
-            ScriptsExecuted[scriptRelativePath]++;
-            return Task.FromResult(0);
         }
 
         public void BeginProcessing()


### PR DESCRIPTION
Resolves NuGet/Home#5290.

Fixed failing functional tests:
🔨 💯 CI tests failed on MAC due to a stack overflow bug in `MSBuildLogger`
🔨  `BuildIntegratedTests.TestPacManBuildIntegratedInstallPackageWithInitPS1` 	
🔨  `BuildIntegratedTests.TestPacManBuildIntegratedUpdatePackageCallsInitPs1OnNewPackages`	
🔨  `MSBuildNuGetProjectTests.TestMSBuildNuGetProjectPSInstallAndInit`	
🔨  `MSBuildNuGetProjectTests.TestMSBuildNuGetProjectPSUninstall`	

//cc @rrelyea 