### PR TITLE
Adding ProjectPath to RestoreCollectorLogger to improve default logging

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs
@@ -17,7 +17,9 @@ namespace NuGet.Commands
 
         public IEnumerable<IRestoreLogMessage> Errors => _errors.ToArray();
 
-        public WarningPropertiesCollection WarningPropertiesCollection;
+        public WarningPropertiesCollection WarningPropertiesCollection { get; set; }
+        
+        public string ProjectPath { get; set; }
 
         /// <summary>
         /// Initializes an instance of the <see cref="RestoreCollectorLogger"/>, while still
@@ -71,6 +73,10 @@ namespace NuGet.Commands
             // This will be true only when the Message is a Warning and should be suppressed.
             if (WarningPropertiesCollection == null || !WarningPropertiesCollection.ApplyWarningProperties(message))
             {
+                if (string.IsNullOrEmpty(message.FilePath))
+                {
+                    message.FilePath = message.ProjectPath ?? ProjectPath;
+                }
 
                 if (CollectMessage(message.Level))
                 {
@@ -90,6 +96,10 @@ namespace NuGet.Commands
             // This will be true only when the Message is a Warning and should be suppressed.
             if (WarningPropertiesCollection == null || !WarningPropertiesCollection.ApplyWarningProperties(message))
             {
+                if (string.IsNullOrEmpty(message.FilePath))
+                {
+                    message.FilePath = message.ProjectPath ?? ProjectPath;
+                }
 
                 if (CollectMessage(message.Level))
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -54,6 +54,7 @@ namespace NuGet.Commands
 
             var collectorLogger = new RestoreCollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors)
             {
+                ProjectPath = _request.Project.RestoreMetadata.ProjectPath,
                 WarningPropertiesCollection =  new WarningPropertiesCollection()
                 {
                     ProjectWideWarningProperties = request.Project?.RestoreMetadata?.ProjectWideWarningProperties,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -54,7 +54,7 @@ namespace NuGet.Commands
 
             var collectorLogger = new RestoreCollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors)
             {
-                ProjectPath = _request.Project.RestoreMetadata.ProjectPath,
+                ProjectPath = _request.Project?.RestoreMetadata?.ProjectPath,
                 WarningPropertiesCollection =  new WarningPropertiesCollection()
                 {
                     ProjectWideWarningProperties = request.Project?.RestoreMetadata?.ProjectWideWarningProperties,


### PR DESCRIPTION
This PR adds `ProjectPath` to `RestoreCollectorLogger` to make the default logging experience better as current default displays `NuGet.Targets` as the file path.

Should go in after https://github.com/NuGet/NuGet.Client/pull/1472 to prevent displaying -1's as line and column numbers.