### PR TITLE
Adding additional source and fallback folder properties

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -204,6 +204,14 @@ namespace NuGet.PackageManagement.VisualStudio
                 GetReferenceMetadataValue(reference, ProjectItemProperties.ExcludeAssets),
                 GetReferenceMetadataValue(reference, ProjectItemProperties.PrivateAssets));
 
+            dependency.AutoReferenced = MSBuildStringUtility.IsTrue(GetReferenceMetadataValue(reference, ProjectItemProperties.IsImplicitlyDefined));
+
+            // Add warning suppressions
+            foreach (var code in MSBuildRestoreUtility.GetNuGetLogCodes(GetReferenceMetadataValue(reference, ProjectItemProperties.NoWarn)))
+            {
+                dependency.NoWarn.Add(code);
+            }
+
             return dependency;
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -58,6 +58,31 @@ namespace NuGet.VisualStudio
         /// RestoreFallbackFolders DTE property
         /// </summary>
         string RestoreFallbackFolders { get; }
+
+        /// <summary>
+        /// Additional Sources DTE property
+        /// </summary>
+        string RestoreAdditionalProjectSources { get; }
+
+        /// <summary>
+        /// Additional fallback folders DTE property
+        /// </summary>
+        string RestoreAdditionalProjectFallbackFolders { get; }
+
+        /// <summary>
+        /// Comma or Semicolon separated list of NU* diagnostic codes e.g. NU1000,NU1001
+        /// </summary>
+        string NoWarn { get; }
+
+        /// <summary>
+        /// Comma or Semicolon separated list of NU* diagnostic codes e.g. NU1000,NU1001
+        /// </summary>
+        string WarningsAsErrors { get; }
+
+        /// <summary>
+        /// TreatWarningsAsErrors true/false
+        /// </summary>
+        string TreatWarningsAsErrors { get; }
 
         /// <summary>
         /// In unavoidable circumstances where we need to DTE object, it's exposed here

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestorePackageReferencesTask.cs
@@ -66,6 +66,8 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "IncludeAssets");
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "ExcludeAssets");
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "PrivateAssets");
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "NoWarn");
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "IsImplicitlyDefined");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
             }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -433,6 +433,8 @@ Copyright (c) .NET Foundation. All rights reserved.
      RestoreFallbackFolders="$(RestoreFallbackFolders)"
      RestoreConfigFile="$(RestoreConfigFile)"
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
+     RestoreAdditionalProjectFallbackFolders="$(RestoreAdditionalProjectFallbackFolders)"
+     RestoreAdditionalProjectSources="$(RestoreAdditionalProjectSources)"
      >
       <Output
         TaskParameter="OutputSources"
@@ -525,6 +527,9 @@ Copyright (c) .NET Foundation. All rights reserved.
         <ValidateRuntimeAssets>$(ValidateRuntimeIdentifierCompatibility)</ValidateRuntimeAssets>
         <SkipContentFileWrite>$(_RestoreSkipContentFileWrite)</SkipContentFileWrite>
         <ConfigFilePaths>$(_OutputConfigFilePaths)</ConfigFilePaths>
+        <TreatWarningsAsErrors>$(TreatWarningsAsErrors)</TreatWarningsAsErrors>
+        <WarningsAsErrors>$(WarningsAsErrors)</WarningsAsErrors>
+        <NoWarn>$(NoWarn)</NoWarn>
       </_RestoreGraphEntry>
     </ItemGroup>
 

--- a/src/NuGet.Core/NuGet.Commands/Utility/MsBuildStringUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/MsBuildStringUtility.cs
@@ -14,11 +14,20 @@ namespace NuGet.Commands
         /// </summary>
         public static string[] Split(string s)
         {
+            return Split(s, ';');
+        }
+
+        /// <summary>
+        /// Split on ; and trim. Null or empty inputs will return an
+        /// empty array.
+        /// </summary>
+        public static string[] Split(string s, params char[] chars)
+        {
             if (!string.IsNullOrEmpty(s))
             {
                 // Split on ; and trim all entries
                 // After trimming remove any entries that are now empty due to trim.
-                return s.Split(';')
+                return s.Split(chars)
                     .Select(entry => entry.Trim())
                     .Where(entry => entry.Length != 0)
                     .ToArray();

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectItemProperties.cs
@@ -12,5 +12,7 @@ namespace NuGet.ProjectManagement
         public const string IncludeAssets = "IncludeAssets";
         public const string ExcludeAssets = "ExcludeAssets";
         public const string PrivateAssets = "PrivateAssets";
+        public const string IsImplicitlyDefined = nameof(IsImplicitlyDefined);
+        public const string NoWarn = nameof(NoWarn);
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -109,7 +109,7 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Contains Project wide properties for Warnings.
         /// </summary>
-        public WarningProperties ProjectWideWarningProperties { get; set; }
+        public WarningProperties ProjectWideWarningProperties { get; set; } = new WarningProperties();
 
         public override int GetHashCode()
         {

--- a/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/WarningProperties.cs
@@ -26,9 +26,14 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Indicates if all warnings should be ignored.
         /// </summary>
-        public bool AllWarningsAsErrors { get; } = false;
+        public bool AllWarningsAsErrors { get; set; } = false;
+
+        public WarningProperties()
+        {
+        }
 
         public WarningProperties(ISet<NuGetLogCode> warningsAsErrorsSet, ISet<NuGetLogCode> noWarnSet, bool allWarningsAsErrors)
+            : base()
         {
             WarningsAsErrors = warningsAsErrorsSet;
             NoWarn = noWarnSet;

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using FluentAssertions;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
@@ -305,7 +307,7 @@ namespace NuGet.Commands.Test
 
                 var items = new List<IDictionary<string, string>>();
 
-                //TODO NK - Add tests
+                
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "ProjectSpec" },
@@ -1457,6 +1459,238 @@ namespace NuGet.Commands.Test
         public void MSBuildRestoreUtility_ContainsClearKeyword(string input, bool expected)
         {
             Assert.Equal(expected, MSBuildRestoreUtility.ContainsClearKeyword(MSBuildStringUtility.Split(input)));
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyProjectWideWarningProperties()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+                var configFilePath = Path.Combine(project1Root, "nuget.config");
+
+                var items = new List<IDictionary<string, string>>();
+
+                
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0-rc.2+a.b.c" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "ConfigFilePaths", configFilePath },
+                    { "TreatWarningsAsErrors", "true" },
+                    { "WarningsAsErrors", "NU1001;NU1002" },
+                    { "NoWarn", "NU1100;NU1101" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var props = project1Spec.RestoreMetadata.ProjectWideWarningProperties;
+
+                // Assert
+                props.AllWarningsAsErrors.Should().BeTrue();
+                props.NoWarn.ShouldBeEquivalentTo(new[] { NuGetLogCode.NU1100, NuGetLogCode.NU1101 });
+                props.WarningsAsErrors.ShouldBeEquivalentTo(new[] { NuGetLogCode.NU1001, NuGetLogCode.NU1002 });
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyEmptyProjectWideWarningProperties()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+                var configFilePath = Path.Combine(project1Root, "nuget.config");
+
+                var items = new List<IDictionary<string, string>>();
+
+                
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0-rc.2+a.b.c" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "ConfigFilePaths", configFilePath },
+                    { "TreatWarningsAsErrors", "" },
+                    { "WarningsAsErrors", "" },
+                    { "NoWarn", "" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var props = project1Spec.RestoreMetadata.ProjectWideWarningProperties;
+
+                // Assert
+                props.AllWarningsAsErrors.Should().BeFalse();
+                props.NoWarn.Should().BeEmpty();
+                props.WarningsAsErrors.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyPackageWarningProperties()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var uniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(CreateProject(project1Root, uniqueName));
+
+                // Package references
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "Id", "x" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "CrossTargeting", "true" },
+                    { "NoWarn", "NU1001;NU1002" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var packageDependency = project1Spec.TargetFrameworks[0].Dependencies[0];
+
+                // Assert
+                packageDependency.NoWarn.ShouldBeEquivalentTo(new[] { NuGetLogCode.NU1001, NuGetLogCode.NU1002 });
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyEmptyPackageWarningProperties()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var uniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(CreateProject(project1Root, uniqueName));
+
+                // Package references
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "Id", "x" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "CrossTargeting", "true" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var packageDependency = project1Spec.TargetFrameworks[0].Dependencies[0];
+
+                // Assert
+                packageDependency.NoWarn.Should().BeEmpty();
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyAutoReferencedTrue()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var uniqueName = "482C20DE-DFF9-4BD0-B90A-BD3201AA351A";
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(CreateProject(project1Root, uniqueName));
+
+                // Package references
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "Dependency" },
+                    { "ProjectUniqueName", uniqueName },
+                    { "Id", "x" },
+                    { "VersionRange", "1.0.0" },
+                    { "TargetFrameworks", "net46" },
+                    { "IsImplicitlyDefined", "true" },
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+                var packageDependency = project1Spec.TargetFrameworks[0].Dependencies[0];
+
+                // Assert
+                packageDependency.AutoReferenced.Should().BeTrue();
+            }
+        }
+
+        private static IDictionary<string, string> CreateProject(string root, string uniqueName)
+        {
+            var project1Path = Path.Combine(root, "a.csproj");
+            var outputPath1 = Path.Combine(root, "obj");
+            var fallbackFolder = Path.Combine(root, "fallback");
+            var packagesFolder = Path.Combine(root, "packages");
+            var configFilePath = Path.Combine(root, "nuget.config");
+
+            return new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "Version", "2.0.0-rc.2+a.b.c" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", uniqueName },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "ConfigFilePaths", configFilePath },
+                };
         }
 
         private IMSBuildItem CreateItems(IDictionary<string, string> properties)


### PR DESCRIPTION
This adds support for reading warning properties from packagereferences and the project file on the command line. 

* Adding warning and errors properties
* Adding additional source and fallback folder properties

