### PR TITLE
Adding Logging for non sdk based projects in VS and adding ErrorCode while logging errors in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -393,7 +393,7 @@ namespace NuGet.CommandLine
                 {
                     if (message.Code >= NuGetLogCode.NU1000)
                     {
-                        WriteWarning(FormatWithCode(message));
+                        WriteWarning(message.FormatWithCode());
                     }
                     else
                     {
@@ -412,7 +412,7 @@ namespace NuGet.CommandLine
                         // Write out codes for messages that have codes.
                         if (message.Code >= NuGetLogCode.NU1000)
                         {
-                            WriteError(FormatWithCode(message));
+                            WriteError(message.FormatWithCode());
                         }
                         else
                         {
@@ -434,11 +434,6 @@ namespace NuGet.CommandLine
             Log(message);
 
             return Task.FromResult(0);
-        }
-
-        private static string FormatWithCode(ILogMessage message)
-        {
-            return $"{Enum.GetName(typeof(NuGetLogCode), message.Code)}: {message.Message}";
         }
 
         private static LogLevel GetVerbosityLevel(Verbosity level)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -198,7 +198,7 @@ namespace NuGet.SolutionRestoreManager
             // Output console
             if (showAsOutputMessage)
             {
-                WriteLine(verbosityLevel, logMessage.Message);
+                WriteLine(verbosityLevel, logMessage.FormatWithCode());
             }
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -207,7 +207,7 @@ namespace NuGet.SolutionRestoreManager
             // Display only errors/warnings
             if (logMessage.Level >= LogLevel.Warning)
             {
-                var errorListEntry = new ErrorListTableEntry(logMessage.Message, logMessage.Level);
+                var errorListEntry = new ErrorListTableEntry(logMessage);
 
                 // Add the entry to the list
                 _errorListDataSource.Value.AddNuGetEntries(errorListEntry);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -253,7 +253,8 @@ namespace NuGet.SolutionRestoreManager
                     OriginalTargetFrameworks = originalTargetFrameworks,
                     CrossTargeting = crossTargeting
                 },
-                RuntimeGraph = GetRuntimeGraph(projectRestoreInfo)
+                RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
+                ProjectSettings = new Dictionary<string, object> { { PackageSpec.HideWarningsAndErrorsProperty, true } }
             };
 
             return packageSpec;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -254,7 +254,7 @@ namespace NuGet.SolutionRestoreManager
                     CrossTargeting = crossTargeting
                 },
                 RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
-                ProjectSettings = new Dictionary<string, object> { { PackageSpec.HideWarningsAndErrorsProperty, true } }
+                RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors  = true }
             };
 
             return packageSpec;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -47,18 +47,8 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            var collectorLoggerHideWarningsAndErrors = false;
-
-            if (request.Project.ProjectSettings != null &&
-                request.Project.ProjectSettings.ContainsKey(PackageSpec.HideWarningsAndErrorsProperty))
-            {
-                collectorLoggerHideWarningsAndErrors = (bool)request.Project.ProjectSettings[PackageSpec.HideWarningsAndErrorsProperty] 
-                    || request.HideWarningsAndErrors;
-            }
-            else
-            {
-                collectorLoggerHideWarningsAndErrors = request.HideWarningsAndErrors;
-            }
+            var collectorLoggerHideWarningsAndErrors = request.Project.RestoreSettings.HideWarningsAndErrors 
+                || request.HideWarningsAndErrors;
 
             var collectorLogger = new CollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors);
             _logger = collectorLogger;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -47,7 +47,19 @@ namespace NuGet.Commands
                 throw new ArgumentOutOfRangeException(nameof(_request.LockFileVersion));
             }
 
-            var collectorLogger = new CollectorLogger(_request.Log, request.HideWarningsAndErrors);
+            var collectorLoggerHideWarningsAndErrors = false;
+
+            if (request.Project.ProjectSettings != null &&
+                request.Project.ProjectSettings.ContainsKey(PackageSpec.HideWarningsAndErrorsProperty))
+            {
+                collectorLoggerHideWarningsAndErrors = (bool)request.Project.ProjectSettings[PackageSpec.HideWarningsAndErrorsProperty] || request.HideWarningsAndErrors;
+            }
+            else
+            {
+                collectorLoggerHideWarningsAndErrors = request.HideWarningsAndErrors;
+            }
+
+            var collectorLogger = new CollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors);
             _logger = collectorLogger;
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -52,7 +52,8 @@ namespace NuGet.Commands
             if (request.Project.ProjectSettings != null &&
                 request.Project.ProjectSettings.ContainsKey(PackageSpec.HideWarningsAndErrorsProperty))
             {
-                collectorLoggerHideWarningsAndErrors = (bool)request.Project.ProjectSettings[PackageSpec.HideWarningsAndErrorsProperty] || request.HideWarningsAndErrors;
+                collectorLoggerHideWarningsAndErrors = (bool)request.Project.ProjectSettings[PackageSpec.HideWarningsAndErrorsProperty] 
+                    || request.HideWarningsAndErrors;
             }
             else
             {

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
@@ -1,0 +1,15 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NuGet.Common
+{
+    public static class LoggingExtensions
+    {
+        public static string FormatWithCode(this ILogMessage message)
+        {
+            return $"{message.Code}: {message.Message}";
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
@@ -1,7 +1,7 @@
-﻿
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace NuGet.Common
 {
@@ -9,7 +9,12 @@ namespace NuGet.Common
     {
         public static string FormatWithCode(this ILogMessage message)
         {
-            return $"{message.Code}: {message.Message}";
+            return $"{message.Code.GetName()}: {message.Message}";
+        }
+
+        public static string GetName(this NuGetLogCode code)
+        {
+            return Enum.GetName(typeof(NuGetLogCode), code);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -21,6 +21,8 @@ namespace NuGet.ProjectModel
     public class JsonPackageSpecReader
     {
         public static readonly string RestoreOptions = "restore";
+        public static readonly string RestoreSettings = "restoreSettings";
+        public static readonly string HideWarningsAndErrors = "hideWarningsAndErrors";
         public static readonly string PackOptions = "packOptions";
         public static readonly string PackageType = "packageType";
         public static readonly string Files = "files";
@@ -161,6 +163,8 @@ namespace NuGet.ProjectModel
 
             packageSpec.PackOptions = GetPackOptions(packageSpec, rawPackageSpec);
 
+            packageSpec.RestoreSettings = GetRestoreSettings(packageSpec, rawPackageSpec);
+
             packageSpec.RestoreMetadata = GetMSBuildMetadata(packageSpec, rawPackageSpec);
 
             // Read the runtime graph
@@ -180,6 +184,19 @@ namespace NuGet.ProjectModel
             }
 
             return packageSpec;
+        }
+
+        private static ProjectRestoreSettings GetRestoreSettings(PackageSpec packageSpec, JObject rawPackageSpec)
+        {
+            var rawRestoreSettings = rawPackageSpec.Value<JToken>(RestoreSettings) as JObject;
+            var restoreSettings = new ProjectRestoreSettings();
+
+            if (rawRestoreSettings != null)
+            {
+                restoreSettings.HideWarningsAndErrors = GetBoolOrFalse(rawRestoreSettings, HideWarningsAndErrors, packageSpec.FilePath);
+            }
+
+            return restoreSettings;
         }
 
         private static ProjectRestoreMetadata GetMSBuildMetadata(PackageSpec packageSpec, JObject rawPackageSpec)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -19,6 +19,7 @@ namespace NuGet.ProjectModel
     public class PackageSpec
     {
         public static readonly string PackageSpecFileName = "project.json";
+        public static readonly string HideWarningsAndErrorsProperty  = "HideWarningsAndErrors";
         public static readonly NuGetVersion DefaultVersion = new NuGetVersion(1, 0, 0);
 
         public PackageSpec(IList<TargetFrameworkInformation> frameworks)
@@ -32,10 +33,7 @@ namespace NuGet.ProjectModel
 
         public string FilePath { get; set; }
 
-        public string BaseDirectory
-        {
-            get { return Path.GetDirectoryName(FilePath); }
-        }
+        public string BaseDirectory => Path.GetDirectoryName(FilePath);
 
         public string Name { get; set; }
 
@@ -51,7 +49,7 @@ namespace NuGet.ProjectModel
             set
             {
                 _version = value;
-                this.IsDefaultVersion = false;
+                IsDefaultVersion = false;
             }
         }
         public bool IsDefaultVersion { get; set; } = true;
@@ -97,6 +95,12 @@ namespace NuGet.ProjectModel
         public IList<TargetFrameworkInformation> TargetFrameworks { get; private set; } = new List<TargetFrameworkInformation>();
 
         public RuntimeGraph RuntimeGraph { get; set; } = new RuntimeGraph();
+
+        /// <summary>
+        /// Project Settings is used to pass settings like HideWarningsAndErrors down to lower levels.
+        /// This should not be part of the Equals and GetHashCode.
+        /// </summary>
+        public IDictionary<string, object> ProjectSettings { get; set; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Additional MSBuild properties.

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -19,7 +19,6 @@ namespace NuGet.ProjectModel
     public class PackageSpec
     {
         public static readonly string PackageSpecFileName = "project.json";
-        public static readonly string HideWarningsAndErrorsProperty  = "HideWarningsAndErrors";
         public static readonly NuGetVersion DefaultVersion = new NuGetVersion(1, 0, 0);
 
         public PackageSpec(IList<TargetFrameworkInformation> frameworks)
@@ -100,7 +99,7 @@ namespace NuGet.ProjectModel
         /// Project Settings is used to pass settings like HideWarningsAndErrors down to lower levels.
         /// This should not be part of the Equals and GetHashCode.
         /// </summary>
-        public IDictionary<string, object> ProjectSettings { get; set; } = new Dictionary<string, object>();
+        public ProjectRestoreSettings RestoreSettings { get; set; } = new ProjectRestoreSettings();
 
         /// <summary>
         /// Additional MSBuild properties.

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -51,6 +51,7 @@ namespace NuGet.ProjectModel
             SetArrayValue(writer, "contentFiles", packageSpec.ContentFiles);
             SetDictionaryValue(writer, "packInclude", packageSpec.PackInclude);
             SetPackOptions(writer, packageSpec);
+            SetRestoreSettings(writer, packageSpec);
             SetMSBuildMetadata(writer, packageSpec);
             SetDictionaryValues(writer, "scripts", packageSpec.Scripts);
 
@@ -81,7 +82,7 @@ namespace NuGet.ProjectModel
                 throw new ArgumentException(Strings.ArgumentNullOrEmpty, nameof(filePath));
             }
 
-            var writer = new RuntimeModel.JsonObjectWriter();
+            var writer = new JsonObjectWriter();
 
             Write(packageSpec, writer);
 
@@ -92,6 +93,23 @@ namespace NuGet.ProjectModel
                 jsonWriter.Formatting = Formatting.Indented;
                 writer.WriteTo(jsonWriter);
             }
+        }
+
+        private static void SetRestoreSettings(IObjectWriter writer, PackageSpec packageSpec)
+        {
+            var restoreSettings = packageSpec.RestoreSettings;
+
+            // Do not write Restore Setting if the HideWarningsAndErrors is false
+            // This should be changed in the future as more properties are added to ProjectRestoreSettings
+            if (restoreSettings == null || !restoreSettings.HideWarningsAndErrors)
+            {
+                return;
+            }
+            writer.WriteObjectStart(JsonPackageSpecReader.RestoreSettings);
+
+            SetValueIfTrue(writer, JsonPackageSpecReader.HideWarningsAndErrors, restoreSettings.HideWarningsAndErrors);
+
+            writer.WriteObjectEnd();
         }
 
         private static void SetMSBuildMetadata(IObjectWriter writer, PackageSpec packageSpec)

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreSettings.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NuGet.ProjectModel
+{
+    /// <summary>
+    /// This class is used to hold restore related, project specific settings.
+    /// </summary>
+    public class ProjectRestoreSettings
+    {
+        /// <summary>
+        /// Bool property is used inr estore command to not log errors and warning.
+        /// Currently this is only being used for net core based projects on nomination.
+        /// </summary>
+        public bool HideWarningsAndErrors { get; set; } = false;
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -368,7 +369,7 @@ namespace NuGet.ProjectModel.Test
         public void PackageSpecReader_PackOptions_Files1()
         {
             // Arrange & Act
-            string json = @"{
+            var json = @"{
                         ""packOptions"": {
                           ""files"": {
                             ""include"": ""file1"",
@@ -407,7 +408,7 @@ namespace NuGet.ProjectModel.Test
         public void PackageSpecReader_PackOptions_Files2()
         {
             // Arrange & Act
-            string json = @"{
+            var json = @"{
                         ""packOptions"": {
                           ""files"": {
                             ""include"": [""file1a"", ""file1b""],
@@ -492,6 +493,55 @@ namespace NuGet.ProjectModel.Test
                 Assert.NotNull(actual.BuildOptions);
                 Assert.Equal(expectedValue, actual.BuildOptions.OutputName);
             }
+        }
+
+        [Fact]
+        public void PackageSpecReader_ReadsWithRestoreSettings()
+        {
+            // Arrange
+            var json = @"{
+                          ""dependencies"": {
+                                ""packageA"": {
+                                    ""target"": ""package"",
+                                    ""version"": ""1.0.0""
+                                }
+                            },
+                            ""frameworks"": {
+                                ""net46"": {}
+                            },
+                            ""restoreSettings"": {
+                            ""hideWarningsAndErrors"": true
+                            },
+                        }";
+
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actual.RestoreSettings);
+            Assert.True(actual.RestoreSettings.HideWarningsAndErrors);
+        }
+
+        [Fact]
+        public void PackageSpecReader_ReadsWithoutRestoreSettings()
+        {
+            // Arrange
+            var json = @"{
+                          ""dependencies"": {
+                                ""packageA"": {
+                                    ""target"": ""package"",
+                                    ""version"": ""1.0.0""
+                                }
+                            },
+                            ""frameworks"": {
+                                ""net46"": {}
+                            },
+                        }";
+
+            var actual = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            Assert.NotNull(actual);
+            Assert.NotNull(actual.RestoreSettings);
+            Assert.False(actual.RestoreSettings.HideWarningsAndErrors);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -10,6 +10,7 @@ using NuGet.LibraryModel;
 using NuGet.RuntimeModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.ProjectModel.Test
@@ -163,11 +164,22 @@ namespace NuGet.ProjectModel.Test
         public void Write_SerializesMembersAsJson()
         {
             var expectedJson = ResourceTestUtility.GetResource("NuGet.ProjectModel.Test.compiler.resources.PackageSpecWriter_Write_SerializesMembersAsJson.json", typeof(PackageSpecWriterTests));
-            var packageSpec = CreatePackageSpec();
+            var packageSpec = CreatePackageSpec(withRestoreSettings: true);
             var actualJson = GetJson(packageSpec);
 
             Assert.Equal(expectedJson, actualJson);
         }
+
+        [Fact]
+        public void Write_SerializesMembersAsJsonWithoutRestoreSettings()
+        {
+            var expectedJson = ResourceTestUtility.GetResource("NuGet.ProjectModel.Test.compiler.resources.PackageSpecWriter_Write_SerializesMembersAsJsonWithoutRestoreSettings.json", typeof(PackageSpecWriterTests));
+            var packageSpec = CreatePackageSpec(withRestoreSettings: false);
+            var actualJson = GetJson(packageSpec);
+
+            Assert.Equal(expectedJson, actualJson);
+        }
+
 
         private static string GetJson(PackageSpec packageSpec)
         {
@@ -178,7 +190,7 @@ namespace NuGet.ProjectModel.Test
             return writer.GetJson();
         }
 
-        private static PackageSpec CreatePackageSpec()
+        private static PackageSpec CreatePackageSpec(bool withRestoreSettings)
         {
             var unsortedArray = new[] { "b", "a", "c" };
             var unsortedReadOnlyList = new List<string>(unsortedArray).AsReadOnly();
@@ -242,6 +254,11 @@ namespace NuGet.ProjectModel.Test
                 Title = "title",
                 Version = new NuGetVersion("1.2.3")
             };
+
+            if (withRestoreSettings)
+            {
+                packageSpec.RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true };
+            }
 
             packageSpec.PackInclude.Add("b", "d");
             packageSpec.PackInclude.Add("a", "e");

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJsonWithoutRestoreSettings.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJsonWithoutRestoreSettings.json
@@ -37,9 +37,6 @@
     "licenseUrl": "licenseUrl",
     "requireLicenseAcceptance": true
   },
-  "restoreSettings": {
-    "hideWarningsAndErrors": true
-  },
   "restore": {
     "projectUniqueName": "projectUniqueName",
     "projectName": "projectName",


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/33

This PR addresses the following - 

1. Adds a `ProjectSettings` section in `PackageSpec` which is used to add a `HideWarningsAndErrors` property. This property is added as true for CPS/sdk based projects so that we do not throw errors on restore. We rely on the SDK target to throw errors post restore by reading them from the `AssetsFile`.

2. For cases where we do throw errors in VS (non-cps/sdk based projects), I have added an `ErrorCode` property to `ErrorListTableEntry` to display the error code in the `ErrorList` in VS. 

3. Improved Logging Extensions a bit.