### PR TITLE
Fixing PackageSpecific NoWarn filtering logic and changing/adding tests to cover the scenario

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -58,10 +58,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         static VsManagedLanguagesProjectSystemServices()
         {
-            _referenceMetadata = Array.CreateInstance(typeof(string), 3);
+            _referenceMetadata = Array.CreateInstance(typeof(string), 4);
             _referenceMetadata.SetValue(ProjectItemProperties.IncludeAssets, 0);
             _referenceMetadata.SetValue(ProjectItemProperties.ExcludeAssets, 1);
             _referenceMetadata.SetValue(ProjectItemProperties.PrivateAssets, 2);
+            _referenceMetadata.SetValue(ProjectItemProperties.NoWarn, 3);
         }
 
         public VsManagedLanguagesProjectSystemServices(

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -65,15 +65,14 @@ namespace NuGet.Commands
                     }
                     else
                     {
-                        message.TargetGraphs = message.TargetGraphs.Where(e => !PackageSpecificWarningProperties.Contains(message.Code, message.LibraryId, GetNuGetFramework(e))).ToList();
+                        message.TargetGraphs = message.TargetGraphs
+                            .Where(e => !PackageSpecificWarningProperties.Contains(message.Code, message.LibraryId, GetNuGetFramework(e))).ToList();
 
                         if (message.TargetGraphs.Count == 0)
                         {
                             return true;
                         }
                     }
-
-                   
 
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -11,11 +11,17 @@ using NuGet.ProjectModel;
 namespace NuGet.Commands
 {
     /// <summary>
-    /// Class to hold ProjectWIde and PackageSpecific WarningProperties
+    /// Class to hold ProjectWide and PackageSpecific WarningProperties.
     /// </summary>
     public class WarningPropertiesCollection
     {
         private readonly ConcurrentDictionary<string, NuGetFramework> _getFrameworkCache = new ConcurrentDictionary<string, NuGetFramework>();
+
+        /// <summary>
+        /// Contains the target frameworks for the project.
+        /// These are used for no warn filtering in case of a log message without a target graph.
+        /// </summary>
+        public IEnumerable<NuGetFramework> ProjectFrameworks { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
         /// Contains Project wide properties for Warnings.
@@ -27,7 +33,6 @@ namespace NuGet.Commands
         /// NuGetLogCode -> LibraryId -> Set of Frameworks.
         /// </summary>
         public PackageSpecificWarningProperties PackageSpecificWarningProperties { get; set; }
-
 
         /// <summary>
         /// Attempts to suppress a warning log message or upgrade it to error log message.
@@ -93,7 +98,10 @@ namespace NuGet.Commands
 
             foreach (var dependency in packageSpec.Dependencies)
             {
-                warningProperties.AddRange(dependency.NoWarn, dependency.Name);
+                foreach (var framework in packageSpec.TargetFrameworks)
+                {
+                    warningProperties.AddRange(dependency.NoWarn, dependency.Name, framework.FrameworkName);
+                }
             }
 
             foreach (var framework in packageSpec.TargetFrameworks)

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -60,7 +60,8 @@ namespace NuGet.Commands
                     if (messageTargetFrameworks.Count == 0)
                     {
                         // Suppress the warning if the code + libraryId combination is suppressed for all project frameworks.
-                        if (ProjectFrameworks.All(e => PackageSpecificWarningProperties.Contains(message.Code, message.LibraryId, e)))
+                        if (ProjectFrameworks.Count > 0 &&
+                            ProjectFrameworks.All(e => PackageSpecificWarningProperties.Contains(message.Code, message.LibraryId, e)))
                         {
                             return true;
                         }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/WarningPropertiesCollection.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using NuGet.Common;
 using NuGet.Frameworks;
@@ -23,7 +24,7 @@ namespace NuGet.Commands
         /// Contains the target frameworks for the project.
         /// These are used for no warn filtering in case of a log message without a target graph.
         /// </summary>
-        public IReadOnlyList<NuGetFramework> ProjectFrameworks { get; set; } = new List<NuGetFramework>();
+        public IReadOnlyList<NuGetFramework> ProjectFrameworks { get; set; } = new ReadOnlyCollection<NuGetFramework>(new List<NuGetFramework>());
 
         /// <summary>
         /// Contains Project wide properties for Warnings.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -55,10 +55,11 @@ namespace NuGet.Commands
             var collectorLogger = new RestoreCollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors)
             {
                 ProjectPath = _request.Project?.RestoreMetadata?.ProjectPath,
-                WarningPropertiesCollection =  new WarningPropertiesCollection()
+                WarningPropertiesCollection = new WarningPropertiesCollection()
                 {
                     ProjectWideWarningProperties = request.Project?.RestoreMetadata?.ProjectWideWarningProperties,
-                    PackageSpecificWarningProperties = WarningPropertiesCollection.GetPackageSpecificWarningProperties(request.Project)
+                    PackageSpecificWarningProperties = WarningPropertiesCollection.GetPackageSpecificWarningProperties(request.Project),
+                    ProjectFrameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName)
                 }
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -18,6 +18,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
 using NuGet.Repositories;
 using NuGet.RuntimeModel;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.Commands
@@ -54,12 +55,12 @@ namespace NuGet.Commands
 
             var collectorLogger = new RestoreCollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors)
             {
-                ProjectPath = _request.Project?.RestoreMetadata?.ProjectPath,
+                ProjectPath = _request.Project.RestoreMetadata?.ProjectPath,
                 WarningPropertiesCollection = new WarningPropertiesCollection()
                 {
-                    ProjectWideWarningProperties = request.Project?.RestoreMetadata?.ProjectWideWarningProperties,
-                    PackageSpecificWarningProperties = WarningPropertiesCollection.GetPackageSpecificWarningProperties(request.Project),
-                    ProjectFrameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName)
+                    ProjectWideWarningProperties = request.Project.RestoreMetadata?.ProjectWideWarningProperties,
+                    PackageSpecificWarningProperties = PackageSpecificWarningProperties.CreatePackageSpecificWarningProperties(request.Project),
+                    ProjectFrameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName).ToList()
                 }
             };
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -60,7 +60,7 @@ namespace NuGet.Commands
                 {
                     ProjectWideWarningProperties = request.Project.RestoreMetadata?.ProjectWideWarningProperties,
                     PackageSpecificWarningProperties = PackageSpecificWarningProperties.CreatePackageSpecificWarningProperties(request.Project),
-                    ProjectFrameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName).ToList()
+                    ProjectFrameworks = request.Project.TargetFrameworks.Select(f => f.FrameworkName).AsList().AsReadOnly()
                 }
             };
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -14,7 +14,7 @@ namespace NuGet.CommandLine.Test
     public class RestoreLoggingTests
     {
         [Fact]
-        public async Task RestoreLogging_WarningsContainNuGetLogCodes()
+        public async Task RestoreLogging_NetCore_WarningsContainNuGetLogCodes()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -62,7 +62,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_WarningsAsErrorsFailsRestore()
+        public async Task RestoreLogging_NetCore_WarningsAsErrorsFailsRestore()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -117,7 +117,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("NU1603;$(NoWarn);")]
         [InlineData("NU1603;NU1701")]
         [InlineData("NU1603,NU1701")]
-        public async Task RestoreLogging_NoWarnRemovesWarning(string noWarn)
+        public async Task RestoreLogging_NetCore_NoWarnRemovesWarning(string noWarn)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -162,7 +162,7 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeTrue();
-                r.Output.Should().NotContain("NU1603");
+                r.AllOutput.Should().NotContain("NU1603");
             }
         }
 
@@ -172,7 +172,7 @@ namespace NuGet.CommandLine.Test
         [InlineData("NU1603;$(NoWarn);")]
         [InlineData("NU1603;NU1701")]
         [InlineData("NU1603,NU1701")]
-        public async Task RestoreLogging_WarningsAsErrorsForSpecificWarningFails(string warnAsError)
+        public async Task RestoreLogging_NetCore_WarningsAsErrorsForSpecificWarningFails(string warnAsError)
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -223,7 +223,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_WarningsAsErrorsForSpecificWarningOfAnotherTypeIgnored()
+        public async Task RestoreLogging_NetCore_WarningsAsErrorsForSpecificWarningOfAnotherTypeIgnored()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -269,14 +269,14 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeTrue();
-                r.Output.Should().Contain("NU1603");
-                r.Output.Should().NotContain("NU1602");
-                r.Output.Should().NotContain("NU1701");
+                r.AllOutput.Should().Contain("NU1603");
+                r.AllOutput.Should().NotContain("NU1602");
+                r.AllOutput.Should().NotContain("NU1701");
             }
         }
 
         [Fact]
-        public async Task RestoreLogging_NoWarnWithWarnAsErrorRemovesWarning()
+        public async Task RestoreLogging_NetCore_NoWarnWithTreatWarningsAsErrorRemovesWarning()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -322,12 +322,63 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeTrue();
-                r.Output.Should().NotContain("NU1603");
+                r.AllOutput.Should().NotContain("NU1603");
             }
         }
 
         [Fact]
-        public async Task RestoreLogging_NoWarnWithWarnSpecificAsErrorRemovesWarning()
+        public async Task RestoreLogging_NetCore_DifferentNoWarnWithTreatWarningsAsErrorFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+                projectA.Properties.Add("NoWarn", "NU1607");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_NetCore_NoWarnWithWarnSpecificAsErrorRemovesWarning()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -373,12 +424,63 @@ namespace NuGet.CommandLine.Test
 
                 // Assert
                 r.Success.Should().BeTrue();
-                r.Output.Should().NotContain("NU1603");
+                r.AllOutput.Should().NotContain("NU1603");
             }
         }
 
         [Fact]
-        public async Task RestoreLogging_PackageSpecificNoWarnRemovesWarning()
+        public async Task RestoreLogging_NetCore_DifferentNoWarnWithWarnSpecificAsErrorFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+                projectA.Properties.Add("NoWarn", "NU1607");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_NetCore_PackageSpecificNoWarnRemovesWarning()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -427,7 +529,109 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_PackageSpecificDifferentNoWarnDonesNotRemoveWarning()
+        public async Task RestoreLogging_NetCore_WithMultiTargeting_AllTfmPackageSpecificNoWarnRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net45 = NuGetFramework.Parse("net45");
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2,
+                    net45);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_NetCore_WithMultiTargeting_PartialTfmPackageSpecificNoWarnRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var net45 = NuGetFramework.Parse("net45");
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2,
+                    net45);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToFramework("net45", packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_NetCore_PackageSpecificDifferentNoWarnDoesNotRemoveWarning()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -477,7 +681,7 @@ namespace NuGet.CommandLine.Test
 
 
         [Fact]
-        public async Task RestoreLogging_PackageSpecificNoWarnAndTreatWarningsAsErrors()
+        public async Task RestoreLogging_NetCore_PackageSpecificNoWarnAndTreatWarningsAsErrors()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -528,7 +732,7 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task RestoreLogging_PackageSpecificNoWarnAndTreatSpecificWarningsAsErrors()
+        public async Task RestoreLogging_NetCore_PackageSpecificNoWarnAndTreatSpecificWarningsAsErrors()
         {
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
@@ -539,6 +743,674 @@ namespace NuGet.CommandLine.Test
                 var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
 
                 var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_WarningsContainNuGetLogCodes()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().Contain("WARNING: NU1603:");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_WarningsAsErrorsFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Theory]
+        [InlineData("NU1603")]
+        [InlineData("$(NoWarn);NU1603")]
+        [InlineData("NU1603;$(NoWarn);")]
+        [InlineData("NU1603;NU1701")]
+        [InlineData("NU1603,NU1701")]
+        public async Task RestoreLogging_Legacy_NoWarnRemovesWarning(string noWarn)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("NoWarn", noWarn);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Theory]
+        [InlineData("NU1603")]
+        [InlineData("$(NoWarn);NU1603")]
+        [InlineData("NU1603;$(NoWarn);")]
+        [InlineData("NU1603;NU1701")]
+        [InlineData("NU1603,NU1701")]
+        public async Task RestoreLogging_Legacy_WarningsAsErrorsForSpecificWarningFails(string warnAsError)
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "false");
+                projectA.Properties.Add("WarningsAsErrors", warnAsError);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_WarningsAsErrorsForSpecificWarningOfAnotherTypeIgnored()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "false");
+                projectA.Properties.Add("WarningsAsErrors", "NU1602;NU1701");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().Contain("NU1603");
+                r.AllOutput.Should().NotContain("NU1602");
+                r.AllOutput.Should().NotContain("NU1701");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_NoWarnWithTreatWarningsAsErrorRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+                projectA.Properties.Add("NoWarn", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_DifferentNoWarnWithTreatWarningsAsErrorFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+                projectA.Properties.Add("NoWarn", "NU1607");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_NoWarnWithWarnSpecificAsErrorRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+                projectA.Properties.Add("NoWarn", "NU1603");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_DifferentNoWarnWithWarnSpecificAsErrorFailsRestore()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("WarningsAsErrors", "NU1603");
+                projectA.Properties.Add("NoWarn", "NU1607");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_PackageSpecificNoWarnRemovesWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }        
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_PackageSpecificDifferentNoWarnDoesNotRemoveWarning()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1607"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().Contain("NU1603");
+            }
+        }
+
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_PackageSpecificNoWarnAndTreatWarningsAsErrors()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("TreatWarningsAsErrors", "true");
+
+                // Referenced but not created
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0",
+                    NoWarn = "NU1603"
+                };
+
+                // Created in the source
+                var packageX9 = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "9.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    packageX9);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext, expectedExitCode: 0);
+
+                // Assert
+                r.Success.Should().BeTrue();
+                r.AllOutput.Should().NotContain("NU1603");
+            }
+        }
+
+        [Fact]
+        public async Task RestoreLogging_Legacy_PackageSpecificNoWarnAndTreatSpecificWarningsAsErrors()
+        {
+
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateLegacyPackageReference(
                     "a",
                     pathContext.SolutionRoot,
                     netcoreapp2);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CollectorLoggerTests.cs
@@ -700,11 +700,13 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var libraryId = "test_library";
+            var frameworkString = "net45";
+            var targetFramework = NuGetFramework.Parse(frameworkString);
             var noWarnSet = new HashSet<NuGetLogCode> { };
             var warnAsErrorSet = new HashSet<NuGetLogCode> { };
             var allWarningsAsErrors = false;
             var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, targetFramework);
 
             var innerLogger = new Mock<ILogger>();
             var collector = new RestoreCollectorLogger(innerLogger.Object)
@@ -737,13 +739,15 @@ namespace NuGet.Commands.Test
         {
             // Arrange
             var libraryId = "test_library";
+            var frameworkString = "net45";
+            var targetFramework = NuGetFramework.Parse(frameworkString);
             var noWarnSet = new HashSet<NuGetLogCode> { };
             var warnAsErrorSet = new HashSet<NuGetLogCode> { };
             var allWarningsAsErrors = false;
             var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId);
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1601, libraryId);
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1605, libraryId);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, targetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1601, libraryId, targetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1605, libraryId, targetFramework);
 
             var innerLogger = new Mock<ILogger>();
             var collector = new RestoreCollectorLogger(innerLogger.Object)

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
@@ -331,9 +331,9 @@ namespace NuGet.Commands.Test
             {
                 ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
                 PackageSpecificWarningProperties = packageSpecificWarningProperties,
-                ProjectFrameworks = new List<string>
+                ProjectFrameworks = new List<NuGetFramework>
                 {
-                    frameworkString
+                    targetFramework
                 }
             };
 
@@ -368,9 +368,9 @@ namespace NuGet.Commands.Test
             {
                 ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
                 PackageSpecificWarningProperties = packageSpecificWarningProperties,
-                ProjectFrameworks = new List<string>
+                ProjectFrameworks = new List<NuGetFramework>
                 {
-                    frameworkString
+                    targetFramework
                 }
             };
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
@@ -228,7 +228,8 @@ namespace NuGet.Commands.Test
 
             var warningPropertiesCollection = new WarningPropertiesCollection()
             {
-                PackageSpecificWarningProperties = packageSpecificWarningProperties
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<NuGetFramework> { targetFramework }
             };
 
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
@@ -404,7 +405,8 @@ namespace NuGet.Commands.Test
             var warningPropertiesCollection = new WarningPropertiesCollection()
             {
                 ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
-                PackageSpecificWarningProperties = packageSpecificWarningProperties
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<NuGetFramework> { targetFramework }
             };
 
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString);
@@ -416,7 +418,7 @@ namespace NuGet.Commands.Test
             Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage2));
             Assert.Equal(0, suppressedMessage2.TargetGraphs.Count);
-            Assert.True(warningPropertiesCollection.ApplyWarningProperties(unaffectedMessage));
+            Assert.False(warningPropertiesCollection.ApplyWarningProperties(unaffectedMessage));
             Assert.Equal(0, unaffectedMessage.TargetGraphs.Count);
         }
 
@@ -452,7 +454,7 @@ namespace NuGet.Commands.Test
             Assert.False(warningPropertiesCollection.ApplyWarningProperties(nonSuppressedMessage));
             Assert.Equal(0, nonSuppressedMessage.TargetGraphs.Count);
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
-            Assert.Equal(0, nonSuppressedMessage.TargetGraphs.Count);
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
         }
 
         [Fact]
@@ -482,6 +484,189 @@ namespace NuGet.Commands.Test
             };
 
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
+
+            // Act && Assert
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForSomeTfm()
+        {
+
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+            var netcoreFrameworkString = "netcoreapp1.0";
+            var netcoreTargetFramework = NuGetFramework.Parse(netcoreFrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<NuGetFramework> { net45TargetFramework, netcoreTargetFramework }
+            };
+
+            var nonSuppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString, netcoreFrameworkString });
+
+            // Act && Assert
+            Assert.False(warningPropertiesCollection.ApplyWarningProperties(nonSuppressedMessage));
+            Assert.Equal(1, nonSuppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForAllTfm()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+            var netcoreFrameworkString = "netcoreapp1.0";
+            var netcoreTargetFramework = NuGetFramework.Parse(netcoreFrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, netcoreTargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<NuGetFramework> { net45TargetFramework, netcoreTargetFramework }
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString, netcoreFrameworkString });
+
+            // Act && Assert
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForAllTfm_2()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<NuGetFramework> { net45TargetFramework }
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString });
+
+            // Act && Assert
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForSomeTfmAndNoProjectFrameworks()
+        {
+
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+            var netcoreFrameworkString = "netcoreapp1.0";
+            var netcoreTargetFramework = NuGetFramework.Parse(netcoreFrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties
+            };
+
+            var nonSuppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString, netcoreFrameworkString });
+
+            // Act && Assert
+            Assert.False(warningPropertiesCollection.ApplyWarningProperties(nonSuppressedMessage));
+            Assert.Equal(1, nonSuppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForAllTfmAndNoProjectFrameworks()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+            var netcoreFrameworkString = "netcoreapp1.0";
+            var netcoreTargetFramework = NuGetFramework.Parse(netcoreFrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, netcoreTargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString, netcoreFrameworkString });
+
+            // Act && Assert
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_MessageWithTargetGraphAndDependencyWithNoWarnForAllTfmAndNoProjectFrameworks_2()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var net45FrameworkString = "net45";
+            var net45TargetFramework = NuGetFramework.Parse(net45FrameworkString);
+
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, net45TargetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, new string[] { net45FrameworkString });
 
             // Act && Assert
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/WarningPropertiesCollectionTests.cs
@@ -216,9 +216,8 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
-        public void WarningPropertiesCollection_PackagePropertiesWithPerFrameworkAndWarningWithoutFramework()
+        public void WarningPropertiesCollection_PackagePropertiesWithoutFrameworkAndWarningWithoutFramework()
         {
-            // Arrange
             // Arrange
             var libraryId = "test_library";
             var frameworkString = "net45";
@@ -232,55 +231,32 @@ namespace NuGet.Commands.Test
                 PackageSpecificWarningProperties = packageSpecificWarningProperties
             };
 
-            var nonSuppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
-
-            // Act && Assert
-            Assert.False(warningPropertiesCollection.ApplyWarningProperties(nonSuppressedMessage));
-            Assert.Equal(LogLevel.Warning, nonSuppressedMessage.Level);
-        }
-
-        [Fact]
-        public void WarningPropertiesCollection_PackagePropertiesWithoutFrameworkAndWarningWithFramework()
-        {
-            // Arrange
-            // Arrange
-            var libraryId = "test_library";
-            var frameworkString = "net45";
-
-            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId);
-
-            var warningPropertiesCollection = new WarningPropertiesCollection()
-            {
-                PackageSpecificWarningProperties = packageSpecificWarningProperties
-            };
-
-            var nonSuppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString);
-
-            // Act && Assert
-            Assert.False(warningPropertiesCollection.ApplyWarningProperties(nonSuppressedMessage));
-            Assert.Equal(LogLevel.Warning, nonSuppressedMessage.Level);
-        }
-
-        [Fact]
-        public void WarningPropertiesCollection_PackagePropertiesWithoutFrameworkAndWarningWithoutFramework()
-        {
-            // Arrange
-            // Arrange
-            var libraryId = "test_library";
-
-            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
-            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId);
-
-            var warningPropertiesCollection = new WarningPropertiesCollection()
-            {
-                PackageSpecificWarningProperties = packageSpecificWarningProperties
-            };
-
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
 
             // Act && Assert
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+        }
+
+        [Fact]
+        public void WarningPropertiesCollection_PackagePropertiesWithoutFrameworkAndWarningWithDifferentFramework()
+        {
+            // Arrange
+            var libraryId = "test_library";
+            var frameworkString = "net45";
+            var targetFramework = NuGetFramework.Parse(frameworkString);
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, targetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                PackageSpecificWarningProperties = packageSpecificWarningProperties
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, "netcoreapp1.0");
+
+            // Act && Assert
+            Assert.False(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
         }
 
         [Fact]
@@ -339,7 +315,7 @@ namespace NuGet.Commands.Test
         [Fact]
         public void WarningPropertiesCollection_PackagePropertiesWithNoWarnAndProjectPropertiesWithWarnAsError()
         {
-            // Arrange
+
             // Arrange
             var libraryId = "test_library";
             var frameworkString = "net45";
@@ -354,19 +330,23 @@ namespace NuGet.Commands.Test
             var warningPropertiesCollection = new WarningPropertiesCollection()
             {
                 ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
-                PackageSpecificWarningProperties = packageSpecificWarningProperties
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<string>
+                {
+                    frameworkString
+                }
             };
 
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString);
-            var upgradedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
+            var suppressedMessage2 = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
             var unaffectedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, "Warning", libraryId);
 
             // Act && Assert
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
-            Assert.False(warningPropertiesCollection.ApplyWarningProperties(upgradedMessage));
-            Assert.Equal(LogLevel.Error, upgradedMessage.Level);
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage2));
             Assert.False(warningPropertiesCollection.ApplyWarningProperties(unaffectedMessage));
             Assert.Equal(LogLevel.Warning, unaffectedMessage.Level);
+            Assert.Equal(1, unaffectedMessage.TargetGraphs.Count);
         }
 
         [Fact]
@@ -387,16 +367,58 @@ namespace NuGet.Commands.Test
             var warningPropertiesCollection = new WarningPropertiesCollection()
             {
                 ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
+                PackageSpecificWarningProperties = packageSpecificWarningProperties,
+                ProjectFrameworks = new List<string>
+                {
+                    frameworkString
+                }
+            };
+
+            var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString);
+            var suppressedMessage2 = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
+            var unaffectedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, "Warning", libraryId);
+
+            // Act && Assert
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage2));
+            Assert.False(warningPropertiesCollection.ApplyWarningProperties(unaffectedMessage));
+            Assert.Equal(LogLevel.Error, unaffectedMessage.Level);
+            Assert.Equal(1, unaffectedMessage.TargetGraphs.Count);
+        }
+
+
+        [Fact]
+        public void WarningPropertiesCollection_PackagePropertiesWithNoWarnAndProjectPropertiesWithWarnAsErrorAndProjectWithoutTargetFramework()
+        {
+
+            // Arrange
+            var libraryId = "test_library";
+            var frameworkString = "net45";
+            var targetFramework = NuGetFramework.Parse(frameworkString);
+            var noWarnSet = new HashSet<NuGetLogCode> { };
+            var warnAsErrorSet = new HashSet<NuGetLogCode> { NuGetLogCode.NU1500 };
+            var allWarningsAsErrors = false;
+
+            var packageSpecificWarningProperties = new PackageSpecificWarningProperties();
+            packageSpecificWarningProperties.Add(NuGetLogCode.NU1500, libraryId, targetFramework);
+
+            var warningPropertiesCollection = new WarningPropertiesCollection()
+            {
+                ProjectWideWarningProperties = new WarningProperties(warnAsErrorSet, noWarnSet, allWarningsAsErrors),
                 PackageSpecificWarningProperties = packageSpecificWarningProperties
             };
 
             var suppressedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId, frameworkString);
-            var upgradedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
+            var suppressedMessage2 = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1500, "Warning", libraryId);
+            var unaffectedMessage = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, "Warning", libraryId);
 
             // Act && Assert
             Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage));
-            Assert.False(warningPropertiesCollection.ApplyWarningProperties(upgradedMessage));
-            Assert.Equal(LogLevel.Error, upgradedMessage.Level);
+            Assert.Equal(0, suppressedMessage.TargetGraphs.Count);
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(suppressedMessage2));
+            Assert.Equal(0, suppressedMessage2.TargetGraphs.Count);
+            Assert.True(warningPropertiesCollection.ApplyWarningProperties(unaffectedMessage));
+            Assert.Equal(0, unaffectedMessage.TargetGraphs.Count);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Common.Test/PackageSpecificWanringPropertiesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Common.Test/PackageSpecificWanringPropertiesTests.cs
@@ -5,6 +5,9 @@ using System;
 using System.Collections.Generic;
 using NuGet.Commands;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 
@@ -14,18 +17,20 @@ namespace NuGet.Common.Test
     {
 
         [Fact]
-        public void PackageSpecificWanringProperties_DefaultValue()
+        public void PackageSpecificWarningProperties_DefaultValue()
         {
 
             // Arrange
             var properties = new PackageSpecificWarningProperties();
+            var libraryId = "test_libraryId";
+            var targetFramework = NuGetFramework.Parse("net45");
 
             // Assert
-            Assert.False(properties.Contains(NuGetLogCode.NU1500, "test_libraryId"));
+            Assert.False(properties.Contains(NuGetLogCode.NU1500, libraryId, targetFramework));
         }
 
         [Fact]
-        public void PackageSpecificWanringProperties_AddsValue()
+        public void PackageSpecificWarningProperties_AddsValue()
         {
 
             // Arrange
@@ -38,12 +43,12 @@ namespace NuGet.Common.Test
             // Assert
             Assert.True(properties.Contains(code, libraryId, targetFramework));
             Assert.False(properties.Contains(code, libraryId, NuGetFramework.Parse("random_target_graph")));
-            Assert.False(properties.Contains(code, libraryId));
         }
 
         [Fact]
-        public void PackageSpecificWanringProperties_AddsRangeValue()
+        public void PackageSpecificWarningProperties_AddsRangeValueWithGlobalTFM()
         {
+
             // Arrange
             var codes = new List<NuGetLogCode> { NuGetLogCode.NU1500, NuGetLogCode.NU1601, NuGetLogCode.NU1701 };
             var libraryId = "test_libraryId";
@@ -54,43 +59,147 @@ namespace NuGet.Common.Test
             // Assert
             foreach (var code in codes)
             {
+                Assert.False(properties.Contains(code, libraryId, NuGetFramework.Parse("random_target_graph")));
                 Assert.True(properties.Contains(code, libraryId, targetFramework));
-                Assert.False(properties.Contains(code, libraryId, NuGetFramework.Parse("random_target_graph")));
-                Assert.False(properties.Contains(code, libraryId));
             }
         }
 
         [Fact]
-        public void PackageSpecificWanringProperties_AddsValueWithGlobalTFM()
+        public void PackageSpecificWarningProperties_CreatesPackageSpecificWarningPropertiesWithUnconditionalDependencies()
         {
 
             // Arrange
-            var code = NuGetLogCode.NU1500;
-            var libraryId = "test_libraryId";
-            var properties = new PackageSpecificWarningProperties();
-            properties.Add(code, libraryId);
-
-            // Assert
-            Assert.False(properties.Contains(code, libraryId, NuGetFramework.Parse("random_target_graph")));
-            Assert.True(properties.Contains(code, libraryId));
-        }
-
-        [Fact]
-        public void PackageSpecificWanringProperties_AddsRangeValueWithGlobalTFM()
-        {
-
-            // Arrange
-            var codes = new List<NuGetLogCode> { NuGetLogCode.NU1500, NuGetLogCode.NU1601, NuGetLogCode.NU1701 };
-            var libraryId = "test_libraryId";
-            var properties = new PackageSpecificWarningProperties();
-            properties.AddRange(codes, libraryId);
-
-            // Assert
-            foreach (var code in codes)
+            var net45Framework = NuGetFramework.Parse("net45");
+            var netcoreappFramework = NuGetFramework.Parse("netcoreapp1.1");
+            var libraryId = "test_library";
+            var libraryVersion = "1.0.0";
+            var NoWarnList = new List<NuGetLogCode>
             {
-                Assert.False(properties.Contains(code, libraryId, NuGetFramework.Parse("random_target_graph")));
-                Assert.True(properties.Contains(code, libraryId));
-            }
+                NuGetLogCode.NU1603,
+                NuGetLogCode.NU1605
+            };
+
+            var targetFrameworkInformation = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net45Framework
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = netcoreappFramework
+                }
+            };
+
+            var packageSpec = new PackageSpec(targetFrameworkInformation)
+            {
+                Dependencies = new List<LibraryDependency>
+                {
+                    new LibraryDependency ()
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = libraryId,
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse(libraryVersion)
+                        },
+                        NoWarn = NoWarnList
+                    }
+                }
+            };
+
+            // Act
+            var warningProperties = PackageSpecificWarningProperties.CreatePackageSpecificWarningProperties(packageSpec);
+
+            // Assert
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, net45Framework));
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, netcoreappFramework));
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, net45Framework));
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, netcoreappFramework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, libraryId, NuGetFramework.Parse("random_framework")));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1605, libraryId, NuGetFramework.Parse("random_framework")));
+        }
+
+        [Fact]
+        public void PackageSpecificWarningProperties_CreatesPackageSpecificWarningPropertiesWithFrameworkConditionalDependencies()
+        {
+
+            // Arrange
+            var net45Framework = NuGetFramework.Parse("net45");
+            var netcoreappFramework = NuGetFramework.Parse("netcoreapp1.1");
+            var NoWarnList = new List<NuGetLogCode>
+            {
+                NuGetLogCode.NU1603,
+                NuGetLogCode.NU1605
+            };
+
+            var dependency1 = new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "test_library_1",
+                    TypeConstraint = LibraryDependencyTarget.Package,
+                    VersionRange = VersionRange.Parse("1.0.0")
+                },
+                NoWarn = new List<NuGetLogCode>
+                {
+                    NuGetLogCode.NU1603,
+                    NuGetLogCode.NU1607
+                }
+            };
+
+            var dependency2 = new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "test_library_2",
+                    TypeConstraint = LibraryDependencyTarget.Package,
+                    VersionRange = VersionRange.Parse("1.0.0")
+                },
+                NoWarn = new List<NuGetLogCode>
+                {
+                    NuGetLogCode.NU1603,
+                    NuGetLogCode.NU1605
+                }
+            };
+
+            var targetFrameworkInformation = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = net45Framework,
+                    Dependencies = new List<LibraryDependency>
+                    {
+                        dependency1
+                    }
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = netcoreappFramework,
+                    Dependencies = new List<LibraryDependency>
+                    {
+                        dependency2
+                    }
+                }
+            };
+
+            var packageSpec = new PackageSpec(targetFrameworkInformation);
+
+            // Act
+            var warningProperties = PackageSpecificWarningProperties.CreatePackageSpecificWarningProperties(packageSpec);
+
+            // Assert
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, "test_library_1", net45Framework));
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1607, "test_library_1", net45Framework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, "test_library", net45Framework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1701, "test_library_1", net45Framework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, "test_library_1", netcoreappFramework));
+
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1603, "test_library_2", netcoreappFramework));
+            Assert.True(warningProperties.Contains(NuGetLogCode.NU1605, "test_library_2", netcoreappFramework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, "test_library", netcoreappFramework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1701, "test_library_2", netcoreappFramework));
+            Assert.False(warningProperties.Contains(NuGetLogCode.NU1603, "test_library_2", net45Framework));
         }
     }
 }


### PR DESCRIPTION
This PR fixes the case where `PackageSpecific` `NoWarn` was not processed correctly for Legacy `PackageReference`projects.

Changes - 
1. Changes the way `PackageSpec.Dependencies` are processed for `NoWarn`. Previously the `NoWarn` properties were being added with `AnyFramework` into `PackageSpecificWarningProperties`. Now they are added for with all frameworks in `packageSpec.TargetFrameworks`.

2. Removes `AnyFramework` from `PackageSpecificWarningProperties` since it is no longer used.

3. Adds a `IReadOnlyList<NuGetFramework> ProjectFrameworks` to `WarningPropertiesCollection` to allow the next point.

4. Improves the logic in `WarningPropertiesCollection.ApplyWarningProperties`  for `PackageSpecificWarningProperties` such that is a log message comes in with no `TargetGraph`, then it is filtered against all the project frameworks in 'ProjectFrameworks'. The message is suppressed if it has a `NoWarn` for all project frameworks.

5. Moved `GetPackageSpecificWarningProperties` into `PackageSpecificWarningProperties` class because it is a better fit there.

6. Added/adjusted some Unit Tests in `PackageSpecificWanringPropertiesTests.cs`, `WarningPropertiesCollectionTests.cs` and `CollectorLoggerTests.cs`.

7. Added functional tests in `RestoreLoggingTests.cs` to cover Legacy `PackageReference` with the same scenarios as net core.