### PR TITLE
Include satellite resource assemblies when packing

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -796,7 +796,8 @@ namespace NuGet.CommandLine
                 $"{targetFileName}.dll",
                 $"{targetFileName}.exe",
                 $"{targetFileName}.xml",
-                $"{targetFileName}.winmd"
+                $"{targetFileName}.winmd",
+                $"{targetFileName}.resources.dll"
             };
 
             if (IncludeSymbols)
@@ -833,7 +834,7 @@ namespace NuGet.CommandLine
                 var packageFile = new Packaging.PhysicalPackageFile
                 {
                     SourcePath = file,
-                    TargetPath = Path.Combine(targetFolder, Path.GetFileName(file))
+                    TargetPath = Path.Combine(targetFolder, FileSystemUtility.MakeRelativePath(projectOutputDirectory, file))
                 };
                 AddFileToBuilder(builder, packageFile);
             }


### PR DESCRIPTION
Looks for *.resources.dll in subfolders of output directory and places them in correct subfolder in package
Nuget/Home#1482