### PR TITLE
Switching to UIthread to uninstall a package from legacy packageRef

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -270,11 +270,11 @@ namespace NuGet.PackageManagement.VisualStudio
                 metadataValues);
         }
 
-        public void RemovePackageReference(string packageName)
+        public async Task RemovePackageReferenceAsync(string packageName)
         {
             Assumes.NotNullOrEmpty(packageName);
 
-            _threadingService.ThrowIfNotOnUIThread();
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             AsVSProject4.PackageReferences.Remove(packageName);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -748,7 +748,7 @@ namespace NuGet.PackageManagement.VisualStudio
             throw new NotSupportedException();
         }
 
-        public void RemovePackageReference(string packageName)
+        public Task RemovePackageReferenceAsync(string packageName)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -144,12 +144,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
-        public override Task<bool> UninstallPackageAsync(
+        public override async Task<bool> UninstallPackageAsync(
             PackageIdentity packageIdentity, INuGetProjectContext _, CancellationToken token)
         {
-            ProjectServices.References.RemovePackageReference(packageIdentity.Id);
+            await ProjectServices.References.RemovePackageReferenceAsync(packageIdentity.Id);
 
-            return Task.FromResult(true);
+            return true;
         }
 
         #endregion

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/DefaultProjectServices.cs
@@ -72,7 +72,7 @@ namespace NuGet.ProjectManagement
             return null;
         }
 
-        public void RemovePackageReference(string packageName)
+        public Task RemovePackageReferenceAsync(string packageName)
         {
             throw new NotSupportedException();
         }

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IProjectSystemReferencesService.cs
@@ -31,6 +31,6 @@ namespace NuGet.ProjectManagement
         /// <param name="packageName">Name of a package to remove from project</param>
         /// <exception cref="NotSupportedException">Thrown when the project system doesn't support package references.</exception>
         /// <remarks>A caller should verify project system's capabilities before calling this method.</remarks>
-        void RemovePackageReference(string packageName);
+        Task RemovePackageReferenceAsync(string packageName);
     }
 }


### PR DESCRIPTION
Instead of throwing if not on UI thread, it will now switch to UI thread before calling RemoveReference on VSProject4.

Fixes https://github.com/NuGet/Home/issues/5305

@rrelyea 