### PR TITLE
lcl files don't have resources.dll extension anymore

### DIFF
--- a/build/common.targets
+++ b/build/common.targets
@@ -188,7 +188,7 @@
   <Target Name="GetBuildOutputWithLocMetadata" DependsOnTargets="BuiltProjectOutputGroup" Returns="@(DllsToLocalizeWithMetadata)">
     <ItemGroup>
       <DllsToLocalizeWithMetadata Include="@(BuiltProjectOutputGroupOutput->'%(FinalOutputPath)')" Condition="'%(Extension)' == '.dll' OR '%(Filename)' == 'NuGet.CommandLine.XPlat'" KeepDuplicates="false">
-        <TranslationFile>$(LocalizationRootDirectory)\{Lang}\15\%(Filename).resources.dll.lcl</TranslationFile>    <!--Required: translation file-->
+        <TranslationFile>$(LocalizationRootDirectory)\{Lang}\15\%(Filename).dll.lcl</TranslationFile>    <!--Required: translation file-->
 	      <LciCommentFile>$(LocalizationRootDirectory)\comments\15\%(Filename).resources.dll.lci</LciCommentFile>
       </DllsToLocalizeWithMetadata>
     </ItemGroup>

--- a/build/loc.proj
+++ b/build/loc.proj
@@ -27,7 +27,7 @@
     <Copy SourceFiles="@(NonProjectFilesToMove)" DestinationFiles="@(NonProjectFilesToMove->'%(DestinationDir)')"/>
     <ItemGroup>
       <FilesToLocalize Include="@(NonProjectFilesToMove->'%(DestinationDir)')">
-        <TranslationFile Condition="'%(Extension)' == '.dll'">$(LocalizationRootDirectory)\{Lang}\15\%(Filename).resources.dll.lcl</TranslationFile>    <!--Required: translation file-->
+        <TranslationFile Condition="'%(Extension)' == '.dll'">$(LocalizationRootDirectory)\{Lang}\15\%(Filename).dll.lcl</TranslationFile>    <!--Required: translation file-->
 	      <LciCommentFile Condition="'%(Extension)' == '.dll'">$(LocalizationRootDirectory)\comments\15\%(Filename).resources.dll.lci</LciCommentFile>
         <TranslationFile Condition="'%(Extension)' != '.dll'">$(LocalizationRootDirectory)\{Lang}\15\%(Filename)%(Extension).lcl</TranslationFile>    <!--Required: translation file-->
 	      <LciCommentFile Condition="'%(Extension)' != '.dll'">$(LocalizationRootDirectory)\comments\15\%(Filename)%(Extension).lci</LciCommentFile>


### PR DESCRIPTION
the new check-in in nuget.build.localization will not use *.resources.dll.lcl extension anymore, instead it will use *.dll.lcl

Explanation from Daniel Ye:

> What Hyun described is another way to generate loc resource file. Basically it was the way your former system is using. (main assembly->English satellite resource assembly->lcg of English satellite resource assembly->lcl of satellite resource assembly->loc’d satellite resource assembly). It has its benefit, in some cases, the satellite resource assembly file size can be reduced.
> Your current way go to the route of (main assembly->lcg of main assembly->lcl of main assembly-> loc’d satellite resource assembly). 
> It produces same result. But you need to reference main assembly file name for both lcl and lci. Loc platform will check in NuGet.Frameworks.dll.lcl. Not NuGet.Frameworks.resources.dll.lcl.
