### PR TITLE
Fix flaky test

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Providers/PluginResourceProvider.cs
@@ -40,7 +40,7 @@ namespace NuGet.Protocol.Core.Types
         /// Gets an environment variable reader.
         /// </summary>
         /// <remarks>This is non-private only to facilitate testing.</remarks>
-        public static IEnvironmentVariableReader EnvironmentVariableReader { get; private set; }
+        public IEnvironmentVariableReader EnvironmentVariableReader { get; private set; }
 
         /// <summary>
         /// Initializes a new <see cref="PluginResourceProvider" /> class.

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/Plugins/PluginResourceProviderTests.cs
@@ -250,7 +250,7 @@ namespace NuGet.Protocol.Plugins.Tests
                 new Lazy<IPluginDiscoverer>(() => Mock.Of<IPluginDiscoverer>()),
                 Mock.Of<IPluginFactory>());
 
-            Assert.Same(reader, PluginResourceProvider.EnvironmentVariableReader);
+            Assert.Same(reader, provider.EnvironmentVariableReader);
         }
 
         private static SourceRepository CreateSourceRepository(


### PR DESCRIPTION
Fix NuGet/Home#5628.

The static property `NuGet.Protocol.Core.Types.PluginResourceProvider.EnvironmentVariableReader` may be updated by concurrently executing tests from different test collections.  The fix is to convert the property into an instance property.

Internally within the product, the property is written to but never read.  The property is read only by this unit test.