### PR TITLE
Fix request cancellation for plugins

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/IRequestHandler.cs
@@ -18,28 +18,6 @@ namespace NuGet.Protocol.Plugins
         CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="connection" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="request" /> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="responseHandler" />
-        /// is <c>null</c>.</exception>
-        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
-        /// is cancelled.</exception>
-        /// <exception cref="NotSupportedException">Thrown if cancellation is not supported.</exception>
-        Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken);
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/InboundRequestContext.cs
@@ -193,9 +193,6 @@ namespace NuGet.Protocol.Plugins
             {
                 _cancellationTokenSource.Cancel();
             }
-            catch (AggregateException)
-            {
-            }
             catch (ObjectDisposedException)
             {
             }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext.cs
@@ -27,9 +27,9 @@ namespace NuGet.Protocol.Plugins
         protected abstract void Dispose(bool disposing);
 
         /// <summary>
-        /// Handles cancellation for the outbound request.
+        /// Handles a cancellation response for the outbound request.
         /// </summary>
-        public abstract void HandleCancel();
+        public abstract void HandleCancelResponse();
 
         /// <summary>
         /// Handles progress notifications for the outbound request.

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/OutboundRequestContext`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +18,7 @@ namespace NuGet.Protocol.Plugins
         private readonly CancellationToken _cancellationToken;
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly IConnection _connection;
+        private int _isCancellationRequested; // int for Interlocked.CompareExchange(...).  0 == false, 1 == true.
         private bool _isClosed;
         private bool _isDisposed;
         private bool _isKeepAlive;
@@ -80,7 +82,7 @@ namespace NuGet.Protocol.Plugins
 
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            _cancellationTokenSource.Token.Register(Close);
+            _cancellationTokenSource.Token.Register(TryCancel);
 
             // Capture the cancellation token now because if the cancellation token source
             // is disposed race conditions may cause an exception acccessing its Token property.
@@ -88,10 +90,19 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Handles cancellation for the outbound request.
+        /// Handles a cancellation response for the outbound request.
         /// </summary>
-        public override void HandleCancel()
+        public override void HandleCancelResponse()
         {
+            if (Interlocked.CompareExchange(ref _isCancellationRequested, value: 0, comparand: 0) == 0)
+            {
+                throw new ProtocolException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.Plugin_InvalidMessageType,
+                        MessageType.Cancel));
+            }
+
             _taskCompletionSource.TrySetCanceled();
         }
 
@@ -196,7 +207,28 @@ namespace NuGet.Protocol.Plugins
         {
             Debug.WriteLine($"Request {_request.RequestId} timed out.");
 
-            _taskCompletionSource.TrySetCanceled();
+            TryCancel();
+        }
+
+        private void TryCancel()
+        {
+            if (_taskCompletionSource.TrySetCanceled())
+            {
+                if (Interlocked.CompareExchange(ref _isCancellationRequested, value: 1, comparand: 0) == 0)
+                {
+                    Task.Run(async () =>
+                    {
+                        // Top-level exception handler for a worker pool thread.
+                        try
+                        {
+                            await _connection.MessageDispatcher.DispatchCancelAsync(_request, CancellationToken.None);
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    });
+                }
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/CloseRequestHandler.cs
@@ -45,24 +45,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="NotSupportedException">Thrown always.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetCredentialsRequestHandler.cs
@@ -92,24 +92,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="NotSupportedException">Thrown always.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/GetServiceIndexRequestHandler.cs
@@ -78,24 +78,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="NotSupportedException">Thrown always.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/LogRequestHandler.cs
@@ -37,25 +37,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles progress notifications for a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="NotSupportedException">Cancellation requests are not supported
-        /// by this request handler.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandler.cs
@@ -55,24 +55,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="NotSupportedException">Thrown always.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotSupportedException();
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/RequestHandlers/SymmetricHandshake.cs
@@ -138,25 +138,6 @@ namespace NuGet.Protocol.Plugins
         }
 
         /// <summary>
-        /// Asynchronously handles cancelling a request.
-        /// </summary>
-        /// <param name="connection">The connection.</param>
-        /// <param name="request">A request message.</param>
-        /// <param name="responseHandler">A response handler.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        /// <exception cref="ProtocolException">Cancellation requests are not supported
-        /// by this request handler.</exception>
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message request,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new ProtocolException(Strings.Plugin_IllegalMessageWhileHandshaking);
-        }
-
-        /// <summary>
         /// Asynchronously handles responding to a request.
         /// </summary>
         /// <param name="connection">The connection.</param>

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/ConnectionTests.cs
@@ -617,15 +617,6 @@ namespace NuGet.Protocol.Plugins.Tests
                 _payload = payload;
             }
 
-            public Task HandleCancelAsync(
-                IConnection connection,
-                Message request,
-                IResponseHandler responseHandler,
-                CancellationToken cancellationToken)
-            {
-                throw new NotImplementedException();
-            }
-
             public Task HandleResponseAsync(
                 IConnection connection,
                 Message request,

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/MessageDispatcherTests.cs
@@ -310,9 +310,15 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
             using (var connection = new ConnectionMock())
-            using (var messageSentEvent = new ManualResetEventSlim(initialState: false))
             {
                 dispatcher.SetConnection(connection);
+
+                Message message = null;
+
+                connection.MessageSent += (object sender, MessageEventArgs e) =>
+                {
+                    message = e.Message;
+                };
 
                 var request = new Message(_idGenerator.Id, MessageType.Request, MessageMethod.GetOperationClaims);
 
@@ -320,15 +326,6 @@ namespace NuGet.Protocol.Plugins.Tests
                     request.Method,
                     new Request(),
                     cancellationToken: CancellationToken.None);
-
-                Message message = null;
-
-                connection.MessageSent += (object sender, MessageEventArgs e) =>
-                {
-                    message = e.Message;
-
-                    messageSentEvent.Set();
-                };
 
                 await dispatcher.DispatchCancelAsync(request, CancellationToken.None);
 
@@ -418,9 +415,15 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
             using (var connection = new ConnectionMock())
-            using (var messageSentEvent = new ManualResetEventSlim(initialState: false))
             {
                 dispatcher.SetConnection(connection);
+
+                Message message = null;
+
+                connection.MessageSent += (object sender, MessageEventArgs e) =>
+                {
+                    message = e.Message;
+                };
 
                 var request = new Message(
                     _idGenerator.Id,
@@ -434,15 +437,6 @@ namespace NuGet.Protocol.Plugins.Tests
                     cancellationToken: CancellationToken.None);
 
                 var fault = new Fault(message: "a");
-
-                Message message = null;
-
-                connection.MessageSent += (object sender, MessageEventArgs e) =>
-                {
-                    message = e.Message;
-
-                    messageSentEvent.Set();
-                };
 
                 await dispatcher.DispatchFaultAsync(request, fault, CancellationToken.None);
 
@@ -534,9 +528,15 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
             using (var connection = new ConnectionMock())
-            using (var messageSentEvent = new ManualResetEventSlim(initialState: false))
             {
                 dispatcher.SetConnection(connection);
+
+                Message message = null;
+
+                connection.MessageSent += (object sender, MessageEventArgs e) =>
+                {
+                    message = e.Message;
+                };
 
                 var payload = JObject.FromObject(new Request());
                 var request = new Message(
@@ -550,15 +550,6 @@ namespace NuGet.Protocol.Plugins.Tests
                     request.Method,
                     new Request(),
                     cancellationToken: CancellationToken.None);
-
-                Message message = null;
-
-                connection.MessageSent += (object sender, MessageEventArgs e) =>
-                {
-                    message = e.Message;
-
-                    messageSentEvent.Set();
-                };
 
                 await dispatcher.DispatchProgressAsync(request, progress, CancellationToken.None);
 
@@ -737,6 +728,200 @@ namespace NuGet.Protocol.Plugins.Tests
             }
         }
 
+        [Fact]
+        public async Task OnMessageReceived_DoesNotThrowForResponseAfterWaitForResponseIsCancelled()
+        {
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            using (var sentEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                connection.Setup(x => x.SendAsync(It.IsNotNull<Message>(), It.IsAny<CancellationToken>()))
+                    .Callback<Message, CancellationToken>(
+                        (message, cancellationToken) =>
+                        {
+                            sentEvent.Set();
+                        })
+                    .Returns(Task.FromResult(0));
+
+                dispatcher.SetConnection(connection.Object);
+
+                var outboundRequestTask = Task.Run(() => dispatcher.DispatchRequestAsync<PrefetchPackageRequest, PrefetchPackageResponse>(
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageRequest(
+                        packageSourceRepository: "a",
+                        packageId: "b",
+                        packageVersion: "c"),
+                    cancellationTokenSource.Token));
+
+                sentEvent.Wait();
+
+                cancellationTokenSource.Cancel();
+
+                await Assert.ThrowsAsync<TaskCanceledException>(() => outboundRequestTask);
+
+                var response = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Response,
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageResponse(MessageResponseCode.Success));
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(response));
+            }
+        }
+
+        [Fact]
+        public async Task OnMessageReceived_DoesNotThrowForCancelResponseAfterWaitForResponseIsCancelled()
+        {
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            using (var sentEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                connection.Setup(x => x.SendAsync(It.IsNotNull<Message>(), It.IsAny<CancellationToken>()))
+                    .Callback<Message, CancellationToken>(
+                        (message, cancellationToken) =>
+                        {
+                            sentEvent.Set();
+                        })
+                    .Returns(Task.FromResult(0));
+
+                dispatcher.SetConnection(connection.Object);
+
+                var outboundRequestTask = Task.Run(() => dispatcher.DispatchRequestAsync<PrefetchPackageRequest, PrefetchPackageResponse>(
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageRequest(
+                        packageSourceRepository: "a",
+                        packageId: "b",
+                        packageVersion: "c"),
+                    cancellationTokenSource.Token));
+
+                sentEvent.Wait();
+
+                cancellationTokenSource.Cancel();
+
+                await Assert.ThrowsAsync<TaskCanceledException>(() => outboundRequestTask);
+
+                var response = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Cancel,
+                    MessageMethod.PrefetchPackage);
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(response));
+            }
+        }
+
+        [Fact]
+        public void OnMessageReceived_CancelRequestIgnoredIfNoActiveRequest()
+        {
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
+            using (var handlingEvent = new ManualResetEventSlim(initialState: false))
+            using (var cancelEvent = new ManualResetEventSlim(initialState: false))
+            using (var sentEvent = new ManualResetEventSlim(initialState: false))
+            {
+                var cancellationRequest = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Cancel,
+                    MessageMethod.PrefetchPackage);
+
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                dispatcher.SetConnection(connection.Object);
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(cancellationRequest));
+
+                connection.Verify();
+            }
+        }
+
+        [Fact]
+        public void OnMessageReceived_CancelRequestCancelsActiveRequest()
+        {
+            using (var dispatcher = new MessageDispatcher(new RequestHandlers(), _idGenerator))
+            using (var handlingEvent = new ManualResetEventSlim(initialState: false))
+            using (var respondingEvent = new ManualResetEventSlim(initialState: false))
+            using (var sentEvent = new ManualResetEventSlim(initialState: false))
+            {
+                CancellationToken actualCancellationToken;
+
+                var requestHandler = new RequestHandler()
+                {
+                    HandleResponseAsyncFunc = (conn, message, responseHandler, cancellationToken) =>
+                    {
+                        handlingEvent.Set();
+
+                        actualCancellationToken = cancellationToken;
+
+                        respondingEvent.Wait(cancellationToken);
+
+                        return Task.FromResult(0);
+                    }
+                };
+
+                dispatcher.RequestHandlers.TryAdd(MessageMethod.PrefetchPackage, requestHandler);
+
+                var request = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Request,
+                    MessageMethod.PrefetchPackage,
+                    new PrefetchPackageRequest(
+                        packageSourceRepository: "a",
+                        packageId: "b",
+                        packageVersion: "c"));
+
+                var connection = new Mock<IConnection>(MockBehavior.Strict);
+
+                connection.SetupGet(x => x.Options)
+                    .Returns(ConnectionOptions.CreateDefault());
+
+                connection.Setup(x => x.SendAsync(
+                        It.Is<Message>(
+                            m => m.RequestId == request.RequestId &&
+                            m.Type == MessageType.Cancel &&
+                            m.Method == request.Method &&
+                            m.Payload == null),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<Message, CancellationToken>(
+                        (message, cancellationToken) =>
+                        {
+                            sentEvent.Set();
+                        })
+                    .Returns(Task.FromResult(0));
+
+                dispatcher.SetConnection(connection.Object);
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(request));
+
+                handlingEvent.Wait();
+
+                var cancellationRequest = MessageUtilities.Create(
+                    _idGenerator.Id,
+                    MessageType.Cancel,
+                    MessageMethod.PrefetchPackage);
+
+                Assert.False(actualCancellationToken.IsCancellationRequested);
+
+                connection.Raise(x => x.MessageReceived += null, new MessageEventArgs(cancellationRequest));
+
+                Assert.True(actualCancellationToken.IsCancellationRequested);
+
+                sentEvent.Wait();
+
+                connection.Verify();
+            }
+        }
+
         private sealed class ConstantIdGenerator : IIdGenerator
         {
             internal string Id { get; }
@@ -893,23 +1078,12 @@ namespace NuGet.Protocol.Plugins.Tests
         {
             public CancellationToken CancellationToken { get; internal set; }
 
-            internal Func<IConnection, Message, IResponseHandler, CancellationToken, Task> HandleCancelAsyncFunc { get; set; }
             internal Func<IConnection, Message, IResponseHandler, CancellationToken, Task> HandleResponseAsyncFunc { get; set; }
 
             internal RequestHandler()
             {
                 CancellationToken = CancellationToken.None;
-                HandleCancelAsyncFunc = (connection, request, responseHandler, cancellationToken) => throw new NotImplementedException();
                 HandleResponseAsyncFunc = (connection, request, responseHandler, cancellationToken) => throw new NotImplementedException();
-            }
-
-            public Task HandleCancelAsync(
-                IConnection connection,
-                Message request,
-                IResponseHandler responseHandler,
-                CancellationToken cancellationToken)
-            {
-                return HandleCancelAsyncFunc(connection, request, responseHandler, cancellationToken);
             }
 
             public Task HandleResponseAsync(

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/CloseRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/CloseRequestHandlerTests.cs
@@ -47,24 +47,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            using (var test = new CloseRequestHandlerTest())
-            {
-                await Assert.ThrowsAsync<NotSupportedException>(
-                    () => test.Handler.HandleCancelAsync(
-                        Mock.Of<IConnection>(),
-                        new Message(
-                            requestId: "a",
-                            type: MessageType.Cancel,
-                            method: MessageMethod.Close,
-                            payload: null),
-                        Mock.Of<IResponseHandler>(),
-                        CancellationToken.None));
-            }
-        }
-
-        [Fact]
         public async Task HandleResponseAsync_ThrowsForNullConnection()
         {
             using (var test = new CloseRequestHandlerTest())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetCredentialsRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetCredentialsRequestHandlerTests.cs
@@ -86,22 +86,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            using (var provider = CreateDefaultRequestHandler())
-            {
-                var request = CreateRequest(MessageType.Cancel);
-
-                await Assert.ThrowsAsync<NotSupportedException>(
-                    () => provider.HandleCancelAsync(
-                        Mock.Of<IConnection>(),
-                        request,
-                        Mock.Of<IResponseHandler>(),
-                        CancellationToken.None));
-            }
-        }
-
-        [Fact]
         public async Task HandleResponseAsync_ThrowsForNullConnection()
         {
             using (var provider = CreateDefaultRequestHandler())

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetServiceIndexRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/GetServiceIndexRequestHandlerTests.cs
@@ -76,22 +76,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            using (var provider = new GetServiceIndexRequestHandler(Mock.Of<IPlugin>()))
-            {
-                var request = CreateRequest(MessageType.Cancel);
-
-                await Assert.ThrowsAsync<NotSupportedException>(
-                    () => provider.HandleCancelAsync(
-                        Mock.Of<IConnection>(),
-                        request,
-                        Mock.Of<IResponseHandler>(),
-                        CancellationToken.None));
-            }
-        }
-
-        [Fact]
         public async Task HandleResponseAsync_ThrowsForNullConnection()
         {
             using (var provider = new GetServiceIndexRequestHandler(Mock.Of<IPlugin>()))

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/LogRequestHandlerTests.cs
@@ -30,19 +30,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            var test = new LogRequestHandlerTest();
-
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => test.Handler.HandleCancelAsync(
-                    Mock.Of<IConnection>(),
-                    test.Request,
-                    Mock.Of<IResponseHandler>(),
-                    CancellationToken.None));
-        }
-
-        [Fact]
         public async Task HandleResponseAsync_ThrowsForNullConnection()
         {
             var test = new LogRequestHandlerTest();

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/MonitorNuGetProcessExitRequestHandlerTests.cs
@@ -45,19 +45,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            var request = CreateRequest(MessageType.Cancel);
-
-            await Assert.ThrowsAsync<NotSupportedException>(
-                () => _handler.HandleCancelAsync(
-                    Mock.Of<IConnection>(),
-                    request,
-                    Mock.Of<IResponseHandler>(),
-                    CancellationToken.None));
-        }
-
-        [Fact]
         public async Task HandleResponseAsync_ThrowsForNullConnection()
         {
             var request = CreateRequest(MessageType.Request);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/SymmetricHandshakeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/RequestHandlers/SymmetricHandshakeTests.cs
@@ -154,20 +154,6 @@ namespace NuGet.Protocol.Plugins.Tests
         }
 
         [Fact]
-        public async Task HandleCancelAsync_Throws()
-        {
-            using (var handshake = CreateHandshake())
-            {
-                await Assert.ThrowsAsync<ProtocolException>(
-                    () => handshake.HandleCancelAsync(
-                        Mock.Of<IConnection>(),
-                        request: null,
-                        responseHandler: Mock.Of<IResponseHandler>(),
-                        cancellationToken: CancellationToken.None));
-            }
-        }
-
-        [Fact]
         public async Task HandleRequestAsync_ThrowsForNullConnection()
         {
             using (var handshake = CreateHandshake())

--- a/test/TestExtensions/TestablePlugin/TestablePlugin.cs
+++ b/test/TestExtensions/TestablePlugin/TestablePlugin.cs
@@ -64,15 +64,6 @@ namespace NuGet.Test.TestExtensions.TestablePlugin
             await Task.Delay(Timeout.InfiniteTimeSpan, CancellationToken);
         }
 
-        public Task HandleCancelAsync(
-            IConnection connection,
-            Message message,
-            IResponseHandler responseHandler,
-            CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
-
         public async Task HandleResponseAsync(
             IConnection connection,
             Message message,


### PR DESCRIPTION
Resolve NuGet/Home#5328.

In short, these changes:

*  remove `IRequestHandler.HandleCancelAsync(...)`
*  signal request cancellation through the `CancellationToken` argument of `IRequestHandler.HandleRequestAsync(...)`
*  ignore cancellation requests/responses for nonexistent (likely already complete or cancelled) requests

CC @jmyersmsft, @cajonemsft, @zjrunner