### PR TITLE
Revert unnecessary project.json change in #1512

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/project.json
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/project.json
@@ -1,6 +1,5 @@
 ﻿{
   "dependencies": {
-    "Microsoft.VisualStudio.Threading": "15.0.240",
     "PdbGit": {
       "version": "3.0.41",
       "suppressParent": "all"


### PR DESCRIPTION
Revert unnecessary project.json change in #1512.  Microsoft.VisualStudio.Threading.dll is referenced transitively through the NuGet.VisualStudio.Common reference.

For NuGet/Home#5486.