### PR TITLE
Reduce allocations in NuGet.DependencyResolver.GraphOperations

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -341,20 +341,46 @@ namespace NuGet.DependencyResolver
         public static void ForEach<TItem>(this IEnumerable<GraphNode<TItem>> roots, Action<GraphNode<TItem>> visitor)
         {
             var graphNodes = roots.AsList();
-            for (var i = 0; i < graphNodes.Count; i++)
+            var queue = new Queue<GraphNode<TItem>>();
+
+            var count = graphNodes.Count;
+            for (var g = 0; g < count; g++)
             {
-                graphNodes[i].ForEach(visitor);
+                queue.Enqueue(graphNodes[g]);
+                while (queue.Count > 0)
+                {
+                    var node = queue.Dequeue();
+                    visitor(node);
+
+                    var innerNodes = node.InnerNodes;
+                    var innerCount = innerNodes.Count;
+                    for (var i = 0; i < innerCount; i++)
+                    {
+                        var innerNode = innerNodes[i];
+                        queue.Enqueue(innerNode);
+                    }
+                }
             }
         }
 
         public static void ForEach<TItem>(this GraphNode<TItem> root, Action<GraphNode<TItem>> visitor)
         {
-            // breadth-first walk of Node tree, without TState parameter
-            ForEach(root, 0, (node, _) =>
+            // breadth-first walk of Node tree, no state
+            var queue = new Queue<GraphNode<TItem>>();
+            queue.Enqueue(root);
+            while (queue.Count > 0)
+            {
+                var node = queue.Dequeue();
+                visitor(node);
+
+                var innerNodes = node.InnerNodes;
+                var count = innerNodes.Count;
+                for (var i = 0; i < count; i++)
                 {
-                    visitor(node);
-                    return 0;
-                });
+                    var innerNode = innerNodes[i];
+                    queue.Enqueue(innerNode);
+                }
+            }
         }
 
         // Box Drawing Unicode characters:

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -121,11 +121,23 @@ namespace NuGet.DependencyResolver
                 node.OuterNode.InnerNodes.Remove(node);
             });
 
-            downgrades.AddRange(workingDowngrades.Select(p => new DowngradeResult<RemoteResolveResult>
+
+#if NET45
+            // Increase List size for items to be added, if too small
+            var requiredCapacity = downgrades.Count + workingDowngrades.Count;
+            if (downgrades.Capacity < requiredCapacity)
             {
-                DowngradedFrom = p.Key,
-                DowngradedTo = p.Value
-            }));
+                downgrades.Capacity = requiredCapacity;
+            }
+#endif
+            foreach (var p in workingDowngrades)
+            {
+                downgrades.Add(new DowngradeResult<RemoteResolveResult>
+                {
+                    DowngradedFrom = p.Key,
+                    DowngradedTo = p.Value
+                });
+            }
         }
 
         public static string GetPath<TItem>(this GraphNode<TItem> node)

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -84,8 +84,11 @@ namespace NuGet.DependencyResolver
                 // of what is nearer as we walk down the graph (BFS)
                 for (var n = node.OuterNode; n != null; n = n.OuterNode)
                 {
-                    foreach (var sideNode in n.InnerNodes)
+                    var innerNodes = n.InnerNodes;
+                    var count = innerNodes.Count;
+                    for (var i = 0; i < count; i++)
                     {
+                        var sideNode = innerNodes[i];
                         if (sideNode != node && StringComparer.OrdinalIgnoreCase.Equals(sideNode.Key.Name, node.Key.Name))
                         {
                             // Nodes that have no version range should be ignored as potential downgrades e.g. framework reference
@@ -276,8 +279,11 @@ namespace NuGet.DependencyResolver
 
                 // For all accepted nodes, find dependencies that aren't satisfied by the version
                 // of the package that we have selected
-                foreach (var childNode in node.InnerNodes)
+                var innerNodes = node.InnerNodes;
+                var count = innerNodes.Count;
+                for (var i = 0; i < count; i++)
                 {
+                    var childNode = innerNodes[i];
                     GraphNode<TItem> acceptedNode;
                     if (acceptedLibraries.TryGetValue(childNode.Key.Name, out acceptedNode) &&
                         childNode != acceptedNode &&
@@ -322,9 +328,11 @@ namespace NuGet.DependencyResolver
 
                 // avoid Foreach here since it's inside 3 layer nested loops which might make it to
                 // be called 100 of 1000 times so GetEnumerator() might end up taking lot of memory space.
-                for (var i = 0; i < work.Item1.InnerNodes.Count; i++)
+                var innerNodes = work.Item1.InnerNodes;
+                var count = innerNodes.Count;
+                for (var i = 0; i < count; i++)
                 {
-                    var innerNode = work.Item1.InnerNodes[i];
+                    var innerNode = innerNodes[i];
                     queue.Enqueue(ValueTuple.Create(innerNode, innerState));
                 }
             }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -313,8 +313,8 @@ namespace NuGet.DependencyResolver
         {
             // breadth-first walk of Node tree
 
-            var queue = new Queue<Tuple<GraphNode<TItem>, TState>>();
-            queue.Enqueue(Tuple.Create(root, state));
+            var queue = new Queue<ValueTuple<GraphNode<TItem>, TState>>();
+            queue.Enqueue(ValueTuple.Create(root, state));
             while (queue.Count > 0)
             {
                 var work = queue.Dequeue();
@@ -325,7 +325,7 @@ namespace NuGet.DependencyResolver
                 for (var i = 0; i < work.Item1.InnerNodes.Count; i++)
                 {
                     var innerNode = work.Item1.InnerNodes[i];
-                    queue.Enqueue(Tuple.Create(innerNode, innerState));
+                    queue.Enqueue(ValueTuple.Create(innerNode, innerState));
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -147,8 +147,18 @@ namespace NuGet.DependencyResolver
         {
             foreach (var item in path)
             {
-                var childNode = node.InnerNodes.FirstOrDefault(n =>
-                    StringComparer.OrdinalIgnoreCase.Equals(n.Key.Name, item));
+                GraphNode<TItem> childNode = null;
+                var innerNodes = node.InnerNodes;
+                var count = innerNodes.Count;
+                for (var i = 0; i < count; i++)
+                {
+                    var candidateNode = innerNodes[i];
+                    if (StringComparer.OrdinalIgnoreCase.Equals(candidateNode.Key.Name, item))
+                    {
+                        childNode = candidateNode;
+                        break;
+                    }
+                }
 
                 if (childNode == null)
                 {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using NuGet.LibraryModel;
 using NuGet.Shared;

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/GraphOperations.cs
@@ -41,7 +41,7 @@ namespace NuGet.DependencyResolver
 
             root.ForEach((node, context) => WalkTreeCheckCycleAndNearestWins(context, node), CreateState(cycles, workingDowngrades));
 
-#if NET45
+#if IS_DESKTOP || NETSTANDARD2_0
             // Increase List size for items to be added, if too small
             var requiredCapacity = downgrades.Count + workingDowngrades.Count;
             if (downgrades.Capacity < requiredCapacity)

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/GraphModel/Tracker.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace NuGet.DependencyResolver
 {
@@ -40,10 +39,25 @@ namespace NuGet.DependencyResolver
         {
             var entry = GetEntry(item);
 
-            return entry.List.All(known => item.Key.Version >= known.Key.Version);
+            var version = item.Key.Version;
+
+            foreach (var known in entry.List)
+            {
+                if (version < known.Key.Version)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public IEnumerable<GraphItem<TItem>> GetDisputes(GraphItem<TItem> item) => GetEntry(item).List;
+
+        internal void Clear()
+        {
+            _entries.Clear();
+        }
 
         private Entry GetEntry(GraphItem<TItem> item)
         {

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -17,10 +17,6 @@
     <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
-   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
-   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\NuGet.LibraryModel\NuGet.LibraryModel.csproj" />
     <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />

--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/NuGet.DependencyResolver.Core.csproj
@@ -17,6 +17,10 @@
     <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
+   <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\NuGet.LibraryModel\NuGet.LibraryModel.csproj" />
     <ProjectReference Include="..\NuGet.Frameworks\NuGet.Frameworks.csproj" />


### PR DESCRIPTION
#### Fixes

Strong typed and named structs rather than Tuple
Remove IEnumerator boxing
Remove ForEach allocations
Remove closure captures
Cache temp queues for reuse

#### Measurement

delete `roslyn\Binaries\Obj`

Run `nuget restore Roslyn.sln -NoCache `

#### Results

Before

![821MB](https://aoa.blob.core.windows.net/aspnet/analyse-before.png)

After

![276MB](https://aoa.blob.core.windows.net/aspnet/analyse-after.png)

Resolves https://github.com/NuGet/Home/issues/5673