### PR TITLE
Fix copy package throttling on macOS

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -374,11 +374,15 @@ namespace NuGet.Commands
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                return await _findPackagesByIdResource.GetPackageDownloaderAsync(
+                var packageDownloader = await _findPackagesByIdResource.GetPackageDownloaderAsync(
                     packageIdentity,
                     cacheContext,
                     logger,
                     cancellationToken);
+
+                packageDownloader.SetThrottle(_throttle);
+
+                return packageDownloader;
             }
             catch (FatalProtocolException e) when (_ignoreFailedSources)
             {

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -54,5 +54,11 @@ namespace NuGet.Packaging
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken" />
         /// is cancelled.</exception>
         Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Sets a throttle for package downloads.
+        /// </summary>
+        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        void SetThrottle(SemaphoreSlim throttle);
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -22,6 +22,7 @@ namespace NuGet.Packaging
         private readonly PackageIdentity _packageIdentity;
         private Lazy<PackageArchiveReader> _packageReader;
         private Lazy<FileStream> _sourceStream;
+        private SemaphoreSlim _throttle;
 
         /// <summary>
         /// Gets an asynchronous package content reader.
@@ -142,23 +143,35 @@ namespace NuGet.Packaging
                     nameof(destinationFilePath));
             }
 
-            cancellationToken.ThrowIfCancellationRequested();
-
-            using (var source = File.OpenRead(_packageFilePath))
-            using (var destination = new FileStream(
-                destinationFilePath,
-                FileMode.Create,
-                FileAccess.ReadWrite,
-                FileShare.ReadWrite | FileShare.Delete,
-                bufferSize: 4096,
-                useAsync: false))
+            try
             {
-                // This value comes from NuGet.Protocol.StreamExtensions.CopyToAsync(...).
-                // While 8K may or may not be the optimal buffer size for copy performance,
-                // it is better than 4K.
-                const int bufferSize = 8192;
+                if (_throttle != null)
+                {
+                    await _throttle.WaitAsync();
+                }
 
-                await source.CopyToAsync(destination, bufferSize, cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using (var source = File.OpenRead(_packageFilePath))
+                using (var destination = new FileStream(
+                    destinationFilePath,
+                    FileMode.Create,
+                    FileAccess.ReadWrite,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    bufferSize: 4096,
+                    useAsync: false))
+                {
+                    // This value comes from NuGet.Protocol.StreamExtensions.CopyToAsync(...).
+                    // While 8K may or may not be the optimal buffer size for copy performance,
+                    // it is better than 4K.
+                    const int bufferSize = 8192;
+
+                    await source.CopyToAsync(destination, bufferSize, cancellationToken);
+                }
+            }
+            finally
+            {
+                _throttle?.Release();
             }
 
             return true;
@@ -196,6 +209,15 @@ namespace NuGet.Packaging
             var packageHash = Convert.ToBase64String(bytes);
 
             return Task.FromResult(packageHash);
+        }
+
+        /// <summary>
+        /// Sets a throttle for package downloads.
+        /// </summary>
+        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        public void SetThrottle(SemaphoreSlim throttle)
+        {
+            _throttle = throttle;
         }
 
         private PackageArchiveReader GetPackageReader()

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -183,6 +183,15 @@ namespace NuGet.Protocol.Plugins
             return null;
         }
 
+        /// <summary>
+        /// Sets a throttle for package downloads.
+        /// </summary>
+        /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>
+        public void SetThrottle(SemaphoreSlim throttle)
+        {
+            // Do nothing.  Plugins are not implemented on macOS.
+        }
+
         private void ThrowIfDisposed()
         {
             if (_isDisposed)

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/LocalPackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/LocalPackageArchiveDownloaderTests.cs
@@ -145,7 +145,7 @@ namespace NuGet.Packaging.Test
         }
 
         [Fact]
-        public async Task CopyNupkgFileToAsync_ReturnsPackageHash()
+        public async Task CopyNupkgFileToAsync_ReturnsTrueOnSuccess()
         {
             using (var test = LocalPackageArchiveDownloaderTest.Create())
             {
@@ -161,6 +161,76 @@ namespace NuGet.Packaging.Test
                 var destinationBytes = File.ReadAllBytes(destinationFilePath);
 
                 Assert.Equal(sourceBytes, destinationBytes);
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgFileToAsync_RespectsThrottle()
+        {
+            using (var test = LocalPackageArchiveDownloaderTest.Create())
+            using (var throttle = new SemaphoreSlim(initialCount: 0, maxCount: 1))
+            {
+                var destinationFilePath = Path.Combine(test.TestDirectory.Path, "copied.nupkg");
+
+                test.Downloader.SetThrottle(throttle);
+
+                var wasCopied = false;
+
+                var copyTask = Task.Run(async () =>
+                {
+                    wasCopied = await test.Downloader.CopyNupkgFileToAsync(
+                        destinationFilePath,
+                        CancellationToken.None);
+                });
+
+                await Task.Delay(100);
+
+                Assert.False(wasCopied);
+                Assert.False(File.Exists(destinationFilePath));
+
+                throttle.Release();
+
+                await copyTask;
+
+                Assert.True(wasCopied);
+                Assert.True(File.Exists(destinationFilePath));
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgFileToAsync_ReleasesThrottleOnException()
+        {
+            using (var test = LocalPackageArchiveDownloaderTest.Create())
+            using (var throttle = new SemaphoreSlim(initialCount: 1, maxCount: 1))
+            {
+                var destinationFilePath = Path.Combine(test.TestDirectory.Path, "a");
+
+                // Locking the destination file path will cause the copy operation to throw.
+                using (var fileLock = new FileStream(
+                    destinationFilePath,
+                    FileMode.Create,
+                    FileAccess.Write,
+                    FileShare.None))
+                {
+                    test.Downloader.SetThrottle(throttle);
+
+                    var copyTask = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await test.Downloader.CopyNupkgFileToAsync(
+                                destinationFilePath,
+                                CancellationToken.None);
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    });
+
+                    await copyTask;
+
+                    Assert.Equal(1, throttle.CurrentCount);
+                }
             }
         }
 
@@ -220,6 +290,15 @@ namespace NuGet.Packaging.Test
                     CancellationToken.None);
 
                 Assert.Equal(expectedPackageHash, actualPackageHash);
+            }
+        }
+
+        [Fact]
+        public void SetThrottle_AcceptsNullThrottle()
+        {
+            using (var test = LocalPackageArchiveDownloaderTest.Create())
+            {
+                test.Downloader.SetThrottle(throttle: null);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -812,6 +812,10 @@ namespace Commands.Test
                 return Task.FromResult(packageHash);
             }
 
+            public void SetThrottle(SemaphoreSlim throttle)
+            {
+            }
+
             private PackageArchiveReader GetPackageReader()
             {
                 _sourceStream.Value.Seek(0, SeekOrigin.Begin);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemotePackageArchiveDownloaderTests.cs
@@ -263,6 +263,91 @@ namespace NuGet.Protocol.Tests
         }
 
         [Fact]
+        public async Task CopyNupkgFileToAsync_RespectsThrottle()
+        {
+            using (var test = RemotePackageArchiveDownloaderTest.Create())
+            using (var throttle = new SemaphoreSlim(initialCount: 0, maxCount: 1))
+            using (var copyEvent = new ManualResetEventSlim())
+            {
+                test.Resource.Setup(x => x.CopyNupkgToStreamAsync(
+                        It.IsNotNull<string>(),
+                        It.IsNotNull<NuGetVersion>(),
+                        It.IsNotNull<Stream>(),
+                        It.IsNotNull<SourceCacheContext>(),
+                        It.IsNotNull<ILogger>(),
+                        It.IsAny<CancellationToken>()))
+                    .Callback<string, NuGetVersion, Stream, SourceCacheContext, ILogger, CancellationToken>(
+                        (id, version, destination, sourceCacheContext, logger, cancellationToken) =>
+                        {
+                            copyEvent.Set();
+                        })
+                    .ReturnsAsync(true);
+
+                var destinationFilePath = Path.Combine(test.TestDirectory.Path, "a");
+
+                test.Downloader.SetThrottle(throttle);
+
+                var wasCopied = false;
+
+                var copyTask = Task.Run(async () =>
+                {
+                    wasCopied = await test.Downloader.CopyNupkgFileToAsync(
+                        destinationFilePath,
+                        CancellationToken.None);
+                });
+
+                await Task.Delay(100);
+
+                Assert.False(copyEvent.IsSet);
+
+                throttle.Release();
+
+                await copyTask;
+
+                Assert.True(copyEvent.IsSet);
+                Assert.True(wasCopied);
+            }
+        }
+
+        [Fact]
+        public async Task CopyNupkgFileToAsync_ReleasesThrottleOnException()
+        {
+            using (var test = RemotePackageArchiveDownloaderTest.Create())
+            using (var throttle = new SemaphoreSlim(initialCount: 1, maxCount: 1))
+            {
+                test.Resource.Setup(x => x.CopyNupkgToStreamAsync(
+                        It.IsNotNull<string>(),
+                        It.IsNotNull<NuGetVersion>(),
+                        It.IsNotNull<Stream>(),
+                        It.IsNotNull<SourceCacheContext>(),
+                        It.IsNotNull<ILogger>(),
+                        It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new FatalProtocolException("simulated failure"));
+
+                var destinationFilePath = Path.Combine(test.TestDirectory.Path, "a");
+
+                test.Downloader.SetThrottle(throttle);
+
+                var copyTask = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await test.Downloader.CopyNupkgFileToAsync(
+                            destinationFilePath,
+                            CancellationToken.None);
+                    }
+                    catch (Exception)
+                    {
+                    }
+                });
+
+                await copyTask;
+
+                Assert.Equal(1, throttle.CurrentCount);
+            }
+        }
+
+        [Fact]
         public async Task GetPackageHashAsync_ThrowsIfDisposed()
         {
             using (var test = RemotePackageArchiveDownloaderTest.Create())
@@ -331,6 +416,15 @@ namespace NuGet.Protocol.Tests
                     cancellationToken: CancellationToken.None);
 
                 Assert.Equal("z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==", actualResult);
+            }
+        }
+
+        [Fact]
+        public void SetThrottle_AcceptsNullThrottle()
+        {
+            using (var test = RemotePackageArchiveDownloaderTest.Create())
+            {
+                test.Downloader.SetThrottle(throttle: null);
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/5615.

Exposing `SourceRepositoryDependencyProvider`'s `SemaphoreSlim` instance outside the class is not ideal, in part because external consumers might be inclined to dispose it.  However, this current solution minimizes churn.

A better solution would be to move [`IThrottle`](https://github.com/NuGet/NuGet.Client/blob/c002cda7fac86700b2f69bc9146e2abb74f1c5b0/src/NuGet.Core/NuGet.Protocol/HttpSource/IThrottle.cs) and its implementations ([`NullThrottle`](https://github.com/NuGet/NuGet.Client/blob/c002cda7fac86700b2f69bc9146e2abb74f1c5b0/src/NuGet.Core/NuGet.Protocol/HttpSource/NullThrottle.cs) and [`SemaphoreSlimThrottle`](https://github.com/NuGet/NuGet.Client/blob/c002cda7fac86700b2f69bc9146e2abb74f1c5b0/src/NuGet.Core/NuGet.Protocol/HttpSource/SemaphoreSlimThrottle.cs)) out of NuGet.Protocol and into NuGet.Common and replace `SemaphoreSlim` references with `IThrottle`.  A better solution is tracked via NuGet/Home#5616.


1)	What bug does this fix? Give a brief overview and impact of the bug and link to bug.
**NuGet throttles file operations on macOS to avoid the default maximum open files limit.**
2)	Describe the fix and how it fixes the bug.
**The fix applies throttling to package copy operations but only on macOS.**
3)	Was this bug a regression – if so, what had regressed, when was the regression introduced, and what steps are you taking to make sure this won’t happen again.
**It was a regression during 15.3.  PR NuGet/NuGet.Client#1387 broke copy package throttling on macOS.  I added test coverage with this fix.**
4)	What testing/validation was done on the fix?
**CI tests passed (modulo 8-16 persistent functional test failures).**
