### PR TITLE
Adding VSTS build status badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This repo contains the following clients:
 
 ## Build Status
 
-|Windows x64 |
+| VSTS Build |
 |:------:|
-|[![](https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/3736/badge)](https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=3736)|
+|[![](https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/5868/badge)](https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=5868)|
 
 ## Open Source Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This repo contains the following clients:
   * [NuGet Package Manager for Visual Studio 2015/2017](https://docs.nuget.org/ndocs/tools/package-manager-ui)
   * [PowerShell CmdLets](https://docs.nuget.org/ndocs/tools/powershell-reference)
 
+## Build Status
+
+|Windows x64 |
+|:------:|
+|[![](https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/3736/badge)](https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=3736)|
+
 ## Open Source Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Added a functional badge that should display the status of the NuGet.Client official build status.

Look - 

![capture](https://user-images.githubusercontent.com/10507120/27302283-3b66a8d2-54eb-11e7-9cbc-c8123b306382.PNG)
