### PR TITLE
Fixing invalid sources on linux/osx

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -24,6 +24,8 @@ namespace NuGet.Commands
     {
         // Clear keyword for properties.
         public static readonly string Clear = nameof(Clear);
+        private static readonly string[] _httpPrefixes = new string[] { "http:", "https:" };
+        private const string DoubleSlash = "//";
 
         /// <summary>
         /// Convert MSBuild items to a DependencyGraphSpec.
@@ -177,7 +179,7 @@ namespace NuGet.Commands
 
                     foreach (var source in MSBuildStringUtility.Split(specItem.GetProperty("Sources")))
                     {
-                        result.RestoreMetadata.Sources.Add(new PackageSource(source));
+                        result.RestoreMetadata.Sources.Add(new PackageSource(FixSourcePath(source)));
                     }
 
                     foreach (var configFilePath in MSBuildStringUtility.Split(specItem.GetProperty("ConfigFilePaths")))
@@ -735,9 +737,46 @@ namespace NuGet.Commands
             return props;
         }
 
+        /// <summary>
+        /// Convert http:/url to http://url 
+        /// If not needed the same path is returned. This is to work around
+        /// issues with msbuild dropping slashes from paths on linux and osx.
+        /// </summary>
+        public static string FixSourcePath(string s)
+        {
+            var result = s;
+
+            if (result.IndexOf('/') >= -1 && result.IndexOf(DoubleSlash) == -1)
+            {
+                for (var i = 0; i < _httpPrefixes.Length; i++)
+                {
+                    result = FixSourcePath(result, _httpPrefixes[i], DoubleSlash);
+                }
+
+                // For non-windows machines use file:///
+                var fileSlashes = RuntimeEnvironmentHelper.IsWindows ? DoubleSlash : "///";
+                result = FixSourcePath(result, "file:", fileSlashes);
+            }
+
+            return result;
+        }
+
+        private static string FixSourcePath(string s, string prefixWithoutSlashes, string slashes)
+        {
+            if (s.Length >= (prefixWithoutSlashes.Length + 2)
+                && s.StartsWith($"{prefixWithoutSlashes}/", StringComparison.OrdinalIgnoreCase)
+                && !s.StartsWith($"{prefixWithoutSlashes}{DoubleSlash}", StringComparison.OrdinalIgnoreCase))
+            {
+                // original prefix casing + // + rest of the path
+                return s.Substring(0, prefixWithoutSlashes.Length) + slashes + s.Substring(prefixWithoutSlashes.Length + 1);
+            }
+
+            return s;
+        }
+
         private static bool IsPropertyTrue(IMSBuildItem item, string propertyName)
         {
-            return StringComparer.OrdinalIgnoreCase.Equals(item.GetProperty(propertyName), Boolean.TrueString);
+            return StringComparer.OrdinalIgnoreCase.Equals(item.GetProperty(propertyName), bool.TrueString);
         }
 
         private static readonly Lazy<bool> _isPersistDGSet = new Lazy<bool>(() => IsPersistDGSet());

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1668,6 +1668,56 @@ namespace NuGet.Commands.Test
             }
         }
 
+        [Theory]
+        [InlineData("/tmp/test/", "/tmp/test/")]
+        [InlineData("/tmp/test", "/tmp/test")]
+        [InlineData("tmp/test", "tmp/test")]
+        [InlineData("tmp", "tmp")]
+        [InlineData("http:", "http:")]
+        [InlineData("https:", "https:")]
+        [InlineData("file:", "file:")]
+        [InlineData("http:/", "http:/")]
+        [InlineData("https:/", "https:/")]
+        [InlineData("file:/", "file:/")]
+        [InlineData("http://", "http://")]
+        [InlineData("https://", "https://")]
+        [InlineData("file://", "file://")]
+        [InlineData("http://a", "http://a")]
+        [InlineData("https://a", "https://a")]
+        [InlineData("file://a", "file://a")]
+        [InlineData("http:/a", "http://a")]
+        [InlineData("https:/a", "https://a")]
+        [InlineData("file:/a", "file://a")]
+        [InlineData("HTtP:/a", "HTtP://a")]
+        [InlineData("HTTPs:/a", "HTTPs://a")]
+        [InlineData("fiLe:/a", "fiLe://a")]
+        [InlineData("http:///", "http:///")]
+        [InlineData("https:///", "https:///")]
+        [InlineData("file:///", "file:///")]
+        [InlineData("HTTPS:/api.NUGET.org/v3/index.json", "HTTPS://api.NUGET.org/v3/index.json")]
+        [InlineData(@"C:\source\", @"C:\source\")]
+        [InlineData(@"\\share\", @"\\share\")]
+        public void MSBuildRestoreUtility_FixSourcePath(string input, string expected)
+        {
+            MSBuildRestoreUtility.FixSourcePath(input).Should().Be(expected);
+        }
+
+        [PlatformFact(Platform.Windows)]
+        public void MSBuildRestoreUtility_FixSourcePath_VerifyDoubleSlashWindows()
+        {
+            var input = "file:/C:\tmp";
+
+            MSBuildRestoreUtility.FixSourcePath(input).Should().Be("file://C:\tmp");
+        }
+
+        [PlatformFact(Platform.Linux, Platform.Darwin)]
+        public void MSBuildRestoreUtility_FixSourcePath_VerifyTripleSlashOnNonWindows()
+        {
+            var input = "file:/tmp/test/";
+
+            MSBuildRestoreUtility.FixSourcePath(input).Should().Be("file:///tmp/test/");
+        }
+
         private static IDictionary<string, string> CreateProject(string root, string uniqueName)
         {
             var project1Path = Path.Combine(root, "a.csproj");


### PR DESCRIPTION
This works around an issue in MSBuild where `https://` is converted to `https:/`, this code path is limited to only sources coming from MSBuild and attempts to fix up URIs that are missing slashes.

