### PR TITLE
AssetTargetFallback invalid combination error

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -316,7 +316,7 @@ namespace NuGet.PackageManagement.VisualStudio
             };
 
             // Apply fallback settings
-            AssetTargetFallbackUtility.ApplyFramework(projectTfi, packageTargetFallback, assetTargetFallback);
+            PackageSpecUtility.ApplyFallbackFramework(projectTfi, packageTargetFallback, assetTargetFallback);
 
             // Build up runtime information.
             var runtimes = await _vsProjectAdapter.GetRuntimeIdentifiersAsync();

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -404,7 +404,7 @@ namespace NuGet.SolutionRestoreManager
                                           .ToList();
 
             // Update TFI with fallback properties
-            AssetTargetFallbackUtility.ApplyFramework(tfi, ptf, atf);
+            PackageSpecUtility.ApplyFallbackFramework(tfi, ptf, atf);
 
             if (targetFrameworkInfo.PackageReferences != null)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -359,11 +359,8 @@ namespace NuGet.Commands
                         .Select(NuGetFramework.Parse)
                         .ToList();
 
-                    // Throw if an invalid combination was used.
-                    AssetTargetFallbackUtility.EnsureValidFallback(packageTargetFallback, assetTargetFallback, spec.FilePath);
-
                     // Update the framework appropriately
-                    AssetTargetFallbackUtility.ApplyFramework(targetFrameworkInfo, packageTargetFallback, assetTargetFallback);
+                    PackageSpecUtility.ApplyFallbackFramework(targetFrameworkInfo, packageTargetFallback, assetTargetFallback);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -107,7 +107,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment..
+        ///   Looks up a localized string similar to PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment..
         /// </summary>
         internal static string Error_InvalidATF {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -585,6 +585,6 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>'{0}' cannot be used in conjunction with other values.</value>
   </data>
   <data name="Error_InvalidATF" xml:space="preserve">
-    <value>PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.</value>
+    <value>PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.</value>
   </data>
 </root>

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -48,6 +52,70 @@ namespace NuGet.ProjectModel
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Apply a fallback framework to <see cref="TargetFrameworkInformation"/>.
+        /// </summary>
+        public static void ApplyFallbackFramework(
+            TargetFrameworkInformation targetFrameworkInfo,
+            IEnumerable<NuGetFramework> packageTargetFallback,
+            IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            if (targetFrameworkInfo == null)
+            {
+                throw new ArgumentNullException(nameof(targetFrameworkInfo));
+            }
+
+            // Update the framework appropriately
+            targetFrameworkInfo.FrameworkName = GetFallbackFramework(
+                targetFrameworkInfo.FrameworkName,
+                packageTargetFallback,
+                assetTargetFallback);
+
+            if (assetTargetFallback?.Any() == true)
+            {
+                // AssetTargetFallback
+                targetFrameworkInfo.AssetTargetFallback = assetTargetFallback.AsList();
+                targetFrameworkInfo.Warn = true;
+            }
+
+            if (packageTargetFallback?.Any() == true)
+            {
+                // PackageTargetFallback
+                targetFrameworkInfo.Imports = packageTargetFallback.AsList();
+            }
+        }
+
+        /// <summary>
+        /// Returns the fallback framework or the original.
+        /// If both PTF and ATF are set the original is returned.
+        /// </summary>
+        public static NuGetFramework GetFallbackFramework(
+            NuGetFramework projectFramework,
+            IEnumerable<NuGetFramework> packageTargetFallback,
+            IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            if (projectFramework == null)
+            {
+                throw new ArgumentNullException(nameof(projectFramework));
+            }
+
+            var hasATF = assetTargetFallback?.Any() == true;
+            var hasPTF = packageTargetFallback?.Any() == true;
+
+            if (hasATF && !hasPTF)
+            {
+                // AssetTargetFallback
+                return new AssetTargetFallbackFramework(projectFramework, assetTargetFallback.AsList());
+            }
+            else if (hasPTF && !hasATF)
+            {
+                // PackageTargetFallback
+                return new FallbackFramework(projectFramework, packageTargetFallback.AsList());
+            }
+
+            return projectFramework;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -420,13 +420,13 @@ namespace NuGet.ProjectModel
             writer.WriteObjectEnd();
         }
 
-        private static void SetImports(IObjectWriter writer, IList<NuGetFramework> frameworks)
+        private static void SetFrameworkArrayToProperty(IObjectWriter writer, IList<NuGetFramework> frameworks, string propertyName)
         {
             if (frameworks?.Any() == true)
             {
-                var imports = frameworks.Select(framework => framework.GetShortFolderName());
+                var shortNames = frameworks.Select(framework => framework.GetShortFolderName());
 
-                writer.WriteNameArray("imports", imports);
+                writer.WriteNameArray(propertyName, shortNames);
             }
         }
 
@@ -441,8 +441,8 @@ namespace NuGet.ProjectModel
                     writer.WriteObjectStart(framework.FrameworkName.GetShortFolderName());
 
                     SetDependencies(writer, framework.Dependencies);
-                    SetImports(writer, framework.Imports);
-                    SetValueIfTrue(writer, "assetTargetFallback", framework.AssetTargetFallback);
+                    SetFrameworkArrayToProperty(writer, framework.Imports, "imports");
+                    SetFrameworkArrayToProperty(writer, framework.AssetTargetFallback, "assetTargetFallback");
                     SetValueIfTrue(writer, "warn", framework.Warn);
 
                     writer.WriteObjectEnd();

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -17,14 +17,23 @@ namespace NuGet.ProjectModel
 
         /// <summary>
         /// A fallback PCL framework to use when no compatible items
-        /// were found for <see cref="FrameworkName"/>.
+        /// were found for <see cref="FrameworkName"/>. This check is done
+        /// per asset type.
         /// </summary>
+        /// <remarks>Deprecated. Use <see cref="AssetTargetFallback" /> instead.</remarks>
+        /// <see cref="Imports" /> cannot be used with <see cref="AssetTargetFallback" />.
         public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
-        /// If True AssetTargetFallback behavior will be used for Imports.
+        /// A fallback framework to use when no compatible items
+        /// were found for <see cref="FrameworkName"/>. 
+        /// <see cref="AssetTargetFallback" /> will only fallback if the package
+        /// does not contain any assets compatible with <see cref="FrameworkName"/>.
         /// </summary>
-        public bool AssetTargetFallback { get; set; }
+        /// <remarks>
+        /// <see cref="AssetTargetFallback" /> cannot be used with <see cref="Imports" />.
+        /// </remarks>
+        public IList<NuGetFramework> AssetTargetFallback { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
         /// Display warnings when the Imports framework is used.
@@ -41,9 +50,14 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(FrameworkName);
-            hashCode.AddObject(AssetTargetFallback);
             hashCode.AddSequence(Dependencies);
+
+            // Add markers between NuGetFramework objects
+            hashCode.AddObject(nameof(Imports));
             hashCode.AddSequence(Imports);
+
+            hashCode.AddObject(nameof(AssetTargetFallback));
+            hashCode.AddSequence(AssetTargetFallback);
 
             return hashCode.CombinedHash;
         }
@@ -68,7 +82,7 @@ namespace NuGet.ProjectModel
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
-                   AssetTargetFallback == other.AssetTargetFallback;
+                   AssetTargetFallback.SequenceEqualWithNullCheck(other.AssetTargetFallback);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -4561,7 +4561,8 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
 
                 // Assert
-                r.AllOutput.Should().Contain("PackageTargetFallback and AssetTargetFallback cannot be used together.");
+                r.AllOutput.Should().Contain("PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.");
+                r.AllOutput.Should().Contain("NU1003");
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class AssetTargetFallbackUtilityTests
+    {
+        [Fact]
+        public void AssetTargetFallbackUtility_VerifyGetInvalidFallbackCombinationMessage()
+        {
+            var message = AssetTargetFallbackUtility.GetInvalidFallbackCombinationMessage("/tmp/project.csproj");
+
+            message.Code.Should().Be(NuGetLogCode.NU1003);
+            message.FilePath.Should().Be("/tmp/project.csproj");
+            message.TargetGraphs.Should().BeEmpty("this applies to the entire project");
+            message.Level.Should().Be(LogLevel.Error);
+            message.Message.Should().Be("PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.");
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyTrue()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyTrueForMultipleFrameworks()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.1")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseForMultipleFrameworks()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.1")
+                }
+            };
+
+            // Add PTF to one framework, and ATF to another
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[1].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseWithPTFOnly()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseWithATFOnly()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task AssetTargetFallbackUtility_ValidateFallbackFrameworkVerifyFalse()
+        {
+            var testLogger = new TestLogger();
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            var success = await AssetTargetFallbackUtility.ValidateFallbackFrameworkAsync(project, testLogger);
+
+            success.Should().BeFalse();
+            testLogger.Errors.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task AssetTargetFallbackUtility_ValidateFallbackFrameworkVerifyTrue()
+        {
+            var testLogger = new TestLogger();
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            var success = await AssetTargetFallbackUtility.ValidateFallbackFrameworkAsync(project, testLogger);
+
+            success.Should().BeTrue();
+            testLogger.Messages.Should().BeEmpty();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -601,6 +601,133 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyAssetTargetFallback()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "AssetTargetFallback", "portable-net45+win8;dnxcore50;;" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(2, nsTFM.AssetTargetFallback.Count);
+                Assert.Equal(0, netTFM.AssetTargetFallback.Count);
+
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.AssetTargetFallback[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.AssetTargetFallback[1]);
+
+                // Verify fallback framework
+                var assetTargetFallbackFramewrk = (AssetTargetFallbackFramework)project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "netstandard1.6")
+                    .FrameworkName;
+
+                // net46 does not have imports
+                var fallbackFrameworkNet45 = project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "net46")
+                    .FrameworkName
+                    as FallbackFramework;
+
+                Assert.Null(fallbackFrameworkNet45);
+                Assert.Equal(2, assetTargetFallbackFramewrk.Fallback.Count);
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), assetTargetFallbackFramewrk.Fallback[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), assetTargetFallbackFramewrk.Fallback[1]);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyAssetTargetFallbackEmpty()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(0, nsTFM.Imports.Count);
+                Assert.Equal(0, netTFM.Imports.Count);
+
+                // Verify no fallback frameworks
+                var fallbackFrameworks = project1Spec.TargetFrameworks.Select(e => e.FrameworkName as AssetTargetFallbackFramework);
+                Assert.True(fallbackFrameworks.All(e => e == null));
+            }
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyImportsEmpty()
         {
             using (var workingDir = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
@@ -10,23 +10,24 @@ namespace NuGet.ProjectModel.Test
     public class AssetTargetFallbackTests
     {
         [Fact]
-        public void GivenAssetTargetFallbackTrueVerifyValuePersisted()
+        public void GivenAssetTargetFallbackHasAValueVerifyValuePersisted()
         {
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
+            spec.TargetFrameworks[0].AssetTargetFallback.Add(NuGetFramework.Parse("net45"));
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeTrue();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
         [Fact]
         public void GivenAssetTargetFallbackFalseVerifyValuePersisted()
         {
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = false;
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeFalse();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
         [Fact]
@@ -34,11 +35,11 @@ namespace NuGet.ProjectModel.Test
         {
             var net461 = NuGetFramework.Parse("net461");
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
             spec.TargetFrameworks[0].Imports.Add(net461);
 
             var outSpec = spec.RoundTrip();
             outSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { net461 });
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
         }
 
         [Fact]
@@ -47,8 +48,7 @@ namespace NuGet.ProjectModel.Test
             var net461 = NuGetFramework.Parse("net461");
             var projectFramework = NuGetFramework.Parse("netcoreapp2.0");
             var spec = PackageSpecTestUtility.GetSpec(projectFramework);
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
-            spec.TargetFrameworks[0].Imports.Add(net461);
+            spec.TargetFrameworks[0].AssetTargetFallback.Add(net461);
 
             var outSpec = spec.RoundTrip();
 
@@ -60,10 +60,11 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void GivenAssetTargetFallbackDiffersVerifyEquality()
         {
+            var net461 = NuGetFramework.Parse("net461");
             var spec1 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
-            spec1.TargetFrameworks[0].AssetTargetFallback = true;
+            spec1.TargetFrameworks[0].AssetTargetFallback.Add(net461);
             var spec2 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
-            spec2.TargetFrameworks[0].AssetTargetFallback = false;
+            spec2.TargetFrameworks[0].Imports.Add(net461);
 
             spec1.Should().NotBe(spec2);
             spec1.GetHashCode().Should().NotBe(spec2.GetHashCode());

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Frameworks;
 using NuGet.Versioning;
 using Xunit;
 
@@ -54,6 +53,164 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(expected), actual);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithNoFallbacksVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>();
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf);
+
+            result.Should().Be(project, "no atf or ptf frameworks exist");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithNullFallbacksVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, packageTargetFallback: null, assetTargetFallback: null);
+
+            result.Should().Be(project, "no atf or ptf frameworks exist");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithPTFOnlyVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf) as FallbackFramework;
+
+            result.Fallback.ShouldBeEquivalentTo(ptf);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithATFOnlyVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var ptf = new List<NuGetFramework>();
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf) as AssetTargetFallbackFramework;
+
+            result.Fallback.ShouldBeEquivalentTo(atf);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithATFAndPTFVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf);
+
+            result.Should().Be(project, "both atf and ptf will be ignored");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithBothFallbacksVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net45")
+            };
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithNoFallbacksVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>();
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.Imports.Should().BeEmpty();
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithPTFVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().BeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithATFVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var ptf = new List<NuGetFramework>();
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.Imports.Should().BeEmpty();
+            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().BeOfType(typeof(AssetTargetFallbackFramework));
         }
     }
 }


### PR DESCRIPTION
Projects with PackageTargetFallback and AssetTargetFallback will now fail to restore from Visual Studio with NU1003.

* Updating PackageSpec to take both PTF and ATF instead of a bool, this allows restore to fail across all restore types, including Visual Studio in the same way.
* NU1003 will now show up as an error that fails restore, but restore will still proceed using the default project framework without fallbacks. This allows system packages to be restored so that the error is not lost with missing reference errors.
* Updating error message string with the new text from @anangaur 