### PR TITLE
Avoid MEF initialization in NuGet restore manager package load

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreManagerPackage.cs
@@ -35,16 +35,6 @@ namespace NuGet.SolutionRestoreManager
             CancellationToken cancellationToken,
             IProgress<ServiceProgressData> progress)
         {
-            // Don't use CPS thread helper because of RPS perf regression
-            await ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-                var dte = (EnvDTE.DTE)await GetServiceAsync(typeof(SDTE));
-
-                UserAgent.SetUserAgentString(
-                    new UserAgentStringBuilder().WithVisualStudioSKU(dte.GetFullVsVersionString()));
-            });
-
             _handler = await SolutionRestoreBuildHandler.InitializeAsync(this);
 
             await SolutionRestoreCommand.InitializeAsync(this);

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreBuildHandler.cs
@@ -35,9 +35,6 @@ namespace NuGet.SolutionRestoreManager
         private const uint VSCOOKIE_NIL = 0;
 
         [Import]
-        private Lazy<INuGetLockService> LockService { get; set; }
-
-        [Import]
         private Lazy<ISettings> Settings { get; set; }
 
         [Import]
@@ -53,27 +50,30 @@ namespace NuGet.SolutionRestoreManager
         /// </summary>
         private uint _updateSolutionEventsCookieEx;
 
+        private Microsoft.VisualStudio.Shell.IAsyncServiceProvider _serviceProvider;
+
+        private bool _isMEFInitialized;
+
         private SolutionRestoreBuildHandler()
         {
         }
 
         // A constructor utilized for running unit-tests
         public SolutionRestoreBuildHandler(
-            INuGetLockService lockService,
             ISettings settings,
             ISolutionRestoreWorker restoreWorker,
             IVsSolutionBuildManager3 buildManager)
         {
-            Assumes.Present(lockService);
             Assumes.Present(settings);
             Assumes.Present(restoreWorker);
             Assumes.Present(buildManager);
 
-            LockService = new Lazy<INuGetLockService>(() => lockService);
             Settings = new Lazy<ISettings>(() => settings);
             SolutionRestoreWorker = new Lazy<ISolutionRestoreWorker>(() => restoreWorker);
 
             _solutionBuildManager = buildManager;
+
+            _isMEFInitialized = true;
         }
 
         public void Dispose()
@@ -94,9 +94,6 @@ namespace NuGet.SolutionRestoreManager
 
             var instance = new SolutionRestoreBuildHandler();
 
-            var componentModel = await serviceProvider.GetComponentModelAsync();
-            componentModel.DefaultCompositionService.SatisfyImportsOnce(instance);
-
             await instance.SubscribeAsync(serviceProvider);
 
             return instance;
@@ -106,6 +103,8 @@ namespace NuGet.SolutionRestoreManager
         {
             // Don't use CPS thread helper because of RPS perf regression
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            _serviceProvider = serviceProvider;
 
             _solutionBuildManager = await serviceProvider.GetServiceAsync<SVsSolutionBuildManager, IVsSolutionBuildManager3>();
             Assumes.Present(_solutionBuildManager);
@@ -117,6 +116,17 @@ namespace NuGet.SolutionRestoreManager
 
         public void UpdateSolution_QueryDelayBuildAction(uint dwAction, out IVsTask pDelayTask)
         {
+            if (!_isMEFInitialized)
+            {
+                ThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    var componentModel = await _serviceProvider.GetComponentModelAsync();
+                    componentModel.DefaultCompositionService.SatisfyImportsOnce(this);
+                });
+
+                _isMEFInitialized = true;
+            }
+
             pDelayTask = SolutionRestoreWorker.Value.JoinableTaskFactory.RunAsyncAsVsTask(
                 VsTaskRunContext.UIThreadBackgroundPriority, (token) => RestoreAsync(dwAction, token));
         }

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -41,6 +41,10 @@ namespace NuGet.SolutionRestoreManager
 
         private Task _restoreTask = Task.CompletedTask;
 
+        private Microsoft.VisualStudio.Shell.IAsyncServiceProvider _serviceProvider;
+
+        private bool _isMEFInitialized;
+
         private SolutionRestoreCommand()
         {
         }
@@ -55,15 +59,14 @@ namespace NuGet.SolutionRestoreManager
 
             _instance = new SolutionRestoreCommand();
 
-            var componentModel = await serviceProvider.GetComponentModelAsync();
-            componentModel.DefaultCompositionService.SatisfyImportsOnce(_instance);
-
             await _instance.SubscribeAsync(serviceProvider);
         }
 
         private async Task SubscribeAsync(Microsoft.VisualStudio.Shell.IAsyncServiceProvider serviceProvider)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            _serviceProvider = serviceProvider;
 
             var commandService = await serviceProvider.GetServiceAsync<IMenuCommandService>();
 
@@ -85,6 +88,12 @@ namespace NuGet.SolutionRestoreManager
                 ref guidCmdUI, out _solutionNotBuildingAndNotDebuggingContextCookie);
         }
 
+        private async Task InitializeMEFAsync()
+        {
+            var componentModel = await _serviceProvider.GetComponentModelAsync();
+            componentModel.DefaultCompositionService.SatisfyImportsOnce(_instance);
+        }
+
         /// <summary>
         /// This function is the callback used to execute the command when the menu item is clicked.
         /// See the constructor to see how the menu item is associated with this function using
@@ -94,6 +103,16 @@ namespace NuGet.SolutionRestoreManager
         /// <param name="e">Event args.</param>
         private void OnRestorePackages(object sender, EventArgs args)
         {
+            if (!_isMEFInitialized)
+            {
+                NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
+                {
+                    await InitializeMEFAsync();
+                });
+
+                _isMEFInitialized = true;
+            }
+
             if (_restoreTask.IsCompleted)
             {
                 _restoreTask = NuGetUIThreadHelper.JoinableTaskFactory
@@ -108,6 +127,12 @@ namespace NuGet.SolutionRestoreManager
         {
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
             {
+                if (!_isMEFInitialized)
+                {
+                    await InitializeMEFAsync();
+                    _isMEFInitialized = true;
+                }
+
                 await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
                 var command = (OleMenuCommand)sender;

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/SolutionRestoreBuildHandlerTests.cs
@@ -29,13 +29,12 @@ namespace NuGet.SolutionRestoreManager.Test
         [Fact]
         public async Task QueryDelayBuildAction_CleanBuild()
         {
-            var lockService = Mock.Of<INuGetLockService>();
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
             var buildAction = (uint)VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_CLEAN;
 
-            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -54,7 +53,6 @@ namespace NuGet.SolutionRestoreManager.Test
         [Fact]
         public async Task QueryDelayBuildAction_ShouldNotRestoreOnBuild_NoOps()
         {
-            var lockService = Mock.Of<INuGetLockService>();
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
@@ -65,7 +63,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Setup(x => x.GetValue("packageRestore", "automatic", false))
                 .Returns(bool.FalseString);
 
-            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -81,7 +79,6 @@ namespace NuGet.SolutionRestoreManager.Test
         [Fact]
         public async Task QueryDelayBuildAction_ShouldNotRestoreOnBuild_ProjectUpToDateMark()
         {
-            var lockService = Mock.Of<INuGetLockService>();
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
@@ -92,7 +89,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Setup(x => x.GetValue("packageRestore", "automatic", false))
                 .Returns(bool.TrueString);
 
-            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
             {
                 await _jtf.SwitchToMainThreadAsync();
 
@@ -108,7 +105,6 @@ namespace NuGet.SolutionRestoreManager.Test
         [Fact]
         public async Task QueryDelayBuildAction_ShouldRestoreOnBuild()
         {
-            var lockService = Mock.Of<INuGetLockService>();
             var settings = Mock.Of<ISettings>();
             var restoreWorker = Mock.Of<ISolutionRestoreWorker>();
             var buildManager = Mock.Of<IVsSolutionBuildManager3>();
@@ -125,7 +121,7 @@ namespace NuGet.SolutionRestoreManager.Test
                 .Setup(x => x.RestoreAsync(It.IsAny<SolutionRestoreRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
-            using (var handler = new SolutionRestoreBuildHandler(lockService, settings, restoreWorker, buildManager))
+            using (var handler = new SolutionRestoreBuildHandler(settings, restoreWorker, buildManager))
             {
                 await _jtf.SwitchToMainThreadAsync();
 


### PR DESCRIPTION
This PR removes MEF initialization from NuGet `RestoreManagerPackage` package load as part of solution load which sometimes add additional ~10-12 secs to overall solution load.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=402184&_a=edit

@rrelyea @DoRonMotter 