### PR TITLE
Adding retry logic for v2 feed parser.

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -391,6 +391,15 @@ namespace NuGet.Protocol {
         internal static string Log_InvalidNupkgFromUrl {
             get {
                 return ResourceManager.GetString("Log_InvalidNupkgFromUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The V2 feed request for &apos;{0}&apos; failed, trying again..
+        /// </summary>
+        internal static string Log_RetryFetchV2Feed {
+            get {
+                return ResourceManager.GetString("Log_RetryFetchV2Feed", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -461,6 +461,9 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
 {2} is a package ID
 {3} is a package version</comment>
   </data>
+  <data name="Log_RetryFetchV2Feed" xml:space="preserve">
+    <value>The V2 feed request for '{0}' failed, trying again.</value>
+  </data>
   <data name="Plugin_Fault" xml:space="preserve">
     <value>Terminating plugin '{0}' due to an unrecoverable fault:  {1}</value>
     <comment>{0} is the plugin name


### PR DESCRIPTION
Try up to three times when requesting v2 feed pages.

This is the same retry logic used by the v3 feed parsers. It needs to be done when reading the XML to avoid reading multiple pages and then starting over and reading them all again.

I verified that no one else is calling the v2 parser with retry.

Fixes https://github.com/NuGet/Home/issues/5322