### PR TITLE
Add the .nuget.cache files to the clean target, restore solution command does not force restore

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/SolutionRestoreRequest.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/SolutionRestoreRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.VisualStudio
@@ -47,7 +47,7 @@ namespace NuGet.VisualStudio
         public static SolutionRestoreRequest ByMenu()
         {
             return new SolutionRestoreRequest(
-                forceRestore: true,
+                forceRestore: false,
                 restoreSource: RestoreOperationSource.Explicit);
         }
 

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -70,19 +70,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 
-  <Target Name="_CleanCacheFiles"
-          DependsOnTargets="_GetRestoreProjectStyle"
-          Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'PackageReference' "
-          AfterTargets="Clean">
-    <PropertyGroup>
-      <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(BaseIntermediateOutputPath)</RestoreOutputPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <_PackageFilesToDelete Include="$(RestoreOutputPath)*.nuget.cache"/>
-    </ItemGroup>
-    <Delete Files="@(_PackageFilesToDelete)"/>
-  </Target>
-
   <!-- Tasks -->
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WriteRestoreGraphTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
@@ -892,4 +879,21 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_RestoreFallbackFoldersOverride>$(RestoreFallbackFolders)</_RestoreFallbackFoldersOverride>
     </PropertyGroup>
   </Target>
+
+  <!--
+    ============================================================
+    _CleanCacheFiles
+    Deletes all the *.nuget.cache files in the obj directory
+    ============================================================
+  -->
+  <Target Name="_CleanCacheFiles" DependsOnTargets="_GetRestoreProjectStyle" Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'PackageReference' " AfterTargets="Clean">
+    <PropertyGroup>
+        <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</RestoreOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+        <_PackageFilesToDelete Include="$(RestoreOutputPath)*.nuget.cache" />
+    </ItemGroup>
+    <Delete Files="@(_PackageFilesToDelete)" />
+  </Target>
+
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -886,7 +886,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     Deletes all the *.nuget.cache files in the obj directory
     ============================================================
   -->
-  <Target Name="_CleanCacheFiles" DependsOnTargets="_GetRestoreProjectStyle" Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'PackageReference' " AfterTargets="Clean">
+  <Target Name="_CleanCacheFiles" 
+          AfterTargets="Clean">
     <PropertyGroup>
         <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</RestoreOutputPath>
     </PropertyGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -882,11 +882,11 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-    _CleanCacheFiles
+    _CleanRestoreCacheFiles
     Deletes all the *.nuget.cache files in the obj directory
     ============================================================
   -->
-  <Target Name="_CleanCacheFiles" 
+  <Target Name="_CleanRestoreCacheFiles" 
           AfterTargets="Clean">
     <PropertyGroup>
         <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' != '' ">$(RestoreOutputPath)</CacheFileOutputPath>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -889,12 +889,13 @@ Copyright (c) .NET Foundation. All rights reserved.
   <Target Name="_CleanCacheFiles" 
           AfterTargets="Clean">
     <PropertyGroup>
-        <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</RestoreOutputPath>
+        <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' != '' ">$(RestoreOutputPath)</CacheFileOutputPath>
+        <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</CacheFileOutputPath>
     </PropertyGroup>
     <ItemGroup>
-        <_PackageFilesToDelete Include="$(RestoreOutputPath)*.nuget.cache" />
+        <_CacheFilesToDelete Include="$(CacheFileOutputPath)*.nuget.cache" />
     </ItemGroup>
-    <Delete Files="@(_PackageFilesToDelete)" />
+    <Delete Files="@(_CacheFilesToDelete)" />
   </Target>
 
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -71,6 +71,8 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
 
   <Target Name="_CleanCacheFiles"
+          DependsOnTargets="_GetRestoreProjectStyle"
+          Condition=" '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(RestoreProjectStyle)' == 'PackageReference' "
           AfterTargets="Clean">
     <PropertyGroup>
       <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(BaseIntermediateOutputPath)</RestoreOutputPath>

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -70,6 +70,17 @@ Copyright (c) .NET Foundation. All rights reserved.
     </_GenerateRestoreGraphProjectEntryInputProperties>
   </PropertyGroup>
 
+  <Target Name="_CleanCacheFiles"
+          AfterTargets="Clean">
+    <PropertyGroup>
+      <RestoreOutputPath Condition=" '$(RestoreOutputPath)' == '' " >$(BaseIntermediateOutputPath)</RestoreOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_PackageFilesToDelete Include="$(RestoreOutputPath)*.nuget.cache"/>
+    </ItemGroup>
+    <Delete Files="@(_PackageFilesToDelete)"/>
+  </Target>
+
   <!-- Tasks -->
   <UsingTask TaskName="NuGet.Build.Tasks.RestoreTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WriteRestoreGraphTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -117,6 +117,28 @@ function Assert-ProjectJsonLockFilePackage {
     Assert-True $found "Package $Id $Version was not found in the lock file for $($Project.Name)"    
 }
 
+function Assert-ProjectCacheFileExists {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project
+    )
+
+    $cacheFile = Get-ProjectCacheFilePath $Project
+
+    Assert-PathExists $cacheFile
+}
+
+function Assert-ProjectCacheFileNotExists {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project
+    )
+
+    $cacheFile = Get-ProjectCacheFilePath $Project
+
+    Assert-PathNotExists $cacheFile
+}
+
 function Assert-ProjectJsonLockFilePackageNotFound {
     param(
         [parameter(Mandatory = $true)]
@@ -294,6 +316,28 @@ function Set-ProjectJsonLockFile {
 
     return $lockFileFormat.Write($projectJsonLockFilePath, $LockFile)
 }
+
+function Get-ProjectCacheFilePath {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project
+    )
+        return CacheFilePathFromProjectPath $Project.FullName
+}
+
+function Get-CacheFilePathFromProjectPath {
+        param(
+        [parameter(Mandatory = $true)]
+        $ProjectPath
+        )
+        
+    $projectCacheFilePath = Join-Path (Split-Path -parent $ProjectPath) (Join-Path "obj" "$(Split-Path -Leaf $ProjectPath).nuget.cache")
+
+    Write-Host "Evaluated cache file path:" $projectCacheFilePath
+
+    return $projectCacheFilePath
+}
+
 
 function Get-ProjectJsonLockFilePath {
     param(

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -477,3 +477,19 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTr
     # Assert
     Assert-ProjectJsonLockFilePackage $project1 NuGet.Versioning 1.0.7
 }
+
+function Test-BuildIntegratedClean {
+    # Arrange
+    $project = New-BuildIntegratedProj UAPApp
+
+    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
+    Build-Solution
+    
+    Assert-ProjectCacheFileExists $project
+
+    #Act
+    Clean-Solution
+
+    #Assert
+    Assert-ProjectCacheFileNotExists $project
+}

--- a/test/EndToEnd/tests/LightweightSolutionLoadTest.ps1
+++ b/test/EndToEnd/tests/LightweightSolutionLoadTest.ps1
@@ -324,3 +324,29 @@ function Test-DeferredBuildIntegratedProjectGetPackageTransitive {
 function TestCases-DeferredBuildIntegratedProjectGetPackageTransitive{
     BuildProjectTemplateTestCases 'PackageReferenceClassLibrary', 'BuildIntegratedClassLibrary'
 }
+
+function Test-DeferredProjectClean {
+
+    [SkipTestForVS14()]
+    param(
+        $context
+    )
+
+    $project = New-Project BuildIntegratedClassLibrary Project1
+    $project | Install-Package NuGet.Versioning -Version 1.0.7
+
+    Build-Solution
+
+    # Act
+    $cacheFile = Get-CacheFilePathFromProjectPath $project.FullName
+
+    Assert-PathExists $cacheFile
+
+    Enable-LightweightSolutionLoad -Reload
+
+    #Act
+    Clean-Solution
+
+    #Assert
+    Assert-PathNotExists $cacheFile
+}

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -761,3 +761,19 @@ function Test-NetStandardClassLibraryTransitivePackageLimit {
     Assert-NetCoreNoPackageReference $projectX $id
     Assert-NetCorePackageNotInLockFile $projectX $id
 }
+
+function Test-NetCoreConsoleAppClean {
+
+    # Arrange & Act
+    $project = New-NetCoreConsoleApp ConsoleApp
+
+    Build-Solution
+    
+    Assert-ProjectCacheFileExists $project
+
+    #Act
+    Clean-Solution
+
+    #Assert
+    Assert-ProjectCacheFileNotExists $project
+}


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5451
Fixes https://github.com/NuGet/Home/issues/5061

Adding the cache files to the clean target. 
Reverting the Restore Solution Command to allow no-op as it was in 15.1. 

Added E2E for the clean. 

//cc @rrelyea 