### PR TITLE
Avoid using EntityExists LSL API

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,9 +43,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     return null;
                 }
 
-                var projectDirectory = Path.GetDirectoryName(FullPath);
-
-                return Path.Combine(projectDirectory, baseIntermediateOutputPath);
+                return Path.Combine(FullPath, baseIntermediateOutputPath);
             }
         }
 
@@ -268,18 +266,6 @@ namespace NuGet.PackageManagement.VisualStudio
         #endregion Constructors
 
         #region Getters
-
-        public async Task<bool> EntityExistsAsync(string filePath)
-        {
-            if (IsDeferred)
-            {
-                return await _workspaceService.EntityExists(filePath);
-            }
-            else
-            {
-                return File.Exists(filePath);
-            }
-        }
 
         public async Task<IEnumerable<string>> GetReferencedProjectsAsync()
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -42,14 +42,6 @@ namespace NuGet.PackageManagement.VisualStudio
                     return (IVsSolutionWorkspaceService)serviceProvider.GetService(typeof(SVsSolutionWorkspaceService));
                 },
                 NuGetUIThreadHelper.JoinableTaskFactory);
-        }
-
-        public async Task<bool> EntityExists(string filePath)
-        {
-            var workspace = SolutionWorkspaceService.CurrentWorkspace;
-            var indexService = workspace.GetIndexWorkspaceService();
-            var filePathExists = await indexService.EntityExists(filePath);
-            return filePathExists;
         }
 
         public async Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath)

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IVsProjectAdapter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -105,8 +105,6 @@ namespace NuGet.VisualStudio
         string Version { get; }
 
         IVsHierarchy VsHierarchy { get; }
-
-        Task<bool> EntityExistsAsync(string filePath);
 
         Task<IEnumerable<string>> GetReferencedProjectsAsync();
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -9,8 +9,6 @@ namespace NuGet.VisualStudio
 {
     public interface IDeferredProjectWorkspaceService
     {
-        Task<bool> EntityExists(string filePath);
-
         Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath);
 
         Task<IMSBuildProjectDataService> GetMSBuildProjectDataServiceAsync(string projectFilePath, string targetFramework = null);


### PR DESCRIPTION
Resolves NuGet/Home#5391.

`IndexService.EntityExists` API is not reliable as indexing data may not
be available for a long period of time during cold start of LSL.

This change streamlines provider conditionals for PackageRef project
creation in both deferred and non-deferred modes. In summary, PackageRef
project is to be created when underlying project explicitly defines
`RestoreProjectStyle` and/or contains package reference(s).

//cc @rrelyea 