### PR TITLE
Fixing downgrade script for E2E for VS versions that do not support downgrade

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -46,16 +46,16 @@ if($VSVersion -eq '14.0')
 }
 else 
 {
-        #We don't care for the downgrade result...we should be able to install on top anyways.
-        $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+    #We don't care for the downgrade result...we should be able to install on top anyways.
+    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
+    
+    if ($success -eq $false)
+    {
+        exit 1
+    }
         
-        if ($success -eq $false)
-	{
-		exit 1
-	}
-        
-	# Clearing MEF cache helps load the right dlls for vsix
-	ClearDev15MEFCache
+    # Clearing MEF cache helps load the right dlls for vsix
+    ClearDev15MEFCache
 }
 
 $success = InstallVSIX $VSIXPath $VSVersion $VSIXInstallerWaitTimeInSecs

--- a/scripts/e2etests/VSUtils.ps1
+++ b/scripts/e2etests/VSUtils.ps1
@@ -205,8 +205,16 @@ function DowngradeVSIX
 
     if ($p.ExitCode -ne 0)
     {
+        if($p.ExitCode -eq 2001)
+        {
+            Write-Host "This VS2017 version does not support downgrade. Moving on to installing the VSIX! Exit code: $($p.ExitCode)" 
+            return $true
+        }
+        else 
+        {
             Write-Error "Error downgrading the VSIX! Exit code: $($p.ExitCode)"
             return $false
+        }
     }
 
     start-sleep -Seconds $VSIXInstallerWaitTimeInSecs


### PR DESCRIPTION
The E2E machine for private branches has d15Rel installed which does not yet have the `/d` downgrade api for vsix installer.

This PR fixes our scripts so that we do not fail if we run on a VS without the api.

https://stackoverflow.com/questions/21531596/vsixinstaller-exe-exit-code-documentation