### PR TITLE
Adding preview2 and preview3 release labels for build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -50,7 +50,7 @@ param (
     [ValidateSet("debug", "release")]
     [Alias('c')]
     [string]$Configuration,
-    [ValidateSet("release","rtm", "rc", "rc1", "rc2", "rc3", "rc4", "beta", "beta1", "beta2", "final", "preview1", "xprivate", "zlocal")]
+    [ValidateSet("release","rtm", "rc", "rc1", "rc2", "rc3", "rc4", "beta", "beta1", "beta2", "final", "preview1", "preview2", "preview3", "xprivate", "zlocal")]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -43,7 +43,7 @@ param (
     [ValidateSet("debug", "release")]
     [Alias('c')]
     [string]$Configuration,
-    [ValidateSet("release","rtm", "rc", "rc1", "rc2", "rc3", "rc4", "beta", "beta1", "beta2", "final", "preview1", "xprivate", "zlocal")]
+    [ValidateSet("release","rtm", "rc", "rc1", "rc2", "rc3", "rc4", "beta", "beta1", "beta2", "final", "preview1", "preview2", "preview3", "xprivate", "zlocal")]
     [Alias('l')]
     [string]$ReleaseLabel = 'zlocal',
     [Alias('n')]


### PR DESCRIPTION
Fixes failing dev builds due to build.ps1 validation on the inputs