### PR TITLE
add localization validator

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -20,4 +20,5 @@
   <package id="xunit.runner.console" version="2.2.0" targetFramework="net45" />
   <package id="xunit.runner.msbuild" version="2.2.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
+  <package id="NuGetValidator.Localization" version="1.2.0" targetFramework="net45" />
 </packages>

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+Validates the result of the localization process
+
+.DESCRIPTION
+This script is used to validate the results of localization.
+
+.PARAMETER BuildOutputTargetPath
+Path to the location where the build artifacts are output
+
+.PARAMETER BuildRTM
+True/false depending on whether nupkgs are being with or without the release labels.
+
+#>
+
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$BuildOutputTargetPath,
+    [Parameter(Mandatory=$True)]
+    [string]$BuildRTM
+)
+
+
+if ($BuildRTM -eq 'false')
+{    
+    $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
+    $LocValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.Localization.1.2.0', 'tools', 'NuGetValidator.Localization.exe')
+    $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'Insertable', 'NuGet.Tools.vsix' ) 
+    $VsixExtractLocation = Join-Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY "extractedVsix"
+    $LogOutputDir = Join-Path $BuildOutputTargetPath "LocalizationValidation"
+    $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
+    & $LocValidator $VsixLocation $VsixExtractLocation $LogOutputDir $LocalizationRepository
+    # We want to exit the process with success even if there are errors.
+    exit 0
+}


### PR DESCRIPTION
This generates the stats for localization at the end of every build. We will use this script to add more validation steps to our builds in the future.

Once this is checked-in, i will make the corresponding changes to our build definition.

