### PR TITLE
Dont check for the success status of the downgrade

### DIFF
--- a/scripts/e2etests/InstallNuGetVSIX.ps1
+++ b/scripts/e2etests/InstallNuGetVSIX.ps1
@@ -44,12 +44,7 @@ if($VSVersion -eq '14.0')
 else 
 {
     #We don't care for the downgrade result...we should be able to install on top anyways.
-    $success = DowngradeVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
-
-    if ($success -eq $false)
-    {
-        exit 1
-    }
+    DowngradeVSIX $NuGetVSIXID $VSVersion $ProcessExitTimeoutInSeconds
 
     # Clearing MEF cache helps load the right dlls for vsix
     ClearDev15MEFCache


### PR DESCRIPTION
We don't need to check for the success status of the downgrade.
This causes problems when upgrading a machine because it requires us to firstly install a VSIX to start the toggling of the VSIX installation/downgrade.