### PR TITLE
Filter out unsupported projects from restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 NuGet.targets
 
@@ -80,7 +80,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectFrameworks" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSolutionProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSettingsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
-
+  <UsingTask TaskName="NuGet.Build.Tasks.WarnForInvalidProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
 
   <!--
     ============================================================
@@ -209,8 +209,29 @@ Copyright (c) .NET Foundation. All rights reserved.
       Inputs="@(_FilteredRestoreGraphProjectInputItemsTmp)">
       <Output
           TaskParameter="Filtered"
-          ItemName="FilteredRestoreGraphProjectInputItems" />
+          ItemName="FilteredRestoreGraphProjectInputItemsWithoutDuplicates" />
     </RemoveDuplicates>
+
+    <!-- Remove projects that do not support restore. -->
+    <MsBuild
+        Projects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
+        Targets="_IsProjectRestoreSupported"
+        ContinueOnError="$(RestoreContinueOnError)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
+                    %(_MSBuildProjectReferenceExistent.SetPlatform);
+                    $(_GenerateRestoreGraphProjectEntryInputProperties)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="FilteredRestoreGraphProjectInputItems" />
+    </MsBuild>
+
+    <!-- Warn for projects that do not support restore. -->
+    <WarnForInvalidProjectsTask
+      Condition=" '$(DisableWarnForInvalidRestoreProjects)' != 'true' "
+      AllProjects="@(FilteredRestoreGraphProjectInputItemsWithoutDuplicates)"
+      ValidProjects="@(FilteredRestoreGraphProjectInputItems)" />
   </Target>
 
   <!--
@@ -785,8 +806,23 @@ Copyright (c) .NET Foundation. All rights reserved.
       Inputs="@(_RestoreProjectPathItemsOutputs)">
       <Output
           TaskParameter="Filtered"
-          ItemName="_RestoreProjectPathItems" />
+          ItemName="_RestoreProjectPathItemsWithoutDupes" />
     </RemoveDuplicates>
+
+    <!-- Remove projects that do not support restore. -->
+    <MsBuild
+        Projects="@(_RestoreProjectPathItemsWithoutDupes)"
+        Targets="_IsProjectRestoreSupported"
+        ContinueOnError="$(RestoreContinueOnError)"
+        Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
+                    %(_MSBuildProjectReferenceExistent.SetPlatform);
+                    $(_GenerateRestoreGraphProjectEntryInputProperties)"
+        RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_RestoreProjectPathItems" />
+    </MsBuild>
   </Target>
 
   <!--
@@ -886,16 +922,30 @@ Copyright (c) .NET Foundation. All rights reserved.
     Deletes all the *.nuget.cache files in the obj directory
     ============================================================
   -->
-  <Target Name="_CleanRestoreCacheFiles" 
+  <Target Name="_CleanRestoreCacheFiles"
           AfterTargets="Clean">
     <PropertyGroup>
-        <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' != '' ">$(RestoreOutputPath)</CacheFileOutputPath>
-        <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</CacheFileOutputPath>
+      <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' != '' ">$(RestoreOutputPath)</CacheFileOutputPath>
+      <CacheFileOutputPath Condition=" '$(RestoreOutputPath)' == '' ">$(BaseIntermediateOutputPath)</CacheFileOutputPath>
     </PropertyGroup>
     <ItemGroup>
-        <_CacheFilesToDelete Include="$(CacheFileOutputPath)*.nuget.cache" />
+      <_CacheFilesToDelete Include="$(CacheFileOutputPath)*.nuget.cache" />
     </ItemGroup>
     <Delete Files="@(_CacheFilesToDelete)" />
+  </Target>
+
+  <!--
+    ============================================================
+    _IsProjectRestoreSupported
+    Verify restore targets exist in the project.
+    ============================================================
+  -->
+  <Target Name="_IsProjectRestoreSupported"
+          Returns="@(_ValidProjectsForRestore)">
+
+    <ItemGroup>
+      <_ValidProjectsForRestore Include="$(MSBuildProjectFullPath)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/WarnForInvalidProjectsTask.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Commands;
+using NuGet.Common;
+
+namespace NuGet.Build.Tasks
+{
+    public class WarnForInvalidProjectsTask : Task
+    {
+        /// <summary>
+        /// All known projects.
+        /// </summary>
+        [Required]
+        public ITaskItem[] AllProjects { get; set; }
+
+        /// <summary>
+        /// All valid projects for restore.
+        /// </summary>
+        [Required]
+        public ITaskItem[] ValidProjects { get; set; }
+
+        public override bool Execute()
+        {
+            var log = new MSBuildLogger(Log);
+
+            // item -> string
+            var all = AllProjects?.Select(e => e.ItemSpec).ToArray() ?? new string[0];
+            var valid = ValidProjects?.Select(e => e.ItemSpec).ToArray() ?? new string[0];
+
+            // log inputs
+            BuildTasksUtility.LogInputParam(log, nameof(AllProjects), all);
+            BuildTasksUtility.LogInputParam(log, nameof(ValidProjects), valid);
+
+            // Log warnings for invalid projects
+            foreach (var path in all.Except(valid, PathUtility.GetStringComparerBasedOnOS()))
+            {
+                var message = MSBuildRestoreUtility.GetWarningForUnsupportedProject(path);
+                log.Log(message);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -332,6 +332,18 @@ namespace NuGet.Commands
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Log warning NU1503
+        /// </summary>
+        public static RestoreLogMessage GetWarningForUnsupportedProject(string path)
+        {
+            var text = string.Format(CultureInfo.CurrentCulture, Strings.UnsupportedProject, path);
+            var message = RestoreLogMessage.CreateWarning(NuGetLogCode.NU1503, text);
+            message.FilePath = path;
+
+            return message;
         }
 
         private static void AddPackageTargetFallbacks(PackageSpec spec, IEnumerable<IMSBuildItem> items)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1247,6 +1247,15 @@ namespace NuGet.Commands {
         internal static string UnableToFindBuildOutput {
             get {
                 return ResourceManager.GetString("UnableToFindBuildOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Skipping restore for project &apos;{0}&apos;. The project file may be invalid or missing targets required for restore..
+        /// </summary>
+        internal static string UnsupportedProject {
+            get {
+                return ResourceManager.GetString("UnsupportedProject", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -591,4 +591,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_InvalidATF" xml:space="preserve">
     <value>PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.</value>
   </data>
+  <data name="UnsupportedProject" xml:space="preserve">
+    <value>Skipping restore for project '{0}'. The project file may be invalid or missing targets required for restore.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace NuGet.Common
@@ -127,6 +127,11 @@ namespace NuGet.Common
         /// Unknown compatibility profile
         /// </summary>
         NU1502 = 1502,
+
+        /// <summary>
+        /// Skipping project that does not support restore.
+        /// </summary>
+        NU1503 = 1503,
 
         /// <summary>
         /// Dependency bumped up

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/TestBuildEngine.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using Microsoft.Build.Framework;
+using NuGet.Common;
+using NuGet.Test.Utility;
+
+namespace NuGet.Build.Tasks.Test
+{
+    /// <summary>
+    /// MSBuild logger -> TestLogger
+    /// </summary>
+    public class TestBuildEngine : IBuildEngine
+    {
+        /// <summary>
+        /// Test logger
+        /// </summary>
+        public TestLogger TestLogger = new TestLogger();
+
+        public bool ContinueOnError => false;
+
+        public int LineNumberOfTaskNode => 0;
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs)
+        {
+            return true;
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+            // ignored
+        }
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+            var message = new RestoreLogMessage(LogLevel.Error, e.Message)
+            {
+                FilePath = e.File,
+                ProjectPath = e.ProjectFile
+            };
+
+            TestLogger.Log(message);
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+            var level = LogLevel.Debug;
+
+            if (e.Importance == MessageImportance.High)
+            {
+                level = LogLevel.Minimal;
+            }
+
+            if (e.Importance == MessageImportance.Normal)
+            {
+                level = LogLevel.Information;
+            }
+
+            var message = new RestoreLogMessage(level, e.Message)
+            {
+                FilePath = e.File,
+                ProjectPath = e.ProjectFile
+            };
+
+            TestLogger.Log(message);
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+            var message = new RestoreLogMessage(LogLevel.Warning, e.Message)
+            {
+                FilePath = e.File,
+                ProjectPath = e.ProjectFile
+            };
+
+            TestLogger.Log(message);
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/WarnForInvalidProjectsTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/WarnForInvalidProjectsTaskTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Build.Framework;
+using Moq;
+using Xunit;
+
+namespace NuGet.Build.Tasks.Test
+{
+    public class WarnForInvalidProjectsTaskTests
+    {
+        [Fact]
+        public void WarnForInvalidProjectsTask_MissingAllProjectsAreIgnored()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var all = new List<ITaskItem>();
+            var valid = new List<ITaskItem>();
+
+            var project1 = new Mock<ITaskItem>();
+            project1.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            valid.Add(project1.Object);
+
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine,
+                AllProjects = all.ToArray(),
+                ValidProjects = valid.ToArray(),
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void WarnForInvalidProjectsTask_SingleInvalidItemsVerifySingleWarning()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var all = new List<ITaskItem>();
+            var valid = new List<ITaskItem>();
+
+            var project1 = new Mock<ITaskItem>();
+            project1.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+            var project2 = new Mock<ITaskItem>();
+            project2.SetupGet(e => e.ItemSpec).Returns("b.csproj");
+
+            all.Add(project1.Object);
+            all.Add(project2.Object);
+            valid.Add(project1.Object);
+
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine,
+                AllProjects = all.ToArray(),
+                ValidProjects = valid.ToArray(),
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(1);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+            testLogger.Messages.Where(e => e.Contains("Skipping restore for project 'b.csproj'. The project file may be invalid or missing targets required for restore.")).Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void WarnForInvalidProjectsTask_NoValidItemsVerifyWarning()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var all = new List<ITaskItem>();
+            var valid = new List<ITaskItem>();
+
+            var project1 = new Mock<ITaskItem>();
+            project1.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+
+            all.Add(project1.Object);
+            // not added to valid
+
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine,
+                AllProjects = all.ToArray(),
+                ValidProjects = valid.ToArray(),
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(1);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void WarnForInvalidProjectsTask_AllValidItemsVerifyNoWarnings()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+
+            var all = new List<ITaskItem>();
+            var valid = new List<ITaskItem>();
+
+            var project1 = new Mock<ITaskItem>();
+            project1.SetupGet(e => e.ItemSpec).Returns("a.csproj");
+
+            all.Add(project1.Object);
+            valid.Add(project1.Object);
+
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine,
+                AllProjects = all.ToArray(),
+                ValidProjects = valid.ToArray(),
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void WarnForInvalidProjectsTask_NoItemsVerifyNoErrors()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine,
+                AllProjects = new ITaskItem[0],
+                ValidProjects = new ITaskItem[0],
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+        }
+
+        [Fact]
+        public void WarnForInvalidProjectsTask_NullItemsVerifyNoErrors()
+        {
+            var buildEngine = new TestBuildEngine();
+            var testLogger = buildEngine.TestLogger;
+            var task = new WarnForInvalidProjectsTask
+            {
+                BuildEngine = buildEngine
+            };
+
+            var result = task.Execute();
+            result.Should().BeTrue();
+
+            testLogger.Warnings.Should().Be(0);
+            testLogger.Errors.Should().Be(0);
+            testLogger.DebugMessages.Count.Should().Be(2);
+        }
+    }
+}


### PR DESCRIPTION
This change adds a `_IsProjectRestoreSupported` target which will be called for each project to verifiy that the restore targets exist. This target name is easier to understand the current walk target which is displayed for unsupported projects.

Flow: 
1. MSBuild calls `IsProjectRestoreSupported` for each project
1. `IsProjectRestoreSupported` returns the path to the project as an item
1. Where restore is not supported the path is not returned
1. All returned items are considered valid projects
1. Projects that were not in the original list of restore inputs get warnings

This applies only to the command line, VS does not have these issues since the project systems are available to read the projects.

Fixes https://github.com/NuGet/Home/issues/5530



1)	What bug does this fix? Give a brief overview and impact of the bug and link to bug.
**Unblocks command line restore for solutions that contain projects that do not import Microsoft common props/targets. This applies to both NuGet.exe, msbuild /t:restore, and dotnet restore. If a project or solution references a blank project, or a project type such as WIX or some C++ projects restore would fail.**

2)	Describe the fix and how it fixes the bug.
**This fix checks projects for restore support and gracefully handles unsupport projects by displaying a warning and continuing on.**

3)	Was this bug a regression – if so, what had regressed, when was the regression introduced, and what steps are you taking to make sure this won’t happen again.
**This regressed from NuGet 4.2.0. The scenario is now covered by integration tests around MSBuild. The regression was introduced as part of the errors/warnings work which turned several restore warnings into errors.**

4)	What testing/validation was done on the fix?
**Automated integration tests and manual testing of msbuild and nuget.exe** 
