### PR TITLE
[ISSUE #5341, Nuget/Home] Add profiles 44 & 151 to the list of Xamarin supported profiles

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultPortableFrameworkMappings.cs
@@ -109,7 +109,7 @@ namespace NuGet.Frameworks
         // profiles that also support monotouch1+monoandroid1
         private static int[] _profilesWithOptionalFrameworks = new int[]
             {
-                5, 6, 7, 14, 19, 24, 37, 42, 47, 49, 78, 92, 102, 111, 136, 147, 158, 225, 255, 259, 328, 336, 344
+                5, 6, 7, 14, 19, 24, 37, 42, 44, 47, 49, 78, 92, 102, 111, 136, 147, 151, 158, 225, 255, 259, 328, 336, 344
             };
 
         private List<KeyValuePair<int, NuGetFramework[]>> _profileOptionalFrameworks;

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
@@ -222,11 +222,17 @@ namespace NuGet.Test
         [InlineData("portable-net45+win8+monoandroid+monotouch", "portable-net45+win8+wp8")]
         [InlineData("portable-net45+win8+monoandroid1+monotouch1", "portable-net45+win8+wp8")]
         [InlineData("monoandroid10", "portable-net45+win8")]
+        [InlineData("monoandroid10", "portable-net451+netcore451")]
         [InlineData("monotouch10", "portable-net45+win8")]
+        [InlineData("monotouch10", "portable-net451+netcore451")]
         [InlineData("xamarinios10", "portable-net45+win8")]
+        [InlineData("xamarinios10", "portable-net451+netcore451")]
         [InlineData("xamarintvos10", "portable-net45+win8")]
+        [InlineData("xamarintvos10", "portable-net451+netcore451")]
         [InlineData("xamarinwatchos10", "portable-net45+win8")]
+        [InlineData("xamarinwatchos10", "portable-net451+netcore451")]
         [InlineData("xamarinmac20", "portable-net45+win8")]
+        [InlineData("xamarinmac20", "portable-net451+netcore451")]
         public void CompatibilityPCL_Optional(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityPCLTests.cs
@@ -221,18 +221,24 @@ namespace NuGet.Test
         [InlineData("portable-net45+win8", "portable-net45+win8+wp8+monoandroid1+monotouch1")]
         [InlineData("portable-net45+win8+monoandroid+monotouch", "portable-net45+win8+wp8")]
         [InlineData("portable-net45+win8+monoandroid1+monotouch1", "portable-net45+win8+wp8")]
-        [InlineData("monoandroid10", "portable-net45+win8")]
-        [InlineData("monoandroid10", "portable-net451+netcore451")]
-        [InlineData("monotouch10", "portable-net45+win8")]
-        [InlineData("monotouch10", "portable-net451+netcore451")]
-        [InlineData("xamarinios10", "portable-net45+win8")]
-        [InlineData("xamarinios10", "portable-net451+netcore451")]
-        [InlineData("xamarintvos10", "portable-net45+win8")]
-        [InlineData("xamarintvos10", "portable-net451+netcore451")]
-        [InlineData("xamarinwatchos10", "portable-net45+win8")]
-        [InlineData("xamarinwatchos10", "portable-net451+netcore451")]
-        [InlineData("xamarinmac20", "portable-net45+win8")]
-        [InlineData("xamarinmac20", "portable-net451+netcore451")]
+        [InlineData("monoandroid10", "portable-net45+win8")]              //Profile7
+        [InlineData("monoandroid10", "portable-net451+win81")]            //Profile44
+        [InlineData("monoandroid10", "portable-net451+win81+wpa81")]      //Profile151
+        [InlineData("monotouch10", "portable-net45+win8")]                //Profile7
+        [InlineData("monotouch10", "portable-net451+win81")]              //Profile44
+        [InlineData("monotouch10", "portable-net451+win81+wpa81")]        //Profile151
+        [InlineData("xamarinios10", "portable-net45+win8")]               //Profile7
+        [InlineData("xamarinios10", "portable-net451+win81")]             //Profile44
+        [InlineData("xamarinios10", "portable-net451+win81+wpa81")]       //Profile151
+        [InlineData("xamarintvos10", "portable-net45+win8")]              //Profile7
+        [InlineData("xamarintvos10", "portable-net451+win81")]            //Profile44
+        [InlineData("xamarintvos10", "portable-net451+win81+wpa81")]      //Profile151
+        [InlineData("xamarinwatchos10", "portable-net45+win8")]           //Profile7
+        [InlineData("xamarinwatchos10", "portable-net451+win81")]         //Profile44
+        [InlineData("xamarinwatchos10", "portable-net451+win81+wpa81")]   //Profile151
+        [InlineData("xamarinmac20", "portable-net45+win8")]               //Profile7
+        [InlineData("xamarinmac20", "portable-net451+win81")]             //Profile44
+        [InlineData("xamarinmac20", "portable-net451+win81+wpa81")]       //Profile151
         public void CompatibilityPCL_Optional(string fw1, string fw2)
         {
             var framework1 = NuGetFramework.Parse(fw1);


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5341

This PR adds PCL Profiles 44 & 151 to the list of Xamarin supported profiles and adds unit tests to cover them.

These profiles have been supported by Xamarin projects since early 2016 but were missing from NuGet's compatibility list.