### PR TITLE
Normalize target paths to use forward slashes when checking for a match during nuget.exe update

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -50,9 +50,18 @@ namespace NuGet.Common
             yield break;
         }
 
+        /// <summary>
+        /// Replace all back slashes with forward slashes.
+        /// </summary>
         public static string GetPathWithForwardSlashes(string path)
         {
-            return path.Replace('\\', '/');
+            if (path != null && path.IndexOf('\\') >= -1)
+            {
+                return path.Replace('\\', '/');
+            }
+
+            // Leave the path unchanged.
+            return path;
         }
 
         public static string EnsureTrailingSlash(string path)

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -147,5 +147,35 @@ namespace NuGet.CommandLine.Test
                 Assert.False(proj.HasElements, "The <Import /> and <Target Name=\"EnsureNuGetPackageBuildImports\" /> elements should have been removed.");
             }
         }
+
+        // Verify for mono scenarios that / slash paths are also removed.
+        [Fact]
+        public void MSBuildProjectSystem_RemoveImportForwardSlashes()
+        {
+            // Arrange
+            var import = @"packages\mypackage.1.0.0\build\mypackage.targets";
+            var projectFileContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Import Project=""packages/mypackage.1.0.0/build/mypackage.targets"" Condition=""Exists('packages/mypackage.1.0.0/build/mypackage.targets')"" />
+  <Target Name=""EnsureNuGetPackageBuildImports"" BeforeTargets=""PrepareForBuild"" >
+    <PropertyGroup>   
+      <ErrorText>This project references NuGet package(s) that are missing on this computer.Enable NuGet Package Restore to download them.For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition=""!Exists('packages/mypackage.1.0.0/build/mypackage.targets')"" Text=""$([System.String]::Format('$(ErrorText)', 'packages/mypackage.1.0.0/build/mypackage.targets'))"" />
+  </Target>
+</Project>";
+
+            using (var testInfo = new TestInfo(projectFileContent))
+            {
+                var targetFullPath = Path.Combine(testInfo.MSBuildProjectSystem.ProjectFullPath, import);
+
+                // Act
+                testInfo.MSBuildProjectSystem.RemoveImport(targetFullPath);
+
+                // Assert
+                var proj = XElement.Load(testInfo.MSBuildProjectSystem.ProjectFileFullPath);
+                Assert.False(proj.HasElements, "The <Import /> and <Target Name=\"EnsureNuGetPackageBuildImports\" /> elements should have been removed.");
+            }
+        }
     }
 }


### PR DESCRIPTION
Normalize target paths to use forward slashes when checking for a match during nuget.exe update

* Normalize target paths to forward slashes when removing targets from packages.config projects
* Fix to noop if needed when converting to forward slashes for perf

Fixes https://github.com/NuGet/Home/issues/5336