### PR TITLE
Adding RID to NU1203 test for mono

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreLoggingTests.cs
@@ -115,6 +115,7 @@ namespace NuGet.CommandLine.Test
                     pathContext.SolutionRoot,
                     netcoreapp1);
                 projectA.Properties.Add("ValidateRuntimeIdentifierCompatibility", "true");
+                projectA.Properties.Add("RuntimeIdentifiers", "win10-x64");
 
                 var packageX = new SimpleTestPackageContext("x", "1.0.0");
                 packageX.Files.Clear();


### PR DESCRIPTION
A mac mono test is failing because the xplat SDK does not add RIDs, this test requires a RID graph in the assets file to generated the RID specific errors.