### PR TITLE
Avoid allocation in VsPackageMetadataComparer

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageMetadataComparer.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageMetadataComparer.cs
@@ -32,8 +32,8 @@ namespace NuGet.VisualStudio
                 return 0;
             }
 
-            return obj.Id.ToUpperInvariant().GetHashCode() * 397
-                   ^ obj.VersionString.ToUpperInvariant().GetHashCode();
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Id) * 397
+                   ^ StringComparer.OrdinalIgnoreCase.GetHashCode(obj.VersionString);
         }
     }
 }


### PR DESCRIPTION
This was producing ~500 KB of garbage in a certain scenario installing NuGet packages.

![image](https://user-images.githubusercontent.com/1103906/27901104-1a574f7a-6274-11e7-8959-4b7a7c393c75.png)
