### PR TITLE
Filtering out projects which are not part of current solution update operation

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/NuGetPackageManager.cs
@@ -654,24 +654,38 @@ namespace NuGet.PackageManagement
             // add tasks for all build integrated projects
             foreach (var project in buildIntegratedProjects)
             {
-                // if tasks count reachs max then wait until an existing task is completed
-                if (tasks.Count >= maxTasks)
+                var packagesToUpdateInProject = await GetPackagesToUpdateInProject(project, packageIdentities, token);
+                if (packagesToUpdateInProject.Count > 0)
                 {
-                    var actions = await CompleteTaskAsync(tasks);
-                    nugetActions.AddRange(actions);
-                }
+                    var includePrerelease = packagesToUpdateInProject.Any(
+                        package => package.Version.IsPrerelease);
 
-                // project.json based projects are handled here
-                tasks.Add(Task.Run(async ()
-                    => await PreviewUpdatePackagesForBuildIntegratedAsync(
-                        packageId,
-                        packageIdentities,
-                        project,
-                        resolutionContext,
-                        nuGetProjectContext,
-                        primarySources,
-                        secondarySources,
-                        token)));
+                    var updatedResolutionContext = new ResolutionContext(
+                        dependencyBehavior: resolutionContext.DependencyBehavior,
+                        includePrelease: includePrerelease,
+                        includeUnlisted: resolutionContext.IncludeUnlisted,
+                        versionConstraints: resolutionContext.VersionConstraints,
+                        gatherCache: resolutionContext.GatherCache);
+
+                    // if tasks count reachs max then wait until an existing task is completed
+                    if (tasks.Count >= maxTasks)
+                    {
+                        var actions = await CompleteTaskAsync(tasks);
+                        nugetActions.AddRange(actions);
+                    }
+
+                    // project.json based projects are handled here
+                    tasks.Add(Task.Run(async ()
+                        => await PreviewUpdatePackagesForBuildIntegratedAsync(
+                            packageId,
+                            packagesToUpdateInProject,
+                            project,
+                            updatedResolutionContext,
+                            nuGetProjectContext,
+                            primarySources,
+                            secondarySources,
+                            token)));
+                }
             }
 
             // Wait for all restores to finish
@@ -680,19 +694,52 @@ namespace NuGet.PackageManagement
 
             foreach (var project in nonBuildIntegratedProjects)
             {
-                // packages.config based projects are handled here
-                nugetActions.AddRange(await PreviewUpdatePackagesForClassicAsync(
+                var packagesToUpdateInProject = await GetPackagesToUpdateInProject(project, packageIdentities, token);
+                if (packagesToUpdateInProject.Count > 0)
+                {
+                    var includePrerelease = packagesToUpdateInProject.Any(
+                        package => package.Version.IsPrerelease);
+
+                    var updatedResolutionContext = new ResolutionContext(
+                        dependencyBehavior: resolutionContext.DependencyBehavior,
+                        includePrelease: includePrerelease,
+                        includeUnlisted: resolutionContext.IncludeUnlisted,
+                        versionConstraints: resolutionContext.VersionConstraints,
+                        gatherCache: resolutionContext.GatherCache);
+
+                    // packages.config based projects are handled here
+                    nugetActions.AddRange(await PreviewUpdatePackagesForClassicAsync(
                     packageId,
-                    packageIdentities,
+                    packagesToUpdateInProject,
                     project,
-                    resolutionContext,
+                    updatedResolutionContext,
                     nuGetProjectContext,
                     primarySources,
                     secondarySources,
                     token));
+                }
             }
 
             return nugetActions;
+        }
+
+        private async Task<List<PackageIdentity>> GetPackagesToUpdateInProject(
+            NuGetProject project,
+            List<PackageIdentity> packages,
+            CancellationToken token)
+        {
+            var installedPackages = await project.GetInstalledPackagesAsync(token);
+
+            var packageIds = new HashSet<string>(
+                installedPackages.Select(p => p.PackageIdentity.Id), StringComparer.OrdinalIgnoreCase);
+
+            // We need to filter out packages from packagesToUpdate that are not installed
+            // in the current project. Otherwise, we'll incorrectly install a
+            // package that is not installed before.
+            var packagesToUpdateInProject = packages.Where(
+                package => packageIds.Contains(package.Id)).ToList();
+
+            return packagesToUpdateInProject;
         }
 
         private async Task<IEnumerable<NuGetProjectAction>> CompleteTaskAsync(

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/TestNuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -22,11 +22,22 @@ namespace NuGet.Test
             _installedPackages = installedPackages;
         }
 
+        public TestNuGetProject(string projectName, IList<Packaging.PackageReference> installedPackages)
+            : base(CreateMetadata(projectName))
+        {
+            _installedPackages = installedPackages;
+        }
+
         private static Dictionary<string, object> CreateMetadata()
+        {
+            return CreateMetadata(nameof(TestNuGetProject));
+        }
+
+        private static Dictionary<string, object> CreateMetadata(string projectName)
         {
             return new Dictionary<string, object>
             {
-                { NuGetProjectMetadataKeys.Name, nameof(TestNuGetProject) },
+                { NuGetProjectMetadataKeys.Name, projectName },
                 { NuGetProjectMetadataKeys.TargetFramework, NuGetFramework.Parse("net45") },
                 { NuGetProjectMetadataKeys.ProjectId, Guid.NewGuid().ToString() },
             };


### PR DESCRIPTION
So it was a regression post 3.5.0 where we stopped filtering our projects which shouldn't be checked for updates which are not part of current solution update operation. 

Fixes https://github.com/NuGet/Home/issues/5508

After this change - shows total 38 installs across 6 projects for different combination of 15 packages
![image](https://user-images.githubusercontent.com/18219758/27750405-883a7978-5d8c-11e7-9a86-eb1041e6d513.png)

Compare to previous update where it showed total 86 installs across 18 projects for different combination of 28 packages (even installing packages out of those 15)

@rrelyea 