### PR TITLE
Fix assets file reading problem ATF vs PTF

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Utility/AssetTargetFallbackUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/AssetTargetFallbackUtility.cs
@@ -67,7 +67,7 @@ namespace NuGet.Commands
                 throw new ArgumentNullException(nameof(spec));
             }
 
-            return spec.TargetFrameworks.Any(e => e.Imports.Count > 0 && e.AssetTargetFallback.Count > 0);
+            return spec.TargetFrameworks.Any(e => e.PackageTargetFallbacks.Count > 0 && e.AssetTargetFallbacks.Count > 0);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -732,16 +732,23 @@ namespace NuGet.ProjectModel
             var frameworkName = GetFramework(targetFramework.Key);
 
             var properties = targetFramework.Value.Value<JObject>();
-
+            
+            // Legacy behavior
             var importFrameworks = GetFrameworksFromArray(properties["imports"], packageSpec);
-            var assetTargetFallbackFrameworks = GetFrameworksFromArray(properties["assetTargetFallback"], packageSpec);
+            var assetTargetFallback = GetBoolOrFalse(properties, "assetTargetFallback", filePath);
+
+            // atf vs. ptf warnings hack
+            var assetTargetFallbackFrameworks = GetFrameworksFromArray(properties["assetTargetFallbacks"], packageSpec);
+            var packageTargetFallbackFrameworks = GetFrameworksFromArray(properties["packageTargetFallbacks"], packageSpec);
 
             var targetFrameworkInformation = new TargetFrameworkInformation
             {
                 FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, importFrameworks, assetTargetFallbackFrameworks),
                 Dependencies = new List<LibraryDependency>(),
                 Imports = importFrameworks,
-                AssetTargetFallback = assetTargetFallbackFrameworks,
+                AssetTargetFallback = assetTargetFallback,
+                AssetTargetFallbacks = assetTargetFallbackFrameworks,
+                PackageTargetFallbacks = packageTargetFallbackFrameworks,
                 Warn = GetWarnSetting(properties)
             };
 

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -743,7 +743,7 @@ namespace NuGet.ProjectModel
 
             var targetFrameworkInformation = new TargetFrameworkInformation
             {
-                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, packageTargetFallbackFrameworks, assetTargetFallbackFrameworks),
+                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, importFrameworks, packageTargetFallbackFrameworks, assetTargetFallbackFrameworks),
                 Dependencies = new List<LibraryDependency>(),
                 Imports = importFrameworks,
                 AssetTargetFallback = assetTargetFallback,

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -743,7 +743,7 @@ namespace NuGet.ProjectModel
 
             var targetFrameworkInformation = new TargetFrameworkInformation
             {
-                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, importFrameworks, assetTargetFallbackFrameworks),
+                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, packageTargetFallbackFrameworks, assetTargetFallbackFrameworks),
                 Dependencies = new List<LibraryDependency>(),
                 Imports = importFrameworks,
                 AssetTargetFallback = assetTargetFallback,

--- a/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/JsonPackageSpecReader.cs
@@ -743,7 +743,7 @@ namespace NuGet.ProjectModel
 
             var targetFrameworkInformation = new TargetFrameworkInformation
             {
-                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, importFrameworks, packageTargetFallbackFrameworks, assetTargetFallbackFrameworks),
+                FrameworkName = PackageSpecUtility.GetFallbackFramework(frameworkName, assetTargetFallback, importFrameworks, packageTargetFallbackFrameworks, assetTargetFallbackFrameworks),
                 Dependencies = new List<LibraryDependency>(),
                 Imports = importFrameworks,
                 AssetTargetFallback = assetTargetFallback,

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -70,6 +70,7 @@ namespace NuGet.ProjectModel
             // Update the framework appropriately
             targetFrameworkInfo.FrameworkName = GetFallbackFramework(
                 targetFrameworkInfo.FrameworkName,
+                null, // There are no imports here. This utility is used in pack ref scenarios
                 packageTargetFallback,
                 assetTargetFallback);
 
@@ -102,6 +103,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static NuGetFramework GetFallbackFramework(
             NuGetFramework projectFramework,
+            IEnumerable<NuGetFramework> imports,
             IEnumerable<NuGetFramework> packageTargetFallback,
             IEnumerable<NuGetFramework> assetTargetFallback)
         {
@@ -110,8 +112,15 @@ namespace NuGet.ProjectModel
                 throw new ArgumentNullException(nameof(projectFramework));
             }
 
+            var hasImports = imports?.Any() == true;
             var hasATF = assetTargetFallback?.Any() == true;
             var hasPTF = packageTargetFallback?.Any() == true;
+
+            // Legacy Project.Json case
+            if (hasImports && !hasATF && !hasPTF)
+            {
+                return new FallbackFramework(projectFramework, imports.AsList());
+            }
 
             if (hasATF && !hasPTF)
             {

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -73,21 +73,25 @@ namespace NuGet.ProjectModel
                 packageTargetFallback,
                 assetTargetFallback);
 
-            if (assetTargetFallback?.Any() == true)
+            var hasAssetTargetFallback = assetTargetFallback?.Any() == true;
+            var hasPackageTargetFallback = packageTargetFallback?.Any() == true;
+
+            if (hasAssetTargetFallback)
             {
                 // AssetTargetFallback
                 // Legacy readers
                 targetFrameworkInfo.Imports = assetTargetFallback.AsList();
                 targetFrameworkInfo.AssetTargetFallback = true;
-
                 targetFrameworkInfo.AssetTargetFallbacks = assetTargetFallback.AsList();
                 targetFrameworkInfo.Warn = true;
             }
 
-            if (packageTargetFallback?.Any() == true)
+            if (hasPackageTargetFallback)
             {
                 // PackageTargetFallback
-                targetFrameworkInfo.Imports = packageTargetFallback.AsList();
+                if (!hasAssetTargetFallback) {  // Only override if there's no asset target fallback
+                    targetFrameworkInfo.Imports =  packageTargetFallback.AsList();
+                }
                 targetFrameworkInfo.PackageTargetFallbacks = packageTargetFallback.AsList();
             }
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -70,6 +70,7 @@ namespace NuGet.ProjectModel
             // Update the framework appropriately
             targetFrameworkInfo.FrameworkName = GetFallbackFramework(
                 targetFrameworkInfo.FrameworkName,
+                false, // Imports is null, so doesn't really matter what we have here
                 null, // There are no imports here. This utility is used in pack ref scenarios
                 packageTargetFallback,
                 assetTargetFallback);
@@ -103,6 +104,7 @@ namespace NuGet.ProjectModel
         /// </summary>
         public static NuGetFramework GetFallbackFramework(
             NuGetFramework projectFramework,
+            bool isAssetTargetFallback,
             IEnumerable<NuGetFramework> imports,
             IEnumerable<NuGetFramework> packageTargetFallback,
             IEnumerable<NuGetFramework> assetTargetFallback)
@@ -119,7 +121,14 @@ namespace NuGet.ProjectModel
             // Legacy Project.Json case
             if (hasImports && !hasATF && !hasPTF)
             {
-                return new FallbackFramework(projectFramework, imports.AsList());
+                if (isAssetTargetFallback)
+                {
+                    return new AssetTargetFallbackFramework(projectFramework, imports.AsList());
+                }
+                else
+                {
+                    return new FallbackFramework(projectFramework, imports.AsList());
+                }
             }
 
             if (hasATF && !hasPTF)

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -76,7 +76,11 @@ namespace NuGet.ProjectModel
             if (assetTargetFallback?.Any() == true)
             {
                 // AssetTargetFallback
-                targetFrameworkInfo.AssetTargetFallback = assetTargetFallback.AsList();
+                // Legacy readers
+                targetFrameworkInfo.Imports = assetTargetFallback.AsList();
+                targetFrameworkInfo.AssetTargetFallback = true;
+
+                targetFrameworkInfo.AssetTargetFallbacks = assetTargetFallback.AsList();
                 targetFrameworkInfo.Warn = true;
             }
 
@@ -84,6 +88,7 @@ namespace NuGet.ProjectModel
             {
                 // PackageTargetFallback
                 targetFrameworkInfo.Imports = packageTargetFallback.AsList();
+                targetFrameworkInfo.PackageTargetFallbacks = packageTargetFallback.AsList();
             }
         }
 

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -118,15 +118,16 @@ namespace NuGet.ProjectModel
             var hasATF = assetTargetFallback?.Any() == true;
             var hasPTF = packageTargetFallback?.Any() == true;
 
-            // Legacy Project.Json case
             if (hasImports && !hasATF && !hasPTF)
             {
                 if (isAssetTargetFallback)
                 {
+                    // Case where an older version of the package spec is being read
                     return new AssetTargetFallbackFramework(projectFramework, imports.AsList());
                 }
                 else
                 {
+                    // Legacy Project.Json case
                     return new FallbackFramework(projectFramework, imports.AsList());
                 }
             }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -441,8 +441,12 @@ namespace NuGet.ProjectModel
                     writer.WriteObjectStart(framework.FrameworkName.GetShortFolderName());
 
                     SetDependencies(writer, framework.Dependencies);
+                    // legacy behavior
                     SetFrameworkArrayToProperty(writer, framework.Imports, "imports");
-                    SetFrameworkArrayToProperty(writer, framework.AssetTargetFallback, "assetTargetFallback");
+                    SetValueIfTrue(writer, "assetTargetFallback", framework.AssetTargetFallback);
+                    // atf vs. ptf warnings hack
+                    SetFrameworkArrayToProperty(writer, framework.AssetTargetFallbacks, "assetTargetFallbacks");
+                    SetFrameworkArrayToProperty(writer, framework.PackageTargetFallbacks, "packageTargetFallbacks");
                     SetValueIfTrue(writer, "warn", framework.Warn);
 
                     writer.WriteObjectEnd();

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -75,6 +75,11 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(nameof(AssetTargetFallbacks));
             hashCode.AddSequence(AssetTargetFallbacks);
 
+            hashCode.AddObject(nameof(PackageTargetFallbacks ));
+            hashCode.AddSequence(PackageTargetFallbacks);
+
+            hashCode.AddObject(AssetTargetFallback);
+
             return hashCode.CombinedHash;
         }
 
@@ -98,6 +103,8 @@ namespace NuGet.ProjectModel
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
+                   PackageTargetFallbacks.SequenceEqualWithNullCheck(other.PackageTargetFallbacks) &&
+                   AssetTargetFallback == other.AssetTargetFallback &&
                    AssetTargetFallbacks.SequenceEqualWithNullCheck(other.AssetTargetFallbacks);
         }
     }

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -19,21 +19,37 @@ namespace NuGet.ProjectModel
         /// A fallback PCL framework to use when no compatible items
         /// were found for <see cref="FrameworkName"/>. This check is done
         /// per asset type.
+        /// Imports will contain either ATF or PTF, whichever one is being used.
         /// </summary>
-        /// <remarks>Deprecated. Use <see cref="AssetTargetFallback" /> instead.</remarks>
-        /// <see cref="Imports" /> cannot be used with <see cref="AssetTargetFallback" />.
+        /// <remarks>Deprecated. Use <see cref="AssetTargetFallbacks" /> instead.</remarks>
+        /// <see cref="Imports" /> cannot be used with <see cref="AssetTargetFallbacks" />.
         public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
+
+        /// <summary>
+        /// This is just kept for legacy readers.
+        /// </summary>
+        public bool AssetTargetFallback { get; set; }
 
         /// <summary>
         /// A fallback framework to use when no compatible items
         /// were found for <see cref="FrameworkName"/>. 
-        /// <see cref="AssetTargetFallback" /> will only fallback if the package
+        /// <see cref="AssetTargetFallbacks" /> will only fallback if the package
         /// does not contain any assets compatible with <see cref="FrameworkName"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="AssetTargetFallback" /> cannot be used with <see cref="Imports" />.
+        /// <see cref="AssetTargetFallbacks" /> cannot be used with <see cref="Imports" />.
         /// </remarks>
-        public IList<NuGetFramework> AssetTargetFallback { get; set; } = new List<NuGetFramework>();
+        public IList<NuGetFramework> AssetTargetFallbacks { get; set; } = new List<NuGetFramework>();
+
+        /// <summary>
+        /// A fallback framework to use when no compatible items
+        /// were found for <see cref="FrameworkName"/>. 
+        /// This is only used in order to preserve the behavior for legacy readers
+        /// </summary>
+        /// <remarks>
+        /// <see cref="PackageTargetFallbacks" /> cannot be used with <see cref="AssetTargetFallbacks" />.
+        /// </remarks>
+        public IList<NuGetFramework> PackageTargetFallbacks { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
         /// Display warnings when the Imports framework is used.
@@ -56,8 +72,8 @@ namespace NuGet.ProjectModel
             hashCode.AddObject(nameof(Imports));
             hashCode.AddSequence(Imports);
 
-            hashCode.AddObject(nameof(AssetTargetFallback));
-            hashCode.AddSequence(AssetTargetFallback);
+            hashCode.AddObject(nameof(AssetTargetFallbacks));
+            hashCode.AddSequence(AssetTargetFallbacks);
 
             return hashCode.CombinedHash;
         }
@@ -82,7 +98,7 @@ namespace NuGet.ProjectModel
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
-                   AssetTargetFallback.SequenceEqualWithNullCheck(other.AssetTargetFallback);
+                   AssetTargetFallbacks.SequenceEqualWithNullCheck(other.AssetTargetFallbacks);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -641,7 +641,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var actualRestoreSpec = packageSpecs.Single();
 
                 actualRestoreSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
-                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
             }
         }
 
@@ -684,7 +684,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 var actualRestoreSpec = packageSpecs.Single();
 
                 actualRestoreSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
-                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallbacks.Should().BeEmpty();
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -640,8 +640,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 var actualRestoreSpec = packageSpecs.Single();
 
-                actualRestoreSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
+                actualRestoreSpec.TargetFrameworks[0].PackageTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
                 actualRestoreSpec.TargetFrameworks[0].AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+                actualRestoreSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.Should().Be(true);
+
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -535,7 +535,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Assert
             project.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
-            project.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+            project.TargetFrameworks[0].AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
         }
 
         [Fact]
@@ -558,7 +558,7 @@ namespace NuGet.SolutionRestoreManager.Test
 
             // Assert
             project.TargetFrameworks[0].Imports.Should().BeEmpty();
-            project.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            project.TargetFrameworks[0].AssetTargetFallbacks.Should().BeEmpty();
         }
 
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -534,8 +534,10 @@ namespace NuGet.SolutionRestoreManager.Test
             var project = actualRestoreSpec.Projects.Single();
 
             // Assert
-            project.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
+            project.TargetFrameworks[0].PackageTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
             project.TargetFrameworks[0].AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+            project.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+            project.TargetFrameworks[0].AssetTargetFallback.Should().Be(true);
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
@@ -39,6 +39,8 @@ namespace NuGet.Commands.Test
                 }
             };
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback = true;
+            tfis[0].PackageTargetFallbacks.Add(NuGetFramework.Parse("net461"));
             tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
@@ -65,6 +67,8 @@ namespace NuGet.Commands.Test
                 }
             };
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback = true;
+            tfis[0].PackageTargetFallbacks.Add(NuGetFramework.Parse("net461"));
             tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
@@ -146,6 +150,8 @@ namespace NuGet.Commands.Test
                 }
             };
             tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
+            tfis[0].PackageTargetFallbacks.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback = true;
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
@@ -39,7 +39,7 @@ namespace NuGet.Commands.Test
                 }
             };
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
-            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
 
@@ -65,7 +65,7 @@ namespace NuGet.Commands.Test
                 }
             };
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
-            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
 
@@ -93,7 +93,7 @@ namespace NuGet.Commands.Test
 
             // Add PTF to one framework, and ATF to another
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
-            tfis[1].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[1].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
 
@@ -127,7 +127,7 @@ namespace NuGet.Commands.Test
                     FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
                 }
             };
-            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
 
@@ -145,7 +145,7 @@ namespace NuGet.Commands.Test
                     FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
                 }
             };
-            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
             tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
@@ -167,7 +167,7 @@ namespace NuGet.Commands.Test
                     FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
                 }
             };
-            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net461"));
 
             var project = new PackageSpec(tfis);
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -647,11 +647,11 @@ namespace NuGet.Commands.Test
                 var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
 
                 // Assert
-                Assert.Equal(2, nsTFM.AssetTargetFallback.Count);
-                Assert.Equal(0, netTFM.AssetTargetFallback.Count);
+                Assert.Equal(2, nsTFM.AssetTargetFallbacks.Count);
+                Assert.Equal(0, netTFM.AssetTargetFallbacks.Count);
 
-                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.AssetTargetFallback[0]);
-                Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.AssetTargetFallback[1]);
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.AssetTargetFallbacks[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.AssetTargetFallbacks[1]);
 
                 // Verify fallback framework
                 var assetTargetFallbackFramewrk = (AssetTargetFallbackFramework)project1Spec.TargetFrameworks

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
@@ -13,10 +13,10 @@ namespace NuGet.ProjectModel.Test
         public void GivenAssetTargetFallbackHasAValueVerifyValuePersisted()
         {
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback.Add(NuGetFramework.Parse("net45"));
+            spec.TargetFrameworks[0].AssetTargetFallbacks.Add(NuGetFramework.Parse("net45"));
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            outSpec.TargetFrameworks[0].AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
             outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
@@ -26,7 +26,7 @@ namespace NuGet.ProjectModel.Test
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            outSpec.TargetFrameworks[0].AssetTargetFallbacks.Should().BeEmpty();
             outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
@@ -39,7 +39,7 @@ namespace NuGet.ProjectModel.Test
 
             var outSpec = spec.RoundTrip();
             outSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { net461 });
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            outSpec.TargetFrameworks[0].AssetTargetFallbacks.Should().BeEmpty();
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace NuGet.ProjectModel.Test
             var net461 = NuGetFramework.Parse("net461");
             var projectFramework = NuGetFramework.Parse("netcoreapp2.0");
             var spec = PackageSpecTestUtility.GetSpec(projectFramework);
-            spec.TargetFrameworks[0].AssetTargetFallback.Add(net461);
+            spec.TargetFrameworks[0].AssetTargetFallbacks.Add(net461);
 
             var outSpec = spec.RoundTrip();
 
@@ -62,7 +62,7 @@ namespace NuGet.ProjectModel.Test
         {
             var net461 = NuGetFramework.Parse("net461");
             var spec1 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
-            spec1.TargetFrameworks[0].AssetTargetFallback.Add(net461);
+            spec1.TargetFrameworks[0].AssetTargetFallbacks.Add(net461);
             var spec2 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
             spec2.TargetFrameworks[0].Imports.Add(net461);
 

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -62,7 +62,7 @@ namespace NuGet.ProjectModel.Test
             var atf = new List<NuGetFramework>();
             var ptf = new List<NuGetFramework>();
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, null,  ptf, atf);
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, null, ptf, atf);
 
             result.Should().Be(project, "no atf or ptf frameworks exist");
         }
@@ -72,7 +72,7 @@ namespace NuGet.ProjectModel.Test
         {
             var project = NuGetFramework.Parse("netcoreapp2.0");
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, null, packageTargetFallback: null, assetTargetFallback: null);
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, null, packageTargetFallback: null, assetTargetFallback: null);
 
             result.Should().Be(project, "no atf or ptf frameworks exist");
         }
@@ -87,7 +87,7 @@ namespace NuGet.ProjectModel.Test
                 NuGetFramework.Parse("net461")
             };
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, null, ptf, atf) as FallbackFramework;
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, null, ptf, atf) as FallbackFramework;
 
             result.Fallback.ShouldBeEquivalentTo(ptf);
         }
@@ -102,7 +102,7 @@ namespace NuGet.ProjectModel.Test
                 NuGetFramework.Parse("net461")
             };
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, null, ptf, atf) as AssetTargetFallbackFramework;
+            var result = PackageSpecUtility.GetFallbackFramework(project, true, null, ptf, atf) as AssetTargetFallbackFramework;
 
             result.Fallback.ShouldBeEquivalentTo(atf);
         }
@@ -120,7 +120,7 @@ namespace NuGet.ProjectModel.Test
                 NuGetFramework.Parse("net461")
             };
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, null, ptf, atf);
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, null, ptf, atf);
 
             result.Should().Be(project, "both atf and ptf will be ignored");
         }
@@ -134,7 +134,21 @@ namespace NuGet.ProjectModel.Test
                 NuGetFramework.Parse("net461")
             };
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, imports, null, null) as FallbackFramework;
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, imports, null, null) as FallbackFramework;
+
+            result.Fallback.ShouldBeEquivalentTo(imports, "When there is no ATF/PTF the imports is used. this is the project.json scenario");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworWithImportsAndATFFlagOnlyVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var imports = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project,true, imports, null, null) as AssetTargetFallbackFramework;
 
             result.Fallback.ShouldBeEquivalentTo(imports, "When there is no ATF/PTF the imports is used. this is the project.json scenario");
         }
@@ -154,7 +168,7 @@ namespace NuGet.ProjectModel.Test
             };
 
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, imports, ptf, null) as FallbackFramework;
+            var result = PackageSpecUtility.GetFallbackFramework(project, false, imports, ptf, null) as FallbackFramework;
 
             result.Fallback.ShouldBeEquivalentTo(ptf, "When there is ptf and imports, ptf is favored");
         }
@@ -174,7 +188,7 @@ namespace NuGet.ProjectModel.Test
             };
 
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, imports, null, atf) as AssetTargetFallbackFramework;
+            var result = PackageSpecUtility.GetFallbackFramework(project, true, imports, null, atf) as AssetTargetFallbackFramework;
 
             result.Fallback.ShouldBeEquivalentTo(atf, "When there is ptf and imports, ptf is favored");
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -206,8 +206,10 @@ namespace NuGet.ProjectModel.Test
 
             PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
 
-            frameworkInfo.Imports.Should().BeEmpty();
+            frameworkInfo.PackageTargetFallbacks.Should().BeEmpty();
+            frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
             frameworkInfo.AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(true);
 
             frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
             frameworkInfo.FrameworkName.Should().BeOfType(typeof(AssetTargetFallbackFramework));

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -72,7 +72,7 @@ namespace NuGet.ProjectModel.Test
         {
             var project = NuGetFramework.Parse("netcoreapp2.0");
 
-            var result = PackageSpecUtility.GetFallbackFramework(project, false, null, packageTargetFallback: null, assetTargetFallback: null);
+            var result = PackageSpecUtility.GetFallbackFramework(project, isAssetTargetFallback : false, imports : null, packageTargetFallback: null, assetTargetFallback: null);
 
             result.Should().Be(project, "no atf or ptf frameworks exist");
         }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -143,7 +143,7 @@ namespace NuGet.ProjectModel.Test
 
             PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
 
-            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            frameworkInfo.AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
             frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
 
             frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
@@ -162,7 +162,7 @@ namespace NuGet.ProjectModel.Test
 
             PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
 
-            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.AssetTargetFallbacks.Should().BeEmpty();
             frameworkInfo.Imports.Should().BeEmpty();
 
             frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
@@ -184,7 +184,7 @@ namespace NuGet.ProjectModel.Test
 
             PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
 
-            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.AssetTargetFallbacks.Should().BeEmpty();
             frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
 
             frameworkInfo.FrameworkName.Should().BeOfType(typeof(FallbackFramework));
@@ -207,7 +207,7 @@ namespace NuGet.ProjectModel.Test
             PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
 
             frameworkInfo.Imports.Should().BeEmpty();
-            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+            frameworkInfo.AssetTargetFallbacks.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
 
             frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
             frameworkInfo.FrameworkName.Should().BeOfType(typeof(AssetTargetFallbackFramework));


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5449

Currently we have different dlls in SDK + VS.
In SDK based projects, the SDK loads nuget bits outside of devenv.exe so the old reader could not cope with the changes made to the assets file/package spec. 

To workaround this, instead of changing what we write, we will just do both right now, and use each in the appropriate situation. 
Since the last change's target was to add a warning message, this one preserves that. 
Yet it allows the old reader to just read the assetTargetFallback and Imports object it expected. 

//cc
@rrelyea 

PS. The conflicts are ok...since the release branch currently has Justin's commit reverted. Before merging this commit we would need to reapply Justin's change. 

*** impact ***

This changes covers the scenarios of assets file backwards compatibility among assets files written by old and new style atf/ptf warning. 

Meaning if an assets file contained only imports and assetTargetFallback bool, then the fallback framework will be interpreted as AssetTargetFallbackFramework/FallbackFramework based on the bool. 

Open issue is that when we insert for 15.3 P4, lock files generated by VS P3/CLI P2 will be incompatible with that and break. 
This break is similar to the break that would've happened with the initial assetTargetFallback bool to array change, and since it doesn't affect official release rather just previews, this should be ok. 
