### PR TITLE
Changing replay call from _request.Log to _logger while replaying restore warnings during no-op

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -230,7 +230,7 @@ namespace NuGet.Commands
                     EndColumnNumber = logMessage.EndColumnNumber
                 };
 
-                _request.Log.LogAsync(restoreLogMessage);
+                _logger.LogAsync(restoreLogMessage);
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5470

Change - 
Currently we were using `_request.Log` to replay the warnings from the assets file in case of a restore no-op. This was causing duplicate warnings in the VS error list because the `_request.Log` does not have enough context to filter messages based on the project type. `_logger` is a `RestoreCollectoreLogger` and has more context while filtering messages [here](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Commands/RestoreCommand/Logging/RestoreCollectorLogger.cs#L109).