### PR TITLE
Add support for AssetTargetFallback

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -295,21 +295,26 @@ namespace NuGet.PackageManagement.VisualStudio
                 .GetPackageReferencesAsync(targetFramework, CancellationToken.None))
                 .ToList();
 
-            var packageTargetFallback = _vsProjectAdapter.PackageTargetFallback?.Split(new[] { ';' })
+            var splitChars = new[] { ';' };
+
+            var packageTargetFallback = _vsProjectAdapter.PackageTargetFallback?.Split(splitChars)
                 .Select(NuGetFramework.Parse)
-                .ToList();
+                .ToList()
+                ?? new List<NuGetFramework>();
+
+            var assetTargetFallback = _vsProjectAdapter.AssetTargetFallback?.Split(splitChars)
+                .Select(NuGetFramework.Parse)
+                .ToList()
+                ?? new List<NuGetFramework>();
 
             var projectTfi = new TargetFrameworkInformation
             {
                 FrameworkName = targetFramework,
                 Dependencies = packageReferences,
-                Imports = packageTargetFallback ?? new List<NuGetFramework>()
             };
 
-            if ((projectTfi.Imports?.Count ?? 0) > 0)
-            {
-                projectTfi.FrameworkName = new FallbackFramework(projectTfi.FrameworkName, packageTargetFallback);
-            }
+            // Apply fallback settings
+            AssetTargetFallbackUtility.ApplyFramework(projectTfi, packageTargetFallback, assetTargetFallback);
 
             // Build up runtime information.
             var runtimes = await _vsProjectAdapter.GetRuntimeIdentifiersAsync();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -158,6 +158,14 @@ namespace NuGet.PackageManagement.VisualStudio
             get
             {
                 return BuildProperties.GetPropertyValue(ProjectBuildProperties.PackageTargetFallback);
+            }
+        }
+
+        public string AssetTargetFallback
+        {
+            get
+            {
+                return BuildProperties.GetPropertyValue(ProjectBuildProperties.AssetTargetFallback);
             }
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -38,6 +38,11 @@ namespace NuGet.VisualStudio
         /// PackageTargetFallback project property
         /// </summary>
         string PackageTargetFallback { get; }
+
+        /// <summary>
+        /// AssetTargetFallback project property
+        /// </summary>
+        string AssetTargetFallback { get; }
 
         /// <summary>
         /// Restore Packages Path DTE property

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -635,13 +635,18 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="RestoreGraphItems"
         ItemName="_RestoreGraphEntry" />
     </GetRestorePackageReferencesTask>
-
+    
+    <PropertyGroup>
+      <_CombinedFallbacks>$(PackageTargetFallback);$(AssetTargetFallback)</_CombinedFallbacks>
+    </PropertyGroup>
+    
     <!-- Write out target framework information -->
-    <ItemGroup Condition="  '$(RestoreProjectStyle)' == 'PackageReference' AND '$(PackageTargetFallback)' != '' ">
+    <ItemGroup Condition="  '$(RestoreProjectStyle)' == 'PackageReference' AND '$(_CombinedFallbacks)' != '' ">
       <_RestoreGraphEntry Include="$([System.Guid]::NewGuid())">
         <Type>TargetFrameworkInformation</Type>
         <ProjectUniqueName>$(MSBuildProjectFullPath)</ProjectUniqueName>
         <PackageTargetFallback>$(PackageTargetFallback)</PackageTargetFallback>
+        <AssetTargetFallback>$(AssetTargetFallback)</AssetTargetFallback>
         <TargetFramework>$(TargetFramework)</TargetFramework>
       </_RestoreGraphEntry>
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -295,16 +295,26 @@ namespace NuGet.Commands
         {
             // A package is compatible if it has...
             return
-                compatibilityData.TargetLibrary.RuntimeAssemblies.Count > 0 ||                          // Runtime Assemblies, or
-                compatibilityData.TargetLibrary.CompileTimeAssemblies.Count > 0 ||                      // Compile-time Assemblies, or
-                compatibilityData.TargetLibrary.FrameworkAssemblies.Count > 0 ||                        // Framework Assemblies, or
-                compatibilityData.TargetLibrary.ContentFiles.Count > 0 ||                               // Shared content
-                compatibilityData.TargetLibrary.ResourceAssemblies.Count > 0 ||                         // Resources (satellite package)
-                compatibilityData.TargetLibrary.Build.Count > 0 ||                                      // Build
-                compatibilityData.TargetLibrary.BuildMultiTargeting.Count > 0 ||                        // Cross targeting build
+                HasCompatibleAssets(compatibilityData.TargetLibrary) ||
                 !compatibilityData.Files.Any(p =>
                     p.StartsWith("ref/", StringComparison.OrdinalIgnoreCase)
                     || p.StartsWith("lib/", StringComparison.OrdinalIgnoreCase));                       // No assemblies at all (for any TxM)
+        }
+
+        /// <summary>
+        /// Check if the library contains assets.
+        /// </summary>
+        internal static bool HasCompatibleAssets(LockFileTargetLibrary targetLibrary)
+        {
+            // A package is compatible if it has...
+            return
+                targetLibrary.RuntimeAssemblies.Count > 0 ||                          // Runtime Assemblies, or
+                targetLibrary.CompileTimeAssemblies.Count > 0 ||                      // Compile-time Assemblies, or
+                targetLibrary.FrameworkAssemblies.Count > 0 ||                        // Framework Assemblies, or
+                targetLibrary.ContentFiles.Count > 0 ||                               // Shared content
+                targetLibrary.ResourceAssemblies.Count > 0 ||                         // Resources (satellite package)
+                targetLibrary.Build.Count > 0 ||                                      // Build
+                targetLibrary.BuildMultiTargeting.Count > 0;                          // Cross targeting build
         }
 
         private CompatibilityData GetCompatibilityData(RestoreTargetGraph graph, LibraryIdentity libraryId)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandException.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandException.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Holds an <see cref="IRestoreLogMessage"/> and returns the message for the exception.
+    /// </summary>
+    public class RestoreCommandException : Exception, ILogMessageException
+    {
+        private readonly IRestoreLogMessage _logMessage;
+
+        public RestoreCommandException(IRestoreLogMessage logMessage)
+            : base(logMessage?.Message)
+        {
+            _logMessage = logMessage ?? throw new ArgumentNullException(nameof(logMessage));
+        }
+
+        public ILogMessage AsLogMessage()
+        {
+            return _logMessage;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -107,6 +107,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment..
+        /// </summary>
+        internal static string Error_InvalidATF {
+            get {
+                return ResourceManager.GetString("Error_InvalidATF", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid input &apos;{0}&apos;. The file type was not recognized..
         /// </summary>
         internal static string Error_InvalidCommandLineInput {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -584,4 +584,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="CannotBeUsedWithOtherValues" xml:space="preserve">
     <value>'{0}' cannot be used in conjunction with other values.</value>
   </data>
+  <data name="Error_InvalidATF" xml:space="preserve">
+    <value>PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/AssetTargetFallbackUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/AssetTargetFallbackUtility.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Shared;
+
+namespace NuGet.Commands
+{
+    public static class AssetTargetFallbackUtility
+    {
+        public static readonly string AssetTargetFallback = nameof(AssetTargetFallback);
+
+        /// <summary>
+        /// Throw if an invalid combination exists.
+        /// </summary>
+        public static void EnsureValidFallback(IEnumerable<NuGetFramework> packageTargetFallback, IEnumerable<NuGetFramework> assetTargetFallback, string filePath)
+        {
+            if (packageTargetFallback?.Any() == true && assetTargetFallback?.Any() == true)
+            {
+                var error = GetInvalidFallbackCombinationMessage(filePath);
+                throw new RestoreCommandException(error);
+            }
+        }
+
+        public static RestoreLogMessage GetInvalidFallbackCombinationMessage(string path)
+        {
+            var error = RestoreLogMessage.CreateError(NuGetLogCode.NU1003, Strings.Error_InvalidATF);
+            error.ProjectPath = path;
+            error.FilePath = path;
+
+            return error;
+        }
+
+        /// <summary>
+        /// Returns the fallback framework or the original.
+        /// </summary>
+        public static NuGetFramework GetFallbackFramework(NuGetFramework projectFramework, IEnumerable<NuGetFramework> packageTargetFallback, IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            if (assetTargetFallback?.Any() == true)
+            {
+                // AssetTargetFallback
+                return new AssetTargetFallbackFramework(projectFramework, assetTargetFallback.AsList());
+            }
+            else if (packageTargetFallback?.Any() == true)
+            {
+                // PackageTargetFallback
+                return new FallbackFramework(projectFramework, packageTargetFallback.AsList());
+            }
+
+            return projectFramework;
+        }
+
+        /// <summary>
+        /// Update TargetFrameworkInformation properties.
+        /// </summary>
+        public static void ApplyFramework(TargetFrameworkInformation targetFrameworkInfo, IEnumerable<NuGetFramework> packageTargetFallback, IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            // Update the framework appropriately
+            targetFrameworkInfo.FrameworkName = GetFallbackFramework(
+                targetFrameworkInfo.FrameworkName,
+                packageTargetFallback,
+                assetTargetFallback);
+
+            if (assetTargetFallback?.Any() == true)
+            {
+                // AssetTargetFallback
+                targetFrameworkInfo.Imports = assetTargetFallback.AsList();
+                targetFrameworkInfo.AssetTargetFallback = true;
+                targetFrameworkInfo.Warn = true;
+            }
+            else if (packageTargetFallback?.Any() == true)
+            {
+                // PackageTargetFallback
+                targetFrameworkInfo.Imports = packageTargetFallback.AsList();
+            }
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -52,6 +52,11 @@ namespace NuGet.Common
         NU1002 = 1002,
 
         /// <summary>
+        /// Invalid combination of PTF and ATF
+        /// </summary>
+        NU1003 = 1003,
+
+        /// <summary>
         /// Unable to resolve package, generic message for unknown type constraints.
         /// </summary>
         NU1100 = 1100,

--- a/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/AssetTargetFallbackFramework.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Shared;
+
+#if IS_NET40_CLIENT
+using FallbackList = System.Collections.Generic.IList<NuGet.Frameworks.NuGetFramework>;
+#else
+using FallbackList = System.Collections.Generic.IReadOnlyList<NuGet.Frameworks.NuGetFramework>;
+#endif
+
+namespace NuGet.Frameworks
+{
+    /// <summary>
+    /// AssetTargetFallbackFramework only fallback when zero assets are selected. These do not 
+    /// auto fallback during GetNearest as FallbackFramework would.
+    /// </summary>
+#if NUGET_FRAMEWORKS_INTERNAL
+    internal
+#else
+    public
+#endif
+    class AssetTargetFallbackFramework : NuGetFramework, IEquatable<AssetTargetFallbackFramework>
+    {
+        private readonly FallbackList _fallback;
+        private int? _hashCode;
+        private NuGetFramework _rootFramework;
+
+        /// <summary>
+        /// List framework to fall back to.
+        /// </summary>
+        public FallbackList Fallback
+        {
+            get { return _fallback; }
+        }
+
+        /// <summary>
+        /// Root project framework.
+        /// </summary>
+        public NuGetFramework RootFramework
+        {
+            get
+            {
+                return _rootFramework;
+            }
+        }
+
+        public AssetTargetFallbackFramework(NuGetFramework framework, FallbackList fallbackFrameworks)
+            : base(framework)
+        {
+            if (framework == null)
+            {
+                throw new ArgumentNullException("framework");
+            }
+
+            if (fallbackFrameworks == null)
+            {
+                throw new ArgumentNullException("fallbackFrameworks");
+            }
+
+            if (fallbackFrameworks.Count == 0)
+            {
+                throw new ArgumentException("Empty fallbackFrameworks is invalid", "fallbackFrameworks");
+            }
+
+            _fallback = fallbackFrameworks;
+            _rootFramework = framework;
+        }
+
+        /// <summary>
+        /// Create a FallbackFramework from the current AssetTargetFallbackFramework.
+        /// </summary>
+        public FallbackFramework AsFallbackFramework()
+        {
+            return new FallbackFramework(_rootFramework, _fallback);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as FallbackFramework);
+        }
+
+        public override int GetHashCode()
+        {
+            if (_hashCode == null)
+            {
+                var combiner = new HashCodeCombiner();
+
+                // Ensure that this is different from a FallbackFramework;
+                combiner.AddStringIgnoreCase("assettargetfallback");
+
+                combiner.AddInt32(NuGetFramework.Comparer.GetHashCode(this));
+
+                foreach (var each in Fallback)
+                {
+                    combiner.AddInt32(NuGetFramework.Comparer.GetHashCode(each));
+                }
+
+                _hashCode = combiner.CombinedHash;
+            }
+
+            return _hashCode.Value;
+        }
+
+        public bool Equals(AssetTargetFallbackFramework other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return NuGetFramework.Comparer.Equals(this, other)
+                && Fallback.SequenceEqual(other.Fallback);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
@@ -11,6 +11,7 @@ namespace NuGet.ProjectManagement
     {
         public const string BaseIntermediateOutputPath = "BaseIntermediateOutputPath";
         public const string PackageTargetFallback = "PackageTargetFallback";
+        public const string AssetTargetFallback = "AssetTargetFallback";
         public const string PackageVersion = "PackageVersion";
         public const string RestoreProjectStyle = "RestoreProjectStyle";
         public const string RuntimeIdentifier = "RuntimeIdentifier";

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecExtensions.cs
@@ -13,7 +13,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static TargetFrameworkInformation GetTargetFramework(this PackageSpec project, NuGetFramework targetFramework)
         {
-            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => f.FrameworkName.Equals(targetFramework));
+            var frameworkInfo = project.TargetFrameworks.FirstOrDefault(f => NuGetFrameworkFullComparer.Equals(targetFramework, f));
             if (frameworkInfo == null)
             {
                 frameworkInfo = NuGetFrameworkUtility.GetNearest(project.TargetFrameworks,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -391,6 +391,8 @@ namespace NuGet.ProjectModel
 
                     SetDependencies(writer, framework.Dependencies);
                     SetImports(writer, framework.Imports);
+                    SetValueIfTrue(writer, "assetTargetFallback", framework.AssetTargetFallback);
+                    SetValueIfTrue(writer, "warn", framework.Warn);
 
                     writer.WriteObjectEnd();
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -22,6 +22,11 @@ namespace NuGet.ProjectModel
         public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
+        /// If True AssetTargetFallback behavior will be used for Imports.
+        /// </summary>
+        public bool AssetTargetFallback { get; set; }
+
+        /// <summary>
         /// Display warnings when the Imports framework is used.
         /// </summary>
         public bool Warn { get; set; }
@@ -36,6 +41,7 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(FrameworkName);
+            hashCode.AddObject(AssetTargetFallback);
             hashCode.AddSequence(Dependencies);
             hashCode.AddSequence(Imports);
 
@@ -61,7 +67,8 @@ namespace NuGet.ProjectModel
 
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
-                   Imports.SequenceEqualWithNullCheck(other.Imports);
+                   Imports.SequenceEqualWithNullCheck(other.Imports) &&
+                   AssetTargetFallback == other.AssetTargetFallback;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using FluentAssertions;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace NuGet.ProjectModel.Test
+{
+    public class AssetTargetFallbackTests
+    {
+        [Fact]
+        public void GivenAssetTargetFallbackTrueVerifyValuePersisted()
+        {
+            var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
+            spec.TargetFrameworks[0].AssetTargetFallback = true;
+
+            var outSpec = spec.RoundTrip();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeTrue();
+        }
+
+        [Fact]
+        public void GivenAssetTargetFallbackFalseVerifyValuePersisted()
+        {
+            var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
+            spec.TargetFrameworks[0].AssetTargetFallback = false;
+
+            var outSpec = spec.RoundTrip();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeFalse();
+        }
+
+        [Fact]
+        public void GivenImportsVerifyValuePersisted()
+        {
+            var net461 = NuGetFramework.Parse("net461");
+            var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
+            spec.TargetFrameworks[0].AssetTargetFallback = true;
+            spec.TargetFrameworks[0].Imports.Add(net461);
+
+            var outSpec = spec.RoundTrip();
+            outSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { net461 });
+        }
+
+        [Fact]
+        public void GivenAssetTargetFallbackVerifyFrameworkIsAssetTargetFallbackFramework()
+        {
+            var net461 = NuGetFramework.Parse("net461");
+            var projectFramework = NuGetFramework.Parse("netcoreapp2.0");
+            var spec = PackageSpecTestUtility.GetSpec(projectFramework);
+            spec.TargetFrameworks[0].AssetTargetFallback = true;
+            spec.TargetFrameworks[0].Imports.Add(net461);
+
+            var outSpec = spec.RoundTrip();
+
+            var outFramework = spec.TargetFrameworks[0].FrameworkName;
+
+            outFramework.Should().Be(new AssetTargetFallbackFramework(projectFramework, new[] { net461 }));
+        }
+
+        [Fact]
+        public void GivenAssetTargetFallbackDiffersVerifyEquality()
+        {
+            var spec1 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
+            spec1.TargetFrameworks[0].AssetTargetFallback = true;
+            var spec2 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
+            spec2.TargetFrameworks[0].AssetTargetFallback = false;
+
+            spec1.Should().NotBe(spec2);
+            spec1.GetHashCode().Should().NotBe(spec2.GetHashCode());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecTestUtility.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.RuntimeModel;
+
+namespace NuGet.ProjectModel.Test
+{
+    public static class PackageSpecTestUtility
+    {
+        public static PackageSpec RoundTrip(this PackageSpec spec)
+        {
+            var writer = new JsonObjectWriter();
+            PackageSpecWriter.Write(spec, writer);
+            var json = writer.GetJObject();
+
+            return JsonPackageSpecReader.GetPackageSpec(json);
+        }
+
+        public static PackageSpec GetSpec()
+        {
+            return GetSpec("netcoreapp2.0");
+        }
+
+        public static PackageSpec GetSpec(params NuGetFramework[] frameworks)
+        {
+            var tfis = new List<TargetFrameworkInformation>(
+                frameworks.Select(e => new TargetFrameworkInformation()
+                {
+                    FrameworkName = e
+                }));
+
+            return new PackageSpec(tfis);
+        }
+
+        public static PackageSpec GetSpec(params string[] frameworks)
+        {
+            return GetSpec(frameworks.Select(NuGetFramework.Parse).ToArray());
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -288,7 +288,6 @@ namespace NuGet.ProjectModel.Test
                 Dependencies = new List<LibraryDependency>() { libraryDependency },
                 FrameworkName = nugetFramework,
                 Imports = new List<NuGetFramework>() { nugetFramework },
-                Warn = true
             });
 
             return packageSpec;

--- a/test/TestUtilities/Test.Utility/CommandRunnerResult.cs
+++ b/test/TestUtilities/Test.Utility/CommandRunnerResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 
 namespace NuGet.Test.Utility
@@ -11,6 +12,19 @@ namespace NuGet.Test.Utility
         public int Item1 { get; }
         public string Item2 { get; }
         public string Item3 { get; }
+
+        public int ExitCode => Item1;
+
+        public bool Success => Item1 == 0;
+
+        /// <summary>
+        /// All output messages including errors
+        /// </summary>
+        public string AllOutput => Item2 + Environment.NewLine + Item3;
+
+        public string Output => Item2;
+
+        public string Errors => Item3;
 
         internal CommandRunnerResult(Process process, int exitCode, string output, string error)
         {


### PR DESCRIPTION
AssetTargetFallback allows falling back to another project framework only if no compatible assets are found in the package.

The changes to lock file creation are almost all to refactor the code into smaller methods. The main change is to loop through creating the library.

Fixes https://github.com/NuGet/Home/issues/5192