### PR TITLE
Making restore display existing warnings and errors incase of no-op from assets file

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -208,7 +208,7 @@ namespace NuGet.Commands
 
         private void ReplayWarningsAndErrors()
         {
-            var logMessages = _request?.ExistingLockFile?.LogMessages;
+            var logMessages = _request.ExistingLockFile?.LogMessages ?? Enumerable.Empty<IAssetsLogMessage>();
 
             if (logMessages != null)
             {
@@ -227,7 +227,7 @@ namespace NuGet.Commands
                         EndColumnNumber = logMessage.EndColumnNumber
                     };
 
-                    _request.Log.Log(restoreLogMessage);
+                    _request.Log.LogAsync(restoreLogMessage);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -210,25 +210,22 @@ namespace NuGet.Commands
         {
             var logMessages = _request.ExistingLockFile?.LogMessages ?? Enumerable.Empty<IAssetsLogMessage>();
 
-            if (logMessages != null)
+            foreach (var logMessage in logMessages)
             {
-                foreach (var logMessage in logMessages)
+                var restoreLogMessage = new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
                 {
-                    var restoreLogMessage = new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
-                    {
-                        ProjectPath = logMessage.ProjectPath,
-                        WarningLevel = logMessage.WarningLevel,
-                        FilePath = logMessage.FilePath,
-                        LibraryId = logMessage.LibraryId,
-                        TargetGraphs = logMessage.TargetGraphs,
-                        StartLineNumber = logMessage.StartLineNumber,
-                        StartColumnNumber = logMessage.StartColumnNumber,
-                        EndLineNumber = logMessage.EndLineNumber,
-                        EndColumnNumber = logMessage.EndColumnNumber
-                    };
+                    ProjectPath = logMessage.ProjectPath,
+                    WarningLevel = logMessage.WarningLevel,
+                    FilePath = logMessage.FilePath,
+                    LibraryId = logMessage.LibraryId,
+                    TargetGraphs = logMessage.TargetGraphs,
+                    StartLineNumber = logMessage.StartLineNumber,
+                    StartColumnNumber = logMessage.StartColumnNumber,
+                    EndLineNumber = logMessage.EndLineNumber,
+                    EndColumnNumber = logMessage.EndColumnNumber
+                };
 
-                    _request.Log.LogAsync(restoreLogMessage);
-                }
+                _request.Log.LogAsync(restoreLogMessage);
             }
         }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -91,6 +91,9 @@ namespace NuGet.Commands
                 {
                     if (NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndPackagesArePresent(_request))
                     {
+                        // Replay Warnings and Errors from an existing lock file in case of a no-op.
+                        ReplayWarningsAndErrors();
+
                         restoreTime.Stop();
 
                         return new NoOpRestoreResult(
@@ -201,6 +204,32 @@ namespace NuGet.Commands
                 cacheFilePath,
                 _request.ProjectStyle,
                 restoreTime.Elapsed);
+        }
+
+        private void ReplayWarningsAndErrors()
+        {
+            var logMessages = _request?.ExistingLockFile?.LogMessages;
+
+            if (logMessages != null)
+            {
+                foreach (var logMessage in logMessages)
+                {
+                    var restoreLogMessage = new RestoreLogMessage(logMessage.Level, logMessage.Code, logMessage.Message)
+                    {
+                        ProjectPath = logMessage.ProjectPath,
+                        WarningLevel = logMessage.WarningLevel,
+                        FilePath = logMessage.FilePath,
+                        LibraryId = logMessage.LibraryId,
+                        TargetGraphs = logMessage.TargetGraphs,
+                        StartLineNumber = logMessage.StartLineNumber,
+                        StartColumnNumber = logMessage.StartColumnNumber,
+                        EndLineNumber = logMessage.EndLineNumber,
+                        EndColumnNumber = logMessage.EndColumnNumber
+                    };
+
+                    _request.Log.Log(restoreLogMessage);
+                }
+            }
         }
 
         private KeyValuePair<CacheFile,bool> EvaluateCacheFile()


### PR DESCRIPTION
Currently, with no-op we do not replay the existing warnings and errors from the previous assets file. This PR fixes that.