### PR TITLE
Perf:  restore stream copy buffer size

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -152,10 +152,15 @@ namespace NuGet.Packaging
                 bufferSize: 4096,
                 useAsync: true))
             {
+                // This value comes from NuGet.Protocol.StreamExtensions.CopyToAsync(...).
+                // While 8K may or may not be the optimal buffer size for copy performance,
+                // it is better than 4K.
+                const int bufferSize = 8192;
+
                 await _sourceStream.Value.CopyToAsync(
                     destination,
-                    bufferSize: 8192,
-                    cancellationToken: cancellationToken);
+                    bufferSize,
+                    cancellationToken);
             }
 
             return true;

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -154,7 +154,7 @@ namespace NuGet.Packaging
             {
                 await _sourceStream.Value.CopyToAsync(
                     destination,
-                    bufferSize: 4096,
+                    bufferSize: 8192,
                     cancellationToken: cancellationToken);
             }
 


### PR DESCRIPTION
Commit https://github.com/NuGet/NuGet.Client/commit/870340673ba75a95407ab55ce1f46f57fe9bf25b (PR NuGet/NuGet.Client#1387) changed the copy buffer size from [8K](https://github.com/NuGet/NuGet.Client/commit/870340673ba75a95407ab55ce1f46f57fe9bf25b#diff-3fdb56bb93e9f668426f7fe2b518070fL60) (via [NuGet.Protocol.StreamExtensions.CopyToAsync(...)](https://github.com/NuGet/NuGet.Client/blob/4eed67e7e159796ae486d2cca406b283e23b6ac8/src/NuGet.Core/NuGet.Protocol/Utility/StreamExtensions.cs#L18)) to [4K](https://github.com/NuGet/NuGet.Client/commit/870340673ba75a95407ab55ce1f46f57fe9bf25b#diff-95f23985964122815a6ded54cd19bbdcR157).

This change restores the original 8K copy buffer.

This is for internal bug 451335.