### PR TITLE
Change NU1701 to "This package may not be fully compatible with your project"

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -603,7 +603,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Package &apos;{0}&apos; was restored using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This may cause compatibility problems..
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; was restored using &apos;{1}&apos; instead of the project target framework &apos;{2}&apos;. This package may not be fully compatible with your project..
         /// </summary>
         internal static string Log_ImportsFallbackWarning {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -198,7 +198,7 @@
     <value>Dependency specified was {0} {1} but ended up with {2} {3}.</value>
   </data>
   <data name="Log_ImportsFallbackWarning" xml:space="preserve">
-    <value>Package '{0}' was restored using '{1}' instead of the project target framework '{2}'. This may cause compatibility problems.</value>
+    <value>Package '{0}' was restored using '{1}' instead of the project target framework '{2}'. This package may not be fully compatible with your project.</value>
   </data>
   <data name="Log_CycleDetected" xml:space="preserve">
     <value>Cycle detected.</value>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -4509,7 +4509,7 @@ namespace NuGet.CommandLine.Test
                     .ShouldBeEquivalentTo(new[] { "lib/net45/a.dll" },
                     "no compatible assets were found for ns2.0");
 
-                r.AllOutput.Should().Contain("This may cause compatibility problems");
+                r.AllOutput.Should().Contain("This package may not be fully compatible with your project.");
             }
         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -746,7 +746,7 @@ namespace NuGet.Commands.FuncTest
                 var lockFileFormat = new LockFileFormat();
                 var command = new RestoreCommand(request);
                 var framework = new FallbackFramework(NuGetFramework.Parse("dotnet"), new List<NuGetFramework> { NuGetFramework.Parse("portable-net452+win81") });
-                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead of the project target framework '.NETPlatform,Version=v5.0'. This may cause compatibility problems.";
+                var warning = "Package 'Newtonsoft.Json 7.0.1' was restored using '.NETPortable,Version=v0.0,Profile=net452+win81' instead of the project target framework '.NETPlatform,Version=v5.0'. This package may not be fully compatible with your project.";
 
                 // Act
                 var result = await command.ExecuteAsync();


### PR DESCRIPTION
The previous message "This may cause compatibility problems" felt ominous. As if I had done something wrong.

The new message is designed to indicate that the package could be partially, or fully, compatible. Also it re-iterates that the package is the potential source of incompatibility. This to mean comes across as saying "this isn't necessarily a problem"

This resolves NuGet/Home#5538