### PR TITLE
Improving log Entensions and filtering the noWarn codes

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/ErrorListTableEntry.cs
@@ -51,15 +51,15 @@ namespace NuGet.SolutionRestoreManager
                     content = ErrorSouce;
                     return true;
                 case StandardTableColumnDefinitions.ErrorCode:
+                    var result = false;
+
                     if (Message.Code > NuGetLogCode.Undefined)
                     {
-                        content = Message.Code.GetName();
-                        return true;
+                        result = Message.Code.TryGetName(out var codeString);
+                        content = codeString;
                     }
-                    else
-                    {
-                        return false;
-                    }
+
+                    return result;
                 case StandardTableColumnDefinitions.DocumentName:
                     if (Message.ProjectPath != null)
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -40,7 +40,6 @@ namespace NuGet.Commands
 
         public RestoreCommand(RestoreRequest request)
         {
-
             _request = request ?? throw new ArgumentNullException(nameof(request));
 
             // Validate the lock file version requested
@@ -178,7 +177,7 @@ namespace NuGet.Commands
             {
                 cacheFile.Success = _success;
             }
-            
+
             // Write the logs into the assets file
             var logs = _logger.Errors
                 .Select(l => AssetsLogMessage.Create(l))

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -767,7 +767,7 @@ namespace NuGet.Commands
         {
             foreach (var item in MSBuildStringUtility.Split(s, ';', ','))
             {
-                if (Enum.TryParse<NuGetLogCode>(item, out var result))
+                if (s.StartsWith("NU") && Enum.TryParse<NuGetLogCode>(item, out var result))
                 {
                     yield return result;
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -767,7 +767,7 @@ namespace NuGet.Commands
         {
             foreach (var item in MSBuildStringUtility.Split(s, ';', ','))
             {
-                if (s.StartsWith("NU") && Enum.TryParse<NuGetLogCode>(item, out var result))
+                if (s.StartsWith("NU", StringComparison.OrdinalIgnoreCase) && Enum.TryParse<NuGetLogCode>(item, out var result))
                 {
                     yield return result;
                 }

--- a/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/LogMessage.cs
@@ -11,7 +11,7 @@ namespace NuGet.Common
     public class LogMessage : ILogMessage
     {
         public LogLevel Level { get; set; }
-        public WarningLevel WarningLevel { get; set; }
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe; //setting default to Severe as 0 implies show no warnings
         public NuGetLogCode Code { get; set; }
         public string Message { get; set; }
         public string ProjectPath { get; set; }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -15,7 +15,7 @@ namespace NuGet.Common
         public string Message { get; set; }
         public DateTimeOffset Time { get; set; }
         public string ProjectPath { get; set; }
-        public WarningLevel WarningLevel { get; set; }
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe; //setting default to Severe as 0 implies show no warnings
         public string FilePath { get; set; }
         public int StartLineNumber { get; set; } = -1;
         public int StartColumnNumber { get; set; } = -1;

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
@@ -7,11 +7,17 @@ namespace NuGet.Common
 {
     public static class LoggingExtensions
     {
+        /// <summary>
+        /// Formats a ILogMessage into a string representation containg the log code and message.
+        /// The log code is added only if it is a valid NuGetLogCode and is greater than NuGetLogCode.Undefined.
+        /// </summary>
+        /// <param name="message">ILogMessage to be formatted.</param>
+        /// <returns>string representation of the ILogMessage.</returns>
         public static string FormatWithCode(this ILogMessage message)
         {
-            if (message.Code > NuGetLogCode.Undefined)
+            if (message.Code > NuGetLogCode.Undefined && message.Code.TryGetName(out var codeString))
             {
-                return $"{message.Code.GetName()}: {message.Message}";
+                return $"{codeString}: {message.Message}";
             }
             else
             {
@@ -19,9 +25,26 @@ namespace NuGet.Common
             }
         }
 
+        /// <summary>
+        /// Formats a NuGetLogCode into a string representation.
+        /// </summary>
+        /// <param name="code">NuGetLogCode to be formatted.</param>
+        /// <returns>strings representation of the NuGetLogCode.</returns>
         public static string GetName(this NuGetLogCode code)
         {
             return Enum.GetName(typeof(NuGetLogCode), code);
+        }
+
+        /// <summary>
+        /// Tries to get the string from the NuGetLogCode enum.
+        /// </summary>
+        /// <param name="code">NuGetLogCode</param>
+        /// <param name="codeString">strings representation of the NuGetLogCode if the result is true else null.</param>
+        /// <returns>bool indcating if the GetName operation was successfull or not.</returns>
+        public static bool TryGetName(this NuGetLogCode code, out string codeString)
+        {
+            codeString = code.GetName();
+            return codeString == null ? false : true; 
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
+++ b/src/NuGet.Core/NuGet.Common/Logging/LoggingExtensions.cs
@@ -28,7 +28,7 @@ namespace NuGet.Common
         /// <summary>
         /// Formats a NuGetLogCode into a string representation.
         /// </summary>
-        /// <param name="code">NuGetLogCode to be formatted.</param>
+        /// <param name="code">NuGetLogCode to be formatted into string.</param>
         /// <returns>strings representation of the NuGetLogCode.</returns>
         public static string GetName(this NuGetLogCode code)
         {
@@ -38,13 +38,13 @@ namespace NuGet.Common
         /// <summary>
         /// Tries to get the string from the NuGetLogCode enum.
         /// </summary>
-        /// <param name="code">NuGetLogCode</param>
+        /// <param name="code">NuGetLogCode to be formatted into string.</param>
         /// <param name="codeString">strings representation of the NuGetLogCode if the result is true else null.</param>
         /// <returns>bool indcating if the GetName operation was successfull or not.</returns>
         public static bool TryGetName(this NuGetLogCode code, out string codeString)
         {
             codeString = code.GetName();
-            return codeString == null ? false : true; 
+            return codeString != null; 
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -262,7 +262,8 @@ namespace NuGet.ProjectModel
                        .NoWarn
                        .ToArray()
                        .OrderBy(c => c)
-                       .Select(c => c.GetName()));
+                       .Select(c => c.GetName())
+                       .Where(c => !string.IsNullOrEmpty(c)));
                 }
 
                 if (msbuildMetadata.ProjectWideWarningProperties.WarningsAsErrors.Count > 0)
@@ -272,7 +273,9 @@ namespace NuGet.ProjectModel
                         .WarningsAsErrors
                         .ToArray()
                         .OrderBy(c => c)
-                        .Select(c => c.GetName()));
+                        .Select(c => c.GetName())
+                        .Where(c => !string.IsNullOrEmpty(c)));
+
                 }
 
                 writer.WriteObjectEnd();
@@ -398,7 +401,7 @@ namespace NuGet.ProjectModel
 
                     if (dependency.NoWarn.Count > 0)
                     {
-                        SetArrayValue(writer, "noWarn", dependency.NoWarn.Select(code => code.GetName()));
+                        SetArrayValue(writer, "noWarn", dependency.NoWarn.OrderBy(c => c).Select(code => code.GetName()).Where(s => !string.IsNullOrEmpty(s)));
                     }
 
                     writer.WriteObjectEnd();

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -401,7 +401,12 @@ namespace NuGet.ProjectModel
 
                     if (dependency.NoWarn.Count > 0)
                     {
-                        SetArrayValue(writer, "noWarn", dependency.NoWarn.OrderBy(c => c).Select(code => code.GetName()).Where(s => !string.IsNullOrEmpty(s)));
+                        SetArrayValue(writer, "noWarn", dependency
+                            .NoWarn
+                            .OrderBy(c => c)
+                            .Distinct()
+                            .Select(code => code.GetName())
+                            .Where(s => !string.IsNullOrEmpty(s)));
                     }
 
                     writer.WriteObjectEnd();


### PR DESCRIPTION
fixes: https://github.com/NuGet/Home/issues/5342

1. Better filtering in project properties for `NuGetLogCode` i.e. drop any code which does not start with `NU*`.
2. Adding better `LogExtensions` for `NuGetLogCode.GetName`.
3. Adding `OrderBy` into `LibraryDependency` `noWarn` properties.

