### PR TITLE
Allow specifying copyToOutput and flatten as Metadata on Content items when packing sdk csproj

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -507,7 +507,9 @@ namespace NuGet.Build.Tasks.Pack
             {
                 BuildAction = buildAction.IsKnown ? buildAction.Value : null,
                 Source = sourcePath,
-                Target = target
+                Target = target,
+                CopyToOutput = packageFile.GetProperty("PackageCopyToOutput"),
+                Flatten = packageFile.GetProperty("PackageFlatten")
             });
         }
 

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -226,6 +226,8 @@ namespace NuGet.Commands
                         {
                             BuildAction = contentMetadata.BuildAction,
                             Include = includePath,
+                            CopyToOutput = contentMetadata.CopyToOutput,
+                            Flatten = contentMetadata.Flatten
                         };
                         
                         builder.ContentFiles.Add(manifestContentFile);


### PR DESCRIPTION
This PR adds support for two new properties on project items which are to be included as content files in the package created from a csproj:

PackageCopyToOutput - maps to the copyToOutput attribute on contentFiles/file element in the nuspec 
PackageFlatten - maps to the flatten attribute on contentFiles/file element in the nuspec

The naming is intended to be consistent with the existing "PackagePath" property.

https://github.com/NuGet/Home/issues/5259