### PR TITLE
Updating the localization validator version and package

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -21,5 +21,5 @@
   <package id="xunit.runner.console" version="2.2.0" targetFramework="net45" />
   <package id="xunit.runner.msbuild" version="2.2.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
-  <package id="NuGetValidator" version="1.3.1" targetFramework="net461" />
+  <package id="NuGetValidator" version="1.3.3" targetFramework="net461" />
 </packages>

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -21,5 +21,5 @@
   <package id="xunit.runner.console" version="2.2.0" targetFramework="net45" />
   <package id="xunit.runner.msbuild" version="2.2.0" targetFramework="net45" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net45" />
-  <package id="NuGetValidator.Localization" version="1.2.0" targetFramework="net45" />
+  <package id="NuGetValidator" version="1.3.1" targetFramework="net461" />
 </packages>

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -18,28 +18,39 @@ param
     [Parameter(Mandatory=$True)]
     [string]$BuildOutputTargetPath,
     [Parameter(Mandatory=$True)]
-    [string]$BuildRTM
+    [string]$BuildRTM,
+    [switch]$ValidateVsix
 )
 
 
 if ($BuildRTM -eq 'false')
 {   
+
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
     $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.1.3.1', 'tools', 'NuGetValidator.exe')
-    $ArtifactsLocation = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts')
-    $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'Insertable', 'NuGet.Tools.vsix' )
-    $VsixExtractLocation = [System.IO.Path]::Combine($env:SYSTEM_DEFAULTWORKINGDIRECTORY, 'extractedVsix' ) 
-    $ArtifactsLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'artifacts' )
     $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
-
-    Write-Host "Running: $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository"
-    & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository
-
-    # We no longer validate the vsix for localization. Leaving this here, in case this is needed in the future.
-    # Write-Host "\n\nRunning: $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository"
-    # & $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository
     
+    if ($ValidateVsix) 
+    {
+        $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'Insertable', 'NuGet.Tools.vsix' )
+        $VsixExtractLocation = [System.IO.Path]::Combine($env:SYSTEM_DEFAULTWORKINGDIRECTORY, 'extractedVsix' ) 
+        $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
+
+        Write-Host "Validating NuGet.Tools.Vsix localization..."
+        Write-Host "Running: $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository"
+        & $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository
+    }
+    else 
+    {
+        $ArtifactsLocation = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts')
+        $ArtifactsLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'artifacts' )
+
+        Write-Host "Validating NuGet.Client repository localization..."
+        Write-Host "Running: $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository"
+        & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository
+    }
+
     # We want to exit the process with success even if there are errors.
     exit 0
 }

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -23,14 +23,23 @@ param
 
 
 if ($BuildRTM -eq 'false')
-{    
+{   
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $LocValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.Localization.1.2.0', 'tools', 'NuGetValidator.Localization.exe')
-    $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'Insertable', 'NuGet.Tools.vsix' ) 
-    $VsixExtractLocation = Join-Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY "extractedVsix"
-    $LogOutputDir = Join-Path $BuildOutputTargetPath "LocalizationValidation"
+    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.1.3.1', 'tools', 'NuGetValidator.exe')
+    $ArtifactsLocation = [System.IO.Path]::Combine($NuGetClientRoot, 'artifacts')
+    $VsixLocation = [System.IO.Path]::Combine($BuildOutputTargetPath, 'artifacts', 'VS15', 'Insertable', 'NuGet.Tools.vsix' )
+    $VsixExtractLocation = [System.IO.Path]::Combine($env:SYSTEM_DEFAULTWORKINGDIRECTORY, 'extractedVsix' ) 
+    $ArtifactsLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'artifacts' )
+    $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
-    & $LocValidator $VsixLocation $VsixExtractLocation $LogOutputDir $LocalizationRepository
+
+    Write-Host "Running: $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository"
+    & $NuGetValidator localization --artifacts-path $ArtifactsLocation --output-path $ArtifactsLogOutputDir --comments-path $LocalizationRepository
+
+    # We no longer validate the vsix for localization. Leaving this here, in case this is needed in the future.
+    # Write-Host "\n\nRunning: $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository"
+    # & $NuGetValidator localization --vsix --vsix-path $VsixLocation --vsix-extract-path $VsixExtractLocation --output-path $VsixLogOutputDir --comments-path $LocalizationRepository
+    
     # We want to exit the process with success even if there are errors.
     exit 0
 }

--- a/scripts/cibuild/BuildValidator.ps1
+++ b/scripts/cibuild/BuildValidator.ps1
@@ -27,7 +27,7 @@ if ($BuildRTM -eq 'false')
 {   
 
     $NuGetClientRoot = $env:BUILD_REPOSITORY_LOCALPATH
-    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.1.3.1', 'tools', 'NuGetValidator.exe')
+    $NuGetValidator = [System.IO.Path]::Combine($NuGetClientRoot, 'packages', 'NuGetValidator.1.3.3', 'tools', 'NuGetValidator.exe')
     $VsixLogOutputDir = [System.IO.Path]::Combine($BuildOutputTargetPath, 'LocalizationValidation', 'vsix' )
     $LocalizationRepository = [System.IO.Path]::Combine($NuGetClientRoot, 'submodules', 'NuGet.Build.Localization', 'localize', 'comments', '15')
     


### PR DESCRIPTION
Updating the localization validator package and changing the call style.

The new package will validate the `NuGet.Client\artifacts` directory on the CI machines and thus will also validate dlls which are not part of the vsix.