### PR TITLE
Added ProjectsCount and NoOpProjectsCount properties in telemetry events

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ActionsTelemetryService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/ActionsTelemetryService.cs
@@ -50,7 +50,8 @@ namespace NuGet.PackageManagement.VisualStudio
                     { TelemetryConstants.OperationStatusPropertyName, actionTelemetryData.Status },
                     { TelemetryConstants.StartTimePropertyName, actionTelemetryData.StartTime.ToString() },
                     { TelemetryConstants.EndTimePropertyName, actionTelemetryData.EndTime.ToString() },
-                    { TelemetryConstants.DurationPropertyName, actionTelemetryData.Duration }
+                    { TelemetryConstants.DurationPropertyName, actionTelemetryData.Duration },
+                    { TelemetryConstants.ProjectsCountPropertyName, actionTelemetryData.ProjectsCount }
                 }
             );
             _telemetrySession.PostEvent(telemetryEvent);

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ActionEventBase.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/ActionEventBase.cs
@@ -26,6 +26,7 @@ namespace NuGet.VisualStudio
             StartTime = startTime;
             EndTime = endTime;
             Duration = duration;
+            ProjectsCount = projectIds.Length;
         }
 
         public string OperationId { get; }
@@ -41,5 +42,7 @@ namespace NuGet.VisualStudio
         public DateTimeOffset EndTime { get; }
 
         public double Duration { get; }
+
+        public int ProjectsCount { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryEvent.cs
@@ -17,12 +17,16 @@ namespace NuGet.VisualStudio
             DateTimeOffset startTime,
             NuGetOperationStatus status,
             int packageCount,
+            int noOpProjectsCount,
             DateTimeOffset endTime,
             double duration) : base(operationId, projectIds, startTime, status, packageCount, endTime, duration)
         {
             Source = source;
+            NoOpProjectsCount = noOpProjectsCount;
         }
 
         public RestoreOperationSource Source { get; }
+
+        public int NoOpProjectsCount { get; }
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Telemetry/RestoreTelemetryService.cs
@@ -39,7 +39,9 @@ namespace NuGet.VisualStudio
                     { TelemetryConstants.OperationStatusPropertyName, restoreTelemetryData.Status },
                     { TelemetryConstants.StartTimePropertyName, restoreTelemetryData.StartTime.ToString() },
                     { TelemetryConstants.EndTimePropertyName, restoreTelemetryData.EndTime.ToString() },
-                    { TelemetryConstants.DurationPropertyName, restoreTelemetryData.Duration }
+                    { TelemetryConstants.DurationPropertyName, restoreTelemetryData.Duration },
+                    { TelemetryConstants.ProjectsCountPropertyName, restoreTelemetryData.ProjectsCount },
+                    { TelemetryConstants.NoOpProjectsCountPropertyName, restoreTelemetryData.NoOpProjectsCount }
                 }
             );
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Telemetry/TelemetryConstants.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Telemetry/TelemetryConstants.cs
@@ -37,6 +37,8 @@ namespace NuGet.ProjectManagement
         public static readonly string StartTimePropertyName = PropertyNamePrefix + "StartTime";
         public static readonly string EndTimePropertyName = PropertyNamePrefix + "EndTime";
         public static readonly string DurationPropertyName = PropertyNamePrefix + "Duration";
+        public static readonly string ProjectsCountPropertyName = PropertyNamePrefix + "ProjectsCount";
+        public static readonly string NoOpProjectsCountPropertyName = PropertyNamePrefix + "NoOpProjectsCount";
 
         // nuget action step event data
         public static readonly string StepNamePropertyName = PropertyNamePrefix + "StepName";

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/RestoreTelemetryServiceTests.cs
@@ -30,6 +30,13 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             string operationId = Guid.NewGuid().ToString();
 
+            var noopProjectsCount = 0;
+
+            if (status == NuGetOperationStatus.NoOp)
+            {
+                noopProjectsCount = 1;
+            }
+
             var stausMessage = status == NuGetOperationStatus.Failed ? "Operation Failed" : string.Empty;
             var restoreTelemetryData = new RestoreTelemetryEvent(
                 operationId: operationId,
@@ -38,6 +45,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 startTime: DateTimeOffset.Now.AddSeconds(-3),
                 status: status,
                 packageCount: 2,
+                noOpProjectsCount: noopProjectsCount,
                 endTime: DateTimeOffset.Now,
                 duration: 2.10);
             var service = new RestoreTelemetryService(telemetrySession.Object);
@@ -56,6 +64,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             Assert.Equal(8, actual.Properties.Count);
 
             Assert.Equal(expected.Source.ToString(), actual.Properties[TelemetryConstants.OperationSourcePropertyName].ToString());
+
+            Assert.Equal(expected.NoOpProjectsCount, (int)actual.Properties[TelemetryConstants.NoOpProjectsCountPropertyName]);
 
             TestTelemetryUtility.VerifyTelemetryEventData(expected, actual);
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TestTelemetryUtility.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Telemetry/TestTelemetryUtility.cs
@@ -13,6 +13,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         public static void VerifyTelemetryEventData(ActionEventBase expected, TelemetryEvent actual)
         {
             Assert.Equal(expected.OperationId, actual.Properties[TelemetryConstants.OperationIdPropertyName].ToString());
+            Assert.Equal(expected.ProjectsCount, (int)actual.Properties[TelemetryConstants.ProjectsCountPropertyName]);
             Assert.Equal(string.Join(",", expected.ProjectIds), actual.Properties[TelemetryConstants.ProjectIdsPropertyName].ToString());
             Assert.Equal(expected.PackagesCount, (int)actual.Properties[TelemetryConstants.PackagesCountPropertyName]);
             Assert.Equal(expected.Status.ToString(), actual.Properties[TelemetryConstants.OperationStatusPropertyName].ToString());


### PR DESCRIPTION
This PR adds new properties for `RestoreInformation` and `NuGetAction` telemetry events. And also, fix restore status mostly being logged as NoOp.

- Added `ProjectsCount` and `NoOpProjectsCount` for restore event.
- Added `ProjectsCount` for other nuget action telemetry events like install/ update.

@rrelyea 