### PR TITLE
Control type is inappropriate for tab item

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+
+namespace NuGet.PackageManagement.UI.Automation
+{
+    public class TabItemButtonAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
+    {
+        private TabItemButton tabItemButton;
+
+        public TabItemButtonAutomationPeer(TabItemButton owner) : base(owner)
+        {
+            this.tabItemButton = owner;
+        }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.TabItem;
+        }
+
+        public override object GetPattern(PatternInterface patternInterface)
+        {
+            if (patternInterface == PatternInterface.SelectionItem)
+            {
+                return this;
+            }
+            return base.GetPattern(patternInterface);
+        }
+
+        #region ISelectionItemProvider Implementation
+        public bool IsSelected
+        {
+            get
+            {
+                return this.tabItemButton.IsPressed;
+            }
+        }
+
+        public IRawElementProviderSimple SelectionContainer
+        {
+            get
+            {
+                return this.ProviderFromPeer(this);
+            }
+        }
+
+        public void Select()
+        {
+            this.tabItemButton.Select();
+        }
+
+        public void AddToSelection()
+        {
+            this.tabItemButton.Select();
+        }
+
+        public void RemoveFromSelection() { /* No-op */ }
+
+        #endregion
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Diagnostics;
+using System;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 
@@ -15,11 +15,15 @@ namespace NuGet.PackageManagement.UI
     /// </summary>
     internal class TabItemButtonAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
     {
-        private TabItemButton _tabItemButton;
+        private readonly TabItemButton _tabItemButton;
 
         public TabItemButtonAutomationPeer(TabItemButton owner) : base(owner)
         {
-            Debug.Assert(owner != null);
+            if (owner == null)
+            {
+                throw new ArgumentNullException(nameof(owner));
+            }
+
             _tabItemButton = owner;
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
@@ -34,7 +34,7 @@ namespace NuGet.PackageManagement.UI.Automation
         {
             get
             {
-                return this.tabItemButton.IsPressed;
+                return this.tabItemButton.IsFocused;
             }
         }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Automation/TabItemButtonAutomationPeer.cs
@@ -1,18 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Windows.Automation.Peers;
 using System.Windows.Automation.Provider;
 
-namespace NuGet.PackageManagement.UI.Automation
+namespace NuGet.PackageManagement.UI
 {
-    public class TabItemButtonAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
+    /// <summary>
+    /// Automation peer to Represents Button controls which are used as Clickable Tab Items.
+    /// This changes the ControlType for such buttons to TabItems and provides the necessary
+    /// AutomationPatterns suitable for a tab item. 
+    /// Example: Browse, Installed, Update Tab items in the Nuget Package Manager tab
+    /// </summary>
+    internal class TabItemButtonAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
     {
-        private TabItemButton tabItemButton;
+        private TabItemButton _tabItemButton;
 
         public TabItemButtonAutomationPeer(TabItemButton owner) : base(owner)
         {
-            this.tabItemButton = owner;
+            Debug.Assert(owner != null);
+            _tabItemButton = owner;
         }
 
         protected override AutomationControlType GetAutomationControlTypeCore()
@@ -34,7 +42,7 @@ namespace NuGet.PackageManagement.UI.Automation
         {
             get
             {
-                return this.tabItemButton.IsFocused;
+                return _tabItemButton.IsFocused;
             }
         }
 
@@ -42,18 +50,18 @@ namespace NuGet.PackageManagement.UI.Automation
         {
             get
             {
-                return this.ProviderFromPeer(this);
+                return ProviderFromPeer(this);
             }
         }
 
         public void Select()
         {
-            this.tabItemButton.Select();
+            _tabItemButton.Select();
         }
 
         public void AddToSelection()
         {
-            this.tabItemButton.Select();
+            _tabItemButton.Select();
         }
 
         public void RemoveFromSelection() { /* No-op */ }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Controls/TabItemButton.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Controls/TabItemButton.cs
@@ -3,11 +3,14 @@
 
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
-using NuGet.PackageManagement.UI.Automation;
 
 namespace NuGet.PackageManagement.UI
 {
-    public class TabItemButton: Button
+    /// <summary>
+    /// Represents Button controls which are used as Clickable Tab Items.
+    /// Example: Browse, Installed, Update Tab items in the Nuget Package Manager tab
+    /// </summary>
+    internal class TabItemButton : Button
     {
         protected override AutomationPeer OnCreateAutomationPeer()
         {
@@ -16,7 +19,7 @@ namespace NuGet.PackageManagement.UI
 
         public void Select()
         {
-            this.OnClick();
+            OnClick();
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -46,7 +46,7 @@
   <ItemGroup>
     <Compile Include="Actions\UIActionEngine.cs" />
     <Compile Include="Actions\UpdatePreviewResult.cs" />
-    <Compile Include="Automation\TabItemAutomationPeer.cs" />
+    <Compile Include="Automation\TabItemButtonAutomationPeer.cs" />
     <Compile Include="Common\ErrorFloodGate.cs" />
     <Compile Include="Common\NuGetEvent.cs" />
     <Compile Include="Common\NuGetEventTrigger.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Common\ErrorFloodGate.cs" />
     <Compile Include="Common\NuGetEvent.cs" />
     <Compile Include="Common\NuGetEventTrigger.cs" />
+    <Compile Include="Controls\TabItemButton.cs" />
     <Compile Include="Converters\RadioBoolToIntConverter.cs" />
     <Compile Include="Converters\TooltipConverter.cs" />
     <Compile Include="Converters\BooleanToFontWeightConverter.cs" />
@@ -93,7 +94,6 @@
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>
     </Compile>
-    <Compile Include="TabItemButton.cs" />
     <Compile Include="UserInterfaceService\IUserSettingsManager.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Xamls\DeprecatedFrameworkWindow.xaml.cs">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="Actions\UIActionEngine.cs" />
     <Compile Include="Actions\UpdatePreviewResult.cs" />
+    <Compile Include="Automation\TabItemAutomationPeer.cs" />
     <Compile Include="Common\ErrorFloodGate.cs" />
     <Compile Include="Common\NuGetEvent.cs" />
     <Compile Include="Common\NuGetEventTrigger.cs" />
@@ -92,6 +93,7 @@
     <Compile Include="Resources\Resources.xaml.cs">
       <DependentUpon>Resources.xaml</DependentUpon>
     </Compile>
+    <Compile Include="TabItemButton.cs" />
     <Compile Include="UserInterfaceService\IUserSettingsManager.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Xamls\DeprecatedFrameworkWindow.xaml.cs">

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/TabItemButton.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/TabItemButton.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Windows.Automation.Peers;
+using System.Windows.Controls;
+using NuGet.PackageManagement.UI.Automation;
+
+namespace NuGet.PackageManagement.UI
+{
+    public class TabItemButton: Button
+    {
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new TabItemButtonAutomationPeer(this);
+        }
+
+        public void Select()
+        {
+            this.OnClick();
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/FilterLabel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="NuGet.PackageManagement.UI.FilterLabel"
+<UserControl x:Class="NuGet.PackageManagement.UI.FilterLabel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -19,17 +19,17 @@
       <RowDefinition Height="auto" />
       <RowDefinition Height="auto" />
     </Grid.RowDefinitions>
-    <Button x:Name="_labelButton"
+    <nuget:TabItemButton x:Name="_labelButton"
       Grid.Row="0"
       Click="ButtonClicked"
       AutomationProperties.AutomationId="{Binding ElementName=_labelText, Path=Text}"
       AutomationProperties.Name="{Binding ElementName=_labelText, Path=Text}"
       FocusVisualStyle="{DynamicResource ControlsFocusVisualStyle}">
-      <Button.Template>
+      <nuget:TabItemButton.Template>
         <ControlTemplate TargetType="{x:Type Button}">
           <ContentPresenter />
         </ControlTemplate>
-      </Button.Template>
+      </nuget:TabItemButton.Template>
       <StackPanel Orientation="Horizontal">
         <TextBlock
           x:Name="_labelText"
@@ -58,7 +58,7 @@
             Foreground="{DynamicResource {x:Static nuget:Brushes.ContentSelectedTextBrushKey}}"/>
         </Border>
       </StackPanel>
-    </Button>
+    </nuget:TabItemButton>
 
     <!-- the line under the text to indicate that this label is selected -->
     <Rectangle


### PR DESCRIPTION
Fix for Bug 395738: Inspect: Control type is inappropriate for tab item

The "Browse", "Installed", "Update" and "Consolidate" tabs (Which are actually buttons) in the Nuget Package Manager currently have default "button" as LocalizedControlType and the narrator reads them as "button" and not "tabitem". 
Created automation peer to explicitly set the control type to tabitem. Also added ISelectionItemProvider to the automation peer to enable the property IsSelectionItemPatternAvailable.