### PR TITLE
Call IVsProjectBuildSystem methods on UI thread

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -178,9 +178,10 @@ namespace NuGet.Common
             return Task.FromResult(0);
         }
 
-        public void BeginProcessing()
+        public Task BeginProcessingAsync()
         {
             // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
+            return Task.FromResult(0);
         }
 
         public void RegisterProcessedFiles(IEnumerable<string> files)
@@ -188,9 +189,10 @@ namespace NuGet.Common
             // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
         }
 
-        public void EndProcessing()
+        public Task EndProcessingAsync()
         {
             // No-op outside of visual studio, this is implemented in other project systems, like vsmsbuild & website.
+            return Task.FromResult(0);
         }
 
         public void DeleteDirectory(string path, bool recursive)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsMSBuildProjectSystem.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -589,9 +588,10 @@ namespace NuGet.PackageManagement.VisualStudio
 
         #endregion Binding Redirects Stuff
 
-        [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "NuGet/Home#4833 Baseline")]
-        public virtual void BeginProcessing()
+        public virtual async Task BeginProcessingAsync()
         {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             ProjectBuildSystem?.StartBatchEdit();
         }
 
@@ -600,9 +600,10 @@ namespace NuGet.PackageManagement.VisualStudio
             // No-op, this is implemented in other project systems, like website.
         }
 
-        [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "NuGet/Home#4833 Baseline")]
-        public virtual void EndProcessing()
+        public virtual async Task EndProcessingAsync()
         {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
             ProjectBuildSystem?.EndBatchEdit();
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/WebSiteProjectSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -189,8 +189,9 @@ namespace NuGet.PackageManagement.VisualStudio
             return base.GetDirectories(path);
         }
 
-        public override void BeginProcessing()
+        public override Task BeginProcessingAsync()
         {
+            return Task.FromResult(0);
         }
 
         public override void RegisterProcessedFiles(IEnumerable<string> files)
@@ -218,9 +219,11 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public override void EndProcessing()
+        public override Task EndProcessingAsync()
         {
             _excludedCodeFiles.Clear();
+
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -2105,7 +2105,7 @@ namespace NuGet.PackageManagement
                         if (msbuildProject != null)
                         {
                             //start batch processing for msbuild
-                            msbuildProject.ProjectSystem.BeginProcessing();
+                            await msbuildProject.ProjectSystem.BeginProcessingAsync();
 
                             // raise Nuget batch start event
                             var batchId = Guid.NewGuid().ToString();
@@ -2175,7 +2175,7 @@ namespace NuGet.PackageManagement
                         {
                             // end batch for msbuild and let it save everything.
                             // always calls it before PostProcessAsync or binding redirects
-                            msbuildProject.ProjectSystem.EndProcessing();
+                            await msbuildProject.ProjectSystem.EndProcessingAsync();
                         }
                     }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/IMSBuildProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/IMSBuildProjectSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -46,13 +46,15 @@ namespace NuGet.ProjectManagement
         bool IsSupportedFile(string path);
         void AddBindingRedirects();
 
-        void BeginProcessing();
+        Task BeginProcessingAsync();
+
         /// <summary>
-        /// This method can be called multiple times during a batch operation in between a single BeginProcessing/EndProcessing calls.
+        /// This method can be called multiple times during a batch operation in between a single BeginProcessingAsync/EndProcessingAsync calls.
         /// </summary>
         /// <param name="files">a list of files being changed.</param>
         void RegisterProcessedFiles(IEnumerable<string> files);
-        void EndProcessing();
+
+        Task EndProcessingAsync();
 
         void DeleteDirectory(string path, bool recursive);
 

--- a/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/test/TestUtilities/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Test.Utility;
 
@@ -158,8 +157,9 @@ namespace Test.Utility
             BindingRedirectsCallCount++;
         }
 
-        public void BeginProcessing()
+        public Task BeginProcessingAsync()
         {
+            return Task.FromResult(0);
         }
 
         public void RegisterProcessedFiles(IEnumerable<string> files)
@@ -175,11 +175,13 @@ namespace Test.Utility
             }
         }
 
-        public void EndProcessing()
+        public Task EndProcessingAsync()
         {
             ++BatchCount;
             ProcessedFiles = FilesInProcessing;
             FilesInProcessing = null;
+
+            return Task.FromResult(0);
         }
 
         public void DeleteDirectory(string path, bool recursive)


### PR DESCRIPTION
`IVsProjectBuildSystem.StartBatchEdit()` and `IVsProjectBuildSystem.EndBatchEdit()` must be called on the UI thread.

Resolves internal bug 150355.
https://github.com/NuGet/Home/issues/5354
@jainaashish