### PR TITLE
Reduce Pattern matching allocations

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItem.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItem.cs
@@ -7,12 +7,25 @@ namespace NuGet.ContentModel
 {
     public class ContentItem
     {
+        private Dictionary<string, object> _properties;
         public string Path { get; set; }
-        public IDictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+
+        public Dictionary<string, object> Properties
+        {
+            get => _properties ?? CreateDictionary();
+            internal set => _properties = value;
+        }
 
         public override string ToString()
         {
             return Path;
+        }
+
+        private Dictionary<string, object> CreateDictionary()
+        {
+            var properties = new Dictionary<string, object>();
+            _properties = properties;
+            return properties;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemGroup.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentItemGroup.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace NuGet.ContentModel
 {
+    [DebuggerDisplay("Items: {Items.Count}, Properties: {Properties.Count}")]
     public class ContentItemGroup
     {
         public ContentItemGroup()

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
@@ -13,7 +13,7 @@ namespace NuGet.ContentModel
     /// </summary>
     public class ContentPropertyDefinition
     {
-        private static readonly char[] SlashChars = new char[] { '/', '\\' };
+        private static readonly Func<object, object, bool> EqualsTest = (left, right) => Equals(left, right);
 
         public ContentPropertyDefinition(string name)
             : this(name, null, null, null, null, false)
@@ -92,9 +92,9 @@ namespace NuGet.ContentModel
         {
             Name = name;
             Parser = parser;
-            CompatibilityTest = compatibilityTest ?? Equals;
+            CompatibilityTest = compatibilityTest ?? EqualsTest;
             CompareTest = compareTest;
-            FileExtensions = (fileExtensions ?? Enumerable.Empty<string>()).ToList();
+            FileExtensions = fileExtensions?.ToList();
             FileExtensionAllowSubFolders = allowSubfolders;
         }
 
@@ -114,11 +114,9 @@ namespace NuGet.ContentModel
                 return false;
             }
 
-            if (FileExtensions != null
-                && FileExtensions.Count > 0)
+            if (FileExtensions?.Count > 0)
             {
-                if (FileExtensionAllowSubFolders == true
-                    || name.IndexOfAny(SlashChars) == -1)
+                if (FileExtensionAllowSubFolders || ContainsSlash(name))
                 {
                     foreach (var fileExtension in FileExtensions)
                     {
@@ -142,6 +140,21 @@ namespace NuGet.ContentModel
 
             value = null;
             return false;
+        }
+
+        private static bool ContainsSlash(string name)
+        {
+            var containsSlash = false;
+            foreach (var ch in name)
+            {
+                if (ch == '/' || ch == '\\')
+                {
+                    containsSlash = true;
+                    break;
+                }
+            }
+
+            return containsSlash;
         }
 
         public Func<object, object, bool> CompatibilityTest { get; }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentPropertyDefinition.cs
@@ -116,7 +116,7 @@ namespace NuGet.ContentModel
 
             if (FileExtensions?.Count > 0)
             {
-                if (FileExtensionAllowSubFolders || ContainsSlash(name))
+                if (FileExtensionAllowSubFolders || !ContainsSlash(name))
                 {
                     foreach (var fileExtension in FileExtensions)
                     {

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentQueryDefinition.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/ContentQueryDefinition.cs
@@ -72,7 +72,7 @@ namespace NuGet.ContentModel
             Pattern = pattern;
 
             Table = table;
-            Defaults = new ReadOnlyDictionary<string, object>(defaults.ToDictionary(p => p.Key, p => p.Value));
+            Defaults = defaults.ToDictionary(p => p.Key, p => p.Value);
         }
 
         public static implicit operator PatternDefinition(string pattern)

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace NuGet.ContentModel.Infrastructure
@@ -108,6 +109,7 @@ namespace NuGet.ContentModel.Infrastructure
             internal abstract bool TryMatch(ref ContentItem item, string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
         }
 
+        [DebuggerDisplay("{_pattern.Substring(_start, _length)}")]
         private class LiteralSegment : Segment
         {
             private readonly string _pattern;
@@ -141,6 +143,7 @@ namespace NuGet.ContentModel.Infrastructure
             }
         }
 
+        [DebuggerDisplay("Token = {_token}, Delimiter = {_delimiter}, MatchOnly = {_matchOnly}")]
         private class TokenSegment : Segment
         {
             private readonly string _token;

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -23,8 +23,25 @@ namespace NuGet.ContentModel.Infrastructure
         {
             for (var scanIndex = 0; scanIndex < pattern.Length;)
             {
-                var beginToken = (pattern + '{').IndexOf('{', scanIndex);
-                var endToken = (pattern + '}').IndexOf('}', beginToken);
+                var beginToken = pattern.Length;
+                var endToken = pattern.Length;
+                for (var i = scanIndex; i < pattern.Length; i++)
+                {
+                    var ch = pattern[i];
+                    if (beginToken == pattern.Length)
+                    {
+                        if (ch == '{')
+                        {
+                            beginToken = i;
+                        }
+                    }
+                    else if (ch == '}')
+                    {
+                        endToken = i;
+                        break;
+                    }
+                }
+
                 if (scanIndex != beginToken)
                 {
                     var literal = pattern.Substring(scanIndex, beginToken - scanIndex);
@@ -32,7 +49,7 @@ namespace NuGet.ContentModel.Infrastructure
                 }
                 if (beginToken != endToken)
                 {
-                    var delimiter = (pattern + '\0')[endToken + 1];
+                    var delimiter = endToken + 1 < pattern.Length ? pattern[endToken + 1] : '\0';
                     var matchOnly = pattern[endToken - 1] == '?';
 
                     var beginName = beginToken + 1;
@@ -132,15 +149,26 @@ namespace NuGet.ContentModel.Infrastructure
                 {
                     throw new Exception(string.Format("Unable to find property definition for {{{0}}}", _token));
                 }
-                for (var scanIndex = startIndex; scanIndex != item.Path.Length;)
+                var path = item.Path;
+
+                for (var scanIndex = startIndex; scanIndex != path.Length;)
                 {
-                    var delimiterIndex = (item.Path + _delimiter).IndexOf(_delimiter, scanIndex + 1);
-                    if (delimiterIndex == item.Path.Length
+                    var delimiterIndex = path.Length;
+                    for (var i = scanIndex + 1; i < path.Length; i++)
+                    {
+                        if (path[i] == _delimiter)
+                        {
+                            delimiterIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (delimiterIndex == path.Length
                         && _delimiter != '\0')
                     {
                         break;
                     }
-                    var substring = item.Path.Substring(startIndex, delimiterIndex - startIndex);
+                    var substring = path.Substring(startIndex, delimiterIndex - startIndex);
                     object value;
                     if (propertyDefinition.TryLookup(substring, _table, out value))
                     {

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -44,8 +44,7 @@ namespace NuGet.ContentModel.Infrastructure
 
                 if (scanIndex != beginToken)
                 {
-                    var literal = pattern.Substring(scanIndex, beginToken - scanIndex);
-                    _segments.Add(new LiteralSegment(literal));
+                    _segments.Add(new LiteralSegment(pattern, scanIndex, beginToken - scanIndex));
                 }
                 if (beginToken != endToken)
                 {
@@ -100,11 +99,15 @@ namespace NuGet.ContentModel.Infrastructure
 
         private class LiteralSegment : Segment
         {
-            private readonly string _literal;
+            private readonly string _pattern;
+            private readonly int _start;
+            private readonly int _length;
 
-            public LiteralSegment(string literal)
+            public LiteralSegment(string pattern, int start, int length)
             {
-                _literal = literal;
+                _pattern = pattern;
+                _start = start;
+                _length = length;
             }
 
             internal override bool TryMatch(
@@ -113,12 +116,11 @@ namespace NuGet.ContentModel.Infrastructure
                 int startIndex,
                 out int endIndex)
             {
-                if (item.Path.Length >= startIndex + _literal.Length)
+                if (item.Path.Length >= startIndex + _length)
                 {
-                    var substring = item.Path.Substring(startIndex, _literal.Length);
-                    if (string.Equals(_literal, substring, StringComparison.OrdinalIgnoreCase))
+                    if (string.Compare(item.Path, startIndex, _pattern, _start, _length, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        endIndex = startIndex + _literal.Length;
+                        endIndex = startIndex + _length;
                         return true;
                     }
                 }

--- a/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
+++ b/src/NuGet.Core/NuGet.Packaging/ContentModel/Infrastructure/Parser.cs
@@ -3,19 +3,20 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NuGet.ContentModel.Infrastructure
 {
     public class PatternExpression
     {
         private readonly List<Segment> _segments = new List<Segment>();
-        private readonly IReadOnlyDictionary<string, object> _defaults;
+        private readonly Dictionary<string, object> _defaults;
         private readonly PatternTable _table;
 
         public PatternExpression(PatternDefinition pattern)
         {
             _table = pattern.Table;
-            _defaults = pattern.Defaults;
+            _defaults = pattern.Defaults.ToDictionary(p => p.Key, p => p.Value);
             Initialize(pattern.Pattern);
         }
 
@@ -63,15 +64,12 @@ namespace NuGet.ContentModel.Infrastructure
 
         public ContentItem Match(string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions)
         {
-            var item = new ContentItem
-                {
-                    Path = path
-                };
+            ContentItem item = null;
             var startIndex = 0;
             foreach (var segment in _segments)
             {
                 int endIndex;
-                if (segment.TryMatch(item, propertyDefinitions, startIndex, out endIndex))
+                if (segment.TryMatch(ref item, path, propertyDefinitions, startIndex, out endIndex))
                 {
                     startIndex = endIndex;
                     continue;
@@ -83,9 +81,22 @@ namespace NuGet.ContentModel.Infrastructure
             {
                 // Successful match!
                 // Apply defaults from the pattern
-                foreach (var pair in _defaults)
+                if (item == null)
                 {
-                    item.Properties[pair.Key] = pair.Value;
+                    // item not created, use shared defaults
+                    item = new ContentItem
+                    {
+                        Path = path,
+                        Properties = _defaults
+                    };
+                }
+                else
+                {
+                    // item already created, append defaults
+                    foreach (var pair in _defaults)
+                    {
+                        item.Properties[pair.Key] = pair.Value;
+                    }
                 }
                 return item;
             }
@@ -94,7 +105,7 @@ namespace NuGet.ContentModel.Infrastructure
 
         private abstract class Segment
         {
-            internal abstract bool TryMatch(ContentItem item, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
+            internal abstract bool TryMatch(ref ContentItem item, string path, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex);
         }
 
         private class LiteralSegment : Segment
@@ -111,14 +122,15 @@ namespace NuGet.ContentModel.Infrastructure
             }
 
             internal override bool TryMatch(
-                ContentItem item,
+                ref ContentItem item,
+                string path,
                 IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions,
                 int startIndex,
                 out int endIndex)
             {
-                if (item.Path.Length >= startIndex + _length)
+                if (path.Length >= startIndex + _length)
                 {
-                    if (string.Compare(item.Path, startIndex, _pattern, _start, _length, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (string.Compare(path, startIndex, _pattern, _start, _length, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         endIndex = startIndex + _length;
                         return true;
@@ -144,14 +156,18 @@ namespace NuGet.ContentModel.Infrastructure
                 _table = table;
             }
 
-            internal override bool TryMatch(ContentItem item, IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions, int startIndex, out int endIndex)
+            internal override bool TryMatch(
+                ref ContentItem item,
+                string path,
+                IReadOnlyDictionary<string, ContentPropertyDefinition> propertyDefinitions,
+                int startIndex,
+                out int endIndex)
             {
                 ContentPropertyDefinition propertyDefinition;
                 if (!propertyDefinitions.TryGetValue(_token, out propertyDefinition))
                 {
                     throw new Exception(string.Format("Unable to find property definition for {{{0}}}", _token));
                 }
-                var path = item.Path;
 
                 for (var scanIndex = startIndex; scanIndex != path.Length;)
                 {
@@ -176,6 +192,15 @@ namespace NuGet.ContentModel.Infrastructure
                     {
                         if (!_matchOnly)
                         {
+                            // Adding property, create item if not already created
+                            if (item == null)
+                            {
+                                item = new ContentItem
+                                {
+                                    Path = path
+                                };
+                            }
+
                             item.Properties.Add(_token, value);
                         }
                         endIndex = delimiterIndex;


### PR DESCRIPTION
Saves 8,292 MB on delete `roslyn\Binaries\Obj` + run `nuget restore Roslyn.sln -NoCache`

![](https://aoa.blob.core.windows.net/aspnet/beforeandafter.png)

Resolves https://github.com/NuGet/Home/issues/5668 (Except `SubString`s used for `TokenSegment`)
Resolves https://github.com/NuGet/Home/issues/5665 (Except `TokenSegment.TryMatch` calls `string.Substring`)
Contributes to https://github.com/NuGet/Home/issues/5664 (`PatternExpression.Match`)  

@sharwell is this more what you meant? Specifically https://github.com/benaadams/NuGet.Client/commit/3dac48b06a903c8f9ab9ce7719bd370d6f5f45aa