### PR TITLE
fetching ProjectTypeGuid in LSL mode

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/NuGet.PackageManagement.VisualStudio.csproj
@@ -104,7 +104,6 @@
     <Compile Include="ProjectServices\VsCoreProjectSystemReferenceReader.cs" />
     <Compile Include="ProjectSystems\VsCoreProjectSystem.cs" />
     <Compile Include="Projects\VsMSBuildProjectSystemServices.cs" />
-    <Compile Include="Utility\SupportedProjectTypes.cs" />
     <Compile Include="Common\VersionCollectionExtensions.cs" />
     <Compile Include="DefaultVSCredentialServiceProvider.cs" />
     <Compile Include="Handlers\ProjectRetargetingHandler.cs" />

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -78,6 +78,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 vsHierarchyItem,
                 projectNames,
                 fullProjectPath,
+                dteProject.Kind,
                 loadDteProject,
                 vsBuildProperties,
                 _threadingService);
@@ -104,10 +105,13 @@ namespace NuGet.PackageManagement.VisualStudio
             var workspaceBuildProperties = new WorkspaceProjectBuildProperties(
                 fullProjectPath, _workspaceService.Value, _threadingService);
 
+            var projectTypeGuid = await _workspaceService.Value.GetProjectTypeGuidAsync(fullProjectPath);
+
             return new VsProjectAdapter(
                 vsHierarchyItem,
                 projectNames,
                 fullProjectPath,
+                projectTypeGuid,
                 EnsureProjectIsLoaded,
                 workspaceBuildProperties,
                 _threadingService,

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
@@ -76,5 +76,27 @@ namespace NuGet.PackageManagement.VisualStudio
                     projectFilePath, projectProperties: projectProperties);
             }
         }
+
+        public async Task<string> GetProjectTypeGuidAsync(string projectFilePath)
+        {
+            var workspace = SolutionWorkspaceService.CurrentWorkspace;
+            var solutionPath = SolutionWorkspaceService.SolutionFile;
+            var indexService = workspace.GetIndexWorkspaceService();
+            var indexedSolutionProjectTypes = (await indexService.GetFileDataValuesAsync<ProjectBaseTypesInSolution>(solutionPath,
+                ProjectBaseTypesInSolution.TypeGuid, refreshOption: true)).FirstOrDefault();
+
+            if (indexedSolutionProjectTypes != null)
+            {
+                var relativeProjectPath = Common.PathUtility.GetRelativePath(solutionPath, projectFilePath);
+
+                if (!string.IsNullOrEmpty(relativeProjectPath)
+                    && indexedSolutionProjectTypes.Value.Types.TryGetValue(relativeProjectPath, out Guid projectTypeGuid))
+                {
+                    return projectTypeGuid.ToString("B");
+                }
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Utility/EnvDTEProjectUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -29,11 +29,6 @@ namespace NuGet.PackageManagement.VisualStudio
     public static class EnvDTEProjectUtility
     {
         #region Constants and Statics
-
-        private static readonly HashSet<string> UnsupportedProjectCapabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "SharedAssetsProject", // This is true for shared projects in universal apps
-            };
 
         private static readonly Dictionary<string, string> KnownNestedFiles = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
@@ -417,7 +412,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var hierarchy = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
 
-            return hierarchy.IsCapabilityMatch("AssemblyReferences + DeclaredSourceItems + UserSourceItems");
+            return VsHierarchyUtility.IsProjectCapabilityCompliant(hierarchy);
         }
 
         public static NuGetProject GetNuGetProject(EnvDTE.Project project, ISolutionManager solutionManager)
@@ -751,15 +746,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var hier = VsHierarchyUtility.ToVsHierarchy(envDTEProject);
 
-            foreach (var unsupportedProjectCapability in UnsupportedProjectCapabilities)
-            {
-                if (hier.IsCapabilityMatch(unsupportedProjectCapability))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return VsHierarchyUtility.HasUnsupportedProjectCapability(hier);
         }
 
         #endregion // Check Project Types

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
@@ -12,5 +12,7 @@ namespace NuGet.VisualStudio
         Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath);
 
         Task<IMSBuildProjectDataService> GetMSBuildProjectDataServiceAsync(string projectFilePath, string targetFramework = null);
+
+        Task<string> GetProjectTypeGuidAsync(string projectFilePath);
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SupportedProjectTypes.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SupportedProjectTypes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using NuGet.VisualStudio;
 
-namespace NuGet.PackageManagement.VisualStudio
+namespace NuGet.VisualStudio
 {
-    internal static class SupportedProjectTypes
+    public static class SupportedProjectTypes
     {
         private static readonly HashSet<string> _supportedProjectTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectBuildProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 
@@ -27,6 +27,7 @@ namespace NuGet.ProjectManagement
         public const string RestorePackagesPath = "RestorePackagesPath";
         public const string RestoreSources = "RestoreSources";
         public const string RestoreFallbackFolders = "RestoreFallbackFolders";
+        public const string ProjectTypeGuids = "ProjectTypeGuids";
         public const string RestoreAdditionalProjectSources = nameof(RestoreAdditionalProjectSources);
         public const string RestoreAdditionalProjectFallbackFolders = nameof(RestoreAdditionalProjectFallbackFolders);
         public const string NoWarn = nameof(NoWarn);


### PR DESCRIPTION
the bug is in LSL mode, IsSupport() check for project always return true, then nuget initialize lots of unsupport projects. That cause perf issue and also show unsupport project in project list of UI or powershell.

Fix here is fetching ProjectTypeGuid and ProjectTypeGuids from AnyCode database and filtering out unsupport projects 
