### PR TITLE
Fix regression in ignoring failed sources during package copy

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -381,6 +381,24 @@ namespace NuGet.Commands
                     cancellationToken);
 
                 packageDownloader.SetThrottle(_throttle);
+                packageDownloader.SetExceptionHandler(async exception =>
+                {
+                    if (exception is FatalProtocolException && _ignoreFailedSources)
+                    {
+                        if (!_ignoreWarning)
+                        {
+                            await _logger.LogAsync(
+                                RestoreLogMessage.CreateWarning(
+                                    NuGetLogCode.NU1801,
+                                    exception.Message,
+                                    packageIdentity.Id));
+                        }
+
+                        return true;
+                    }
+
+                    return false;
+                });
 
                 return packageDownloader;
             }

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -58,6 +58,10 @@ namespace NuGet.Packaging
         /// <summary>
         /// Sets an exception handler for package downloads.
         /// </summary>
+        /// <remarks>The exception handler returns a task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indicating whether or not the exception was handled.  To handle an exception and stop its
+        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
         /// is <c>null</c>.</exception>

--- a/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Definitions/IPackageDownloader.cs
@@ -56,6 +56,14 @@ namespace NuGet.Packaging
         Task<string> GetPackageHashAsync(string hashAlgorithm, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Sets an exception handler for package downloads.
+        /// </summary>
+        /// <param name="handleExceptionAsync">An exception handler.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
+        /// is <c>null</c>.</exception>
+        void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync);
+
+        /// <summary>
         /// Sets a throttle for package downloads.
         /// </summary>
         /// <param name="throttle">A throttle.  Can be <c>null</c>.</param>

--- a/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Packaging/LocalPackageArchiveDownloader.cs
@@ -92,6 +92,7 @@ namespace NuGet.Packaging
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
             _sourceStream = new Lazy<FileStream>(GetSourceStream);
+            _handleExceptionAsync = exception => Task.FromResult(false);
         }
 
         /// <summary>
@@ -174,7 +175,7 @@ namespace NuGet.Packaging
             }
             catch (Exception ex)
             {
-                if (_handleExceptionAsync == null || !await _handleExceptionAsync(ex))
+                if (!await _handleExceptionAsync(ex))
                 {
                     throw;
                 }
@@ -224,6 +225,10 @@ namespace NuGet.Packaging
         /// <summary>
         /// Sets an exception handler for package downloads.
         /// </summary>
+        /// <remarks>The exception handler returns a task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indicating whether or not the exception was handled.  To handle an exception and stop its
+        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
         /// is <c>null</c>.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Plugins/PluginPackageDownloader.cs
@@ -94,6 +94,7 @@ namespace NuGet.Protocol.Plugins
             _packageIdentity = packageIdentity;
             _packageReader = packageReader;
             _packageSourceRepository = packageSourceRepository;
+            _handleExceptionAsync = exception => Task.FromResult(false);
         }
 
         /// <summary>
@@ -144,7 +145,7 @@ namespace NuGet.Protocol.Plugins
             }
             catch (Exception ex)
             {
-                if (_handleExceptionAsync == null || !await _handleExceptionAsync(ex))
+                if (!await _handleExceptionAsync(ex))
                 {
                     throw;
                 }
@@ -199,6 +200,10 @@ namespace NuGet.Protocol.Plugins
         /// <summary>
         /// Sets an exception handler for package downloads.
         /// </summary>
+        /// <remarks>The exception handler returns a task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indicating whether or not the exception was handled.  To handle an exception and stop its
+        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
         /// is <c>null</c>.</exception>

--- a/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemotePackageArchiveDownloader.cs
@@ -99,6 +99,7 @@ namespace NuGet.Protocol
             _cacheContext = cacheContext;
             _logger = logger;
             _packageReader = new Lazy<PackageArchiveReader>(GetPackageReader);
+            _handleExceptionAsync = exception => Task.FromResult(false);
         }
 
         /// <summary>
@@ -173,7 +174,7 @@ namespace NuGet.Protocol
             }
             catch (Exception ex)
             {
-                if (_handleExceptionAsync == null || !await _handleExceptionAsync(ex))
+                if (!await _handleExceptionAsync(ex))
                 {
                     throw;
                 }
@@ -222,6 +223,10 @@ namespace NuGet.Protocol
         /// <summary>
         /// Sets an exception handler for package downloads.
         /// </summary>
+        /// <remarks>The exception handler returns a task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indicating whether or not the exception was handled.  To handle an exception and stop its
+        /// propagation, the task should return <c>true</c>.  Otherwise, the exception will be rethrown.</remarks>
         /// <param name="handleExceptionAsync">An exception handler.</param>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="handleExceptionAsync" />
         /// is <c>null</c>.</exception>

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/NugetPackageUtilTests.cs
@@ -812,6 +812,10 @@ namespace Commands.Test
                 return Task.FromResult(packageHash);
             }
 
+            public void SetExceptionHandler(Func<Exception, Task<bool>> handleExceptionAsync)
+            {
+            }
+
             public void SetThrottle(SemaphoreSlim throttle)
             {
             }


### PR DESCRIPTION
Fix NuGet/Home#5618.

An earlier change refactored package copy out of [`SourceRepositoryDependencyProvider.CopyToAsync(...)`](https://github.com/NuGet/NuGet.Client/pull/1387/files#diff-f84aa3ab989112fac580abee863fd333L225) into `IPackageDownloader.CopyNupkgFileToAsync(...)` implementations without preserving the internal capability for ignoring and logging failed package sources.

This change restores that capability.