### PR TITLE
Adding library id and target graphs for log messages

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/ProjectRestoreCommand.cs
@@ -187,7 +187,7 @@ namespace NuGet.Commands
                             string.Join(", ", conflict.Requests),
                             graphName);
 
-                        _logger.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1106, message));
+                        _logger.Log(RestoreLogMessage.CreateError(NuGetLogCode.NU1106, message, conflict.Name, graph.TargetGraphName));
                     }
                 }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -55,7 +55,7 @@ namespace NuGet.Commands
             var collectorLogger = new RestoreCollectorLogger(_request.Log, collectorLoggerHideWarningsAndErrors)
             {
                 ProjectPath = _request.Project?.RestoreMetadata?.ProjectPath,
-                WarningPropertiesCollection =  new WarningPropertiesCollection()
+                WarningPropertiesCollection = new WarningPropertiesCollection()
                 {
                     ProjectWideWarningProperties = request.Project?.RestoreMetadata?.ProjectWideWarningProperties,
                     PackageSpecificWarningProperties = WarningPropertiesCollection.GetPackageSpecificWarningProperties(request.Project)
@@ -81,11 +81,12 @@ namespace NuGet.Commands
             };
 
             localRepositories.AddRange(_request.DependencyProviders.FallbackPackageFolders);
-            
+
             var contextForProject = CreateRemoteWalkContext(_request, _logger);
 
             CacheFile cacheFile = null;
-            if (NoOpRestoreUtilities.IsNoOpSupported(_request)) {
+            if (NoOpRestoreUtilities.IsNoOpSupported(_request))
+            {
                 var cacheFileAndStatus = EvaluateCacheFile();
                 cacheFile = cacheFileAndStatus.Key;
                 if (cacheFileAndStatus.Value)
@@ -128,7 +129,7 @@ namespace NuGet.Commands
             _success &= await ValidateRestoreGraphsAsync(graphs, _logger);
 
             // Check package compatibility
-            var checkResults = VerifyCompatibility(
+            var checkResults = await VerifyCompatibilityAsync(
                 _request.Project,
                 _includeFlagGraphs,
                 localRepositories,
@@ -231,7 +232,7 @@ namespace NuGet.Commands
             }
         }
 
-        private KeyValuePair<CacheFile,bool> EvaluateCacheFile()
+        private KeyValuePair<CacheFile, bool> EvaluateCacheFile()
         {
             CacheFile cacheFile;
             var noOp = false;
@@ -277,7 +278,7 @@ namespace NuGet.Commands
                     _request.Project.RestoreMetadata.CacheFilePath = null;
                 }
             }
-            return new KeyValuePair<CacheFile,bool>(cacheFile, noOp) ;
+            return new KeyValuePair<CacheFile, bool>(cacheFile, noOp);
         }
 
         private string GetAssetsFilePath(LockFile lockFile)
@@ -483,7 +484,7 @@ namespace NuGet.Commands
             return logger.LogMessagesAsync(mergedMessages);
         }
 
-        private static IList<CompatibilityCheckResult> VerifyCompatibility(
+        private static async Task<IList<CompatibilityCheckResult>> VerifyCompatibilityAsync(
                 PackageSpec project,
                 Dictionary<RestoreTargetGraph, Dictionary<string, LibraryIncludeFlags>> includeFlagGraphs,
                 IReadOnlyList<NuGetv3LocalRepository> localRepositories,
@@ -499,15 +500,15 @@ namespace NuGet.Commands
                 var checker = new CompatibilityChecker(localRepositories, lockFile, validateRuntimeAssets, logger);
                 foreach (var graph in graphs)
                 {
-                    logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_CheckingCompatibility, graph.Name));
+                    await logger.LogAsync(LogLevel.Verbose, string.Format(CultureInfo.CurrentCulture, Strings.Log_CheckingCompatibility, graph.Name));
 
                     var includeFlags = IncludeFlagUtils.FlattenDependencyTypes(includeFlagGraphs, project, graph);
 
-                    var res = checker.Check(graph, includeFlags);
+                    var res = await checker.CheckAsync(graph, includeFlags);
                     checkResults.Add(res);
                     if (res.Success)
                     {
-                        logger.LogVerbose(string.Format(CultureInfo.CurrentCulture, Strings.Log_PackagesAndProjectsAreCompatible, graph.Name));
+                        await logger.LogAsync(LogLevel.Verbose, string.Format(CultureInfo.CurrentCulture, Strings.Log_PackagesAndProjectsAreCompatible, graph.Name));
                     }
                     else
                     {
@@ -518,12 +519,12 @@ namespace NuGet.Commands
                         // Log a summary with compatibility error counts
                         if (projectCount > 0)
                         {
-                            logger.LogDebug($"Incompatible projects: {projectCount}");
+                            await logger.LogAsync(LogLevel.Debug, $"Incompatible projects: {projectCount}");
                         }
 
                         if (packageCount > 0)
                         {
-                            logger.LogDebug($"Incompatible packages: {packageCount}");
+                            await logger.LogAsync(LogLevel.Debug, $"Incompatible packages: {packageCount}");
                         }
                     }
                 }

--- a/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileExtensions.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/LockFile/LockFileExtensions.cs
@@ -12,6 +12,8 @@ namespace NuGet.ProjectModel
         /// <summary>
         /// Get target graphs for the current log message.
         /// </summary>
+        /// <remarks>If the message does not contain target graphs all graphs in the file
+        /// will be returned.</remarks>
         public static IEnumerable<LockFileTarget> GetTargetGraphs(this IAssetsLogMessage message, LockFile assetsFile)
         {
             if (message == null)
@@ -22,6 +24,12 @@ namespace NuGet.ProjectModel
             if (assetsFile == null)
             {
                 throw new ArgumentNullException(nameof(assetsFile));
+            }
+
+            // If the message does not contain any target graph it should apply to all graphs.
+            if (message.TargetGraphs == null || message.TargetGraphs.Count == 0)
+            {
+                return assetsFile.Targets;
             }
 
             return assetsFile.Targets.Where(target => message.TargetGraphs.Contains(target.Name, StringComparer.OrdinalIgnoreCase));

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileExtensionsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/LockFileExtensionsTests.cs
@@ -63,6 +63,38 @@ namespace NuGet.ProjectModel.Test
         }
 
         [Fact]
+        public void GivenALogMessageWithNoTargetGraphsVerifyAllGraphsAreReturned()
+        {
+            var assetsFile = new LockFile();
+            assetsFile.Targets.Add(new LockFileTarget()
+            {
+                TargetFramework = NuGetFramework.Parse("net45"),
+            });
+
+            assetsFile.Targets.Add(new LockFileTarget()
+            {
+                TargetFramework = NuGetFramework.Parse("net46"),
+                RuntimeIdentifier = "win8"
+            });
+
+            assetsFile.Targets.Add(new LockFileTarget()
+            {
+                TargetFramework = NuGetFramework.Parse("netstandard2.0")
+            });
+
+            var expected1 = NuGetFramework.Parse("net45").DotNetFrameworkName;
+            var expected2 = NuGetFramework.Parse("net46").DotNetFrameworkName + "/win8";
+            var expected3 = NuGetFramework.Parse("netstandard2.0").DotNetFrameworkName;
+
+            // Create a message with no target graphs
+            var message = new AssetsLogMessage(LogLevel.Warning, NuGetLogCode.NU1103, "test");
+
+            var graphs = message.GetTargetGraphs(assetsFile);
+
+            graphs.Select(e => e.Name).ShouldBeEquivalentTo(new[] { expected1, expected2, expected3 });
+        }
+
+        [Fact]
         public void GivenATargetGraphVerifyLibraryReturned()
         {
             var graph = new LockFileTarget()


### PR DESCRIPTION
Cleaning up warning and error logging, adding library ids and target graphs for all relevant messages.

Fixes https://github.com/NuGet/Home/issues/5405