### PR TITLE
Fixing AdditionalProjectSource and AdditionalFallbackSources to read from the configs when the RestoreSources/RestoreFallbackFolders are set.

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-
   <PropertyGroup>
     <Shipping>true</Shipping>
     <IncludeInVSIX>true</IncludeInVSIX>
@@ -17,7 +16,6 @@
     <SkipValidatePackageReferences>true</SkipValidatePackageReferences>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -27,7 +25,6 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -55,7 +52,6 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime">
@@ -75,21 +71,18 @@
     <Reference Include="WindowsBase" />
     <Reference Include="System.Management.Automation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '14.0'">
     <Reference Include="Microsoft.Build">
       <HintPath>$(MSBuildToolsPath)\Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <Reference Include="Microsoft.Build">
       <HintPath>$(SolutionPackagesFolder)Microsoft.Build.15.1.262-preview5\lib\net46\Microsoft.Build.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
     <Compile Include="Projects\LegacyPackageReferenceProject.cs" />
     <Compile Include="Projects\LegacyPackageReferenceProjectProvider.cs" />
@@ -196,6 +189,7 @@
     <Compile Include="Utility\SettingsHelper.cs" />
     <Compile Include="Utility\TaskCombinators.cs" />
     <Compile Include="Utility\VCProjectHelper.cs" />
+    <Compile Include="Utility\VSRestoreSettingsUtilities.cs" />
     <Compile Include="VisualStudioAccountProvider.cs" />
     <Compile Include="VisualStudioActivityLogger.cs" />
     <Compile Include="VisualStudioCredentialProvider.cs" />
@@ -251,7 +245,6 @@
     </ProjectReference>
     <ProjectReference Include="..\NuGet.VisualStudio.Common\NuGet.VisualStudio.Common.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\NuGet.Core\NuGet.Commands\NuGet.Commands.csproj">
       <Project>{567e8582-0e73-4a34-a7d3-ed9486415523}</Project>
@@ -298,13 +291,11 @@
       <Name>NuGet.Versioning</Name>
     </ProjectReference>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Include="$(SharedDirectory)\HashCodeCombiner.cs">
       <Link>HashCodeCombiner.cs</Link>
     </Compile>
   </ItemGroup>
-
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -205,7 +205,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                sources = HandleClear(sources);
+                sources = VSRestoreSettingsUtilities.HandleClear(sources);
             }
 
             // Add additional sources
@@ -226,7 +226,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
-                fallbackFolders = HandleClear(fallbackFolders);
+                fallbackFolders = VSRestoreSettingsUtilities.HandleClear(fallbackFolders);
             }
 
             // Add additional fallback folders
@@ -238,16 +238,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private static bool ShouldReadFromSettings(IEnumerable<string> values)
         {
             return !values.Any() && values.All(e => !StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e));
-        }
-
-        private static IEnumerable<string> HandleClear(IEnumerable<string> values)
-        {
-            if (values.Any(e => StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e)))
-            {
-                return Enumerable.Empty<string>();
-            }
-
-            return values;
         }
 
         private IList<string> GetConfigFilePaths(ISettings settings)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -151,10 +151,11 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 var project = originalProject.Clone();
 
-                // Read restore settings from ISettings if it doesn't exist in the project.
-                project.RestoreMetadata.PackagesPath = GetPackagesPath(settings, project);
-                project.RestoreMetadata.Sources = GetSources(settings, project);
-                project.RestoreMetadata.FallbackFolders = GetFallbackFolders(settings, project);
+                // Read restore settings from ISettings if it doesn't exist in the project
+                // NOTE: Very important that the original project is used in the arguments, because cloning sorts the sources and compromises how the sources will be evaluated
+                project.RestoreMetadata.PackagesPath = GetPackagesPath(settings, originalProject);
+                project.RestoreMetadata.Sources = GetSources(settings, originalProject);
+                project.RestoreMetadata.FallbackFolders = GetFallbackFolders(settings, originalProject);
                 project.RestoreMetadata.ConfigFilePaths = GetConfigFilePaths(settings);
                 projects.Add(project);
             }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -31,7 +31,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 path: project.RestoreMetadata.PackagesPath);
         }
 
-        public static List<PackageSource> GetSources(ISettings settings, PackageSpec project)
+        public static IList<PackageSource> GetSources(ISettings settings, PackageSpec project)
         {
             var sources = new List<string>();
             var additionalSources = new List<string>();
@@ -70,7 +70,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .ToList();
         }
 
-        public static List<string> GetFallbackFolders(ISettings settings, PackageSpec project)
+        public static IList<string> GetFallbackFolders(ISettings settings, PackageSpec project)
         {
             var fallbackFolders = new List<string>();
             var additionalFallbackFolders = new List<string>();

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -40,7 +40,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var readingAdditionalSources = false;
             foreach (var source in project.RestoreMetadata.Sources)
             {
-                if (RestoreAdditionalProjectSources.Equals(source.Source))
+                if (StringComparer.OrdinalIgnoreCase.Equals(RestoreAdditionalProjectSources,source.Source))
                 {
                     readingAdditionalSources = true;
                 }
@@ -79,7 +79,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var readingAdditionalFallbackFolders = false;
             foreach (var fallbackFolder in project.RestoreMetadata.FallbackFolders)
             {
-                if (RestoreAdditionalProjectFallbackFolders.Equals(fallbackFolder))
+                if (StringComparer.OrdinalIgnoreCase.Equals(RestoreAdditionalProjectFallbackFolders,fallbackFolder))
                 {
                     readingAdditionalFallbackFolders = true;
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -46,7 +46,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var readingAdditional = false;
             foreach (var entry in entries)
             {
-                if (StringComparer.OrdinalIgnoreCase.Equals(AdditionalValue, entry))
+                if (StringComparer.Ordinal.Equals(AdditionalValue, entry))
                 {
                     readingAdditional = true;
                 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -78,7 +78,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var readingAdditionalFallbackFolders = false;
             foreach (var fallbackFolder in project.RestoreMetadata.FallbackFolders)
             {
-                if (RestoreAdditionalProjectSources.Equals(fallbackFolder))
+                if (RestoreAdditionalProjectFallbackFolders.Equals(fallbackFolder))
                 {
                     readingAdditionalFallbackFolders = true;
                 }
@@ -96,9 +96,9 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             var processedFallbackFolders = (
-                        ShouldReadFromSettings(fallbackFolders)) ?
+                        ShouldReadFromSettings(fallbackFolders) ?
                             SettingsUtility.GetFallbackPackageFolders(settings) :
-                            HandleClear(fallbackFolders)
+                            HandleClear(fallbackFolders))
                         .Concat(additionalFallbackFolders);
 
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.ProjectModel;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    public class VSRestoreSettingsUtilities
+    {
+        private static string RestoreAdditionalProjectFallbackFolders = nameof(RestoreAdditionalProjectFallbackFolders);
+        private static string RestoreAdditionalProjectSources = nameof(RestoreAdditionalProjectSources);
+
+        public static string GetPackagesPath(ISettings settings, PackageSpec project)
+        {
+            // Set from Settings if not given. Clear is not an option here.
+            if (string.IsNullOrEmpty(project.RestoreMetadata.PackagesPath))
+            {
+                return SettingsUtility.GetGlobalPackagesFolder(settings);
+            }
+
+            // Resolve relative paths
+            return UriUtility.GetAbsolutePathFromFile(
+                sourceFile: project.RestoreMetadata.ProjectPath,
+                path: project.RestoreMetadata.PackagesPath);
+        }
+
+        public static List<PackageSource> GetSources(ISettings settings, PackageSpec project)
+        {
+            var sources = new List<string>();
+            var additionalSources = new List<string>();
+
+            var readingAdditionalSources = false;
+            foreach (var source in project.RestoreMetadata.Sources)
+            {
+                if (RestoreAdditionalProjectSources.Equals(source.Source))
+                {
+                    readingAdditionalSources = true;
+                }
+                else
+                {
+                    if (readingAdditionalSources)
+                    {
+                        additionalSources.Add(source.Source);
+                    }
+                    else
+                    {
+                        sources.Add(source.Source);
+                    }
+                }
+            }
+
+            var processedSources = (
+                        ShouldReadFromSettings(sources) ?
+                            SettingsUtility.GetEnabledSources(settings).Select(e => e.Source) :
+                            HandleClear(sources))
+                        .Concat(additionalSources);
+
+            // Resolve relative paths
+            return processedSources.Select(e => new PackageSource(
+                UriUtility.GetAbsolutePathFromFile(
+                    sourceFile: project.RestoreMetadata.ProjectPath,
+                    path: e)))
+                .ToList();
+        }
+
+        public static List<string> GetFallbackFolders(ISettings settings, PackageSpec project)
+        {
+            var fallbackFolders = new List<string>();
+            var additionalFallbackFolders = new List<string>();
+
+            var readingAdditionalFallbackFolders = false;
+            foreach (var fallbackFolder in project.RestoreMetadata.FallbackFolders)
+            {
+                if (RestoreAdditionalProjectSources.Equals(fallbackFolder))
+                {
+                    readingAdditionalFallbackFolders = true;
+                }
+                else
+                {
+                    if (readingAdditionalFallbackFolders)
+                    {
+                        additionalFallbackFolders.Add(fallbackFolder);
+                    }
+                    else
+                    {
+                        fallbackFolders.Add(fallbackFolder);
+                    }
+                }
+            }
+
+            var processedFallbackFolders = (
+                        ShouldReadFromSettings(fallbackFolders)) ?
+                            SettingsUtility.GetFallbackPackageFolders(settings) :
+                            HandleClear(fallbackFolders)
+                        .Concat(additionalFallbackFolders);
+
+
+            // Resolve relative paths
+            return processedFallbackFolders.Select(e =>
+                UriUtility.GetAbsolutePathFromFile(
+                    sourceFile: project.RestoreMetadata.ProjectPath,
+                    path: e))
+                .ToList();
+        }
+
+        private static bool ShouldReadFromSettings(IEnumerable<string> values)
+        {
+            return !values.Any() && values.All(e => !StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e));
+        }
+
+        public static IEnumerable<string> HandleClear(IEnumerable<string> values)
+        {
+            if (values.Any(e => StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e)))
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return values;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/VSRestoreSettingsUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.ProjectModel;
@@ -112,12 +113,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private static bool ShouldReadFromSettings(IEnumerable<string> values)
         {
-            return !values.Any() && values.All(e => !StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e));
+            return !values.Any() && !MSBuildRestoreUtility.ContainsClearKeyword(values);
         }
 
         public static IEnumerable<string> HandleClear(IEnumerable<string> values)
         {
-            if (values.Any(e => StringComparer.OrdinalIgnoreCase.Equals("CLEAR", e)))
+            
+            if ((MSBuildRestoreUtility.ContainsClearKeyword(values)))
             {
                 return Enumerable.Empty<string>();
             }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -340,7 +340,7 @@ namespace NuGet.SolutionRestoreManager
             {
                 folders = (folders.Concat(new string[] { RestoreAdditionalProjectFallbackFolders }).Concat(additional)).ToArray();
             }
-            return folders.Concat(additional);
+            return folders;
         }
 
         private static string[] HandleClear(string[] input)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -307,6 +307,10 @@ namespace NuGet.SolutionRestoreManager
             return GetNonEvaluatedPropertyOrNull(tfms, RestorePackagesPath, e => e);
         }
 
+        /// <summary>
+        /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
+        /// If there are additional sources specified, the value RestoreAdditionalProjectSources will be set in the result and then all the additional sources will follow
+        /// </summary>
         private static string[] GetRestoreSources(IVsTargetFrameworks tfms)
         {
             var sources = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreSources, e => e));
@@ -314,11 +318,17 @@ namespace NuGet.SolutionRestoreManager
             sources = HandleClear(sources);
 
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectSources, e => e));
-            sources = sources.Concat(additional).ToArray();
-
+            if (additional.Length != 0)
+            {
+                sources = sources.Concat(additional.Concat(new string[] { RestoreAdditionalProjectSources })).ToArray();
+            }
             return sources;
         }
 
+        /// <summary>
+        /// The result will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
+        /// If there are additional fallback folders specified, the value RestoreAdditionalProjectFallbackFolders will be set in the result and then all the additional fallback folders will follow
+        /// </summary>
         private static IEnumerable<string> GetRestoreFallbackFolders(IVsTargetFrameworks tfms)
         {
             var folders = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreFallbackFolders, e => e));
@@ -326,6 +336,10 @@ namespace NuGet.SolutionRestoreManager
             folders = HandleClear(folders);
 
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectFallbackFolders, e => e));
+            if (additional.Length != 0)
+            {
+                folders = folders.Concat(additional.Concat(new string[] { RestoreAdditionalProjectFallbackFolders })).ToArray();
+            }
             return folders.Concat(additional);
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -13,6 +13,7 @@ using NuGet.Commands;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
+using NuGet.PackageManagement.VisualStudio;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 using NuGet.ProjectModel;
@@ -311,18 +312,13 @@ namespace NuGet.SolutionRestoreManager
         /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
         /// If there are additional sources specified, the value RestoreAdditionalProjectSources will be set in the result and then all the additional sources will follow
         /// </summary>
-        private static string[] GetRestoreSources(IVsTargetFrameworks tfms)
+        private static IEnumerable<string> GetRestoreSources(IVsTargetFrameworks tfms)
         {
-            var sources = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreSources, e => e));
-
-            sources = HandleClear(sources);
+            var sources = HandleClear(MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreSources, e => e)));
 
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectSources, e => e));
-            if (additional.Length != 0)
-            {
-                sources = (sources.Concat(new string[] { RestoreAdditionalProjectSources }).Concat(additional)).ToArray();
-            }
-            return sources;
+
+            return VSRestoreSettingsUtilities.GetEntriesWithAdditional(sources, additional);
         }
 
         /// <summary>
@@ -331,16 +327,12 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         private static IEnumerable<string> GetRestoreFallbackFolders(IVsTargetFrameworks tfms)
         {
-            var folders = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreFallbackFolders, e => e));
-
-            folders = HandleClear(folders);
+            var folders = HandleClear(MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreFallbackFolders, e => e)));
 
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectFallbackFolders, e => e));
-            if (additional.Length != 0)
-            {
-                folders = (folders.Concat(new string[] { RestoreAdditionalProjectFallbackFolders }).Concat(additional)).ToArray();
-            }
-            return folders;
+
+            return VSRestoreSettingsUtilities.GetEntriesWithAdditional(folders, additional);
+         
         }
 
         private static string[] HandleClear(string[] input)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -310,7 +310,7 @@ namespace NuGet.SolutionRestoreManager
 
         /// <summary>
         /// The result will contain CLEAR and no sources specified in RestoreSources if the clear keyword is in it.
-        /// If there are additional sources specified, the value RestoreAdditionalProjectSources will be set in the result and then all the additional sources will follow
+        /// If there are additional sources specified, the value AdditionalValue will be set in the result and then all the additional sources will follow
         /// </summary>
         private static IEnumerable<string> GetRestoreSources(IVsTargetFrameworks tfms)
         {
@@ -323,7 +323,7 @@ namespace NuGet.SolutionRestoreManager
 
         /// <summary>
         /// The result will contain CLEAR and no sources specified in RestoreFallbackFolders if the clear keyword is in it.
-        /// If there are additional fallback folders specified, the value RestoreAdditionalProjectFallbackFolders will be set in the result and then all the additional fallback folders will follow
+        /// If there are additional fallback folders specified, the value AdditionalValue will be set in the result and then all the additional fallback folders will follow
         /// </summary>
         private static IEnumerable<string> GetRestoreFallbackFolders(IVsTargetFrameworks tfms)
         {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -320,7 +320,7 @@ namespace NuGet.SolutionRestoreManager
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectSources, e => e));
             if (additional.Length != 0)
             {
-                sources = sources.Concat(additional.Concat(new string[] { RestoreAdditionalProjectSources })).ToArray();
+                sources = (sources.Concat(new string[] { RestoreAdditionalProjectSources }).Concat(additional)).ToArray();
             }
             return sources;
         }
@@ -338,7 +338,7 @@ namespace NuGet.SolutionRestoreManager
             var additional = MSBuildStringUtility.Split(GetNonEvaluatedPropertyOrNull(tfms, RestoreAdditionalProjectFallbackFolders, e => e));
             if (additional.Length != 0)
             {
-                folders = folders.Concat(additional.Concat(new string[] { RestoreAdditionalProjectFallbackFolders })).ToArray();
+                folders = (folders.Concat(new string[] { RestoreAdditionalProjectFallbackFolders }).Concat(additional)).ToArray();
             }
             return folders.Concat(additional);
         }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/NuGet.PackageManagement.VisualStudio.Test.csproj
@@ -38,6 +38,7 @@
     <Compile Include="VisualStudioCredentialProviderTests.cs" />
     <Compile Include="VsCredentialProviderAdapterTests.cs" />
     <Compile Include="VsCredentialProviderImporterTests.cs" />
+    <Compile Include="VSRestoreSettingsUtilityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
@@ -15,16 +15,11 @@ namespace NuGet.PackageManagement.VisualStudio.Test
     public class VSRestoreSettingsUtilityTests
     {
         [Theory]
-        [MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData1))]
-        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData2))]
-        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData3))]
-        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData4))]
-        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData5))]
+        [MemberData(nameof(GetVSRestoreSettingsUtilities_RestoreSourceData))]
         public void VSRestoreSettingsUtilities_RestoreSource(string[] restoreSources, string[] expectedRestoreSources)
         {
             using (var mockBaseDirectory = TestDirectory.Create())
             {
-
                 var spec = new PackageSpec();
                 spec.RestoreMetadata = new ProjectRestoreMetadata();
                 spec.RestoreMetadata.ProjectPath = @"C:\project\projectPath";
@@ -37,51 +32,36 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                        "expected: " + string.Join(",", expectedRestoreSources.ToArray()) + "\nactual: " + string.Join(",", actualSources.Select(e => e.Source).ToArray()));
             }
         }
-        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData1
-        {
-            get
-            {
-                yield return new object[] {
-                   new object[] { @"C:\source1" },
-                   new object[] { @"C:\source1" }
-                };
-            }
-       }
 
-    public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData2
+        public static IEnumerable<object[]> GetVSRestoreSettingsUtilities_RestoreSourceData()
         {
-            get
-            {
-                yield return new object[] { @"Clear" };
-                yield return new object[] { };
-            }
-        }
+            yield return new object[] {
+                new string[] { @"C:\source1" },
+                new string[] { @"C:\source1" }
+            };
 
-        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData3
-        {
-            get
+            yield return new object[]
             {
-                yield return new object[] { @"Clear;RestoreAdditionalProjectSources;C:\additionalSource" };
-                yield return new object[] { @"C:\additionalSource" };
-            }
-        }
+                new string[] { @"Clear" },
+                new string[] { }
+            };
 
-        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData4
-        {
-            get
+            yield return new object[]
             {
-                yield return new object[] { @"C:\source1;RestoreAdditionalProjectSources;C:\additionalSource" };
-                yield return new object[] { @"C:\source1;C:\additionalSource" };
-            }
-        }
+                new string[] { @"Clear", "RestoreAdditionalProjectSources", @"C:\additionalSource" },
+                new string[] { @"C:\additionalSource" }
+            };
 
-        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData5
-        {
-            get
+            yield return new object[] {
+                new string[] { @"C:\source1", "RestoreAdditionalProjectSources",@"C:\additionalSource" },
+                new string[] { @"C:\source1" ,@"C:\additionalSource" }
+            };
+
+            yield return new object[]
             {
-                yield return new object[] { @"RestoreAdditionalProjectSources;C:\additionalSource" };
-                yield return new object[] { NuGetConstants.V3FeedUrl + @"; C:\additionalSource" };
-            }
+                new string[] { "RestoreAdditionalProjectSources", @"C:\additionalSource" },
+                new string[] { NuGetConstants.V3FeedUrl, @"C:\additionalSource" }
+            };
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using NuGet.ProjectModel;
+using NuGet.Commands;
+using System.Linq;
+using NuGet.Configuration;
+using NuGet.Test.Utility;
+using System.Collections.Generic;
+using Xunit.Extensions;
+
+namespace NuGet.PackageManagement.VisualStudio.Test
+{
+    public class VSRestoreSettingsUtilityTests
+    {
+        [Theory]
+        [MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData1))]
+        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData2))]
+        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData3))]
+        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData4))]
+        //[MemberData(nameof(VSRestoreSettingsUtilities_RestoreSourceData5))]
+        public void VSRestoreSettingsUtilities_RestoreSource(string[] restoreSources, string[] expectedRestoreSources)
+        {
+            using (var mockBaseDirectory = TestDirectory.Create())
+            {
+
+                var spec = new PackageSpec();
+                spec.RestoreMetadata = new ProjectRestoreMetadata();
+                spec.RestoreMetadata.ProjectPath = @"C:\project\projectPath";
+                spec.RestoreMetadata.Sources = restoreSources.Select(e => new PackageSource(e)).ToList();
+                var settings = new Settings(mockBaseDirectory);
+                var actualSources = VSRestoreSettingsUtilities.GetSources(settings, spec);
+
+                Assert.True(
+                       Enumerable.SequenceEqual(expectedRestoreSources.OrderBy(t => t), actualSources.Select(e => e.Source).OrderBy(t => t)),
+                       "expected: " + string.Join(",", expectedRestoreSources.ToArray()) + "\nactual: " + string.Join(",", actualSources.Select(e => e.Source).ToArray()));
+            }
+        }
+        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData1
+        {
+            get
+            {
+                yield return new object[] {
+                   new object[] { @"C:\source1" },
+                   new object[] { @"C:\source1" }
+                };
+            }
+       }
+
+    public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData2
+        {
+            get
+            {
+                yield return new object[] { @"Clear" };
+                yield return new object[] { };
+            }
+        }
+
+        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData3
+        {
+            get
+            {
+                yield return new object[] { @"Clear;RestoreAdditionalProjectSources;C:\additionalSource" };
+                yield return new object[] { @"C:\additionalSource" };
+            }
+        }
+
+        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData4
+        {
+            get
+            {
+                yield return new object[] { @"C:\source1;RestoreAdditionalProjectSources;C:\additionalSource" };
+                yield return new object[] { @"C:\source1;C:\additionalSource" };
+            }
+        }
+
+        public static IEnumerable<object[]> VSRestoreSettingsUtilities_RestoreSourceData5
+        {
+            get
+            {
+                yield return new object[] { @"RestoreAdditionalProjectSources;C:\additionalSource" };
+                yield return new object[] { NuGetConstants.V3FeedUrl + @"; C:\additionalSource" };
+            }
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VSRestoreSettingsUtilityTests.cs
@@ -52,18 +52,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             yield return new object[]
             {
-                new string[] { @"Clear", "RestoreAdditionalProjectSources", @"C:\additionalSource" },
+                new string[] { @"Clear", VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalSource" },
                 new string[] { @"C:\additionalSource" }
             };
 
             yield return new object[] {
-                new string[] { @"C:\source1", "RestoreAdditionalProjectSources",@"C:\additionalSource" },
+                new string[] { @"C:\source1", VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalSource" },
                 new string[] { @"C:\source1" ,@"C:\additionalSource" }
             };
 
             yield return new object[]
             {
-                new string[] { "RestoreAdditionalProjectSources", @"C:\additionalSource" },
+                new string[] { VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalSource" },
                 new string[] { NuGetConstants.V3FeedUrl, @"C:\additionalSource" }
             };
         }
@@ -107,18 +107,18 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             yield return new object[]
             {
-                new string[] { @"Clear", "RestoreAdditionalProjectFallbackFolders", @"C:\additionalFallback" },
+                new string[] { @"Clear", VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalFallback" },
                 new string[] { @"C:\additionalFallback" }
             };
 
             yield return new object[] {
-                new string[] { @"C:\fallback1", "RestoreAdditionalProjectFallbackFolders", @"C:\additionalFallback" },
+                new string[] { @"C:\fallback1", VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalFallback" },
                 new string[] { @"C:\fallback1", @"C:\additionalFallback" }
             };
 
             yield return new object[]
             {
-                new string[] { "RestoreAdditionalProjectFallbackFolders", @"C:\additionalFallback" },
+                new string[] { VSRestoreSettingsUtilities.AdditionalValue, @"C:\additionalFallback" },
                 new string[] { @"C:\defaultFallback", @"C:\additionalFallback" }
             };
         }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/VsCredentialProviderImporterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using EnvDTE;

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -553,7 +553,7 @@ namespace NuGet.SolutionRestoreManager.Test
                     MSBuildStringUtility.Split(restoreSources)).
                 Concat(
                 restoreAdditionalProjectSources != null ?
-                    new List<string>() { "RestoreAdditionalProjectSources" }.Concat(MSBuildStringUtility.Split(restoreAdditionalProjectSources)):
+                    new List<string>() { VSRestoreSettingsUtilities.AdditionalValue }.Concat(MSBuildStringUtility.Split(restoreAdditionalProjectSources)):
                     new string[] { }
                 );
 
@@ -567,7 +567,7 @@ namespace NuGet.SolutionRestoreManager.Test
                     MSBuildStringUtility.Split(restoreFallbackFolders)).
                 Concat(
                 restoreAdditionalFallbackFolders != null ?
-                    new List<string>() { "RestoreAdditionalProjectFallbackFolders" }.Concat(MSBuildStringUtility.Split(restoreAdditionalFallbackFolders)) :
+                    new List<string>() { VSRestoreSettingsUtilities.AdditionalValue }.Concat(MSBuildStringUtility.Split(restoreAdditionalFallbackFolders)) :
                     new string[] { }
                 );
 

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -510,16 +510,79 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.NotNull(actualProjectSpec);
             Assert.Equal("TestPackage", actualProjectSpec.Name);
         }
+
         [Theory]
         [InlineData(@"..\source1", @"..\additionalsource", @"..\fallback1", @"..\additionalFallback1")]
         [InlineData(@"..\source1", null, @"..\fallback1", null)]
         [InlineData(null, @"..\additionalsource", null, @"..\additionalFallback1")]
         [InlineData(@"..\source1", @"Clear;..\additionalsource", @"..\fallback1;Clear", @"..\additionalFallback1")]
         [InlineData(@"..\source1", @"..\additionalsource;Clear", @"Clear;..\fallback1", @"..\additionalFallback1")]
-
         public async Task NominateProjectAsync_WithRestoreAdditionalSourcesAndFallbackFolders(string restoreSources, string restoreAdditionalProjectSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders)
         {
+            var cps = NewCpsProject(@"{ }");
+            var pri = cps.Builder
+                .WithTool("Foo.Test", "2.0.0")
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo(
+                        "netcoreapp2.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] { new VsProjectProperty("RestoreSources", restoreSources),
+                                new VsProjectProperty("RestoreFallbackFolders", restoreFallbackFolders),
+                                new VsProjectProperty("RestoreAdditionalProjectSources", restoreAdditionalProjectSources),
+                                new VsProjectProperty("RestoreAdditionalProjectFallbackFolders", restoreAdditionalFallbackFolders)}))
+                .Build();
+            var projectFullPath = cps.ProjectFullPath;
 
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, pri);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+
+           var specSources = actualProjectSpec.RestoreMetadata.Sources?.Select(e => e.Source);
+
+            var expectedSources = 
+                (MSBuildStringUtility.Split(restoreSources).Any(e => StringComparer.OrdinalIgnoreCase.Equals("clear", e)) ?
+                    new string[] { "Clear" } :
+                    MSBuildStringUtility.Split(restoreSources)).
+                Concat(
+                restoreAdditionalProjectSources != null ?
+                    new List<string>() { "RestoreAdditionalProjectSources" }.Concat(MSBuildStringUtility.Split(restoreAdditionalProjectSources)):
+                    new string[] { }
+                );
+
+            Assert.True(Enumerable.SequenceEqual(expectedSources.OrderBy(t => t), specSources.OrderBy(t => t)));
+
+            var specFallback = actualProjectSpec.RestoreMetadata.FallbackFolders;
+
+            var expectedFallback =
+                (MSBuildStringUtility.Split(restoreFallbackFolders).Any(e => StringComparer.OrdinalIgnoreCase.Equals("clear", e)) ?
+                    new string[] { "Clear" } :
+                    MSBuildStringUtility.Split(restoreFallbackFolders)).
+                Concat(
+                restoreAdditionalFallbackFolders != null ?
+                    new List<string>() { "RestoreAdditionalProjectFallbackFolders" }.Concat(MSBuildStringUtility.Split(restoreAdditionalFallbackFolders)) :
+                    new string[] { }
+                );
+
+            Assert.True(
+                Enumerable.SequenceEqual(expectedFallback.OrderBy(t => t), specFallback.OrderBy(t => t)),
+                "expected: " + string.Join(",", expectedFallback.ToArray()) + "\nactual: " + string.Join(",", specFallback.ToArray()));
+        }
+
+
+        [Theory]
+        [InlineData(@"C:\source1", @"C:\additionalsource", @"C:\fallback1", @"C:\additionalFallback1")]
+        [InlineData(@"C:\source1", null, @"C:\fallback1", null)]
+        [InlineData(null, @"C:\additionalsource", null, @"C:\additionalFallback1")]
+        [InlineData(@"C:\source1", @"Clear;C:\additionalsource", @"C:\fallback1;Clear", @"C:\additionalFallback1")]
+        [InlineData(@"C:\source1", @"C:\additionalsource;Clear", @"Clear;C:\fallback1", @"C:\additionalFallback1")]
+        public async Task NominateProjectAsync_WithRestoreAdditionalSourcesAndFallbackFolders(string restoreSources, string restoreAdditionalProjectSources, string restoreFallbackFolders, string restoreAdditionalFallbackFolders)
+        {
             var cps = NewCpsProject(@"{ }");
             var pri = cps.Builder
                 .WithTool("Foo.Test", "2.0.0")


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5478

More info on what happens here:
https://github.com/NuGet/Home/issues/5478#issuecomment-312142401

//cc
@rrelyea 