### PR TITLE
Dev zhi move init to bg

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSDeleteOnRestartManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -215,9 +215,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)
         {
-            // This is a solution event. Should be on the UI thread
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             // We need to do the check even on Solution Closed because, let's say if the yellow Update bar
             // is showing and the user closes the solution; in that case, we want to hide the Update bar.
             DeleteMarkedPackageDirectories(SolutionManager.NuGetProjectContext);

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSPackageRestoreManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,9 +35,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private void OnSolutionOpenedOrClosed(object sender, EventArgs e)
         {
-            // This is a solution event. Should be on the UI thread
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
                 {
                     // We need to do the check even on Solution Closed because, let's say if the yellow Update bar

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -356,7 +356,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
 #if VS14
             // Not applicable for Dev14 so always return empty list.
-            return Enumerable.Empty<IVsHierarchy>();
+            return await Task.Run(() => Enumerable.Empty<IVsHierarchy>());
 #else
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/WorkspaceProjectBuildProperties.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/WorkspaceProjectBuildProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectSystems/MSBuildNuGetProjectSystemFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -30,8 +30,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public static VsMSBuildProjectSystem CreateMSBuildNuGetProjectSystem(IVsProjectAdapter vsProjectAdapter, INuGetProjectContext nuGetProjectContext)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             if (vsProjectAdapter == null)
             {
                 throw new ArgumentNullException(nameof(vsProjectAdapter));

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -67,14 +67,12 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             Assumes.Present(vsProjectAdapter);
 
-            _threadingService.ThrowIfNotOnUIThread();
-
             result = null;
 
             var projectServices = _threadingService.ExecuteSynchronously(
-                () => TryCreateProjectServicesAsync(
-                    vsProjectAdapter,
-                    forceCreate: forceProjectType));
+                    () => TryCreateProjectServicesAsync(
+                        vsProjectAdapter,
+                        forceCreate: forceProjectType));
 
             if (projectServices == null)
             {
@@ -121,6 +119,7 @@ namespace NuGet.PackageManagement.VisualStudio
             }
             else
             {
+                await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
                 var asVSProject4 = vsProjectAdapter.Project.Object as VSProject4;
 
                 // A legacy CSProj must cast to VSProject4 to manipulate package references
@@ -148,7 +147,7 @@ namespace NuGet.PackageManagement.VisualStudio
             var buildProjectDataService = await _workspaceService.Value.GetMSBuildProjectDataServiceAsync(
                 vsProjectAdapter.FullProjectPath);
             Assumes.Present(buildProjectDataService);
-
+            await TaskScheduler.Default;
             var referenceItems = await buildProjectDataService.GetProjectItems(
                 ProjectItems.PackageReference, CancellationToken.None);
             if (referenceItems == null || referenceItems.Count == 0)

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NuGetProjectFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -62,7 +62,7 @@ namespace NuGet.PackageManagement.VisualStudio
             Assumes.Present(vsProjectAdapter);
             Assumes.Present(context);
 
-            _threadingService.ThrowIfNotOnUIThread();
+            //_threadingService.ThrowIfNotOnUIThread();
 
             var exceptions = new List<Exception>();
             result = _providers

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectKNuGetProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/ProjectKNuGetProjectProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,14 +28,13 @@ namespace NuGet.PackageManagement.VisualStudio
 
             result = null;
 
-            ThreadHelper.ThrowIfNotOnUIThread();
-
             if (project.IsDeferred)
             {
                 return false;
             }
 
             var projectK = EnvDTEProjectUtility.GetProjectKPackageManager(project.Project);
+
             if (projectK == null)
             {
                 return false;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -55,7 +55,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             Assumes.Present(dteProject);
 
-            _threadingService.ThrowIfNotOnUIThread();
+            await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
 
             var vsHierarchyItem = VsHierarchyItem.FromDteProject(dteProject);
             Func<IVsHierarchy, EnvDTE.Project> loadDteProject = _ => dteProject;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -47,35 +47,41 @@ namespace NuGet.VisualStudio
 
         public static string[] GetProjectTypeGuids(EnvDTE.Project project)
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            // Get the vs hierarchy as an IVsAggregatableProject to get the project type guids
-            var hierarchy = ToVsHierarchy(project);
-            var projectTypeGuids = GetProjectTypeGuids(hierarchy, project.Kind);
+                // Get the vs hierarchy as an IVsAggregatableProject to get the project type guids
+                var hierarchy = ToVsHierarchy(project);
+                var projectTypeGuids = GetProjectTypeGuids(hierarchy, project.Kind);
 
-            return projectTypeGuids;
+                return projectTypeGuids;
+            });
         }
 
         public static string[] GetProjectTypeGuids(IVsHierarchy hierarchy, string defaultType = "")
         {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            var aggregatableProject = hierarchy as IVsAggregatableProject;
-            if (aggregatableProject != null)
+            return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
             {
-                string projectTypeGuids;
-                var hr = aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
-                ErrorHandler.ThrowOnFailure(hr);
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-                return projectTypeGuids.Split(';');
-            }
+                var aggregatableProject = hierarchy as IVsAggregatableProject;
+                if (aggregatableProject != null)
+                {
+                    string projectTypeGuids;
+                    var hr = aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
+                    ErrorHandler.ThrowOnFailure(hr);
 
-            if (!string.IsNullOrEmpty(defaultType))
-            {
-                return new[] { defaultType };
-            }
+                    return projectTypeGuids.Split(';');
+                }
 
-            return new string[0];
+                if (!string.IsNullOrEmpty(defaultType))
+                {
+                    return new[] { defaultType };
+                }
+
+                return new string[0];
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
Since anyCode database need to access UI thread, Moving NuGet Init to background thread.

fixed two scenario here: opening solution and restore.

For open solution, Nuget is listening on solutionLoadEvent, when the event raise, nuget will start a IVsTask on Background thread to do NuGet Init and return UI thread to VS.

For restore, NuGet is already on background thread, it will not switch to UI unless it needs UI during NuGet init.


