### PR TITLE
clean restore cache file on build clean in VS

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -674,7 +674,7 @@ namespace NuGet.CommandLine
 
         private static bool IsSolutionOrProjectFile(string fileName)
         {
-            if (!String.IsNullOrEmpty(fileName))
+            if (!string.IsNullOrEmpty(fileName))
             {
                 var extension = Path.GetExtension(fileName);
                 var lastFourCharacters = string.Empty;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -76,6 +76,12 @@ namespace NuGet.PackageManagement.VisualStudio
             return await GetAssetsFilePathAsync(shouldThrow: true);
         }
 
+        public override async Task<string> GetCacheFilePathAsync()
+        {
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+            return NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: GetBaseIntermediatePath(), projectPath: _projectFullPath);
+        }
+
         public override async Task<string> GetAssetsFilePathOrNullAsync()
         {
             return await GetAssetsFilePathAsync(shouldThrow: false);
@@ -345,6 +351,7 @@ namespace NuGet.PackageManagement.VisualStudio
                         }
                     },
                     SkipContentFileWrite = true,
+                    CacheFilePath = await GetCacheFilePathAsync(),
                     PackagesPath = GetPackagesPath(settings),
                     Sources = GetSources(settings),
                     FallbackFolders = GetFallbackFolders(settings),

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -291,6 +291,18 @@ namespace NuGet.PackageManagement.VisualStudio
             return true;
         }
 
+        public override Task<string> GetCacheFilePathAsync()
+        {
+            var spec = GetPackageSpec();
+            if (spec == null)
+            {
+                throw new InvalidOperationException(
+                    string.Format(Strings.ProjectNotLoaded_RestoreFailed, ProjectName));
+            }
+
+            return Task.FromResult(NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: spec.RestoreMetadata.OutputPath, projectPath: spec.RestoreMetadata.ProjectPath));
+        }
+
         #endregion
     }
 }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectJsonNuGetProject.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectManagement;
@@ -50,6 +51,11 @@ namespace NuGet.PackageManagement.VisualStudio
             }
 
             return UriUtility.GetAbsolutePathFromFile(MSBuildProjectPath, baseIntermediatePath);
+        }
+
+        public override async Task<string> GetCacheFilePathAsync()
+        {
+            return NoOpRestoreUtilities.GetProjectCacheFilePath(await GetBaseIntermediatePathAsync(), MSBuildProjectPath);
         }
 
         protected override async Task UpdateInternalTargetFrameworkAsync()

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -132,7 +132,7 @@ namespace NuGet.SolutionRestoreManager
                 (buildAction & (uint)VSSOLNBUILDUPDATEFLAGS3.SBF_FLAGS_UPTODATE_CHECK) == 0)
             {
                 // Clear the project.json restore cache on clean to ensure that the next build restores again
-                SolutionRestoreWorker.Value.CleanCache();
+                await SolutionRestoreWorker.Value.CleanCacheAsync();
             }
             else if ((buildAction & (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD) != 0 &&
                     (buildAction & (uint)VSSOLNBUILDUPDATEFLAGS3.SBF_FLAGS_UPTODATE_CHECK) == 0 &&

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft;
@@ -14,6 +15,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement.VisualStudio;
+using NuGet.ProjectManagement.Projects;
 using NuGet.VisualStudio;
 using Task = System.Threading.Tasks.Task;
 
@@ -304,8 +306,13 @@ namespace NuGet.SolutionRestoreManager
             }
         }
 
-        public void CleanCache()
+        public async Task CleanCacheAsync()
         {
+            // get all build integrated based nuget projects and delete the cache file.
+            await Task.WhenAll(
+                SolutionManager.GetNuGetProjects().OfType<BuildIntegratedNuGetProject>().Select(async e =>
+                    Common.FileUtility.Delete(await e.GetCacheFilePathAsync())));
+
             Interlocked.Exchange(ref _restoreJobContext, new SolutionRestoreJobContext());
         }
 

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -245,7 +245,10 @@ namespace NuGet.SolutionRestoreManager
                 // cross-targeting is always ON even in case of a single tfm in the list.
                 crossTargeting = true;
             }
-
+            var outputPath = Path.GetFullPath(
+                        Path.Combine(
+                            projectDirectory,
+                            projectRestoreInfo.BaseIntermediatePath));
             var packageSpec = new PackageSpec(tfis)
             {
                 Name = GetPackageId(projectNames, projectRestoreInfo.TargetFrameworks),
@@ -256,10 +259,7 @@ namespace NuGet.SolutionRestoreManager
                     ProjectName = projectNames.ShortName,
                     ProjectUniqueName = projectFullPath,
                     ProjectPath = projectFullPath,
-                    OutputPath = Path.GetFullPath(
-                        Path.Combine(
-                            projectDirectory,
-                            projectRestoreInfo.BaseIntermediatePath)),
+                    OutputPath = outputPath,
                     ProjectStyle = ProjectStyle.PackageReference,
                     TargetFrameworks = projectRestoreInfo.TargetFrameworks
                         .Cast<IVsTargetFrameworkInfo>()
@@ -278,7 +278,8 @@ namespace NuGet.SolutionRestoreManager
                     ProjectWideWarningProperties = MSBuildRestoreUtility.GetWarningProperties(
                         treatWarningsAsErrors: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, TreatWarningsAsErrors, e => e),
                         warningsAsErrors: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, WarningsAsErrors, e => e),
-                        noWarn: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, NoWarn, e => e))
+                        noWarn: GetNonEvaluatedPropertyOrNull(projectRestoreInfo.TargetFrameworks, NoWarn, e => e)),
+                    CacheFilePath = NoOpRestoreUtilities.GetProjectCacheFilePath(cacheRoot: outputPath, projectPath: projectFullPath)
                 },
                 RuntimeGraph = GetRuntimeGraph(projectRestoreInfo),
                 RestoreSettings = new ProjectRestoreSettings() { HideWarningsAndErrors = true }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SolutionRestore/ISolutionRestoreWorker.cs
@@ -46,6 +46,6 @@ namespace NuGet.VisualStudio
         /// <summary>
         /// Cleans incremental restore cache.
         /// </summary>
-        void CleanCache();
+        Task CleanCacheAsync();
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -918,24 +918,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-    _CleanRestoreCacheFiles
-    Deletes all the *.nuget.cache files in the obj directory
-    ============================================================
-  -->
-  <Target Name="_CleanRestoreCacheFiles"
-          AfterTargets="Clean">
-    <PropertyGroup>
-      <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' != '' ">$(RestoreOutputPath)</CacheFileOutputPath>
-      <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</CacheFileOutputPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <_CacheFilesToDelete Include="$(CacheFileOutputPath)*.nuget.cache" />
-    </ItemGroup>
-    <Delete Files="@(_CacheFilesToDelete)" />
-  </Target>
-
-  <!--
-    ============================================================
     _IsProjectRestoreSupported
     Verify restore targets exist in the project.
     ============================================================

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RequestFactory/RestoreArgs.cs
@@ -174,7 +174,7 @@ namespace NuGet.Commands
                 request.LockFilePath = ProjectJsonPathUtilities.GetLockFilePath(request.Project.FilePath);
             }
 
-            if (request.Project.RestoreMetadata != null) {
+            if (request.Project.RestoreMetadata?.CacheFilePath == null) {
                 request.Project.RestoreMetadata.CacheFilePath = NoOpRestoreUtilities.GetCacheFilePath(request);
             }
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -248,7 +248,7 @@ namespace NuGet.Commands
             {
                 if (noOp) // Only if the hash matches, then load the lock file. This is a performance hit, so we need to delay it as much as possible.
                 { 
-                    _request.ExistingLockFile = LockFileUtilities.GetLockFile(_request.LockFilePath, _request.Log);
+                    _request.ExistingLockFile = LockFileUtilities.GetLockFile(_request.LockFilePath, _logger);
                 }
                 else
                 {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -19,7 +19,6 @@ namespace NuGet.Commands
 
         /// <summary>
         /// If the dependencyGraphSpec is not set, we cannot no-op on this project restore. 
-        /// No-Op restore is not supported for CLI Tools at this point
         /// </summary>
         internal static bool IsNoOpSupported(RestoreRequest request)
         {
@@ -29,22 +28,25 @@ namespace NuGet.Commands
         /// <summary>
         /// The cache file path is $(BaseIntermediateOutputPath)\$(project).nuget.cache
         /// </summary>
-        private static string GetBuildIntegratedProjectCacheFile(RestoreRequest request)
+        private static string GetBuildIntegratedProjectCacheFilePath(RestoreRequest request)
         {
-            string cacheFilePath = null;
 
             if (request.ProjectStyle == ProjectStyle.ProjectJson
                 || request.ProjectStyle == ProjectStyle.PackageReference
-               || request.ProjectStyle == ProjectStyle.Standalone)
+                || request.ProjectStyle == ProjectStyle.Standalone)
             {
-                var projFileName = Path.GetFileName(request.Project.RestoreMetadata.ProjectPath);
                 var cacheRoot = request.BaseIntermediateOutputPath ?? request.RestoreOutputPath;
-                cacheFilePath = request.Project.RestoreMetadata.CacheFilePath = Path.Combine(cacheRoot, $"{projFileName}.nuget.cache");
+                return request.Project.RestoreMetadata.CacheFilePath = GetProjectCacheFilePath(cacheRoot, request.Project.RestoreMetadata.ProjectPath);
             }
 
-            return cacheFilePath;
+            return null;
         }
 
+        public static string GetProjectCacheFilePath(string cacheRoot, string projectPath)
+        {
+            var projFileName = Path.GetFileName(projectPath);
+            return Path.Combine(cacheRoot, $"{projFileName}.nuget.cache");
+        }
 
         internal static string GetToolCacheFilePath(RestoreRequest request, LockFile lockFile)
         {
@@ -95,7 +97,7 @@ namespace NuGet.Commands
                     || request.ProjectStyle == ProjectStyle.Standalone
                     || request.ProjectStyle == ProjectStyle.ProjectJson)
                 {
-                    projectCacheFilePath = GetBuildIntegratedProjectCacheFile(request);
+                    projectCacheFilePath = GetBuildIntegratedProjectCacheFilePath(request);
                 }
                 else if(request.ProjectStyle == ProjectStyle.DotnetCliTool)
                 {

--- a/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/FileUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -176,7 +176,7 @@ namespace NuGet.Common
             }
 
             // Run up to 3 times
-            for (int i = 0; i < MaxTries; i++)
+            for (var i = 0; i < MaxTries; i++)
             {
                 // Ignore exceptions for the first attempts
                 try
@@ -203,7 +203,7 @@ namespace NuGet.Common
             }
 
             // Run up to 3 times
-            for (int i = 0; i < MaxTries; i++)
+            for (var i = 0; i < MaxTries; i++)
             {
                 // Ignore exceptions for the first attempts
                 try

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,6 +43,8 @@ namespace NuGet.ProjectManagement.Projects
         /// determined.
         /// </summary>
         public abstract Task<string> GetAssetsFilePathAsync();
+
+        public abstract Task<string> GetCacheFilePathAsync();
 
         /// <summary>
         /// Returns the path to the assets file or the lock file. Returns null if the assets file path cannot be

--- a/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Projects/ProjectJsonNuGetProject.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Frameworks;
@@ -150,10 +151,10 @@ namespace NuGet.ProjectManagement.Projects
             return packages;
         }
 
-        protected virtual async Task<string> GetBaseIntermediatePathAsync()
+        protected virtual Task<string> GetBaseIntermediatePathAsync()
         {
             // Extending class will implement the functionality.
-            return null;
+            return Task.FromResult((string) null);
         }
        
         public override async Task<IReadOnlyList<PackageSpec>> GetPackageSpecsAsync(DependencyGraphCacheContext context)
@@ -176,6 +177,7 @@ namespace NuGet.ProjectManagement.Projects
                 metadata.ProjectJsonPath = packageSpec.FilePath;
                 metadata.ProjectName = packageSpec.Name;
                 metadata.ProjectUniqueName = MSBuildProjectPath;
+                metadata.CacheFilePath = await GetCacheFilePathAsync();
 
                 // Reload the target framework from csproj and update the target framework in packageSpec for restore
                 await UpdateInternalTargetFrameworkAsync();
@@ -351,6 +353,12 @@ namespace NuGet.ProjectManagement.Projects
         private bool TryGetInternalFramework(out object internalTargetFramework)
         {
             return InternalMetadata.TryGetValue(NuGetProjectMetadataKeys.TargetFramework, out internalTargetFramework);
+        }
+
+        // Overriding class wil implement the method
+        public override Task<string> GetCacheFilePathAsync()
+        {
+            return Task.FromResult((string)null);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -191,7 +191,7 @@ namespace NuGet.Protocol
 
             private static string TrimNamespace(string packageEntityName)
             {
-                int lastIndex = packageEntityName.LastIndexOf('.');
+                var lastIndex = packageEntityName.LastIndexOf('.');
                 if (lastIndex > 0 && lastIndex < packageEntityName.Length)
                 {
                     packageEntityName = packageEntityName.Substring(lastIndex + 1);

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -478,7 +478,7 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTr
     Assert-ProjectJsonLockFilePackage $project1 NuGet.Versioning 1.0.7
 }
 
-function Test-BuildIntegratedClean {
+function Test-BuildIntegratedCleanDeleteCacheFile {
     # Arrange
     $project = New-BuildIntegratedProj UAPApp
 
@@ -536,4 +536,56 @@ function Remove-PackageReference {
     $node.ParentNode.RemoveChild($node)
 
     $doc.Save($projectPath)
+}
+
+function Test-BuildIntegratedLegacyCleanDeleteCacheFile {
+    # Arrange
+    $project = New-Project PackageReferenceClassLibrary
+    $project | Install-Package Newtonsoft.Json -Version 9.0.1
+    Build-Solution
+    Assert-ProjectCacheFileExists $project
+
+    #Act
+    Clean-Solution
+
+    #Assert
+    Assert-ProjectCacheFileNotExists $project
+}
+
+function Test-BuildIntegratedRebuildDoesNotDeleteCacheFile {
+    # Arrange
+    $project = New-BuildIntegratedProj UAPApp
+    Install-Package NuGet.Versioning -ProjectName $project.Name -version 1.0.7
+    Build-Solution
+    Assert-ProjectCacheFileExists $project
+
+    AdviseSolutionEvents
+
+    #Act
+    Rebuild-Solution
+
+    WaitUntilRebuildCompleted
+    UnadviseSolutionEvents
+
+    #Assert
+    Assert-ProjectCacheFileExists $project
+}
+
+function Test-BuildIntegratedLegacyRebuildDoesNotDeleteCacheFile {
+    # Arrange
+    $project = New-Project PackageReferenceClassLibrary
+    $project | Install-Package Newtonsoft.Json -Version 9.0.1
+    Build-Solution
+    Assert-ProjectCacheFileExists $project
+
+    AdviseSolutionEvents
+
+    #Act
+    Rebuild-Solution
+
+    WaitUntilRebuildCompleted
+    UnadviseSolutionEvents
+
+    #Assert
+    Assert-ProjectCacheFileExists $project
 }

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -777,3 +777,22 @@ function Test-NetCoreConsoleAppClean {
     #Assert
     Assert-ProjectCacheFileNotExists $project
 }
+
+function Test-NetCoreConsoleAppRebuildDoesNotDeleteCacheFile {
+    # Arrange & Act
+    $project = New-NetCoreConsoleApp ConsoleApp
+    Build-Solution
+
+    Assert-ProjectCacheFileExists $project
+
+    AdviseSolutionEvents
+
+    #Act
+    Rebuild-Solution
+
+    WaitUntilRebuildCompleted
+    UnadviseSolutionEvents
+
+    #Assert
+    Assert-ProjectCacheFileExists $project
+}

--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -1,4 +1,4 @@
-﻿param([parameter(Mandatory = $true)]
+param([parameter(Mandatory = $true)]
       [string]$OutputPath,
       [parameter(Mandatory = $true)]
       [string]$TemplatePath)
@@ -605,6 +605,12 @@ function Build-Solution {
     [API.Test.VSSolutionHelper]::BuildSolution()
 }
 
+function Rebuild-Solution {
+    Write-Verbose "Rebuild and wait for it to complete"
+
+    [API.Test.VSSolutionHelper]::RebuildSolution()
+}
+
 function Get-AssemblyReference {
     param(
         [parameter(Mandatory = $true)]
@@ -873,4 +879,20 @@ function Check-NuGetConfig {
 
 function Get-BuildOutput {
     return [API.Test.VSHelper]::GetBuildOutput()
+}
+
+function AdviseSolutionEvents {
+    Write-Verbose "Advise for Solution build events"
+
+    [API.Test.VSSolutionHelper]::AdviseSolutionEvents()
+}
+
+function UnadviseSolutionEvents {
+    Write-Verbose "Unadvise for solution build events"
+
+    [API.Test.VSSolutionHelper]::UnadviseSolutionEvents()
+}
+
+function WaitUntilRebuildCompleted {
+    [API.Test.VSSolutionHelper]::WaitUntilRebuildCompleted()
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -45,7 +45,7 @@ namespace NuGet.SolutionRestoreManager.Test
             }
 
             Mock.Get(restoreWorker)
-                .Verify(x => x.CleanCache(), Times.Once);
+                .Verify(x => x.CleanCacheAsync(), Times.Once);
  
             Mock.Get(restoreWorker)
                 .Verify(x => x.ScheduleRestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -451,6 +451,30 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.True(Enumerable.SequenceEqual(expectedFallback.OrderBy(t => t), specFallback.OrderBy(t => t)));
         }
 
+        [Fact]
+        public async Task NominateProjectAsync_CacheFilePathInPackageSpec_Succeeds()
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new IVsProjectProperty[] {}))
+                .Build();
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+
+            // Assert
+            SpecValidationUtility.ValidateDependencySpec(actualRestoreSpec);
+
+            var actualProjectSpec = actualRestoreSpec.GetProjectSpec(projectFullPath);
+            Assert.NotNull(actualProjectSpec);
+            Assert.Equal(Path.Combine(actualProjectSpec.RestoreMetadata.OutputPath,$"{Path.GetFileName(projectFullPath)}.nuget.cache"), actualProjectSpec.RestoreMetadata.CacheFilePath);
+        }
 
         [Theory]
         [InlineData("1.0.0", "1.2.3")]

--- a/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.VisualStudio.Implementation.Test/Extensibility/VsPathContextProviderTests.cs
@@ -314,6 +314,11 @@ namespace NuGet.VisualStudio.Implementation.Test.Extensibility
                 throw new NotImplementedException();
             }
 
+            public override Task<string> GetCacheFilePathAsync()
+            {
+                throw new NotImplementedException();
+            }
+
             public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
1)	What bug does this fix? Give a brief overview and impact of the bug and link to bug.
**Fixes Internal bug 460684. Perf regression in F5 to breakpoint test scenario since we started clearing restore cache file with Clean MSBuild target which started clearing cache file as part of rebuild.**

2)	Describe the fix and how it fixes the bug.
**Like before (even before we introduced this regression), this PR will only clean restore cache file on build clean in VS instead of cleaning with msbuild clean target which broke rebuild scenario in VS and regressed RPS perf test.**

3)	Was this bug a regression – if so, what had regressed, when was the regression introduced, and what steps are you taking to make sure this won’t happen again.
**Perf regression in F5 to breakpoint test scenario. Added end to end tests to cover the scenario.**

4)	What testing/validation was done on the fix?
**Manual testing, vendor test pass, end to end tests, RPS tests**

@rrelyea 