### PR TITLE
Added a null check while retrieving auto restore requests

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreWorker.cs
@@ -365,7 +365,7 @@ namespace NuGet.SolutionRestoreManager
                             }
 
                             // Upgrade request if necessary
-                            if (next?.RestoreSource != request.RestoreSource)
+                            if (next != null && next.RestoreSource != request.RestoreSource)
                             {
                                 // there could be requests of two types: Auto-Restore or Explicit
                                 // Explicit is always preferred.


### PR DESCRIPTION
1)	What bug does this fix? Give a brief overview and impact of the bug and link to bug.
**Fixes: https://github.com/NuGet/Home/issues/5612 Throw NPE when there are multiple ,net core projects, and some projects are not yet nominated.**

2)	Describe the fix and how it fixes the bug.
**Added a null check while retrieving auto restore requests.**

3)	Was this bug a regression – if so, what had regressed, when was the regression introduced, and what steps are you taking to make sure this won’t happen again.
**n/a**

4)	What testing/validation was done on the fix?
**vendor pass, end to end tests, RPS val build**

Also, logged an engineering workitem to keep track of missing end to end test scenarios which should be added once we move to Apex. https://github.com/NuGet/Client.Engineering/issues/71 