### PR TITLE
Moq 4.7.1 -> 4.7.63

### DIFF
--- a/build/config.props
+++ b/build/config.props
@@ -16,7 +16,7 @@
     <NewtonsoftJsonVersionDeskop>6.0.4</NewtonsoftJsonVersionDeskop>
     <XunitVersion>2.2.0</XunitVersion>
     <TestSDKVersion>15.0.0</TestSDKVersion>
-    <MoqVersion>4.7.1</MoqVersion>
+    <MoqVersion>4.7.63</MoqVersion>
     <FluentAssertionsVersion>4.19.2</FluentAssertionsVersion>
     <MicrosoftBuildPackageVersion>0.1.0-preview-00038-160914</MicrosoftBuildPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
Updating Moq 4.7.1 -> 4.7.63

This removes the dependency on Castle.Core 4.0.0 which is currently slowing down restore due to a non-existent dependency.

Fixes https://github.com/NuGet/Home/issues/5032