### PR TITLE
Read DotnetCliToolTargetFramework from CPS nomation

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -32,5 +32,6 @@ namespace NuGet.ProjectManagement
         public const string NoWarn = nameof(NoWarn);
         public const string WarningsAsErrors = nameof(WarningsAsErrors);
         public const string TreatWarningsAsErrors = nameof(TreatWarningsAsErrors);
+        public const string DotnetCliToolTargetFramework = nameof(DotnetCliToolTargetFramework);
     }
 }


### PR DESCRIPTION
Resolves NuGet/Home#5397.

This change deprecates inferring the tool framework implemented earlier.
Instead NuGet will honor `<DotnetCliToolTargetFramework>` project
property passed via the nomination API.

//cc @rrelyea 