### PR TITLE
NuGet "ImportsFallbackWarning" has grammatical error: 'instead ??? th…

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -21,6 +21,7 @@ namespace NuGet.Commands {
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -603,7 +604,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package &apos;{0}&apos; was restored using &apos;{1}&apos; instead the project target framework &apos;{2}&apos;. This may cause compatibility problems..
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; was restored using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This may cause compatibility problems..
         /// </summary>
         internal static string Log_ImportsFallbackWarning {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -198,7 +198,7 @@
     <value>Dependency specified was {0} {1} but ended up with {2} {3}.</value>
   </data>
   <data name="Log_ImportsFallbackWarning" xml:space="preserve">
-    <value>Package '{0}' was restored using '{1}' instead the project target framework '{2}'. This may cause compatibility problems.</value>
+    <value>Package '{0}' was restored using '{1}' instead of the project target framework '{2}'. This may cause compatibility problems.</value>
   </data>
   <data name="Log_CycleDetected" xml:space="preserve">
     <value>Cycle detected.</value>

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -746,7 +746,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
-                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
+                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead of the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
 
                 // Act
                 var result = await command.ExecuteAsync();


### PR DESCRIPTION
…e project target framework'

 #Closes https://github.com/NuGet/Home/issues/5453

cc @rrelyea - this is the bug I mentioned to you in IM. Alotta people gonna see this error due to the ATF/PTF change so it'd be good to nail the grammar on it.