### PR TITLE
Fix nuget/Home#4019 - check case-variations of NuGet.config on macOS

### DIFF
--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -27,7 +27,7 @@ namespace NuGet.Configuration
         /// NuGet config names with casing ordered by precedence.
         /// </summary>
         public static readonly string[] OrderedSettingsFileNames =
-            RuntimeEnvironmentHelper.IsWindows ?
+            PathUtility.IsFileSystemCaseInsensitive ?
             new[] { DefaultSettingsFileName } :
             new[]
             {

--- a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
+++ b/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs
@@ -27,7 +27,7 @@ namespace NuGet.Configuration
         /// NuGet config names with casing ordered by precedence.
         /// </summary>
         public static readonly string[] OrderedSettingsFileNames =
-            (RuntimeEnvironmentHelper.IsWindows || RuntimeEnvironmentHelper.IsMacOSX) ?
+            RuntimeEnvironmentHelper.IsWindows ?
             new[] { DefaultSettingsFileName } :
             new[]
             {


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/4019

macOS may not always be a case-insensitive file system. This expands the list of file names checked on macOS to include common case variations.

cc @emgarten 