### PR TITLE
Fix UI for Package Sources Options Control

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/PackageSourcesOptionsControl.Designer.cs
@@ -1,4 +1,4 @@
-using System.Windows.Forms;
+﻿using System.Windows.Forms;
 namespace NuGet.Options
 {
     partial class PackageSourcesOptionsControl
@@ -196,6 +196,7 @@ namespace NuGet.Options
             this.tableLayoutPanel1.SetColumnSpan(this.MachineWideSourcesLabel, 4);
             resources.ApplyResources(this.MachineWideSourcesLabel, "MachineWideSourcesLabel");
             this.MachineWideSourcesLabel.Name = "MachineWideSourcesLabel";
+            this.MachineWideSourcesLabel.AutoSize = true;
             // 
             // MachineWidePackageSourcesListBox
             // 


### PR DESCRIPTION
A quick fix: added auto resize for label. Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/193372 and https://github.com/NuGet/Home/issues/2707

Before: 

![image](https://cloud.githubusercontent.com/assets/1646506/26648066/2465d1c0-45f6-11e7-83b0-c173b0f7cd61.png)

Now:

![image](https://cloud.githubusercontent.com/assets/1646506/26648068/29fed33e-45f6-11e7-9100-bf92e33a6aa7.png)

PS: Please ignore the commits, I will squash and merge into dev.