### PR TITLE
add automation scripts into source control

### DIFF
--- a/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
+++ b/scripts/utils/InsertNuGetIntoSdkAndCli.ps1
@@ -1,0 +1,205 @@
+﻿<#
+.SYNOPSIS
+Script to insert NuGet into CLI and SDK
+
+.DESCRIPTION
+Uses the Personal Access Token of NuGetLurker to automate the insertion process into CLI and SDK
+
+.PARAMETER PersonalAccessToken
+PersonalAccessToken of the NuGetLurker account
+
+.PARAMETER RepositoryName
+The Repository to insert into (SDK or CLI)
+
+.PARAMETER BranchName
+The repository's branch to insert into
+
+.PARAMETER NuGetTag
+The xml tag in the DependencyVersions.props file that defines the NuGet version
+
+.PARAMETER BuildOutputPath
+The output path for NuGet Build artifacts.
+
+#>
+
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$PersonalAccessToken,
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [string]$BranchName,
+    [Parameter(Mandatory=$True)]
+    [string]$NuGetTag,
+    [Parameter(Mandatory=$True)]
+    [string]$BuildOutputPath
+)
+
+$repoOwner = "dotnet"
+$Base64Token = [System.Convert]::ToBase64String([char[]]$PersonalAccessToken)
+
+$Headers= @{
+    Authorization='Basic {0}' -f $Base64Token;
+}
+
+$NuGetExePath = [System.IO.Path]::Combine($BuildOutputPath, $Branch, $Build, 'artifacts', 'VS15', "NuGet.exe")
+
+$Build = ${env:BUILD_BUILDNUMBER}
+$ProductVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($NuGetExePath).ProductVersion
+$CreatedBranchName = "nuget-insertbuild$Build"
+
+Function UpdateNuGetVersionInXmlFile {
+    param(
+        [string]$XmlContents,
+        [string]$NuGetVersion,
+        [string]$NuGetTag
+    )
+
+$xmlString = $XmlContents.Split([environment]::NewLine) | where { $_ -cmatch "$NuGetTag"}
+
+$newXmlString = "<$NuGetTag>$NuGetVersion</$NuGetTag>"
+
+$updatedXml = $XmlContents.Replace($xmlString.Trim(), $newXmlString) 
+Write-Host $updatedXml
+return $updatedXml
+
+}
+
+Function GetDependencyVersionPropsFile {
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [string]$BranchName,
+    [Parameter(Mandatory=$True)]
+    [string]$FilePath
+)
+
+$wc = New-Object System.Net.WebClient
+$wc.Encoding = [System.Text.Encoding]::UTF8
+
+$url = "https://raw.githubusercontent.com/$repoOwner/$RepositoryName/$BranchName/$FilePath"
+
+return $wc.DownloadString("$url")
+
+}
+
+Function CreateBranchForPullRequest {
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [System.Collections.IDictionary]$Headers,
+    [Parameter(Mandatory=$True)]
+    [string]$BranchName
+
+)
+
+$commits = Invoke-RestMethod -Method Get -Uri "https://api.github.com/repos/$repoOwner/$RepositoryName/commits?sha=$BranchName"
+$headSha = $commits[0].sha
+$refName = "refs/heads/$CreatedBranchName"
+
+$Body = @{
+sha = $headSha;
+ref = $refName;
+} | ConvertTo-Json;
+
+$r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/$repoOwner/$RepositoryName/git/refs" -Body $Body
+Write-Host $r1
+}
+
+Function UpdateFileContent {
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [System.Collections.IDictionary]$Headers,
+    [Parameter(Mandatory=$True)]
+    [string]$FilePath,
+    [Parameter(Mandatory=$True)]
+    [string]$FileContent
+
+)
+$params = "?ref=$CreatedBranchName"
+$httpGetUrl = "https://api.github.com/repos/$repoOwner/$RepositoryName/contents/$FilePath$Params"
+$content = Invoke-RestMethod -Method Get -Uri $httpGetUrl
+$shaBlob = $content.sha
+$commitMessage = "Insert NuGet Build $ProductVersion into $RepositoryName"
+
+$base64Content = [System.Convert]::ToBase64String([char[]]$FileContent)
+$Uri = "https://api.github.com/repos/$repoOwner/$RepositoryName/contents/$FilePath"
+
+$Body = @{
+path = $FilePath;
+sha = $shaBlob;
+branch = $CreatedBranchName;
+message = $commitMessage;
+content =  $base64Content;
+} | ConvertTo-Json;
+
+$r1 = Invoke-RestMethod -Headers $Headers -Method Put -Uri $Uri -Body $Body
+Write-Host $r1
+}
+
+Function CreatePullRequest {
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [System.Collections.IDictionary]$Headers,
+    [Parameter(Mandatory=$True)]
+    [string]$CreatedBranchName,
+    [Parameter(Mandatory=$True)]
+    [string]$BaseBranch
+
+)
+
+$Uri = "https://api.github.com/repos/$repoOwner/$RepositoryName/pulls"
+$Title = "Insert NuGet Build $ProductVersion into $RepositoryName"
+$PrMessage = "$Title $BaseBranch branch"
+
+$Body = @{
+title = $Title;
+head = $CreatedBranchName;
+base = $BaseBranch;
+body = $PrMessage;
+} | ConvertTo-Json;
+
+Write-Host $Body
+
+$r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri $Uri -Body $Body
+Write-Host $r1.html_url
+return $r1.html_url
+}
+
+Function PrintPullRequestUrlToVsts {
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$RepositoryName,
+    [Parameter(Mandatory=$True)]
+    [string]$PullRequestUrl
+
+)
+
+$mdFolder = Join-Path $env:SYSTEM_DEFAULTWORKINGDIRECTORY (Join-Path 'MicroBuild' 'Output')
+New-Item -ItemType Directory -Force -Path $mdFolder | Out-Null
+$fileExtension = "_Url.md"
+$mdFile = Join-Path $mdFolder "$RepositoryName$fileExtension"
+$PullRequestUrl | Set-Content $mdFile
+Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$RepositoryName Pull Request Url;]$mdFile"  
+}
+
+$xml = GetDependencyVersionPropsFile -RepositoryName $RepositoryName -BranchName $BranchName -FilePath build/DependencyVersions.props
+$updatedXml = UpdateNuGetVersionInXmlFile -XmlContents $xml -NuGetVersion $ProductVersion -NuGetTag $NuGetTag
+
+CreateBranchForPullRequest -RepositoryName $RepositoryName -Headers $Headers -BranchName $BranchName
+UpdateFileContent -RepositoryName $RepositoryName -Headers $Headers -FilePath build/DependencyVersions.props -FileContent $updatedXml
+$PullRequestUrl = CreatePullRequest -RepositoryName $RepositoryName -Headers $Headers -CreatedBranchName $CreatedBranchName -BaseBranch $BranchName
+PrintPullRequestUrlToVsts -RepositoryName $RepositoryName -PullRequestUrl $PullRequestUrl

--- a/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
+++ b/scripts/utils/TagNuGetClientGitRepostoryOnRelease.ps1
@@ -1,0 +1,94 @@
+﻿<#
+.SYNOPSIS
+Script to tag NuGet.Client and NuGet.Build.Localization every time an insertion is made into VS.
+
+.DESCRIPTION
+Uses the Personal Access Token of NuGetLurker to automate the tagging process.
+
+.PARAMETER PersonalAccessToken
+PersonalAccessToken of the NuGetLurker account
+
+.PARAMETER VsTargetBranch
+The VS Branch that the NuGet build is being inserted into. 
+
+.PARAMETER BuildOutputPath
+The output path for NuGet Build artifacts.
+#>
+
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory=$True)]
+    [string]$PersonalAccessToken,
+    [Parameter(Mandatory=$True)]
+    [string]$VsTargetBranch,
+    [Parameter(Mandatory=$True)]
+    [string]$BuildOutputPath
+)
+
+
+
+# These environment variables are set on the VSTS Release Definition agents.
+$Branch = ${env:BUILD_SOURCEBRANCHNAME}
+$Build = ${env:BUILD_BUILDNUMBER}
+$Commit = ${env:BUILD_SOURCEVERSION}
+
+$NuGetExePath = [System.IO.Path]::Combine($BuildOutputPath, $Branch, $Build, 'artifacts', 'VS15', "NuGet.exe")
+Write-Host $NuGetExePath
+
+$TagName = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($NuGetExePath).FileVersion
+$ProductVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($NuGetExePath).ProductVersion
+$Date = Get-Date
+$Message = "Insert $ProductVersion into $VsTargetBranch on $Date"
+$BuildInfoJsonFile = [System.IO.Path]::Combine($OutputPath, $Branch, $Build, 'buildinfo.json')
+$buildInfoJson = (Get-Content $BuildInfoJsonFile -Raw) | ConvertFrom-Json
+$LocRepoCommitHash = $buildInfoJson.LocalizationRepositoryCommitHash
+
+
+Function Tag-GitCommit {
+    param(
+        [string]$NuGetRepository,
+        [string]$PersonalAccessToken,
+        [string]$CommitHash,
+        [string]$TagName,
+        [string]$TagMessage
+    )
+
+$Token = $PersonalAccessToken
+$Base64Token = [System.Convert]::ToBase64String([char[]]$Token)
+
+$Headers= @{
+    Authorization='Basic {0}' -f $Base64Token;
+}
+
+$Body = @{
+tag = $TagName;
+object = $CommitHash;
+type = 'commit';
+message= $TagMessage;
+} | ConvertTo-Json;
+
+Write-Host $Body
+
+$tagObject = "refs/tags/$TagName"
+
+$r1 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/NuGet/$NuGetRepository/git/tags" -Body $Body
+
+Write-Host $r1
+
+$Body2 = @{
+ref = $tagObject;
+sha = $r1.sha;
+} | ConvertTo-Json;
+
+Write-Host $Body2
+
+$r2 = Invoke-RestMethod -Headers $Headers -Method Post -Uri "https://api.github.com/repos/NuGet/$NuGetRepository/git/refs" -Body $Body2
+
+Write-Host $r2
+
+}
+
+Tag-GitCommit -NuGetRepository 'NuGet.Client' -PersonalAccessToken $PersonalAccessToken -CommitHash $Commit -TagName $TagName -TagMessage $Message
+
+Tag-GitCommit -NuGetRepository 'NuGet.Build.Localization' -PersonalAccessToken $PersonalAccessToken -CommitHash $LocRepoCommitHash -TagName $TagName -TagMessage $Message


### PR DESCRIPTION
right now these scripts are triggered from our nuget share.
checking into source control for now and will figure out a way to give release agents the latest copy from github later.


TagNuGetClientGitRepositoryOnRelease.ps1 tags our git repositories whenever we release into VS.
InsertIntoCliAndSdk.ps1 automate the insertion of NuGet payload into SDK and CLI repositories and creates a corresponding pull request.

CC: @alpaix 