### PR TITLE
Fixing Mono test failures on mac related to MSBuildLogger

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -279,11 +279,18 @@ namespace NuGet.Common
                 dynamic importElement = null;
                 foreach (dynamic import in Project.Xml.Imports)
                 {
+
                     if (targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
                     {
                         importElement = import;
                         break;
                     }
+                    else if (targetFullPath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
+                    {
+                        importElement = import;
+                        break;
+                    }
+
                 }
 
                 if (importElement != null)

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -279,18 +279,11 @@ namespace NuGet.Common
                 dynamic importElement = null;
                 foreach (dynamic import in Project.Xml.Imports)
                 {
-
                     if (targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
                     {
                         importElement = import;
                         break;
                     }
-                    else if (targetFullPath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
-                    {
-                        importElement = import;
-                        break;
-                    }
-
                 }
 
                 if (importElement != null)

--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -45,12 +45,9 @@ namespace NuGet.Build
         private delegate void LogErrorAsString(string message,
             params object[] messageArgs);
 
-
-
-
         public MSBuildLogger(TaskLoggingHelper taskLogging)
         {
-            _taskLogging = taskLogging;
+            _taskLogging = taskLogging ?? throw new ArgumentNullException(nameof(taskLogging));
         }
 
         public override void Log(ILogMessage message)
@@ -83,6 +80,9 @@ namespace NuGet.Build
             }
         }
 
+        /// <summary>
+        /// Log using with metadata for non mono platforms.
+        /// </summary>
         private void LogForNonMono(IRestoreLogMessage message)
         {
             switch (message.Level)


### PR DESCRIPTION
Fixes: NuGet/Home#5290

It seems that certain msbuild logging methods are not on mono. added a conditional in msbuild logger.

This PR reverts some changes done in https://github.com/NuGet/NuGet.Client/commit/af0ac322bfacff97bef14e12295c62de29b40fd3 and brings us back to https://github.com/NuGet/NuGet.Client/commit/57932535d16d2c8cbe8872fec304189ab9540146 except removing the unwanted recursion.