### PR TITLE
Disabled e2e tests

### DIFF
--- a/test/EndToEnd/tests/LightweightSolutionLoadTest.ps1
+++ b/test/EndToEnd/tests/LightweightSolutionLoadTest.ps1
@@ -186,7 +186,7 @@ function Test-DeferredProjectJsonProjectUpdatePackage {
 }
 
 function Test-DeferredNativeProjectInstallPackage {
-    [SkipTestForVS14()]
+    [SkipTest('Hang on open solution. Internal bug 456357.')]
     param()
 
     $projectT = New-Project NativeConsoleApplication | Select-Object UniqueName, ProjectName
@@ -201,7 +201,7 @@ function Test-DeferredNativeProjectInstallPackage {
 }
 
 function Test-DeferredNativeProjectUninstallPackage {
-    [SkipTestForVS14()]
+    [SkipTest('Hang on open solution. Internal bug 456357.')]
     param()
 
     $projectT = New-Project NativeConsoleApplication | Select-Object UniqueName, ProjectName


### PR DESCRIPTION
Couple of LSL end-to-end tests hang due to a known issue. 
Internal bug 456357.


