### PR TITLE
Adding Test coverage to Warnings and Errors code paths and improving filtering/logging code

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/Console.cs
@@ -391,35 +391,11 @@ namespace NuGet.CommandLine
                 }
                 else if (message.Level == LogLevel.Warning)
                 {
-                    if (message.Code >= NuGetLogCode.NU1000)
-                    {
-                        WriteWarning(message.FormatWithCode());
-                    }
-                    else
-                    {
-                        // Write warnings without codes otherwise.
-                        WriteWarning(message.Message);
-                    }
+                    WriteWarning(message.FormatWithCode());
                 }
                 else if (message.Level == LogLevel.Error)
                 {
-                    if (message is RestoreLogMessage)
-                    {
-                        WriteLine(ConsoleColor.Red, message.Message);
-                    }
-                    else
-                    {
-                        // Write out codes for messages that have codes.
-                        if (message.Code >= NuGetLogCode.NU1000)
-                        {
-                            WriteError(message.FormatWithCode());
-                        }
-                        else
-                        {
-                            // Write errors without codes otherwise.
-                            WriteError(message.Message);
-                        }
-                    }
+                    WriteError(message.FormatWithCode());
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -121,7 +121,8 @@ namespace NuGet.Commands
                 {
                     return true;
                 }
-                else if (ProjectWideWarningProperties.AllWarningsAsErrors || ProjectWideWarningProperties.WarningsAsErrors.Contains(logMessage.Code))
+                else if (ProjectWideWarningProperties.AllWarningsAsErrors && logMessage.Code > NuGetLogCode.Undefined || 
+                    ProjectWideWarningProperties.WarningsAsErrors.Contains(logMessage.Code))
                 {
                     logMessage.Level = LogLevel.Error;
                     return false;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreSummary.cs
@@ -105,7 +105,7 @@ namespace NuGet.Commands
                     logger.LogError(string.Format(CultureInfo.CurrentCulture, Strings.Log_ErrorSummary, restoreSummary.InputPath));
                     foreach (var error in errors)
                     {
-                        foreach (var line in IndentLines(error.Message))
+                        foreach (var line in IndentLines(error.FormatWithCode()))
                         {
                             logger.LogError(line);
                         }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -61,11 +61,6 @@ namespace NuGet.Common
         {
         }
 
-        public RestoreLogMessage(LogLevel logLevel, string errorString, bool logToInnerLogger)
-            : this(logLevel, LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500, errorString, string.Empty, logToInnerLogger)
-        {
-        }
-
         /// <summary>
         /// Create a log message for a target graph library.
         /// </summary>

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -47,21 +47,17 @@ namespace NuGet.Common
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, 
             string errorString, string targetGraph)
-            : this(logLevel, errorCode, errorString, targetGraph, false)
+            : this(logLevel, errorCode, errorString, targetGraph, logToInnerLogger: false)
         {
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString)
-            : this(logLevel, errorCode, errorString, string.Empty, false)
+            : this(logLevel, errorCode, errorString, string.Empty, logToInnerLogger : false)
         {
         }
 
         public RestoreLogMessage(LogLevel logLevel, string errorString)
-            : this(logLevel, 
-                  LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : (LogLevel.Warning == logLevel ? NuGetLogCode.NU1500: NuGetLogCode.Undefined),
-                  errorString, 
-                  string.Empty, 
-                  false)
+            : this(logLevel, GetDefaultLogCode(logLevel), errorString, string.Empty, logToInnerLogger: false)
         {
         }
 
@@ -117,6 +113,23 @@ namespace NuGet.Common
                 LibraryId = libraryId,
                 TargetGraphs = targetGraphs.ToList()
             };
+        }
+
+
+        /// <summary>
+        /// Get default LogCode based on the log level
+        /// </summary>
+        private static NuGetLogCode GetDefaultLogCode(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Error:
+                    return NuGetLogCode.NU1000;
+                case LogLevel.Warning:
+                    return NuGetLogCode.NU1500;
+                default:
+                    return NuGetLogCode.Undefined;
+            }
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -57,7 +57,11 @@ namespace NuGet.Common
         }
 
         public RestoreLogMessage(LogLevel logLevel, string errorString)
-            : this(logLevel, LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : NuGetLogCode.NU1500, errorString, string.Empty, false)
+            : this(logLevel, 
+                  LogLevel.Error == logLevel ? NuGetLogCode.NU1000 : (LogLevel.Warning == logLevel ? NuGetLogCode.NU1500: NuGetLogCode.Undefined),
+                  errorString, 
+                  string.Empty, 
+                  false)
         {
         }
 

--- a/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/RestoreLogMessage.cs
@@ -52,7 +52,7 @@ namespace NuGet.Common
         }
 
         public RestoreLogMessage(LogLevel logLevel, NuGetLogCode errorCode, string errorString)
-            : this(logLevel, errorCode, errorString, string.Empty, logToInnerLogger : false)
+            : this(logLevel, errorCode, errorString, string.Empty, logToInnerLogger: false)
         {
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class RestoreLoggingTests
+    {
+        [Fact]
+        public async Task RestoreLogging_VerifyWarningsAsErrorsFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.Output.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_VerifyNoWarnRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+                projectA.Properties.Add("NoWarn", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.Output.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_VerifyWarningsAsErrorsForSpecificWarningFails()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "false");
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.Output.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_VerifyWarningsAsErrorsForSpecificWarningOfAnotherTypeIgnored()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "false");
+                projectA.Properties.Add("WarningsAsErrors", "NU1602");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.Output.Should().Contain("NU1603");
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -220,7 +220,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_PackageSPecificNoWarnRemovesWarning()
+        public async Task RestoreLogging_PackageSpecificNoWarnRemovesWarning()
         {
             DebuggerUtils.WaitForDebugger();
             // Arrange

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -81,7 +81,6 @@ namespace NuGet.CommandLine.Test
                     pathContext.SolutionRoot,
                     netcoreapp2);
 
-                projectA.Properties.Add("TreatWarningsAsErrors", "true");
                 projectA.Properties.Add("NoWarn", "NU1603");
 
                 // Referenced but not created
@@ -220,9 +219,8 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_PackageSpecificNoWarnRemovesWarning()
+        public async Task RestoreLogging_NoWarnWithWarnAsErrorRemovesWarning()
         {
-            DebuggerUtils.WaitForDebugger();
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
@@ -237,6 +235,258 @@ namespace NuGet.CommandLine.Test
                     netcoreapp2);
 
                 projectA.Properties.Add("TreatWarningsAsErrors", "true");
+                projectA.Properties.Add("NoWarn", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.Output.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_NoWarnWithWarnSpecificAsErrorRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+                projectA.Properties.Add("NoWarn", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.Output.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_PackageSpecificNoWarnRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);                
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_PackageSpecificDifferentNoWarnDonesNotRemoveWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1607"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+
+        [Fact]
+        public async Task RestoreLogging_PackageSpecificNoWarnAndTreatWarningsAsErrors()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_PackageSpecificNoWarnAndTreatSpecificWarningsAsErrors()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
 
                 // Referenced but not created
                 var packageX = new SimpleTestPackageContext()

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -243,7 +243,7 @@ namespace NuGet.CommandLine.Test
                 {
                     Id = "x",
                     Version = "1.0.0",
-                    NoWarn = "NU1607"
+                    NoWarn = "NU1603"
                 };
 
                 // Created in the source
@@ -263,7 +263,7 @@ namespace NuGet.CommandLine.Test
                     packageX9);
 
                 // Act
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
                 // Assert
                 r.Success.Should().BeTrue();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using NuGet.Frameworks;
 using NuGet.Packaging;
 using NuGet.Test.Utility;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -62,7 +59,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();
-                r.Output.Should().Contain("NU1603");
+                r.AllOutput.Should().Contain("NU1603");
             }
         }
 
@@ -109,7 +106,7 @@ namespace NuGet.CommandLine.Test
                     packageX9);
 
                 // Act
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
                 // Assert
                 r.Success.Should().BeTrue();
@@ -164,7 +161,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeFalse();
-                r.Output.Should().Contain("NU1603");
+                r.AllOutput.Should().Contain("NU1603");
             }
         }
 
@@ -211,11 +208,12 @@ namespace NuGet.CommandLine.Test
                     packageX9);
 
                 // Act
-                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
 
                 // Assert
                 r.Success.Should().BeTrue();
                 r.Output.Should().Contain("NU1603");
+                r.Output.Should().NotContain("NU1607");
             }
         }
     }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
@@ -105,7 +105,6 @@ namespace NuGet.Commands.Test
         [Fact]
         public void WarningPropertiesCollection_ProjectPropertiesWithAllWarningsAsErrorsAndWarningWithUndefinedCode()
         {
-            DebuggerUtils.WaitForDebugger();
             // Arrange
             var noWarnSet = new HashSet<NuGetLogCode> { };
             var warnAsErrorSet = new HashSet<NuGetLogCode> { };

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/RestoreLogMessageTests.cs
@@ -93,7 +93,7 @@ namespace NuGet.Common.Test
         [Theory]
         [InlineData(LogLevel.Error, NuGetLogCode.NU1000, "Error string")]
         [InlineData(LogLevel.Warning, NuGetLogCode.NU1500, "Warning string")]
-        [InlineData(LogLevel.Debug, NuGetLogCode.NU1500, "Debug string")]
+        [InlineData(LogLevel.Debug, NuGetLogCode.Undefined, "Debug string")]
         public void RestoreLogMessage_TestConstructorWithoutCode(LogLevel level, NuGetLogCode expectedCode, string message)
         {
             // Arrange & Act

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml.Linq;
+using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
@@ -44,6 +45,7 @@ namespace NuGet.Test.Utility
         public XDocument Nuspec { get; set; }
         public List<PackageType> PackageTypes { get; set; } = new List<PackageType>();
         public PackageType PackageType { get; set; }
+        public string NoWarn { get; set; }
 
         /// <summary>
         /// runtime.json

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestPackageUtility.cs
@@ -313,6 +313,22 @@ namespace NuGet.Test.Utility
         }
 
         /// <summary>
+        /// Create a v3 folder of nupkgs.
+        /// Does not write out extracted files.
+        /// </summary>
+        public static async Task CreateFolderFeedV3(string root, params SimpleTestPackageContext[] contexts)
+        {
+            using (var tempRoot = TestDirectory.Create())
+            {
+                CreatePackages(tempRoot, contexts);
+
+                var saveMode = PackageSaveMode.Nupkg | PackageSaveMode.Nuspec;
+
+                await CreateFolderFeedV3(root, saveMode, Directory.GetFiles(tempRoot));
+            }
+        }
+
+        /// <summary>
         /// Create a v3 folder of nupkgs
         /// </summary>
         public static async Task CreateFolderFeedV3(string root, PackageSaveMode saveMode, params SimpleTestPackageContext[] contexts)

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -446,6 +446,11 @@ namespace NuGet.Test.Utility
                             props.Add("PrivateAssets", package.PrivateAssets);
                         }
 
+                        if (!string.IsNullOrEmpty(package.NoWarn))
+                        {
+                            props.Add("NoWarn", package.NoWarn);
+                        }
+
                         ProjectFileUtils.AddItem(
                             xml,
                             "PackageReference",


### PR DESCRIPTION
This PR contains functional tests and some code changes which were found while adding the tests.

Changes - 
1, Adds functional tests on `NuGet.CommandLine` to  cover scenarios related to warning properties.
2. Improved `Console` and `RestoreSummary` logging code to use helper methods.
3. Added more filtering in `WarningPropertiesCollection` to not upgrade Warnings if their `NuGetLogCode ` is `Undefined`.
4. Improved the default `NuGetLogCode ` for `RestoreLogMessages ` which are below `LogLevel.Warning` to `NuGetLogCode.Undefined`.