### PR TITLE
Adding NullSettings public constructor back to avoid breaks

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/NullSettings.cs
@@ -11,10 +11,6 @@ namespace NuGet.Configuration
     {
         private static readonly NullSettings _settings = new NullSettings();
 
-        private NullSettings()
-        {
-            //keep this private, use the instance in your tests
-        }
         public event EventHandler SettingsChanged = delegate { };
 
         public static NullSettings Instance


### PR DESCRIPTION
CLI is constructing NullSettings, other 3rd parties might be also. To avoid breaking this I've removed the private constructor.

Ideally users should use the Instance, but since the settings check is now done by checking the type I think enforcing this is no longer needed.