### PR TITLE
Replacing \r\n with \n in MSBuildLogger to workaround an issue with TaskLoggingHelper

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/Common/MSBuildLogger.cs
@@ -171,6 +171,9 @@ namespace NuGet.Build
             LogErrorWithDetails logWithDetails,
             LogErrorAsString logAsString)
         {
+            // Work around for https://github.com/Microsoft/msbuild/issues/2316
+            var logMessageString = logMessage.Message.Replace("\r\n", "\n");
+
             if (logMessage.Code > NuGetLogCode.Undefined)
             {
                 // NuGet does not currently have a subcategory while throwing logs, hence string.Empty
@@ -182,11 +185,11 @@ namespace NuGet.Build
                     logMessage.StartColumnNumber,
                     logMessage.EndLineNumber,
                     logMessage.EndColumnNumber,
-                    logMessage.Message);
+                    logMessageString);
             }
             else
             {
-                logAsString(logMessage.Message);
+                logAsString(logMessageString);
             }
         }
 


### PR DESCRIPTION
Working around https://github.com/Microsoft/msbuild/issues/2316

## Details - 
`NU1102` throws a multiline error [here](https://github.com/NuGet/NuGet.Client/blob/9c1502ee06d60ff9d8b0c9f5477b95ffed45b8cc/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnresolvedMessages.cs#L107) with `Environment.NewLine`  [here](https://github.com/NuGet/NuGet.Client/blob/3dc00f3f9620e131303c083a8703f8bddaa36b68/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/DiagnosticUtility.cs#L83). It seems that msbuild `TaskLoggingHelper` and underlying code does not accept with `\r` unless it is escaped(more info in the bug above).

## Logs - 
```
"C:\Users\anmishr\Source\Repos\ConsoleApp21\ConsoleApp21\ConsoleApp21.csproj" (restore target) (1) ->
(Restore target) ->[C:\Users\anmishr\Source\Repos\ConsoleApp21\ConsoleApp21\ConsoleApp21.csproj]
  C:\Users\anmishr\Source\Repos\ConsoleApp21\ConsoleApp21\ConsoleApp21.csproj : error NU1102: Unable to find package newtonsoft.json with version (>= 12.0.0)\r
C:\Users\anmishr\Source\Repos\ConsoleApp21\ConsoleApp21\ConsoleApp21.csproj : error NU1102:   - Found 57 version(s) in nuget.org [ Nearest version: 10.0.3 ]\r
```

## Fix - 
I have worked around this by replacing `\r\n` with `\n`  in the `MSBuildLogger`. This fixes the display on the console. However, it must be noted that if the output was piped to a file then a simple editor like notepad may not be able to detect a new line without the carriage return.