### PR TITLE
Fix skip content files write flag for legacy in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -354,11 +354,11 @@ namespace NuGet.PackageManagement.VisualStudio
                             ProjectReferences = projectReferences?.ToList()
                         }
                     },
+                    SkipContentFileWrite = true,
                     PackagesPath = GetPackagesPath(settings),
                     Sources = GetSources(settings),
                     FallbackFolders = GetFallbackFolders(settings),
                     ConfigFilePaths = GetConfigFilePaths(settings),
-
                     ProjectWideWarningProperties = MSBuildRestoreUtility.GetWarningProperties(
                         treatWarningsAsErrors: _vsProjectAdapter.TreatWarningsAsErrors, 
                         noWarn: _vsProjectAdapter.NoWarn,

--- a/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/ProjectRestoreMetadata.cs
@@ -102,7 +102,7 @@ namespace NuGet.ProjectModel
         public bool ValidateRuntimeAssets { get; set; }
 
         /// <summary>
-        /// True if this is an XPlat PackageReference project.
+        /// True if this is a Legacy Package Reference project
         /// </summary>
         public bool SkipContentFileWrite { get; set; }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -603,6 +603,49 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
+        [Fact]
+        public async Task GetPackageSpecsAsync_SkipContentFilesAlwaysTrue()
+        {
+            // Arrange
+            using (var randomTestFolder = TestDirectory.Create())
+            {
+                var framework = NuGetFramework.Parse("netstandard13");
+
+                var projectAdapter = CreateProjectAdapter(randomTestFolder);
+
+                var projectServices = new TestProjectSystemServices();
+                projectServices.SetupInstalledPackages(
+                    framework,
+                    new LibraryDependency
+                    {
+                        LibraryRange = new LibraryRange(
+                            "packageA",
+                            VersionRange.Parse("1.*"),
+                            LibraryDependencyTarget.Package)
+                    });
+
+                var testProject = new LegacyPackageReferenceProject(
+                    projectAdapter,
+                    Guid.NewGuid().ToString(),
+                    projectServices,
+                    _threadingService);
+
+                var testDependencyGraphCacheContext = new DependencyGraphCacheContext();
+
+                await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                // Act
+                var packageSpecs = await testProject.GetPackageSpecsAsync(testDependencyGraphCacheContext);
+
+                // Assert
+                Assert.NotNull(packageSpecs);
+
+                var actualRestoreSpec = packageSpecs.Single();
+                SpecValidationUtility.ValidateProjectSpec(actualRestoreSpec);
+
+                Assert.True(actualRestoreSpec.RestoreMetadata.SkipContentFileWrite);
+            }
+        }
         private static Mock<IVsProjectAdapter> CreateProjectAdapter()
         {
             var projectAdapter = new Mock<IVsProjectAdapter>();

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -645,7 +645,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }
         }
 
-                [Fact]
+        [Fact]
         public async Task GetPackageSpecsAsync_SkipContentFilesAlwaysTrue()
         {
             // Arrange


### PR DESCRIPTION
The SkipContentFilesWrite flag is not being set in VS for legacy package reference projects. 
This is a discrepancy between restore from VS & commandline clients.

For reference here's where the flag is being evaluated for commandline clients
https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets#L508-L510

Fixes https://github.com/NuGet/Home/issues/5437
//cc
@rrelyea 