### PR TITLE
Remove TopologicalSortUtility.GetParentCount allocs

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.Core
         public PackageDependencyInfo(string id, NuGetVersion version, IEnumerable<PackageDependency> dependencies)
             : base(id, version)
         {
-            _dependencies = dependencies == null ? _empty : dependencies.ToArray();
+            _dependencies = dependencies?.ToArray() ?? _empty;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
@@ -39,7 +39,7 @@ namespace NuGet.Packaging.Core
         public PackageDependencyInfo(string id, NuGetVersion version, IEnumerable<PackageDependency> dependencies)
             : base(id, version)
         {
-            _dependencies = dependencies == null ? new PackageDependency[0] : dependencies.ToArray();
+            _dependencies = dependencies == null ? Array.Empty<PackageDependency>() : dependencies.ToArray();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
@@ -18,7 +18,7 @@ namespace NuGet.Packaging.Core
     /// </remarks>
     public class PackageDependencyInfo : PackageIdentity, IEquatable<PackageDependencyInfo>
     {
-        private readonly static PackageDependency[] _empty = new PackageDependency[0];
+        private readonly static PackageDependency[] EmptyDependencies = new PackageDependency[0];
         private PackageDependency[] _dependencies;
 
         public PackageDependencyInfo(string id, NuGetVersion version)
@@ -40,7 +40,7 @@ namespace NuGet.Packaging.Core
         public PackageDependencyInfo(string id, NuGetVersion version, IEnumerable<PackageDependency> dependencies)
             : base(id, version)
         {
-            _dependencies = dependencies?.ToArray() ?? _empty;
+            _dependencies = dependencies?.ToArray() ?? EmptyDependencies;
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
+++ b/src/NuGet.Core/NuGet.Packaging.Core/PackageDependencyInfo.cs
@@ -18,6 +18,7 @@ namespace NuGet.Packaging.Core
     /// </remarks>
     public class PackageDependencyInfo : PackageIdentity, IEquatable<PackageDependencyInfo>
     {
+        private readonly static PackageDependency[] _empty = new PackageDependency[0];
         private PackageDependency[] _dependencies;
 
         public PackageDependencyInfo(string id, NuGetVersion version)
@@ -39,7 +40,7 @@ namespace NuGet.Packaging.Core
         public PackageDependencyInfo(string id, NuGetVersion version, IEnumerable<PackageDependency> dependencies)
             : base(id, version)
         {
-            _dependencies = dependencies == null ? Array.Empty<PackageDependency>() : dependencies.ToArray();
+            _dependencies = dependencies == null ? _empty : dependencies.ToArray();
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -32,7 +32,7 @@ namespace NuGet.Packaging
             var toSort = lookup.Values.ToArray();
             var sorted = new List<PackageDependencyInfo>(toSort.Length);
 
-            CalcuateRelationships(toSort, lookup);
+            CalculateRelationships(toSort, lookup);
 
             for (var i = 0; i < toSort.Length; i++)
             {
@@ -62,7 +62,7 @@ namespace NuGet.Packaging
             }
         }
 
-        private static void CalcuateRelationships(PackageInfo[] packages, Dictionary<string, PackageInfo> lookup)
+        private static void CalculateRelationships(PackageInfo[] packages, Dictionary<string, PackageInfo> lookup)
         {
             foreach (var package in packages)
             {

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -39,11 +39,10 @@ namespace NuGet.Packaging
         private static int GetParentCount(List<PackageDependencyInfo> packages, string id)
         {
             var parentCount = 0;
-            var count = packages.Count;
 
-            for (var i = 0; i < count; i++)
+            foreach(var package in packages)
             {
-                var deps = packages[i].Dependencies;
+                var deps = package.Dependencies;
                 var dependencies = deps as PackageDependency[] ?? deps.ToArray();
 
                 foreach (var dependency in dependencies)

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -38,19 +38,25 @@ namespace NuGet.Packaging
 
         private static int GetParentCount(List<PackageDependencyInfo> packages, string id)
         {
-            int count = 0;
+            var parentCount = 0;
+            var count = packages.Count;
 
-            foreach (var package in packages)
+            for (var i = 0; i < count; i++)
             {
-                if (package.Dependencies != null
-                    && package.Dependencies.Any(dependency =>
-                        string.Equals(id, dependency.Id, StringComparison.OrdinalIgnoreCase)))
+                var deps = packages[i].Dependencies;
+                var dependencies = deps as PackageDependency[] ?? deps.ToArray();
+
+                foreach (var dependency in dependencies)
                 {
-                    count++;
+                    if (string.Equals(id, dependency.Id, StringComparison.OrdinalIgnoreCase))
+                    {
+                        parentCount++;
+                        break;
+                    }
                 }
             }
 
-            return count;
+            return parentCount;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -43,7 +43,7 @@ namespace NuGet.Packaging
                 packages[i].ParentCount = GetParentCount(packages, package.Id, start);
             }
 
-            Array.Sort(packages, 0, 0, _comparer);
+            Array.Sort(packages, start, packages.Length - start, _comparer);
         }
 
         private static int GetParentCount(PackageInfo[] packages, string id, int start)

--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -10,7 +10,7 @@ namespace NuGet.Packaging
 {
     public static class TopologicalSortUtility
     {
-        private static readonly Comparer _comparer = new Comparer();
+        private static readonly PackageInfoComparer DefaultComparer = new PackageInfoComparer();
         /// <summary>
         /// Order dependencies by children first.
         /// </summary>
@@ -43,7 +43,7 @@ namespace NuGet.Packaging
                 packages[i].ParentCount = GetParentCount(packages, package.Id, start);
             }
 
-            Array.Sort(packages, start, packages.Length - start, _comparer);
+            Array.Sort(packages, start, packages.Length - start, DefaultComparer);
         }
 
         private static int GetParentCount(PackageInfo[] packages, string id, int start)
@@ -68,7 +68,7 @@ namespace NuGet.Packaging
             return parentCount;
         }
 
-        private class Comparer : IComparer<PackageInfo>
+        private class PackageInfoComparer : IComparer<PackageInfo>
         {
             public int Compare(PackageInfo x, PackageInfo y)
             {


### PR DESCRIPTION
Resolves https://github.com/NuGet/Home/issues/5666

For `nuget restore Roslyn.sln -NoCache`

`TopologicalSortUtility` allocates 4,833 MB; taking 21,577ms (21.5 secs)

`TopologicalSortUtility` allocates 16 MB; taking 338ms

For 1024 dependencies its x 90 times faster and only uses 0.7% of the memory
```
                 Method | Deps |        Mean | Scaled |    Gen 0 |  Gen 1 | Gen 2 |    Allocated |
----------------------- |----- |------------:|-------:|---------:|-------:|------:|-------------:|
 TopologicalSortCurrent | 1024 | 8,047.69 ms |   1.00 | 16125.00 | 768.52 | 62.50 | 49,720.89 KB |
 TopologicalSortReduced | 1024 | 2,018.55 ms |   0.25 |    62.50 |      - |     - |    353.02 KB |
  TopologicalSortLookup | 1024 |    88.84 ms |   0.01 |   125.00 |      - |     - |    476.80 KB |
 TopologicalSortLookup2 | 1024 |    89.90 ms |   0.01 |   125.00 |      - |     - |    388.15 KB |
```