### PR TITLE
Order URI sources first to avoid msbuild issues

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -121,7 +121,9 @@ namespace NuGet.Build.Tasks
                 }
 
                 // Append additional sources
-                OutputSources = AppendItems(OutputSources, RestoreAdditionalProjectSources);
+                OutputSources = AppendItems(OutputSources, RestoreAdditionalProjectSources)
+                    .OrderBy(s => s, new SourceTypeComparer())
+                    .ToArray();
 
                 if (RestoreFallbackFolders == null)
                 {

--- a/src/NuGet.Core/NuGet.Build.Tasks/SourceTypeComparer.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/SourceTypeComparer.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Sort http, https, and file URIs first in a list.
+    /// </summary>
+    public class SourceTypeComparer : IComparer<string>
+    {
+        private static readonly string[] _uriPrefixes = new string[] { "http://", "https://", "file://" };
+
+        public int Compare(string x, string y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x == null)
+            {
+                return 1;
+            }
+
+            if (y == null)
+            {
+                return -1;
+            }
+
+            var xIsUri = IsUri(x);
+            var yIsUri = IsUri(y);
+
+            if (xIsUri && !yIsUri)
+            {
+                return -1;
+            }
+
+            if (!xIsUri && yIsUri)
+            {
+                return 1;
+            }
+
+            // Treat items of the same type as equal.
+            return 0;
+        }
+
+        private static bool IsUri(string s)
+        {
+            if (s == null)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < _uriPrefixes.Length; i++)
+            {
+                if (s.StartsWith(_uriPrefixes[i], StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -168,7 +168,7 @@ namespace NuGet.ProjectModel
             {
                 writer.WriteObjectStart("sources");
 
-                foreach (var source in msbuildMetadata.Sources)
+                foreach (var source in msbuildMetadata.Sources.OrderBy(e => e.Source, StringComparer.Ordinal))
                 {
                     // "source": {}
                     writer.WriteObjectStart(source.Source);

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/SourceTypeComparerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/SourceTypeComparerTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class SourceTypeComparerTests
+    {
+        [Fact]
+        public void SourceTypeComparer_VerifyOrder()
+        {
+            var sources = new[] { "a", "https://dotnet.myget.org/testfeed", "https://api.nuget.org/v3/index.json", "b", "http://testfeed", "file://C:\test", "file:///tmp/test/", "http:invalid", "/tmp/test/" };
+            var expected = new[] { "https://dotnet.myget.org/testfeed", "https://api.nuget.org/v3/index.json", "http://testfeed", "file://C:\test", "file:///tmp/test/", "a", "b", "http:invalid", "/tmp/test/" };
+
+            sources.OrderBy(s => s, new SourceTypeComparer())
+                .ShouldBeEquivalentTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
MSBuild restore fails when a property contains a mix of sources and the first one is local on Linux or OSX. This change orders URI sources first to avoid MSBuild treating them as local paths.