### PR TITLE
fix broken uwp migrator without tests

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -101,6 +101,7 @@
     <Compile Include="ProjectServices\GlobalProjectServiceProvider.cs" />
     <Compile Include="ProjectServices\NetCoreProjectSystemServices.cs" />
     <Compile Include="ProjectServices\VsCoreProjectSystemReferenceReader.cs" />
+    <Compile Include="ProjectSystems\VsCoreProjectSystem.cs" />
     <Compile Include="Projects\VsMSBuildProjectSystemServices.cs" />
     <Compile Include="Utility\SupportedProjectTypes.cs" />
     <Compile Include="Common\VersionCollectionExtensions.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,7 +32,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public IProjectSystemReferencesService References => throw new NotSupportedException();
 
-        public IProjectSystemService ProjectSystem => throw new NotSupportedException();
+        public IProjectSystemService ProjectSystem { get; }
 
         public IProjectScriptHostService ScriptService { get; }
 
@@ -49,6 +49,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             _threadingService = GetGlobalService<IVsProjectThreadingService>();
             Assumes.Present(_threadingService);
+            ProjectSystem = new VsCoreProjectSystem(_vsProjectAdapter);
 
             ReferencesReader = new VsCoreProjectSystemReferenceReader(vsProjectAdapter, this);
             ScriptService = new VsProjectScriptHostService(vsProjectAdapter, this);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/VsCoreProjectSystem.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+
+namespace NuGet.PackageManagement.VisualStudio
+{
+    internal class VsCoreProjectSystem : IProjectSystemService
+    {
+        private IVsProjectAdapter VsProjectAdapter { get; }
+
+        public async Task SaveProjectAsync(CancellationToken token)
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            try
+            {
+                FileSystemUtility.MakeWritable(VsProjectAdapter.FullName);
+                VsProjectAdapter.Project.Save();
+            }
+            catch (Exception ex)
+            {
+                ExceptionHelper.WriteErrorToActivityLog(ex);
+            }
+        }
+
+        public VsCoreProjectSystem(
+            IVsProjectAdapter vsProjectAdapter)
+        {
+            Assumes.Present(vsProjectAdapter);
+
+            VsProjectAdapter = vsProjectAdapter;
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -61,12 +61,11 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public bool TryCreateNuGetProject(
             IVsProjectAdapter vsProjectAdapter,
-            ProjectProviderContext context,
+            ProjectProviderContext _,
             bool forceProjectType,
             out NuGetProject result)
         {
             Assumes.Present(vsProjectAdapter);
-            Assumes.Present(context);
 
             _threadingService.ThrowIfNotOnUIThread();
 


### PR DESCRIPTION
same changeset as https://github.com/NuGet/NuGet.Client/pull/1542 but without tests since all our current E2E machines run Windows 2016 server and UWP projects are not supported on Win2016 Server + VS2017.