### PR TITLE
fallback to identity for lib files if finaloutputpath is not set

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTask.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack.Library/PackTaskLogic.cs
@@ -245,6 +245,14 @@ namespace NuGet.Build.Tasks.Pack
             foreach (var assembly in libFiles)
             {
                 var finalOutputPath = assembly.GetProperty("FinalOutputPath");
+
+                // Fallback to using Identity if FinalOutputPath is not set.
+                // See bug https://github.com/NuGet/Home/issues/5408 
+                if (string.IsNullOrEmpty(finalOutputPath))
+                {
+                    finalOutputPath = assembly.GetProperty(IdentityProperty);
+                }
+
                 var targetPath = assembly.GetProperty("TargetPath");
                 var targetFramework = assembly.GetProperty("TargetFramework");
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5408

While this should be actually fixed on msbuild side (see bug: https://github.com/Microsoft/msbuild/issues/2223) , the fix is a little involved for them at this stage and it doesn't harm to make Pack more robust against such scenarios.

You can see the reasoning for the need of this fix here: https://github.com/Microsoft/msbuild/issues/2223#issuecomment-308836945 