### PR TITLE
Fixing PackageSpec Read/Write test breaks caused by merge conflicts

### DIFF
--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecWriterTests.cs
@@ -160,12 +160,12 @@ namespace NuGet.ProjectModel.Test
     ""outputPath"": ""outputPath"",
     ""projectStyle"": ""PackageReference"",
     ""crossTargeting"": true,
-    ""configFilePaths"": [
+    ""fallbackFolders"": [
       ""b"",
       ""a"",
       ""c""
     ],
-    ""fallbackFolders"": [
+    ""configFilePaths"": [
       ""b"",
       ""a"",
       ""c""

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJson.json
@@ -49,11 +49,6 @@
     "outputPath": "outputPath",
     "projectStyle": "PackageReference",
     "crossTargeting": true,
-    "configFilePaths": [
-      "b",
-      "a",
-      "c"
-    ],
     "fallbackFolders": [
       "b",
       "a",

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJsonWithoutRestoreSettings.json
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/compiler/resources/PackageSpecWriter_Write_SerializesMembersAsJsonWithoutRestoreSettings.json
@@ -46,11 +46,6 @@
     "outputPath": "outputPath",
     "projectStyle": "PackageReference",
     "crossTargeting": true,
-    "configFilePaths": [
-      "b",
-      "a",
-      "c"
-    ],
     "fallbackFolders": [
       "b",
       "a",


### PR DESCRIPTION
Seems the json files used in the tests were not merged correctly. I have fixed them and tested locally. Will wait for approval and CI test run before merging.