### PR TITLE
Ignore the restore settings for net core projects during no-op

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -220,7 +220,7 @@ namespace NuGet.Commands
                 //Ignore the restore settings for net core projects.
                 //This is set by default in VS while it's not set in commandline.
                 //This causes a discrepancy and the project does not cross-client no - op.MSBuild / NuGet.exe vs VS.
-                if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
+                else if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
                 {
                     projectSpec.RestoreSettings = null;
                 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -199,15 +199,26 @@ namespace NuGet.Commands
         /// <summary>
         /// Calculates the hash value, used for the no-op optimization, for the request
         /// This methods handles the deduping of tools
+        /// Handles the ignoring of RestoreSettings
         /// </summary>
         public static string GetHash(RestoreRequest request)
         {
-            if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool)
+            if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool || request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
             {
+
                 var uniqueName = request.DependencyGraphSpec.Restore.First();
                 var dgSpec = request.DependencyGraphSpec.WithProjectClosure(uniqueName);
-                dgSpec.GetProjectSpec(uniqueName).RestoreMetadata.ProjectPath = null;
-                dgSpec.GetProjectSpec(uniqueName).FilePath = null;
+
+                if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool)
+                {
+                    dgSpec.GetProjectSpec(uniqueName).RestoreMetadata.ProjectPath = null;
+                    dgSpec.GetProjectSpec(uniqueName).FilePath = null;
+                }
+
+                if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
+                {
+                    dgSpec.GetProjectSpec(uniqueName).RestoreSettings = null;
+                }
                 return dgSpec.GetHash();
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -208,16 +208,21 @@ namespace NuGet.Commands
 
                 var uniqueName = request.DependencyGraphSpec.Restore.First();
                 var dgSpec = request.DependencyGraphSpec.WithProjectClosure(uniqueName);
+                var projectSpec = dgSpec.GetProjectSpec(uniqueName);
 
+                // The project path where the tool is declared does not affect restore and is only used for logging and transparency.
                 if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {
-                    dgSpec.GetProjectSpec(uniqueName).RestoreMetadata.ProjectPath = null;
-                    dgSpec.GetProjectSpec(uniqueName).FilePath = null;
+                    projectSpec.RestoreMetadata.ProjectPath = null;
+                    projectSpec.FilePath = null;
                 }
 
+                //Ignore the restore settings for net core projects.
+                //This is set by default in VS while it's not set in commandline.
+                //This causes a discrepancy and the project does not cross-client no - op.MSBuild / NuGet.exe vs VS.
                 if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
                 {
-                    dgSpec.GetProjectSpec(uniqueName).RestoreSettings = null;
+                    projectSpec.RestoreSettings = null;
                 }
                 return dgSpec.GetHash();
             }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -217,8 +217,8 @@ namespace NuGet.Commands
                     projectSpec.FilePath = null;
                 }
 
-                //Ignore the restore settings for net core projects.
-                //This is set by default in VS while it's not set in commandline.
+                //Ignore the restore settings for package ref projects.
+                //This is set by default for net core projects in VS while it's not set in commandline.
                 //This causes a discrepancy and the project does not cross-client no - op.MSBuild / NuGet.exe vs VS.
                 else if (request.Project.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference)
                 {

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -117,6 +117,7 @@ namespace NuGet.Test.Utility
 
         public string GlobalPackagesFolder { get; set; }
 
+        public bool WarningsAsErrors { get; set; }
         /// <summary>
         /// project.lock.json or project.assets.json
         /// </summary>
@@ -384,6 +385,14 @@ namespace NuGet.Test.Utility
 
             if (Type == ProjectStyle.PackageReference)
             {
+                if (WarningsAsErrors)
+                {
+                    ProjectFileUtils.AddProperties(xml, new Dictionary<string, string>()
+                    {
+                        { "WarningsAsErrors", "true" }
+                    });
+                }
+
                 ProjectFileUtils.AddProperties(xml, new Dictionary<string, string>()
                 {
                     { "Version", Version },


### PR DESCRIPTION
Ignore the restore settings for net core projects. 
This is set by default in VS while it's not set in commandline. 
This causes a discrepancy and the project does not cross-client no-op. MSBuild/NuGet.exe vs VS. 

//cc @rrelyea 