### PR TITLE
Fixing hang in Blend

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTESolutionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -93,26 +93,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return resultantEnvDTEProjects;
-        }
-
-        public static Task<Dictionary<string, EnvDTE.Project>> GetPathToDTEProjectLookupAsync(EnvDTE.DTE dte)
-        {
-            var pathToProject = new Dictionary<string, EnvDTE.Project>(StringComparer.OrdinalIgnoreCase);
-
-            var supportedProjects = dte.Solution.Projects.Cast<EnvDTE.Project>();
-
-            foreach (var solutionProject in supportedProjects)
-            {
-                var solutionProjectPath = EnvDTEProjectInfoUtility.GetFullProjectPath(solutionProject);
-
-                if (!string.IsNullOrEmpty(solutionProjectPath) &&
-                    !pathToProject.ContainsKey(solutionProjectPath))
-                {
-                    pathToProject.Add(solutionProjectPath, solutionProject);
-                }
-            }
-
-            return Task.FromResult(pathToProject);
         }
     }
 }


### PR DESCRIPTION
Resolves NuGet/Home#5349.

Blend unlike VS calls the extension API on UI thread. This leads to
unstable condition with possible hang when path context provider blocks
the calling thread. This change moves switching to a background thread
to subroutines where actual computations are performed.

//cc @debonte @rrelyea 