### PR TITLE
Update lock count inside NuGetLockService only when that thread acquires the lock

### DIFF
--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Services/NuGetLockServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -78,6 +78,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }, _cts.Token));
 
             Assert.False(_lockService.IsLockHeld);
+            Assert.Equal(0, _lockService.LockCount);
         }
 
         [Fact]
@@ -92,6 +93,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
             }, _cts.Token);
 
             Assert.False(_lockService.IsLockHeld);
+            Assert.Equal(0, _lockService.LockCount);
         }
 
         [Fact]


### PR DESCRIPTION
In continuation to PR# https://github.com/NuGet/NuGet.Client/pull/1469 this change handles updating _lockCount variable only when semaphore has been acquired by the current thread. Unlike in previous case, there could be potential bug when _lockCount was incremented but lock wasn't acquired by the thread (as in cancellation was requested on that operation).

@rrelyea @DoRonMotter 