### PR TITLE
Using unique name instead of custom unique name to access NuGet project

### DIFF
--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -396,8 +396,8 @@ namespace NuGetVSExtension
                 throw new InvalidOperationException(Resources.SolutionIsNotSaved);
             }
 
-            var customUniqueName = await EnvDTEProjectInfoUtility.GetCustomUniqueNameAsync(project);
-            var nugetProject = SolutionManager.GetNuGetProject(customUniqueName);
+            var uniqueName = EnvDTEProjectInfoUtility.GetUniqueName(project);
+            var nugetProject = SolutionManager.GetNuGetProject(uniqueName);
 
             // If we failed to generate a cache entry in the solution manager something went wrong.
             if (nugetProject == null)


### PR DESCRIPTION
When an existing project is moved into a new folder, it changes it custom unique name (which NuGet only construct) since it's parent project item has changed. But this doesn't change anything in dte so dte doesn't raise any event which is why NuGet isn't able to update it's project cache. So the ideal solution is to use unique name instead of custom unique name to retrieve NuGet project from it's cache.

Fixes internal bug# 444702

@rrelyea 