### PR TITLE
fix assembly public key token - Fixes mac tests

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -366,7 +366,7 @@ namespace NuGet.CommandLine
             try
             {
                 var assembly = Assembly.Load(
-                    "Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f1d50a3a");
+                    "Microsoft.Build.Engine, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
                 var solutionParserType = assembly.GetType("Mono.XBuild.CommandLine.SolutionParser");
                 if (solutionParserType == null)
                 {


### PR DESCRIPTION
Fix the assembly public token.
It was accidentally changed in https://github.com/NuGet/NuGet.Client/commit/d76273f17504b18108cd14aa83b2862e4ca1c075#diff-df4212eb808fdbb3ba56db14d9912ac0L281

//cc @rrelyea 