### PR TITLE
Improve E2E test setup time

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -1,4 +1,4 @@
-﻿param (
+param (
     [Parameter(Mandatory=$true)]
     [string]$NuGetDropPath,
     [Parameter(Mandatory=$true)]
@@ -6,12 +6,11 @@
     [Parameter(Mandatory=$true)]
     [string]$NuGetVSIXID,
     [Parameter(Mandatory=$true)]
-    [int]$VSIXInstallerWaitTimeInSecs,
+    [int]$ProcessExitTimeoutInSeconds,
     [Parameter(Mandatory=$true)]
-	[ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
+    [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
     [string]$VSVersion)
 
-. "$PSScriptRoot\Utils.ps1"
 . "$PSScriptRoot\VSUtils.ps1"
 
 $success = IsAdminPrompt
@@ -27,8 +26,6 @@ if ($success -eq $false)
 
 KillRunningInstancesOfVS
 
-start-sleep -Seconds $VSIXInstallerWaitTimeInSecs
-
 $VSIXSrcPath = Join-Path $NuGetDropPath 'NuGet.Tools.vsix'
 $VSIXPath = Join-Path $FuncTestRoot 'NuGet.Tools.vsix'
 
@@ -38,27 +35,27 @@ Copy-Item $VSIXSrcPath $VSIXPath
 # For dev 15, we upgrade an installed system component vsix
 if($VSVersion -eq '14.0')
 {
-	$success = UninstallVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
-	if ($success -eq $false)
-	{
-		exit 1
-	}
-}
-else 
-{
-    #We don't care for the downgrade result...we should be able to install on top anyways.
-    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $VSIXInstallerWaitTimeInSecs
-    
+    $success = UninstallVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
     if ($success -eq $false)
     {
         exit 1
     }
-        
+}
+else 
+{
+    #We don't care for the downgrade result...we should be able to install on top anyways.
+    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
+
+    if ($success -eq $false)
+    {
+        exit 1
+    }
+
     # Clearing MEF cache helps load the right dlls for vsix
     ClearDev15MEFCache
 }
 
-$success = InstallVSIX $VSIXPath $VSVersion $VSIXInstallerWaitTimeInSecs
+$success = InstallVSIX $VSIXPath $VSVersion $ProcessExitTimeoutInSeconds
 if ($success -eq $false)
 {
     exit 1

--- a/scripts/e2etests/LaunchVS.ps1
+++ b/scripts/e2etests/LaunchVS.ps1
@@ -1,4 +1,4 @@
-﻿param (
+param (
 [Parameter(Mandatory=$true)]
 [ValidateSet("15.0", "14.0", "12.0", "11.0", "10.0")]
 [string]$VSVersion,
@@ -18,8 +18,6 @@ trap
 function LaunchVSAndWaitForDTE
 {
     KillRunningInstancesOfVS
-    Write-Host 'Waiting for 5 seconds after killing VS'
-    start-sleep 5
 
     LaunchVS $VSVersion
 
@@ -38,7 +36,7 @@ function LaunchVSAndWaitForDTE
         {
             Write-Host 'Obtained DTE. Wait for 5 seconds...'
             start-sleep 5
-	        return $true
+            return $true
         }
 
         $count++

--- a/scripts/e2etests/Utils.ps1
+++ b/scripts/e2etests/Utils.ps1
@@ -1,4 +1,4 @@
-﻿function CleanTempFolder()
+function CleanTempFolder()
 {
     if (Test-Path $env:temp)
     {
@@ -98,4 +98,29 @@ function DisableCrashDialog()
     }
 
     Write-Host -ForegroundColor Cyan 'Windows crash dialog has been disabled'
+}
+
+function WaitForProcessExit
+{
+    param
+    (
+        [Parameter(Mandatory=$true)]
+        [string]$ProcessName,
+        [Parameter(Mandatory=$true)]
+        [int]$TimeoutInSeconds
+    )
+
+    try
+    {
+        Wait-Process -Name "$ProcessName" -Timeout $TimeoutInSeconds -ErrorAction Stop
+    }
+    catch [System.Management.Automation.ActionPreferenceStopException]
+    {
+        if ($_.Exception -is [System.TimeoutException])
+        {
+            throw;
+        }
+
+        # Otherwise, the process could not be found.
+    }
 }


### PR DESCRIPTION
~6-11 minutes is spent in E2E setup time sleeping until processes exit.  Instead of sleeping a fixed amount of time, the scripts should wait for the processes to exit.  This will shave ~6-11 minutes off every E2E test run.