### PR TITLE
Fixing restore result to fail in case logs have errors

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -184,6 +184,8 @@ namespace NuGet.Commands
                 .Select(l => AssetsLogMessage.Create(l))
                 .ToList();
 
+            _success &= !logs.Any(l => l.Level == LogLevel.Error);
+
             assetsFile.LogMessages = logs;
 
             restoreTime.Stop();


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/5337

Since we now bump warnings to errors, we need to check if the logs contain errors at the end and reflect that in the restore result.

