### PR TITLE
Updated correct ProjectServices for net core projects to execute init scripts

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Common\PackageCollectionItemExtensions.cs" />
     <Compile Include="ProjectServices\DeferredProjectCapabilities.cs" />
     <Compile Include="ProjectServices\GlobalProjectServiceProvider.cs" />
+    <Compile Include="ProjectServices\NetCoreProjectSystemServices.cs" />
     <Compile Include="ProjectServices\VsCoreProjectSystemReferenceReader.cs" />
     <Compile Include="Projects\VsMSBuildProjectSystemServices.cs" />
     <Compile Include="Utility\SupportedProjectTypes.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NetCoreProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/NetCoreProjectSystemServices.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft;
+using Microsoft.VisualStudio.ComponentModelHost;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    /// <summary>
+    /// Represent net core project systems in visual studio.
+    /// </summary>
+    internal class NetCoreProjectSystemServices :
+        GlobalProjectServiceProvider,
+        INuGetProjectServices
+    {
+        public NetCoreProjectSystemServices(
+            IVsProjectAdapter vsProjectAdapter,
+            IComponentModel componentModel) 
+            : base(componentModel)
+        {
+            Assumes.Present(vsProjectAdapter);
+
+            ScriptService = new VsProjectScriptHostService(vsProjectAdapter, this);
+        }
+
+        public IProjectBuildProperties BuildProperties => throw new NotSupportedException();
+
+        public IProjectSystemCapabilities Capabilities => throw new NotSupportedException();
+
+        public IProjectSystemReferencesReader ReferencesReader => throw new NotSupportedException();
+
+        public IProjectSystemReferencesService References => throw new NotSupportedException();
+
+        public IProjectSystemService ProjectSystem => throw new NotSupportedException();
+
+        public IProjectScriptHostService ScriptService { get; }
+
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using NuGet.Commands;
@@ -49,17 +50,12 @@ namespace NuGet.PackageManagement.VisualStudio
             IProjectSystemCache projectSystemCache,
             IVsProjectAdapter vsProjectAdapter,
             UnconfiguredProject unconfiguredProject,
+            INuGetProjectServices projectServices,
             string projectId)
         {
-            if (projectFullPath == null)
-            {
-                throw new ArgumentNullException(nameof(projectFullPath));
-            }
-
-            if (projectSystemCache == null)
-            {
-                throw new ArgumentNullException(nameof(projectSystemCache));
-            }
+            Assumes.Present(projectFullPath);
+            Assumes.Present(projectSystemCache);
+            Assumes.Present(projectServices);
 
             _projectName = projectName;
             _projectUniqueName = projectUniqueName;
@@ -70,6 +66,7 @@ namespace NuGet.PackageManagement.VisualStudio
             _projectSystemCache = projectSystemCache;
             _vsProjectAdapter = vsProjectAdapter;
             _unconfiguredProject = unconfiguredProject;
+            ProjectServices = projectServices;
 
             InternalMetadata.Add(NuGetProjectMetadataKeys.Name, _projectName);
             InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, _projectUniqueName);


### PR DESCRIPTION
We were not setting `INuGetProjectServices` for net core projects, which is why it was using default project services which do nothing while executing init scripts. So I updated right `VsCoreProjectSystemServices` for net core projects which will allow it execute init scripts while intalling/ updating packages.

Fixes https://github.com/NuGet/Home/issues/5381

@rrelyea 