### PR TITLE
Microsoft.Web.XmlTransform.resources.dll path fixed for signing

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -26,6 +26,7 @@
       </FilesToSign>
       <FilesToSign Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
         <Authenticode>Microsoft</Authenticode>
+        <StrongName>25</StrongName>
       </FilesToSign>
     </ItemGroup>
     <MSBuild


### PR DESCRIPTION
We were looking for this dll inside Artifacts directory where as it will be available under solution packages folder so fixed it.

@rrelyea 