### PR TITLE
Updated file share permissions while reading project.json

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -282,10 +282,13 @@ namespace NuGet.ProjectManagement.Projects
         {
             try
             {
-                using (var streamReader = new StreamReader(_jsonConfig.OpenRead()))
+                return FileUtility.SafeRead(JsonConfigPath, (stream, filePath) =>
                 {
-                    return JObject.Parse(streamReader.ReadToEnd());
-                }
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return JObject.Parse(reader.ReadToEnd());
+                    }
+                });
             }
             catch (Exception ex)
             {
@@ -298,10 +301,13 @@ namespace NuGet.ProjectManagement.Projects
         {
             try
             {
-                using (var streamReader = new StreamReader(_jsonConfig.OpenRead()))
+                return await FileUtility.SafeReadAsync(JsonConfigPath, async (stream, filePath) =>
                 {
-                    return JObject.Parse(await streamReader.ReadToEndAsync());
-                }
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return JObject.Parse(await reader.ReadToEndAsync());
+                    }
+                });
             }
             catch (Exception ex)
             {
@@ -312,10 +318,14 @@ namespace NuGet.ProjectManagement.Projects
 
         private async Task SaveJsonAsync(JObject json)
         {
-            using (var writer = new StreamWriter(_jsonConfig.FullName, false, Encoding.UTF8))
+            await FileUtility.ReplaceAsync(async (outputPath) =>
             {
-                await writer.WriteAsync(json.ToString());
-            }
+                using (var writer = new StreamWriter(outputPath, false, Encoding.UTF8))
+                {
+                    await writer.WriteAsync(json.ToString());
+                }
+            },
+            JsonConfigPath);
         }
 
         private async Task UpdateFrameworkAsync(JObject json)

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -35,10 +35,7 @@ namespace NuGet.ProjectModel
         /// <param name="packageSpecPath">file path</param>
         public static PackageSpec GetPackageSpec(string name, string packageSpecPath)
         {
-            using (var stream = new FileStream(packageSpecPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                return GetPackageSpec(stream, name, packageSpecPath, null);
-            }
+            return FileUtility.SafeRead(filePath: packageSpecPath, read: (stream, filePath) => GetPackageSpec(stream, name, filePath, null));
         }
 
         public static PackageSpec GetPackageSpec(string json, string name, string packageSpecPath)

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/FileUtilityTests.cs
@@ -5,6 +5,7 @@ using NuGet.Test.Utility;
 using System.IO;
 using Xunit;
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace NuGet.Common.Test
@@ -213,6 +214,181 @@ namespace NuGet.Common.Test
                         Assert.False(File.Exists(path));
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_ReplaceAsync_BasicSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+
+                // Act
+                await FileUtility.ReplaceAsync(async (path) =>
+                {
+                    using (var stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write))
+                    {
+                        using (var writer = new StreamWriter(stream))
+                        {
+                            await writer.WriteAsync("a");
+                        }
+                    }
+                }, dest);
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal("a", File.ReadAllText(dest));
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_ReplaceAsync_AlreadyExistsSuccess()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "b");
+
+                // Act
+                await FileUtility.ReplaceAsync(async (path) =>
+                {
+                    using (var stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write))
+                    {
+                        using (var writer = new StreamWriter(stream))
+                        {
+                            await writer.WriteAsync("a");
+                        }
+                    }
+                }, dest);
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal("a", File.ReadAllText(dest));
+            }
+        }
+
+        [Fact]
+        public void FileUtility_SafeRead_Success()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "b");
+
+                // Act
+                var fileData = FileUtility.SafeRead(dest, (stream, path) =>
+                {
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return reader.ReadToEnd();
+                    }
+                });
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal("b", fileData);
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_SafeReadAsync_Success()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "b");
+
+                // Act
+                var fileData = await FileUtility.SafeReadAsync(dest, async (stream, path) =>
+                {
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return await reader.ReadToEndAsync();
+                    }
+                });
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal("b", fileData);
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_SafeReadAsync_MultipleReadStreams()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+                File.WriteAllText(dest, "b");
+
+                var firstRead = string.Empty;
+
+                // Act
+                var fileData = await FileUtility.SafeReadAsync(dest, async (stream, path) =>
+                {
+                    using (var reader1 = new StreamReader(stream))
+                    {
+                        firstRead = await reader1.ReadToEndAsync();
+
+                        using (var stream2 = new FileStream(dest, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
+                        {
+                            using (var reader2 = new StreamReader(stream2))
+                            {
+                               return await reader2.ReadToEndAsync();
+                            }
+                        }
+                    }
+                });
+
+                // Assert
+                Assert.True(File.Exists(dest));
+                Assert.Equal("b", fileData);
+                Assert.Equal(firstRead, fileData);
+            }
+        }
+
+        [Fact]
+        public async Task FileUtility_SafeReadAsync_Failure()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                // Arrange
+                var dest = Path.Combine(testDirectory, "b");
+
+                Exception exception = null;
+
+                // Act
+                try
+                {
+                    var fileData = await FileUtility.SafeReadAsync(dest, async (stream, path) =>
+                    {
+                        if (File.Exists(dest))
+                        {
+                            using (var reader = new StreamReader(stream))
+                            {
+                                return await reader.ReadToEndAsync();
+                            }
+                        }
+                        else
+                        {
+                            throw new Exception();
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                // Assert
+                Assert.False(File.Exists(dest));
+                Assert.NotNull(exception);
             }
         }
     }


### PR DESCRIPTION
There are watson crash indicating it failed to access project.json file since it was being used by another program. Although we couldn't repro it locally, but I feel this is to do with the fact that we try to read project.json at multiple level with different file share access. So I'm making all the steam reader to use same file share permissions (even more granular access) to read project.json. Also, we're already using this same file share access for packages.config scenarios and never faced such issue so I'm hopeful that it will resolve this issue.

Fixes https://github.com/NuGet/Home/issues/5404

@rrelyea 