### PR TITLE
Defaulting warning level to Severe in RestoreLogMessage

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
@@ -11,7 +11,7 @@ namespace NuGet.Common
     public class LogMessage : ILogMessage
     {
         public LogLevel Level { get; set; }
-        public WarningLevel WarningLevel { get; set; }
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe; //setting default to Severe as 0 implies show no warnings
         public NuGetLogCode Code { get; set; }
         public string Message { get; set; }
         public string ProjectPath { get; set; }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -15,7 +15,7 @@ namespace NuGet.Common
         public string Message { get; set; }
         public DateTimeOffset Time { get; set; }
         public string ProjectPath { get; set; }
-        public WarningLevel WarningLevel { get; set; }
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe; //setting default to Severe as 0 implies show no warnings
         public string FilePath { get; set; }
         public int StartLineNumber { get; set; } = -1;
         public int StartColumnNumber { get; set; } = -1;


### PR DESCRIPTION
Enum defaults to 0. But in warning levels, 0 means turn off all warnings. I have changed the defaults to 1 = Severe.

Since, no one is consuming this yet, it should have no impact. But will prevent side effects in future.