### PR TITLE
Reenable ATF/PTF raising of error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,3 @@
 [submodule "submodules/NuGet.Build.Localization"]
 	path = submodules/NuGet.Build.Localization
 	url = https://github.com/NuGet/NuGet.Build.Localization.git
-	branch = release-4.3.0-preview3

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "submodules/NuGet.Build.Localization"]
 	path = submodules/NuGet.Build.Localization
 	url = https://github.com/NuGet/NuGet.Build.Localization.git
+	branch = release-4.3.0-preview3

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,3 @@
 [submodule "submodules/NuGet.Build.Localization"]
 	path = submodules/NuGet.Build.Localization
 	url = https://github.com/NuGet/NuGet.Build.Localization.git
-	

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,4 @@
 [submodule "submodules/NuGet.Build.Localization"]
 	path = submodules/NuGet.Build.Localization
 	url = https://github.com/NuGet/NuGet.Build.Localization.git
+	

--- a/build/config.props
+++ b/build/config.props
@@ -3,7 +3,7 @@
   <!-- Version -->
   <PropertyGroup>
     <SemanticVersion Condition=" '$(SemanticVersion)' == '' ">4.3.0</SemanticVersion>
-    <!-- We need to update this netcoreassembly build number with every milestone to workaround any breaking api
+    <!-- We need to update this netcore assembly build number with every milestone to workaround any breaking api
     changes we might have made-->
     <NetCoreAssemblyBuildNumber Condition=" '$(NetCoreAssemblyBuildNumber)' == '' ">5</NetCoreAssemblyBuildNumber>
     <ReleaseLabel Condition=" '$(ReleaseLabel)' == '' ">rtm</ReleaseLabel>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -312,7 +312,7 @@ namespace NuGet.PackageManagement.VisualStudio
             };
 
             // Apply fallback settings
-            AssetTargetFallbackUtility.ApplyFramework(projectTfi, packageTargetFallback, assetTargetFallback);
+            PackageSpecUtility.ApplyFallbackFramework(projectTfi, packageTargetFallback, assetTargetFallback);
 
             // Build up runtime information.
             var runtimes = await _vsProjectAdapter.GetRuntimeIdentifiersAsync();

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -408,7 +408,7 @@ namespace NuGet.SolutionRestoreManager
                                           .ToList();
 
             // Update TFI with fallback properties
-            AssetTargetFallbackUtility.ApplyFramework(tfi, ptf, atf);
+            PackageSpecUtility.ApplyFallbackFramework(tfi, ptf, atf);
 
             if (targetFrameworkInfo.PackageReferences != null)
             {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -112,6 +112,9 @@ namespace NuGet.Commands
                     }
                 }
             }
+
+            // Validate, for noop this will be replayed from the assets file.
+            _success &= await ValidateProjectAsync(_request.Project, _logger);
 
             // Restore
             var graphs = await ExecuteRestoreAsync(
@@ -792,6 +795,14 @@ namespace NuGet.Commands
                 project,
                 msbuildProjectPath: null,
                 projectReferences: Enumerable.Empty<string>());
+        }
+
+        private static async Task<bool> ValidateProjectAsync(PackageSpec project, ILogger log)
+        {
+            // Verify fallback framework, restore will still occur to avoid a large number of errors
+            // due to missing packages, but an error telling the user to fix their project will be logged
+            // and restore will fail.
+            return await AssetTargetFallbackUtility.ValidateFallbackFrameworkAsync(project, log);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -372,11 +372,8 @@ namespace NuGet.Commands
                         .Select(NuGetFramework.Parse)
                         .ToList();
 
-                    // Throw if an invalid combination was used.
-                    AssetTargetFallbackUtility.EnsureValidFallback(packageTargetFallback, assetTargetFallback, spec.FilePath);
-
                     // Update the framework appropriately
-                    AssetTargetFallbackUtility.ApplyFramework(targetFrameworkInfo, packageTargetFallback, assetTargetFallback);
+                    PackageSpecUtility.ApplyFallbackFramework(targetFrameworkInfo, packageTargetFallback, assetTargetFallback);
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -107,7 +107,7 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment..
+        ///   Looks up a localized string similar to PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment..
         /// </summary>
         internal static string Error_InvalidATF {
             get {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -589,7 +589,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>'{0}' cannot be used in conjunction with other values.</value>
   </data>
   <data name="Error_InvalidATF" xml:space="preserve">
-    <value>PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.</value>
+    <value>PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.</value>
   </data>
   <data name="UnsupportedProject" xml:space="preserve">
     <value>Skipping restore for project '{0}'. The project file may be invalid or missing targets required for restore.</value>

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecUtility.cs
@@ -2,6 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Frameworks;
+using NuGet.Shared;
 using NuGet.Versioning;
 
 namespace NuGet.ProjectModel
@@ -48,6 +52,70 @@ namespace NuGet.ProjectModel
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Apply a fallback framework to <see cref="TargetFrameworkInformation"/>.
+        /// </summary>
+        public static void ApplyFallbackFramework(
+            TargetFrameworkInformation targetFrameworkInfo,
+            IEnumerable<NuGetFramework> packageTargetFallback,
+            IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            if (targetFrameworkInfo == null)
+            {
+                throw new ArgumentNullException(nameof(targetFrameworkInfo));
+            }
+
+            // Update the framework appropriately
+            targetFrameworkInfo.FrameworkName = GetFallbackFramework(
+                targetFrameworkInfo.FrameworkName,
+                packageTargetFallback,
+                assetTargetFallback);
+
+            if (assetTargetFallback?.Any() == true)
+            {
+                // AssetTargetFallback
+                targetFrameworkInfo.AssetTargetFallback = assetTargetFallback.AsList();
+                targetFrameworkInfo.Warn = true;
+            }
+
+            if (packageTargetFallback?.Any() == true)
+            {
+                // PackageTargetFallback
+                targetFrameworkInfo.Imports = packageTargetFallback.AsList();
+            }
+        }
+
+        /// <summary>
+        /// Returns the fallback framework or the original.
+        /// If both PTF and ATF are set the original is returned.
+        /// </summary>
+        public static NuGetFramework GetFallbackFramework(
+            NuGetFramework projectFramework,
+            IEnumerable<NuGetFramework> packageTargetFallback,
+            IEnumerable<NuGetFramework> assetTargetFallback)
+        {
+            if (projectFramework == null)
+            {
+                throw new ArgumentNullException(nameof(projectFramework));
+            }
+
+            var hasATF = assetTargetFallback?.Any() == true;
+            var hasPTF = packageTargetFallback?.Any() == true;
+
+            if (hasATF && !hasPTF)
+            {
+                // AssetTargetFallback
+                return new AssetTargetFallbackFramework(projectFramework, assetTargetFallback.AsList());
+            }
+            else if (hasPTF && !hasATF)
+            {
+                // PackageTargetFallback
+                return new FallbackFramework(projectFramework, packageTargetFallback.AsList());
+            }
+
+            return projectFramework;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/PackageSpecWriter.cs
@@ -420,13 +420,13 @@ namespace NuGet.ProjectModel
             writer.WriteObjectEnd();
         }
 
-        private static void SetImports(IObjectWriter writer, IList<NuGetFramework> frameworks)
+        private static void SetFrameworkArrayToProperty(IObjectWriter writer, IList<NuGetFramework> frameworks, string propertyName)
         {
             if (frameworks?.Any() == true)
             {
-                var imports = frameworks.Select(framework => framework.GetShortFolderName());
+                var shortNames = frameworks.Select(framework => framework.GetShortFolderName());
 
-                writer.WriteNameArray("imports", imports);
+                writer.WriteNameArray(propertyName, shortNames);
             }
         }
 
@@ -441,8 +441,8 @@ namespace NuGet.ProjectModel
                     writer.WriteObjectStart(framework.FrameworkName.GetShortFolderName());
 
                     SetDependencies(writer, framework.Dependencies);
-                    SetImports(writer, framework.Imports);
-                    SetValueIfTrue(writer, "assetTargetFallback", framework.AssetTargetFallback);
+                    SetFrameworkArrayToProperty(writer, framework.Imports, "imports");
+                    SetFrameworkArrayToProperty(writer, framework.AssetTargetFallback, "assetTargetFallback");
                     SetValueIfTrue(writer, "warn", framework.Warn);
 
                     writer.WriteObjectEnd();

--- a/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/NuGet.Core/NuGet.ProjectModel/TargetFrameworkInformation.cs
@@ -17,14 +17,23 @@ namespace NuGet.ProjectModel
 
         /// <summary>
         /// A fallback PCL framework to use when no compatible items
-        /// were found for <see cref="FrameworkName"/>.
+        /// were found for <see cref="FrameworkName"/>. This check is done
+        /// per asset type.
         /// </summary>
+        /// <remarks>Deprecated. Use <see cref="AssetTargetFallback" /> instead.</remarks>
+        /// <see cref="Imports" /> cannot be used with <see cref="AssetTargetFallback" />.
         public IList<NuGetFramework> Imports { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
-        /// If True AssetTargetFallback behavior will be used for Imports.
+        /// A fallback framework to use when no compatible items
+        /// were found for <see cref="FrameworkName"/>. 
+        /// <see cref="AssetTargetFallback" /> will only fallback if the package
+        /// does not contain any assets compatible with <see cref="FrameworkName"/>.
         /// </summary>
-        public bool AssetTargetFallback { get; set; }
+        /// <remarks>
+        /// <see cref="AssetTargetFallback" /> cannot be used with <see cref="Imports" />.
+        /// </remarks>
+        public IList<NuGetFramework> AssetTargetFallback { get; set; } = new List<NuGetFramework>();
 
         /// <summary>
         /// Display warnings when the Imports framework is used.
@@ -41,9 +50,14 @@ namespace NuGet.ProjectModel
             var hashCode = new HashCodeCombiner();
 
             hashCode.AddObject(FrameworkName);
-            hashCode.AddObject(AssetTargetFallback);
             hashCode.AddSequence(Dependencies);
+
+            // Add markers between NuGetFramework objects
+            hashCode.AddObject(nameof(Imports));
             hashCode.AddSequence(Imports);
+
+            hashCode.AddObject(nameof(AssetTargetFallback));
+            hashCode.AddSequence(AssetTargetFallback);
 
             return hashCode.CombinedHash;
         }
@@ -68,7 +82,7 @@ namespace NuGet.ProjectModel
             return EqualityUtility.EqualsWithNullCheck(FrameworkName, other.FrameworkName) &&
                    Dependencies.SequenceEqualWithNullCheck(other.Dependencies) &&
                    Imports.SequenceEqualWithNullCheck(other.Imports) &&
-                   AssetTargetFallback == other.AssetTargetFallback;
+                   AssetTargetFallback.SequenceEqualWithNullCheck(other.AssetTargetFallback);
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -4688,7 +4688,8 @@ namespace NuGet.CommandLine.Test
                 var r = Util.RestoreSolution(pathContext, expectedExitCode: 1);
 
                 // Assert
-                r.AllOutput.Should().Contain("PackageTargetFallback and AssetTargetFallback cannot be used together.");
+                r.AllOutput.Should().Contain("PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.");
+                r.AllOutput.Should().Contain("NU1003");
             }
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -801,9 +801,29 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     .Returns("");
 
                 var projectServices = new TestProjectSystemServices();
-                
+
+
+                var testProject = new LegacyPackageReferenceProject(
+                    projectAdapter,
+                    Guid.NewGuid().ToString(),
+                    projectServices,
+                    _threadingService);
+
+                var testDependencyGraphCacheContext = new DependencyGraphCacheContext();
+
+                await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                // Act
+                var packageSpecs = await testProject.GetPackageSpecsAsync(testDependencyGraphCacheContext);
+
+                // Assert
+                Assert.NotNull(packageSpecs);
+
+                var actualRestoreSpec = packageSpecs.Single();
+
                 actualRestoreSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
                 actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            }
         }
 
         private static Mock<IVsProjectAdapter> CreateProjectAdapter()

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/LegacyPackageReferenceProjectTests.cs
@@ -2,12 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -321,8 +320,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 SpecValidationUtility.ValidateProjectSpec(actualRestoreSpec);
 
                 // Assert packagespath
-                Assert.Equal(restorePackagesPath != null? Path.Combine(testDirectory, restorePackagesPath) : SettingsUtility.GetGlobalPackagesFolder(settings),  actualRestoreSpec.RestoreMetadata.PackagesPath);
-                
+                Assert.Equal(restorePackagesPath != null ? Path.Combine(testDirectory, restorePackagesPath) : SettingsUtility.GetGlobalPackagesFolder(settings), actualRestoreSpec.RestoreMetadata.PackagesPath);
+
                 // assert sources
                 var specSources = actualRestoreSpec.RestoreMetadata.Sources.Select(e => e.Source);
                 var expectedSources = sources != null ? MSBuildStringUtility.Split(sources).Select(e => Path.Combine(testDirectory, e)) : SettingsUtility.GetEnabledSources(settings).Select(e => e.Source);
@@ -346,8 +345,8 @@ namespace NuGet.PackageManagement.VisualStudio.Test
         [Theory]
         [InlineData(@"C:\RestorePackagesPath", @"C:\Source1;C:\Source2", @"C:\Fallback1;C:\Fallback2")]
         [InlineData(null, @"C:\Source1;C:\Source2", @"C:\Fallback1;C:\Fallback2")]
-        [InlineData(@"C:\RestorePackagesPath", null , @"C:\Fallback1;C:\Fallback2")]
-        [InlineData(@"C:\RestorePackagesPath", @"C:\Source1;C:\Source2",null)]
+        [InlineData(@"C:\RestorePackagesPath", null, @"C:\Fallback1;C:\Fallback2")]
+        [InlineData(@"C:\RestorePackagesPath", @"C:\Source1;C:\Source2", null)]
         public async Task GetPackageSpecsAsync_ReadSettingsWithFullPaths(string restorePackagesPath, string sources, string fallbackFolders)
         {
             // Arrange
@@ -739,6 +738,72 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
                 Assert.True(actualRestoreSpec.RestoreMetadata.SkipContentFileWrite);
             }
+        }
+
+
+        public async Task GetPackageSpecsAsync_WithFallbackFrameworks_Succeeds(){
+            // Arrange
+            using (var randomTestFolder = TestDirectory.Create())
+            {
+                var framework = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectAdapter = CreateProjectAdapter(randomTestFolder);
+
+                Mock.Get(projectAdapter)
+                    .SetupGet(x => x.PackageTargetFallback)
+                    .Returns("net45;net451");
+
+                Mock.Get(projectAdapter)
+                    .SetupGet(x => x.AssetTargetFallback)
+                    .Returns("net461;net462");
+
+                var projectServices = new TestProjectSystemServices();
+
+                var testProject = new LegacyPackageReferenceProject(
+                    projectAdapter,
+                    Guid.NewGuid().ToString(),
+                    projectServices,
+                    _threadingService);
+
+                var testDependencyGraphCacheContext = new DependencyGraphCacheContext();
+
+                await _threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                // Act
+                var packageSpecs = await testProject.GetPackageSpecsAsync(testDependencyGraphCacheContext);
+
+                // Assert
+                Assert.NotNull(packageSpecs);
+
+                var actualRestoreSpec = packageSpecs.Single();
+
+                actualRestoreSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
+                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+            }
+        }
+
+        [Fact]
+        public async Task GetPackageSpecsAsync_WithNoFallbackFrameworks_Succeeds()
+        {
+            // Arrange
+            using (var randomTestFolder = TestDirectory.Create())
+            {
+                var framework = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectAdapter = CreateProjectAdapter(randomTestFolder);
+
+                Mock.Get(projectAdapter)
+                    .SetupGet(x => x.PackageTargetFallback)
+                    .Returns("");
+
+                Mock.Get(projectAdapter)
+                    .SetupGet(x => x.AssetTargetFallback)
+                    .Returns("");
+
+                var projectServices = new TestProjectSystemServices();
+                
+                actualRestoreSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
+                actualRestoreSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
         }
 
         private static Mock<IVsProjectAdapter> CreateProjectAdapter()

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/VsSolutionRestoreServiceTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Moq;
 using NuGet.Commands;
 using NuGet.Common;
@@ -646,6 +647,53 @@ namespace NuGet.SolutionRestoreManager.Test
             Assert.True(
                 Enumerable.SequenceEqual(expectedFallback.OrderBy(t => t), specFallback.OrderBy(t => t)),
                 "expected: " + string.Join(",", expectedFallback.ToArray()) + "\nactual: " + string.Join(",", specFallback.ToArray()));
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_FallbackFrameworks()
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        new[] {new VsProjectProperty("PackageTargetFallback", "net45;net451"),
+                               new VsProjectProperty("AssetTargetFallback", "net461;net462")}))
+                .Build();
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var project = actualRestoreSpec.Projects.Single();
+
+            // Assert
+            project.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45"), NuGetFramework.Parse("net451") });
+            project.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461"), NuGetFramework.Parse("net462") });
+        }
+
+        [Fact]
+        public async Task NominateProjectAsync_EmptyFallbackFrameworks()
+        {
+            var cps = NewCpsProject("{ }");
+            var projectFullPath = cps.ProjectFullPath;
+            var pri = cps.Builder
+                .WithTargetFrameworkInfo(
+                    new VsTargetFrameworkInfo(
+                        "netcoreapp1.0",
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsReferenceItem>(),
+                        Enumerable.Empty<IVsProjectProperty>()))
+                .Build();
+
+            // Act
+            var actualRestoreSpec = await CaptureNominateResultAsync(projectFullPath, cps.ProjectRestoreInfo);
+            var project = actualRestoreSpec.Projects.Single();
+
+            // Assert
+            project.TargetFrameworks[0].Imports.Should().BeEmpty();
+            project.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
         }
 
         private async Task<DependencyGraphSpec> CaptureNominateResultAsync(

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/AssetTargetFallbackUtilityTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class AssetTargetFallbackUtilityTests
+    {
+        [Fact]
+        public void AssetTargetFallbackUtility_VerifyGetInvalidFallbackCombinationMessage()
+        {
+            var message = AssetTargetFallbackUtility.GetInvalidFallbackCombinationMessage("/tmp/project.csproj");
+
+            message.Code.Should().Be(NuGetLogCode.NU1003);
+            message.FilePath.Should().Be("/tmp/project.csproj");
+            message.TargetGraphs.Should().BeEmpty("this applies to the entire project");
+            message.Level.Should().Be(LogLevel.Error);
+            message.Message.Should().Be("PackageTargetFallback is deprecated. Replace PackageTargetFallback references with AssetTargetFallback in the project environment.");
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyTrue()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyTrueForMultipleFrameworks()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.1")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeTrue();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseForMultipleFrameworks()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.0")
+                },
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp1.1")
+                }
+            };
+
+            // Add PTF to one framework, and ATF to another
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+            tfis[1].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseWithPTFOnly()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AssetTargetFallbackUtility_HasInvalidFallbackCombinationVerifyFalseWithATFOnly()
+        {
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            AssetTargetFallbackUtility.HasInvalidFallbackCombination(project).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task AssetTargetFallbackUtility_ValidateFallbackFrameworkVerifyFalse()
+        {
+            var testLogger = new TestLogger();
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+            tfis[0].Imports.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            var success = await AssetTargetFallbackUtility.ValidateFallbackFrameworkAsync(project, testLogger);
+
+            success.Should().BeFalse();
+            testLogger.Errors.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task AssetTargetFallbackUtility_ValidateFallbackFrameworkVerifyTrue()
+        {
+            var testLogger = new TestLogger();
+            var tfis = new List<TargetFrameworkInformation>
+            {
+                new TargetFrameworkInformation()
+                {
+                    FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+                }
+            };
+            tfis[0].AssetTargetFallback.Add(NuGetFramework.Parse("net461"));
+
+            var project = new PackageSpec(tfis);
+
+            var success = await AssetTargetFallbackUtility.ValidateFallbackFrameworkAsync(project, testLogger);
+
+            success.Should().BeTrue();
+            testLogger.Messages.Should().BeEmpty();
+        }
+    }
+}

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -603,6 +603,133 @@ namespace NuGet.Commands.Test
         }
 
         [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyAssetTargetFallback()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "AssetTargetFallback", "portable-net45+win8;dnxcore50;;" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(2, nsTFM.AssetTargetFallback.Count);
+                Assert.Equal(0, netTFM.AssetTargetFallback.Count);
+
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), nsTFM.AssetTargetFallback[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), nsTFM.AssetTargetFallback[1]);
+
+                // Verify fallback framework
+                var assetTargetFallbackFramewrk = (AssetTargetFallbackFramework)project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "netstandard1.6")
+                    .FrameworkName;
+
+                // net46 does not have imports
+                var fallbackFrameworkNet45 = project1Spec.TargetFrameworks
+                    .Single(e => e.FrameworkName.GetShortFolderName() == "net46")
+                    .FrameworkName
+                    as FallbackFramework;
+
+                Assert.Null(fallbackFrameworkNet45);
+                Assert.Equal(2, assetTargetFallbackFramewrk.Fallback.Count);
+                Assert.Equal(NuGetFramework.Parse("portable-net45+win8"), assetTargetFallbackFramewrk.Fallback[0]);
+                Assert.Equal(NuGetFramework.Parse("dnxcore50"), assetTargetFallbackFramewrk.Fallback[1]);
+            }
+        }
+
+        [Fact]
+        public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyAssetTargetFallbackEmpty()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var project1Root = Path.Combine(workingDir, "a");
+                var project1Path = Path.Combine(project1Root, "a.csproj");
+                var outputPath1 = Path.Combine(project1Root, "obj");
+                var fallbackFolder = Path.Combine(project1Root, "fallback");
+                var packagesFolder = Path.Combine(project1Root, "packages");
+
+                var items = new List<IDictionary<string, string>>();
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "ProjectSpec" },
+                    { "ProjectName", "a" },
+                    { "ProjectStyle", "PackageReference" },
+                    { "OutputPath", outputPath1 },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "ProjectPath", project1Path },
+                    { "TargetFrameworks", "net46;netstandard16" },
+                    { "Sources", "https://nuget.org/a/index.json;https://nuget.org/b/index.json" },
+                    { "FallbackFolders", fallbackFolder },
+                    { "PackagesPath", packagesFolder },
+                    { "CrossTargeting", "true" },
+                });
+
+                items.Add(new Dictionary<string, string>()
+                {
+                    { "Type", "TargetFrameworkInformation" },
+                    { "ProjectUniqueName", "482C20DE-DFF9-4BD0-B90A-BD3201AA351A" },
+                    { "PackageTargetFallback", "" },
+                    { "TargetFramework", "netstandard16" }
+                });
+
+                var wrappedItems = items.Select(CreateItems).ToList();
+
+                // Act
+                var dgSpec = MSBuildRestoreUtility.GetDependencySpec(wrappedItems);
+                var project1Spec = dgSpec.Projects.Single();
+
+                var nsTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("netstandard16"));
+                var netTFM = project1Spec.GetTargetFramework(NuGetFramework.Parse("net46"));
+
+                // Assert
+                Assert.Equal(0, nsTFM.Imports.Count);
+                Assert.Equal(0, netTFM.Imports.Count);
+
+                // Verify no fallback frameworks
+                var fallbackFrameworks = project1Spec.TargetFrameworks.Select(e => e.FrameworkName as AssetTargetFallbackFramework);
+                Assert.True(fallbackFrameworks.All(e => e == null));
+            }
+        }
+
+        [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_NetCoreVerifyImportsEmpty()
         {
             using (var workingDir = TestDirectory.Create())

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/AssetTargetFallbackTests.cs
@@ -10,23 +10,24 @@ namespace NuGet.ProjectModel.Test
     public class AssetTargetFallbackTests
     {
         [Fact]
-        public void GivenAssetTargetFallbackTrueVerifyValuePersisted()
+        public void GivenAssetTargetFallbackHasAValueVerifyValuePersisted()
         {
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
+            spec.TargetFrameworks[0].AssetTargetFallback.Add(NuGetFramework.Parse("net45"));
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeTrue();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
         [Fact]
         public void GivenAssetTargetFallbackFalseVerifyValuePersisted()
         {
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = false;
 
             var outSpec = spec.RoundTrip();
-            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeFalse();
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
+            outSpec.TargetFrameworks[0].Imports.Should().BeEmpty();
         }
 
         [Fact]
@@ -34,11 +35,11 @@ namespace NuGet.ProjectModel.Test
         {
             var net461 = NuGetFramework.Parse("net461");
             var spec = PackageSpecTestUtility.GetSpec(NuGetFramework.Parse("netcoreapp2.0"));
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
             spec.TargetFrameworks[0].Imports.Add(net461);
 
             var outSpec = spec.RoundTrip();
             outSpec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { net461 });
+            outSpec.TargetFrameworks[0].AssetTargetFallback.Should().BeEmpty();
         }
 
         [Fact]
@@ -47,8 +48,7 @@ namespace NuGet.ProjectModel.Test
             var net461 = NuGetFramework.Parse("net461");
             var projectFramework = NuGetFramework.Parse("netcoreapp2.0");
             var spec = PackageSpecTestUtility.GetSpec(projectFramework);
-            spec.TargetFrameworks[0].AssetTargetFallback = true;
-            spec.TargetFrameworks[0].Imports.Add(net461);
+            spec.TargetFrameworks[0].AssetTargetFallback.Add(net461);
 
             var outSpec = spec.RoundTrip();
 
@@ -60,10 +60,11 @@ namespace NuGet.ProjectModel.Test
         [Fact]
         public void GivenAssetTargetFallbackDiffersVerifyEquality()
         {
+            var net461 = NuGetFramework.Parse("net461");
             var spec1 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
-            spec1.TargetFrameworks[0].AssetTargetFallback = true;
+            spec1.TargetFrameworks[0].AssetTargetFallback.Add(net461);
             var spec2 = PackageSpecTestUtility.GetSpec("netcoreapp2.0");
-            spec2.TargetFrameworks[0].AssetTargetFallback = false;
+            spec2.TargetFrameworks[0].Imports.Add(net461);
 
             spec1.Should().NotBe(spec2);
             spec1.GetHashCode().Should().NotBe(spec2.GetHashCode());

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/JsonPackageSpecReaderTests.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
+using FluentAssertions;
 using NuGet.Common;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
@@ -43,6 +45,41 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.Contains("specify a version range", exception.Message);
+        }
+
+        [Fact]
+        public void PackageSpecReader_ReadImports()
+        {
+            // Arrange
+            var json = @"{
+              ""supports"": {
+                ""net46.app"": { },
+                ""uwp.10.0.app"": { },
+                ""dnxcore50.app"": { }
+                    },
+              ""dependencies"": {
+                ""Microsoft.NETCore"": ""5.0.0"",
+                ""Microsoft.NETCore.Portable.Compatibility"": ""1.0.0""
+              },
+              ""frameworks"": {
+                ""dotnet"": {
+                ""imports"": ""portable-net452+win81""
+                }
+              }
+            }";
+
+            // Act
+            var spec = JsonPackageSpecReader.GetPackageSpec(json, "TestProject", "project.json");
+
+            // Assert
+            var framework = spec.TargetFrameworks[0].Imports.Single();
+            Assert.Equal(".NETPortable", framework.Framework);
+            var fallback = spec.TargetFrameworks[0].FrameworkName as FallbackFramework;
+            Assert.Equal(".NETPlatform", fallback.Framework);
+            Assert.Equal(".NETPortable", fallback.Fallback.Single().Framework);
+
+            spec.TargetFrameworks[0].AssetTargetFallback.ShouldBeEquivalentTo(new NuGetFramework[] {});
+            spec.TargetFrameworks[0].Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("portable-net452+win81")});
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/PackageSpecUtilityTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Frameworks;
 using NuGet.Versioning;
 using Xunit;
 
@@ -54,6 +53,164 @@ namespace NuGet.ProjectModel.Test
 
             // Assert
             Assert.Equal(NuGetVersion.Parse(expected), actual);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithNoFallbacksVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>();
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf);
+
+            result.Should().Be(project, "no atf or ptf frameworks exist");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithNullFallbacksVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, packageTargetFallback: null, assetTargetFallback: null);
+
+            result.Should().Be(project, "no atf or ptf frameworks exist");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithPTFOnlyVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf) as FallbackFramework;
+
+            result.Fallback.ShouldBeEquivalentTo(ptf);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithATFOnlyVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var ptf = new List<NuGetFramework>();
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf) as AssetTargetFallbackFramework;
+
+            result.Fallback.ShouldBeEquivalentTo(atf);
+        }
+
+        [Fact]
+        public void PackageSpecUtility_GetFallbackFrameworkWithATFAndPTFVerifyResult()
+        {
+            var project = NuGetFramework.Parse("netcoreapp2.0");
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            var result = PackageSpecUtility.GetFallbackFramework(project, ptf, atf);
+
+            result.Should().Be(project, "both atf and ptf will be ignored");
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithBothFallbacksVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net45")
+            };
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net45") });
+            frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithNoFallbacksVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>();
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.Imports.Should().BeEmpty();
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithPTFVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var atf = new List<NuGetFramework>();
+            var ptf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.AssetTargetFallback.Should().BeEmpty();
+            frameworkInfo.Imports.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().BeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(AssetTargetFallbackFramework));
+        }
+
+        [Fact]
+        public void PackageSpecUtility_ApplyFallbackFrameworkWithATFVerifyResult()
+        {
+            var frameworkInfo = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("netcoreapp2.0")
+            };
+            var ptf = new List<NuGetFramework>();
+            var atf = new List<NuGetFramework>()
+            {
+                NuGetFramework.Parse("net461")
+            };
+
+            PackageSpecUtility.ApplyFallbackFramework(frameworkInfo, ptf, atf);
+
+            frameworkInfo.Imports.Should().BeEmpty();
+            frameworkInfo.AssetTargetFallback.ShouldBeEquivalentTo(new[] { NuGetFramework.Parse("net461") });
+
+            frameworkInfo.FrameworkName.Should().NotBeOfType(typeof(FallbackFramework));
+            frameworkInfo.FrameworkName.Should().BeOfType(typeof(AssetTargetFallbackFramework));
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/NuGet/Home/issues/5622

From original PR
```
Projects with PackageTargetFallback and AssetTargetFallback will now fail to restore from Visual Studio with NU1003.

Updating PackageSpec to take both PTF and ATF instead of a bool, this allows restore to fail across all restore types, including Visual Studio in the same way.
NU1003 will now show up as an error that fails restore, but restore will still proceed using the default project framework without fallbacks. This allows system packages to be restored so that the error is not lost with missing reference errors.
Updating error message string with the new text from @anangaur
```