### PR TITLE
Add RestoreAdditionalProjectFallbackFoldersExcludes property

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -443,8 +443,24 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettings"
-          DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreSettingsOverrides"
+          DependsOnTargets="_GetRestoreProjectStyle;_GetRestoreSettingsOverrides;_GetRestoreTargetFrameworksAsItems"
           Returns="$(_OutputSources);$(_OutputPackagesPath);$(_OutputFallbackFolders);$(_OutputConfigFilePaths)">
+
+    <!-- Read additional sources and fallback folders for each framework  -->
+    <MSBuild
+      Condition=" '$(RestoreProjectStyle)' == 'PackageReference' "
+      Projects="$(MSBuildProjectFullPath)"
+      Targets="_GetRestoreSettingsPerFramework"
+      Properties="TargetFramework=%(_RestoreTargetFrameworkItems.Identity);
+                  %(_MSBuildProjectReferenceExistent.SetConfiguration);
+                  %(_MSBuildProjectReferenceExistent.SetPlatform);
+                  $(_GenerateRestoreGraphProjectEntryInputProperties)"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output
+          TaskParameter="TargetOutputs"
+          ItemName="_RestoreSettingsPerFramework" />
+    </MSBuild>
 
     <!-- For transitive project styles, we rely on evaluating all the settings and including them in the dg spec to faciliate no-op restore-->
     <GetRestoreSettingsTask Condition=" '$(RestoreProjectStyle)' == 'PackageReference' OR '$(RestoreProjectStyle)' == 'ProjectJson' "
@@ -454,8 +470,7 @@ Copyright (c) .NET Foundation. All rights reserved.
      RestoreFallbackFolders="$(RestoreFallbackFolders)"
      RestoreConfigFile="$(RestoreConfigFile)"
      RestoreSolutionDirectory="$(RestoreSolutionDirectory)"
-     RestoreAdditionalProjectFallbackFolders="$(RestoreAdditionalProjectFallbackFolders)"
-     RestoreAdditionalProjectSources="$(RestoreAdditionalProjectSources)"
+     RestoreSettingsPerFramework="@(_RestoreSettingsPerFramework)"
      RestorePackagesPathOverride="$(_RestorePackagesPathOverride)"
      RestoreSourcesOverride="$(_RestoreSourcesOverride)"
      RestoreFallbackFoldersOverride="$(_RestoreFallbackFoldersOverride)"
@@ -473,6 +488,24 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="OutputConfigFilePaths"
         PropertyName="_OutputConfigFilePaths" />
     </GetRestoreSettingsTask>
+  </Target>
+
+  <!--
+    ============================================================
+    _GetRestoreSettingsPerFramework
+    Generate items with framework specific settings.
+    ============================================================
+  -->
+  <Target Name="_GetRestoreSettingsPerFramework"
+    Returns="@(_RestoreSettingsPerFramework)">
+
+    <ItemGroup>
+      <_RestoreSettingsPerFramework Include="$([System.Guid]::NewGuid())">
+        <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
+        <RestoreAdditionalProjectFallbackFolders>$(RestoreAdditionalProjectFallbackFolders)</RestoreAdditionalProjectFallbackFolders>
+        <RestoreAdditionalProjectFallbackFoldersExcludes>$(RestoreAdditionalProjectFallbackFoldersExcludes)</RestoreAdditionalProjectFallbackFoldersExcludes>
+      </_RestoreSettingsPerFramework>
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/MSBuildRestoreUtility.cs
@@ -381,6 +381,30 @@ namespace NuGet.Commands
             }
         }
 
+        /// <summary>
+        /// Remove duplicates and excluded values a set of sources or fallback folders.
+        /// </summary>
+        /// <remarks>Compares with Ordinal, excludes must be exact matches.</remarks>
+        public static IEnumerable<string> AggregateSources(IEnumerable<string> values, IEnumerable<string> excludeValues)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            if (excludeValues == null)
+            {
+                throw new ArgumentNullException(nameof(excludeValues));
+            }
+
+            var result = new SortedSet<string>(values, StringComparer.Ordinal);
+
+            // Remove excludes
+            result.ExceptWith(excludeValues);
+
+            return result;
+        }
+
         private static RuntimeGraph GetRuntimeGraph(IMSBuildItem specItem)
         {
             var runtimes = MSBuildStringUtility.Split(specItem.GetProperty("RuntimeIdentifiers"))

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -4778,6 +4778,295 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public async Task RestoreNetCore_VerifyAdditionalSourcesConditionalOnFramework()
+        {
+            // Arrange
+            using (var extraSourceA = TestDirectory.Create())
+            using (var extraSourceB = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp1 = NuGetFramework.Parse("netcoreapp1.0");
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp1,
+                    netcoreapp2);
+
+                // Add conditional sources
+                projectA.Frameworks[0].Properties.Add("RestoreAdditionalProjectSources", extraSourceA.Path);
+                projectA.Frameworks[1].Properties.Add("RestoreAdditionalProjectSources", extraSourceB.Path);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.AddPackageToAllFrameworks(packageY);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // X is only in the source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceA,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Y is only in the extra source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceB,
+                    PackageSaveMode.Defaultv3,
+                    packageY);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                projectA.AssetsFile.Libraries.Select(e => e.Name).OrderBy(e => e).ShouldBeEquivalentTo(new[] { "x", "y" });
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_VerifyAdditionalFallbackFolderConditionalOnFramework()
+        {
+            // Arrange
+            using (var extraSourceA = TestDirectory.Create())
+            using (var extraSourceB = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp1 = NuGetFramework.Parse("netcoreapp1.0");
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp1,
+                    netcoreapp2);
+
+                // Add conditional sources
+                projectA.Frameworks[0].Properties.Add("RestoreAdditionalProjectFallbackFolders", extraSourceA.Path);
+                projectA.Frameworks[1].Properties.Add("RestoreAdditionalProjectFallbackFolders", extraSourceB.Path);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.AddPackageToAllFrameworks(packageY);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // X is only in the source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceA,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Y is only in the extra source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceB,
+                    PackageSaveMode.Defaultv3,
+                    packageY);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                projectA.AssetsFile.Libraries.Select(e => e.Name).OrderBy(e => e).ShouldBeEquivalentTo(new[] { "x", "y" });
+
+                // Verify fallback folder added
+                projectA.AssetsFile.PackageFolders.Select(e => e.Path).Should().Contain(extraSourceA);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_VerifyAdditionalFallbackFolderExclude()
+        {
+            // Arrange
+            using (var extraSourceA = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp1 = NuGetFramework.Parse("netcoreapp1.0");
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp1,
+                    netcoreapp2);
+
+                // Add and remove a fallback source, also add it as a source
+                projectA.Frameworks[0].Properties.Add("RestoreAdditionalProjectFallbackFolders", extraSourceA.Path);
+                projectA.Frameworks[1].Properties.Add("RestoreAdditionalProjectFallbackFoldersExcludes", extraSourceA.Path);
+                projectA.Frameworks[1].Properties.Add("RestoreAdditionalProjectSources", extraSourceA.Path);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                var packageY = new SimpleTestPackageContext()
+                {
+                    Id = "y",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+                projectA.AddPackageToAllFrameworks(packageY);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // X is only in the source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceA,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Y is only in the extra source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSourceA,
+                    PackageSaveMode.Defaultv3,
+                    packageY);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                projectA.AssetsFile.Libraries.Select(e => e.Name).OrderBy(e => e).ShouldBeEquivalentTo(new[] { "x", "y" });
+
+                // Verify the fallback folder was not added
+                projectA.AssetsFile.PackageFolders.Select(e => e.Path).Should().NotContain(extraSourceA);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_VerifyAdditionalSourcesAppliedWithSingleFramework()
+        {
+            // Arrange
+            using (var extraSource = TestDirectory.Create())
+            using (var extraFallback = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp1.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("RestoreAdditionalProjectSources", extraSource.Path);
+                projectA.Properties.Add("RestoreAdditionalProjectFallbackFoldersExcludes", extraFallback.Path);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // X is only in the source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraSource.Path,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                projectA.AssetsFile.Libraries.Select(e => e.Name).OrderBy(e => e).ShouldBeEquivalentTo(new[] { "x" });
+
+                // Verify the fallback folder was not added
+                projectA.AssetsFile.PackageFolders.Select(e => e.Path).Should().NotContain(extraFallback.Path);
+            }
+        }
+
+        [Fact]
+        public async Task RestoreNetCore_VerifyAdditionalFallbackFolderAppliedWithSingleFramework()
+        {
+            // Arrange
+            using (var extraSource = TestDirectory.Create())
+            using (var extraFallback = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var netcoreapp2 = NuGetFramework.Parse("netcoreapp2.0");
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    netcoreapp2);
+
+                projectA.Properties.Add("RestoreAdditionalProjectFallbackFolders", extraFallback.Path);
+
+                var packageX = new SimpleTestPackageContext()
+                {
+                    Id = "x",
+                    Version = "1.0.0"
+                };
+
+                projectA.AddPackageToAllFrameworks(packageX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                // X is only in the source
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    extraFallback.Path,
+                    PackageSaveMode.Defaultv3,
+                    packageX);
+
+                // Act
+                var r = Util.RestoreSolution(pathContext);
+
+                // Assert
+                projectA.AssetsFile.Libraries.Select(e => e.Name).OrderBy(e => e).ShouldBeEquivalentTo(new[] { "x" });
+
+                // Verify the fallback folder was added
+                projectA.AssetsFile.PackageFolders.Select(e => e.Path).Should().Contain(extraFallback.Path);
+            }
+        }
+
+        [Fact]
         public async Task RestoreNetCore_VerifyPackagesFolderPathResolvedAgainstWorkingDir()
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildRestoreUtilityTests.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
@@ -14,13 +13,29 @@ using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
-using Test.Utility;
 using Xunit;
 
 namespace NuGet.Commands.Test
 {
     public class MSBuildRestoreUtilityTests
     {
+        [Theory]
+        [InlineData("a", "", "a")]
+        [InlineData("a|b", "", "a|b")]
+        [InlineData("a|b", "a|b", "")]
+        [InlineData("a|b", "a|b|c", "")]
+        [InlineData("", "a", "")]
+        [InlineData("a", "A", "a")]
+        public void MSBuildRestoreUtility_AggregateSources(string values, string exclude, string expected)
+        {
+            var inputValues = values.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            var excludeValues = exclude.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+            var expectedValues = expected.Split(new char[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
+
+            MSBuildRestoreUtility.AggregateSources(inputValues, excludeValues)
+                .ShouldBeEquivalentTo(expectedValues);
+        }
+
         [Fact]
         public void MSBuildRestoreUtility_GetPackageSpec_VerifyInvalidProjectReferencesAreIgnored()
         {
@@ -1478,7 +1493,7 @@ namespace NuGet.Commands.Test
 
                 var items = new List<IDictionary<string, string>>();
 
-                
+
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "ProjectSpec" },
@@ -1527,7 +1542,7 @@ namespace NuGet.Commands.Test
 
                 var items = new List<IDictionary<string, string>>();
 
-                
+
                 items.Add(new Dictionary<string, string>()
                 {
                     { "Type", "ProjectSpec" },
@@ -1849,7 +1864,7 @@ namespace NuGet.Commands.Test
             var codes = MSBuildRestoreUtility.ReplayWarningsAndErrorsAsync(lockFile, logger.Object);
 
             // Assert
-            logger.Verify(x => x.LogAsync(It.Is<RestoreLogMessage>(l => l.Level == LogLevel.Warning && l.Message == "Test Warning" && l.Code == NuGetLogCode.NU1500)), 
+            logger.Verify(x => x.LogAsync(It.Is<RestoreLogMessage>(l => l.Level == LogLevel.Warning && l.Message == "Test Warning" && l.Code == NuGetLogCode.NU1500)),
                 Times.Once);
             logger.Verify(x => x.LogAsync(It.Is<RestoreLogMessage>(l => l.Level == LogLevel.Error && l.Message == "Test Error" && l.Code == NuGetLogCode.NU1000)),
                 Times.Once);
@@ -1875,7 +1890,7 @@ namespace NuGet.Commands.Test
                         EndColumnNumber = number,
                         EndLineNumber = number,
                         StartColumnNumber = number,
-                        StartLineNumber = number, 
+                        StartLineNumber = number,
                         FilePath = "Warning File Path",
                         LibraryId = "Warning Package",
                         ProjectPath = "Warning Project Path",
@@ -1901,8 +1916,8 @@ namespace NuGet.Commands.Test
             var codes = MSBuildRestoreUtility.ReplayWarningsAndErrorsAsync(lockFile, logger.Object);
 
             // Assert
-            logger.Verify(x => x.LogAsync(It.Is<RestoreLogMessage>(l => l.Level == LogLevel.Warning && 
-            l.Message == "Test Warning" && 
+            logger.Verify(x => x.LogAsync(It.Is<RestoreLogMessage>(l => l.Level == LogLevel.Warning &&
+            l.Message == "Test Warning" &&
             l.Code == NuGetLogCode.NU1500 &&
             l.EndColumnNumber == number &&
             l.StartColumnNumber == number &&

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectContext.cs
@@ -118,6 +118,12 @@ namespace NuGet.Test.Utility
         public string GlobalPackagesFolder { get; set; }
 
         public bool WarningsAsErrors { get; set; }
+
+        /// <summary>
+        /// If true TargetFramework will be used instead of TargetFrameworks
+        /// </summary>
+        public bool SingleTargetFramework { get; set; }
+
         /// <summary>
         /// project.lock.json or project.assets.json
         /// </summary>
@@ -401,9 +407,11 @@ namespace NuGet.Test.Utility
 
                 if (!IsLegacyPackageReference)
                 {
+                    var tfPropName = SingleTargetFramework ? "TargetFramework" : "TargetFrameworks";
+
                     ProjectFileUtils.AddProperties(xml, new Dictionary<string, string>()
                     {
-                        { "TargetFrameworks", string.Join(";", Frameworks.Select(f => f.Framework.GetShortFolderName())) },
+                        { tfPropName, string.Join(";", Frameworks.Select(f => f.Framework.GetShortFolderName())) },
                     });
                 }
 
@@ -412,6 +420,9 @@ namespace NuGet.Test.Utility
 
                 foreach (var frameworkInfo in Frameworks)
                 {
+                    // Add properties with a TFM condition
+                    ProjectFileUtils.AddProperties(xml, frameworkInfo.Properties, $" '$(TargetFramework)' == '{frameworkInfo.Framework.GetShortFolderName()}' ");
+
                     foreach (var package in frameworkInfo.PackageReferences)
                     {
                         var referenceFramework = frameworkInfo.Framework;

--- a/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectFrameworkContext.cs
+++ b/test/TestUtilities/Test.Utility/SimpleTestSetup/SimpleTestProjectFrameworkContext.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NuGet.Frameworks;
@@ -26,6 +27,11 @@ namespace NuGet.Test.Utility
         /// Project dependencies.
         /// </summary>
         public List<SimpleTestProjectContext> ProjectReferences { get; set; } = new List<SimpleTestProjectContext>();
+
+        /// <summary>
+        /// Framework specific properties.
+        /// </summary>
+        public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// Project framework assembly references.


### PR DESCRIPTION
Additional sources and fallback folders are added conditionally on TargetFramework, to collect those values the following properties will now be read from the inner build
* RestoreAdditionalProjectSources
* RestoreAdditionalProjectFallbackFolders
* RestoreAdditionalProjectFallbackFoldersExcludes

RestoreAdditionalProjectFallbackFoldersExcludes is a new property added in this change, it will remove values from RestoreAdditionalProjectFallbackFolders.

Added support for single TargetFramework and properties conditioned on TargetFramework to SimpleTestProjectContext.

Fixes https://github.com/NuGet/Home/issues/5596 

//cc @DoRonMotter 