### PR TITLE
fix broken uwp migrator

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26703.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -113,7 +113,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.PackageManagement.UI"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManager", "src\NuGet.Clients\NuGet.SolutionRestoreManager\NuGet.SolutionRestoreManager.csproj", "{06662133-1292-4918-90F3-36C930C0B16F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.SolutionRestoreManager.Interop", "src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj", "{4003E1AB-70DE-4B9C-8999-96160EE91D84}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.SolutionRestoreManager.Interop", "src\NuGet.Clients\NuGet.SolutionRestoreManager.Interop\NuGet.SolutionRestoreManager.Interop.csproj", "{4003E1AB-70DE-4B9C-8999-96160EE91D84}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Tools", "src\NuGet.Clients\NuGet.Tools\NuGet.Tools.csproj", "{D0F9864B-D782-4471-81A2-29555E5DC0D7}"
 EndProject
@@ -203,7 +203,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet.Clients", "NuGet.Clie
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NuGet.Core", "NuGet.Core", "{506AF844-92E0-4404-BBFC-0AB073890A72}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Build.Tasks.Test", "test\NuGet.Core.Tests\NuGet.Build.Tasks.Test\NuGet.Build.Tasks.Test.csproj", "{F813268A-1EA1-41E6-A42C-01E7F937E257}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Build.Tasks.Test", "test\NuGet.Core.Tests\NuGet.Build.Tasks.Test\NuGet.Build.Tasks.Test.csproj", "{F813268A-1EA1-41E6-A42C-01E7F937E257}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -467,6 +467,10 @@ Global
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Release|Any CPU.Build.0 = Release|Any CPU
 		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34750BB3-4A21-433A-9C55-C051CA70C4AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -475,10 +479,6 @@ Global
 		{F813268A-1EA1-41E6-A42C-01E7F937E257}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F813268A-1EA1-41E6-A42C-01E7F937E257}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F813268A-1EA1-41E6-A42C-01E7F937E257}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F4CA95DA-0045-4AC4-ABA0-560008CEB963}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -556,10 +556,13 @@ Global
 		{CC657FF4-F66E-4A28-9165-AF112A93EE89} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{96255044-3776-439B-8496-C460DB9C4F97} = {A8F45E94-4CFD-478C-9FE2-8E6DEE7E0770}
 		{79266117-FEDD-45B3-B603-33A4B6E9F12F} = {D1549653-9631-4E16-9967-55427174A0DC}
+		{F4CA95DA-0045-4AC4-ABA0-560008CEB963} = {23CEFC88-9365-4464-A517-700224ECA033}
 		{34750BB3-4A21-433A-9C55-C051CA70C4AE} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 		{08F523EC-3C2A-4A00-A54C-2E54C5AC856B} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{506AF844-92E0-4404-BBFC-0AB073890A72} = {BD1946CE-5544-4F28-A04A-9C3D51113E1A}
 		{F813268A-1EA1-41E6-A42C-01E7F937E257} = {7323F93B-D141-4001-BB9E-7AF14031143E}
-		{F4CA95DA-0045-4AC4-ABA0-560008CEB963} = {23CEFC88-9365-4464-A517-700224ECA033}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A62CA473-1E83-411A-B268-27D1730EFAA3}
 	EndGlobalSection
 EndGlobal

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -101,6 +101,7 @@
     <Compile Include="ProjectServices\GlobalProjectServiceProvider.cs" />
     <Compile Include="ProjectServices\NetCoreProjectSystemServices.cs" />
     <Compile Include="ProjectServices\VsCoreProjectSystemReferenceReader.cs" />
+    <Compile Include="ProjectSystems\VsCoreProjectSystem.cs" />
     <Compile Include="Projects\VsMSBuildProjectSystemServices.cs" />
     <Compile Include="Utility\SupportedProjectTypes.cs" />
     <Compile Include="Common\VersionCollectionExtensions.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
@@ -32,7 +32,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IProjectSystemReferencesService References => throw new NotSupportedException();
 
-        public IProjectSystemService ProjectSystem { get; private set; }
+        public IProjectSystemService ProjectSystem { get; }
 
         public IProjectScriptHostService ScriptService { get; }
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,7 +32,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IProjectSystemReferencesService References => throw new NotSupportedException();
 
-        public IProjectSystemService ProjectSystem => throw new NotSupportedException();
+        public IProjectSystemService ProjectSystem { get; private set; }
 
         public IProjectScriptHostService ScriptService { get; }
 
@@ -49,6 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _threadingService = GetGlobalService<IVsProjectThreadingService>();
             Assumes.Present(_threadingService);
+            ProjectSystem = new VsCoreProjectSystem(_vsProjectAdapter);
 
             ReferencesReader = new VsCoreProjectSystemReferenceReader(vsProjectAdapter, this);
             ScriptService = new VsProjectScriptHostService(vsProjectAdapter, this);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
@@ -13,9 +13,9 @@ using NuGet.VisualStudio;
 
 namespace NuGet.PackageManagement.VisualStudio
 {
-    class VsCoreProjectSystem : IProjectSystemService
+    internal class VsCoreProjectSystem : IProjectSystemService
     {
-        public IVsProjectAdapter VsProjectAdapter { get; private set; }
+        private IVsProjectAdapter VsProjectAdapter { get; }
 
         public async Task SaveProjectAsync(CancellationToken token)
         {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    class VsCoreProjectSystem : IProjectSystemService
+    {
+        public IVsProjectAdapter VsProjectAdapter { get; private set; }
+
+        public async Task SaveProjectAsync(CancellationToken token)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            try
+            {
+                FileSystemUtility.MakeWritable(VsProjectAdapter.FullName);
+                VsProjectAdapter.Project.Save();
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.WriteErrorToActivityLog(ex);
+            }
+        }
+
+        public VsCoreProjectSystem(
+            IVsProjectAdapter vsProjectAdapter)
+        {
+            Assumes.Present(vsProjectAdapter);
+
+            VsProjectAdapter = vsProjectAdapter;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -61,12 +61,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public bool TryCreateNuGetProject(
             IVsProjectAdapter vsProjectAdapter,
-            ProjectProviderContext context,
+            ProjectProviderContext _,
             bool forceProjectType,
             out NuGetProject result)
         {
             Assumes.Present(vsProjectAdapter);
-            Assumes.Present(context);
 
             _threadingService.ThrowIfNotOnUIThread();
 

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -14,38 +14,38 @@
 }
 ## Skipping the Test below, because current E2E machines (Win2016 Server) do not allow creating new UWP projects.
 
-# function Test-MigrateVanilaUwpProjectJsonToPackageReference {
-#     param(
-#         $context
-#     )
+function Test-MigrateVanilaUwpProjectJsonToPackageReference {
+    param(
+        $context
+    )
 
-#     # Arrange
-#     $p = New-UwpClassLibrary UwpClassLibrary1
-#     $cm = Get-VsComponentModel
-#     $projectDir = Get-ProjectDir $p
-#     $result = [API.Test.InternalAPITestHook]::MigrateJsonProject($p.FullName)
+    # Arrange
+    $p = New-UwpClassLibrary UwpClassLibrary1
+    $cm = Get-VsComponentModel
+    $projectDir = Get-ProjectDir $p
+    $result = [API.Test.InternalAPITestHook]::MigrateJsonProject($p.FullName)
 
-#     # Assert
+    # Assert
 
-#     # Check if runtimes were migrated correctly
-#     $expectRuntimeIds = 'win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot'
-#     Assert-True($result.IsSuccess)
-#     $actualRuntimes = Get-MsBuildPropertyValue $p 'RuntimeIdentifiers'
-#     Assert-AreEqual $expectRuntimeIds $actualRuntimes
+    # Check if runtimes were migrated correctly
+    $expectRuntimeIds = 'win10-arm;win10-arm-aot;win10-x86;win10-x86-aot;win10-x64;win10-x64-aot'
+    Assert-True($result.IsSuccess)
+    $actualRuntimes = Get-MsBuildPropertyValue $p 'RuntimeIdentifiers'
+    Assert-AreEqual $expectRuntimeIds $actualRuntimes
 
-#     # Check if project.json file was deleted
-#     Assert-True !(Test-Path (Join-Path $projectDir project.json))
+    # Check if project.json file was deleted
+    Assert-True !(Test-Path (Join-Path $projectDir project.json))
 
-#     # Check if backup was created
-#     Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup project.json)))
-#     Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup UwpClassLibrary1.csproj)))
+    # Check if backup was created
+    Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup project.json)))
+    Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup UwpClassLibrary1.csproj)))
 
-#     # Check if package reference was added correctly
-#     $packageRefs = @(Get-MsBuildItems $p 'PackageReference')
-#     Assert-AreEqual 1 $packageRefs.Count
-#     Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'Microsoft.NETCore.UniversalWindowsPlatform'
-#     Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '5.2.2'
-# }
+    # Check if package reference was added correctly
+    $packageRefs = @(Get-MsBuildItems $p 'PackageReference')
+    Assert-AreEqual 1 $packageRefs.Count
+    Assert-AreEqual $packageRefs[0].GetMetadataValue("Identity") 'Microsoft.NETCore.UniversalWindowsPlatform'
+    Assert-AreEqual $packageRefs[0].GetMetadataValue("Version") '5.2.3'
+}
 
 function Test-VsPackageInstallerServices {
     param(

--- a/test/EndToEnd/tests/ServicesTest.ps1
+++ b/test/EndToEnd/tests/ServicesTest.ps1
@@ -13,15 +13,14 @@
     Assert-NotNull $installerEvents
 }
 ## Skipping the Test below, because current E2E machines (Win2016 Server) do not allow creating new UWP projects.
-
 function Test-MigrateVanilaUwpProjectJsonToPackageReference {
+    [SkipTestForVS14()]
     param(
         $context
     )
 
     # Arrange
     $p = New-UwpClassLibrary UwpClassLibrary1
-    $cm = Get-VsComponentModel
     $projectDir = Get-ProjectDir $p
     $result = [API.Test.InternalAPITestHook]::MigrateJsonProject($p.FullName)
 
@@ -34,7 +33,7 @@ function Test-MigrateVanilaUwpProjectJsonToPackageReference {
     Assert-AreEqual $expectRuntimeIds $actualRuntimes
 
     # Check if project.json file was deleted
-    Assert-True !(Test-Path (Join-Path $projectDir project.json))
+    Assert-False (Test-Path (Join-Path $projectDir project.json))
 
     # Check if backup was created
     Assert-True (Test-Path (Join-Path $projectDir (Join-Path Backup project.json)))

--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -13,23 +13,6 @@ function Get-VSVersion
     return $version
 }
 
-function New-UwpClassLibrary
-{
-    param(
-        [string]$ProjectName,
-        [string]$SolutionFolder
-    )
-
-    if ((Get-VSVersion) -ge '15.0')
-    {
-        New-Project UwpClassLibrary $ProjectName $SolutionFolder
-    }
-    else
-    {
-        throw "SKIP: $($_)"
-    }
-}
-
 function New-UwpPackageRefClassLibrary
 {
     param(
@@ -249,6 +232,21 @@ function New-Project {
     Write-Verbose "New-Project function"
     $p = [API.Test.VSProjectHelper]::NewProject($TemplatePath, $OutputPath, $TemplateName, $ProjectName, $SolutionFolder)
     Write-Verbose "New-Project function end"
+
+    return $p
+}
+
+function New-UwpClassLibrary {
+    param(
+         [parameter(Mandatory = $true)]
+         [string]$ProjectName,
+         [string]$TargetPlatformVersion,
+         [string]$TargetPlatformMinVersion
+    )
+
+    Write-Verbose "New-UwpClassLibrary function"
+    $p = [API.Test.VSProjectHelper]::NewUwpClassLibrary($ProjectName, $OutputPath, $TargetPlatformVersion, $TargetPlatformMinVersion)
+    Write-Verbose "New-UwpClassLibrary function end"
 
     return $p
 }

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio\NuGet.VisualStudio.csproj">
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </ProjectReference>
+    <ProjectReference Include="$(TestUtilitiesDirectory)\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">
@@ -41,6 +42,14 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="14.1.131" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="compiler\resources\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="compiler\resources\UWP\AssemblyInfo.cs" />
+    <Compile Remove="compiler\resources\UWP\Class1.cs" />
+  </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
 
   <Target Name="DeployToArtifacts" AfterTargets="Build;Rebuild">

--- a/test/TestExtensions/API.Test/API.Test.csproj
+++ b/test/TestExtensions/API.Test/API.Test.csproj
@@ -22,7 +22,6 @@
     <ProjectReference Include="$(NuGetClientsSrcDirectory)NuGet.VisualStudio\NuGet.VisualStudio.csproj">
       <EmbedInteropTypes>true</EmbedInteropTypes>
     </ProjectReference>
-    <ProjectReference Include="$(TestUtilitiesDirectory)\Test.Utility\Test.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(VisualStudioVersion)' == '15.0'">

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -152,5 +152,15 @@ namespace API.Test
                            batchStartIds[0].Equals(batchEndIds[0], StringComparison.Ordinal);
                 });
         }
+
+        public static IVsProjectJsonToPackageReferenceMigrateResult MigrateJsonProject(string projectName)
+        {
+            var migrator = ServiceLocator.GetComponent<IVsProjectJsonToPackageReferenceMigrator>();
+            return ThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                return (IVsProjectJsonToPackageReferenceMigrateResult) await migrator.MigrateProjectJsonToPackageReferenceAsync(projectName);
+            });
+        }
     }
 }

--- a/test/TestExtensions/API.Test/InternalAPITestHook.cs
+++ b/test/TestExtensions/API.Test/InternalAPITestHook.cs
@@ -158,7 +158,6 @@ namespace API.Test
             var migrator = ServiceLocator.GetComponent<IVsProjectJsonToPackageReferenceMigrator>();
             return ThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
                 return (IVsProjectJsonToPackageReferenceMigrateResult) await migrator.MigrateProjectJsonToPackageReferenceAsync(projectName);
             });
         }

--- a/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
+++ b/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Reflection;
 
@@ -8,6 +9,7 @@ namespace API.Test
 {
     public class UwpProjectTestsUtil
     {
+        private static readonly Version RS2 = new Version(10, 0, 15063, 0);
         // TODO: Handle creating the right project template for TPV > RS2
         // Returns the path to the solution file
         public static string CreateUwpClassLibrary(string projectName,
@@ -24,14 +26,29 @@ namespace API.Test
             {
                 targetPlatformMinVersion = "10.0.10586.0";
             }
+
+            var tpv = new Version(targetPlatformVersion);
             Directory.CreateDirectory(Path.Combine(outputPath, projectName, projectName));
             var solutionDir = Path.Combine(outputPath, projectName);
-            FormatAndCopyTemplateFiles("AssemblyInfo.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "AssemblyInfo.cs", "Properties");
-            FormatAndCopyTemplateFiles("Class1.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "Class1.cs");
-            FormatAndCopyTemplateFiles("project.json", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "project.json");
-            FormatAndCopyTemplateFiles("projectjsonbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
-            FormatAndCopyTemplateFiles("project.rd.xml", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".rd.xml", "Properties");
+
             FormatAndCopyTemplateFiles("project.sln", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".sln");
+            FormatAndCopyTemplateFiles("project.rd.xml", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".rd.xml", "Properties");
+            FormatAndCopyTemplateFiles("Class1.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "Class1.cs");
+            FormatAndCopyTemplateFiles("AssemblyInfo.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "AssemblyInfo.cs", "Properties");
+            if (tpv >= RS2)
+            {
+                FormatAndCopyTemplateFiles("packagerefbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
+            }
+            else
+            {                
+                FormatAndCopyTemplateFiles("project.json", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "project.json");
+                FormatAndCopyTemplateFiles("projectjsonbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
+                
+                
+            }
+
+            
+            
             return Path.Combine(solutionDir, projectName + ".sln");
         }
 

--- a/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
+++ b/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Reflection;
+
+namespace API.Test
+{
+    public class UwpProjectTestsUtil
+    {
+        // TODO: Handle creating the right project template for TPV > RS2
+        // Returns the path to the solution file
+        public static string CreateUwpClassLibrary(string projectName,
+            string outputPath,
+            string targetPlatformVersion = "10.0.14393.0",
+            string targetPlatformMinVersion = "10.0.10586.0")
+        {
+            if(string.IsNullOrEmpty(targetPlatformVersion))
+            {
+                targetPlatformVersion = "10.0.14393.0";
+            }
+
+            if (string.IsNullOrEmpty(targetPlatformMinVersion))
+            {
+                targetPlatformMinVersion = "10.0.10586.0";
+            }
+            Directory.CreateDirectory(Path.Combine(outputPath, projectName, projectName));
+            var solutionDir = Path.Combine(outputPath, projectName);
+            FormatAndCopyTemplateFiles("AssemblyInfo.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "AssemblyInfo.cs", "Properties");
+            FormatAndCopyTemplateFiles("Class1.cs", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "Class1.cs");
+            FormatAndCopyTemplateFiles("project.json", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "project.json");
+            FormatAndCopyTemplateFiles("projectjsonbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
+            FormatAndCopyTemplateFiles("project.rd.xml", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".rd.xml", "Properties");
+            FormatAndCopyTemplateFiles("project.sln", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".sln");
+            return Path.Combine(solutionDir, projectName + ".sln");
+        }
+
+        private static void FormatAndCopyTemplateFiles(string fileName,
+            string projectName,
+            string solutionDir,
+            string targetPlatformVersion,
+            string targetPlatformMinVersion,
+            string destFileName,
+            string destinationDir = "")
+        {
+            var contents = GetResourceAsString($"API.Test.compiler.resources.UWP.{fileName}");
+            contents = string.Format(contents, projectName, targetPlatformVersion, targetPlatformMinVersion);
+
+            var finalDestinationDir = Path.Combine(solutionDir, projectName, destinationDir);
+            if (Path.GetExtension(destFileName) == ".sln")
+            {
+                finalDestinationDir = solutionDir;
+            }
+            if (!Directory.Exists(finalDestinationDir))
+            {
+                Directory.CreateDirectory(finalDestinationDir);
+            }
+            File.WriteAllText(Path.Combine(finalDestinationDir, destFileName), contents);
+        }
+        public static string GetResourceAsString(string name)
+        {
+            var stream = typeof(UwpProjectTestsUtil).GetTypeInfo().Assembly.GetManifestResourceStream(name);
+            return new StreamReader(stream).ReadToEnd();
+        }
+    }
+}

--- a/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
+++ b/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
@@ -10,8 +10,6 @@ namespace API.Test
     public class UwpProjectTestsUtil
     {
         private static readonly Version RS2 = new Version(10, 0, 15063, 0);
-        // TODO: Handle creating the right project template for TPV > RS2
-        // Returns the path to the solution file
         public static string CreateUwpClassLibrary(string projectName,
             string outputPath,
             string targetPlatformVersion = "10.0.14393.0",

--- a/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
+++ b/test/TestExtensions/API.Test/UwpProjectTestUtils.cs
@@ -40,15 +40,11 @@ namespace API.Test
                 FormatAndCopyTemplateFiles("packagerefbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
             }
             else
-            {                
+            {
                 FormatAndCopyTemplateFiles("project.json", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, "project.json");
                 FormatAndCopyTemplateFiles("projectjsonbaseduwpproject.csproj", projectName, solutionDir, targetPlatformVersion, targetPlatformMinVersion, projectName + ".csproj");
-                
-                
             }
 
-            
-            
             return Path.Combine(solutionDir, projectName + ".sln");
         }
 
@@ -74,6 +70,7 @@ namespace API.Test
             }
             File.WriteAllText(Path.Combine(finalDestinationDir, destFileName), contents);
         }
+
         public static string GetResourceAsString(string name)
         {
             var stream = typeof(UwpProjectTestsUtil).GetTypeInfo().Assembly.GetManifestResourceStream(name);

--- a/test/TestExtensions/API.Test/VSProjectHelper.cs
+++ b/test/TestExtensions/API.Test/VSProjectHelper.cs
@@ -9,7 +9,6 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
-using NuGet.Test.Utility;
 
 namespace API.Test
 {
@@ -55,7 +54,7 @@ namespace API.Test
             return ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                var pathToSln = UwpProjectTestsUtil.CreateUwpClassLibrary(projectName, targetPlatformVersion, targtetPlatformMinVersion);
+                var pathToSln = UwpProjectTestsUtil.CreateUwpClassLibrary(projectName, outputPath, targetPlatformVersion, targtetPlatformMinVersion);
                 VSSolutionHelper.OpenSolution(pathToSln);
                 var dte = ServiceLocator.GetDTE();
                 var dte2 = (DTE2)dte;

--- a/test/TestExtensions/API.Test/VSProjectHelper.cs
+++ b/test/TestExtensions/API.Test/VSProjectHelper.cs
@@ -9,6 +9,7 @@ using EnvDTE;
 using EnvDTE80;
 using Microsoft.VisualStudio.Shell;
 using Task = System.Threading.Tasks.Task;
+using NuGet.Test.Utility;
 
 namespace API.Test
 {
@@ -42,6 +43,30 @@ namespace API.Test
                     templateName,
                     name,
                     solutionFolderName);
+            });
+        }
+
+        public static object NewUwpClassLibrary(string projectName,
+            string outputPath,
+            string targetPlatformVersion = "10.0.14393.0",
+            string targtetPlatformMinVersion = "10.0.10586.0")
+        {
+            
+            return ThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                var pathToSln = UwpProjectTestsUtil.CreateUwpClassLibrary(projectName, targetPlatformVersion, targtetPlatformMinVersion);
+                VSSolutionHelper.OpenSolution(pathToSln);
+                var dte = ServiceLocator.GetDTE();
+                var dte2 = (DTE2)dte;
+                var solution2 = dte2.Solution as Solution2;
+                var window = dte2.ActiveWindow as Window2;
+                await CloseOpenDocumentsAsync(dte2);
+
+                await Activatex86ConfigurationsAsync(dte2);
+
+                window.SetFocus();
+                return await VSSolutionHelper.GetProjectAsync(solution2, projectName);
             });
         }
 

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/AssemblyInfo.cs
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("{0}")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("{0}")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/Class1.cs
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/Class1.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace {0} 
+{{
+    public class Class1
+    {{
+    }}
+}}

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/packagerefbaseduwpproject.csproj
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/packagerefbaseduwpproject.csproj
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{{9961C3C3-A956-4D9D-ABD5-94A709F62A2A}}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>{0}</RootNamespace>
+    <AssemblyName>{0}</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">{1}</TargetPlatformVersion>
+    <TargetPlatformMinVersion>{2}</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A}};{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="Properties\{0}.rd.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>5.4.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/project.json
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/project.json
@@ -1,0 +1,16 @@
+{{
+  "dependencies": {{
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.3"
+  }},
+  "frameworks": {{
+    "uap10.0": {{}}
+  }},
+  "runtimes": {{
+    "win10-arm": {{}},
+    "win10-arm-aot": {{}},
+    "win10-x86": {{}},
+    "win10-x86-aot": {{}},
+    "win10-x64": {{}},
+    "win10-x64-aot": {{}}
+  }}
+}}

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/project.rd.xml
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/project.rd.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This file contains Runtime Directives, specifications about types your application accesses
+    through reflection and other dynamic code patterns. Runtime Directives are used to control the
+    .NET Native optimizer and ensure that it does not remove code accessed by your library. If your
+    library does not do any reflection, then you generally do not need to edit this file. However,
+    if your library reflects over types, especially types passed to it or derived from its types,
+    then you should write Runtime Directives.
+
+    The most common use of reflection in libraries is to discover information about types passed
+    to the library. Runtime Directives have three ways to express requirements on types passed to
+    your library.
+
+    1.  Parameter, GenericParameter, TypeParameter, TypeEnumerableParameter
+        Use these directives to reflect over types passed as a parameter.
+
+    2.  SubTypes
+        Use a SubTypes directive to reflect over types derived from another type.
+
+    3.  AttributeImplies
+        Use an AttributeImplies directive to indicate that your library needs to reflect over
+        types or methods decorated with an attribute.
+
+    For more information on writing Runtime Directives for libraries, please visit
+    https://go.microsoft.com/fwlink/?LinkID=391919
+-->
+<Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
+  <Library Name="{0}">
+
+  	<!-- add directives for your library here -->
+
+  </Library>
+</Directives>

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/project.sln
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/project.sln
@@ -1,0 +1,43 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26703.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}") = "{0}", "{0}\{0}.csproj", "{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|ARM.ActiveCfg = Debug|ARM
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|ARM.Build.0 = Debug|ARM
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|x64.ActiveCfg = Debug|x64
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|x64.Build.0 = Debug|x64
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|x86.ActiveCfg = Debug|x86
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Debug|x86.Build.0 = Debug|x86
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|Any CPU.Build.0 = Release|Any CPU
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|ARM.ActiveCfg = Release|ARM
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|ARM.Build.0 = Release|ARM
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|x64.ActiveCfg = Release|x64
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|x64.Build.0 = Release|x64
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|x86.ActiveCfg = Release|x86
+		{{E8ED13E1-4F47-4E32-A603-E6D885B2FDE2}}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {{274DEC02-ABDD-4F92-971A-D414AAB6AF9F}}
+	EndGlobalSection
+EndGlobal

--- a/test/TestExtensions/API.Test/compiler/resources/UWP/projectjsonbaseduwpproject.csproj
+++ b/test/TestExtensions/API.Test/compiler/resources/UWP/projectjsonbaseduwpproject.csproj
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{{e1a4c929-9107-48cd-ba47-19750fbb371f}}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>{0}</RootNamespace>
+    <AssemblyName>{0}</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">{1}</TargetPlatformVersion>
+    <TargetPlatformMinVersion>{2}</TargetPlatformMinVersion>
+    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A}};{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <PlatformTarget>ARM</PlatformTarget>
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <None Include="project.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="Class1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <EmbeddedResource Include="Properties\{0}.rd.xml" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+    <VisualStudioVersion>14.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
uwp migrator was broken because of some recent lsl related changes that were introduced. this changeset fixes that issue and adds end-to-end test coverage for the scenario

Fixes: devdiv internal bug 454369