### PR TITLE
No allocations LibraryDependencyTargetUtils.Parse

### DIFF
--- a/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
+++ b/src/NuGet.Core/NuGet.LibraryModel/LibraryDependencyTargetUtils.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 
 namespace NuGet.LibraryModel
 {
@@ -23,43 +23,88 @@ namespace NuGet.LibraryModel
                 return LibraryDependencyTarget.All;
             }
 
-            var pieces = flag
-                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(f => f.Trim().ToLowerInvariant())
-                .Where(f => f.Length > 0)
-                .ToList();
-
-            if (!pieces.Any())
+            var flagEnd = flag.IndexOf(',');
+            if (flagEnd == -1)
             {
-                return LibraryDependencyTarget.All;
-            }
+                var segment = StringSegment.CreateTrimmed(flag, 0, flag.Length - 1);
+                if (segment.Length == 0)
+                {
+                    return LibraryDependencyTarget.All;
+                }
 
-            return pieces
-                .Select(f => ParseSingleFlag(f))
-                .Aggregate(LibraryDependencyTarget.None, (a, b) => a | b);
+                return ParseSingleFlag(segment);
+            }
+            else
+            {
+                return ParseMultiFlag(flag, flagEnd);
+            }
         }
 
-        private static LibraryDependencyTarget ParseSingleFlag(string flag)
+        private static LibraryDependencyTarget ParseMultiFlag(string flag, int end)
         {
-            switch (flag.ToLowerInvariant())
+            var result = LibraryDependencyTarget.None;
+            var flagsAdded = 0;
+            var start = 0;
+            do
             {
-                case "package":
-                    return LibraryDependencyTarget.Package;
-                case "project":
-                    return LibraryDependencyTarget.Project;
-                case "externalproject":
-                    return LibraryDependencyTarget.ExternalProject;
-                case "reference":
-                    return LibraryDependencyTarget.Reference;
-                case "assembly":
-                    return LibraryDependencyTarget.Assembly;
-                case "winmd":
-                    return LibraryDependencyTarget.WinMD;
-                case "all":
-                    return LibraryDependencyTarget.All;
-                default:
-                    return LibraryDependencyTarget.None;
+                var segment = StringSegment.CreateTrimmed(flag, start, end - 1);
+                if (segment.Length > 0)
+                {
+                    flagsAdded++;
+                    result |= ParseSingleFlag(segment);
+                }
+
+                start = end + 1;
+                if (start >= flag.Length)
+                {
+                    // Reached end, don't look for next comma
+                    break;
+                }
+
+                end = flag.IndexOf(',', start);
+                if (end == -1)
+                {
+                    end = flag.Length;
+                }
+            } while (true);
+
+            return flagsAdded > 0 ? result : LibraryDependencyTarget.All;
+        }
+
+        private static LibraryDependencyTarget ParseSingleFlag(StringSegment flag)
+        {
+            var result = LibraryDependencyTarget.None;
+
+            if ("package".Length == flag.Length && string.Compare(flag.String, flag.Start, "package", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.Package;
             }
+            else if ("project".Length == flag.Length && string.Compare(flag.String, flag.Start, "project", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.Project;
+            }
+            else if ("externalproject".Length == flag.Length && string.Compare(flag.String, flag.Start, "externalproject", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.ExternalProject;
+            }
+            else if ("reference".Length == flag.Length && string.Compare(flag.String, flag.Start, "reference", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.Reference;
+            }
+            else if ("assembly".Length == flag.Length && string.Compare(flag.String, flag.Start, "assembly", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.Assembly;
+            }
+            else if ("winmd".Length == flag.Length && string.Compare(flag.String, flag.Start, "winmd", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.WinMD;
+            }
+            else if ("all".Length == flag.Length && string.Compare(flag.String, flag.Start, "all", 0, flag.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                result = LibraryDependencyTarget.All;
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -88,6 +133,34 @@ namespace NuGet.LibraryModel
             }
 
             return string.Join(",", flagStrings);
+        }
+
+        [DebuggerDisplay("{String.Substring(Start, Length)}")]
+        private struct StringSegment
+        {
+            public static StringSegment CreateTrimmed(string String, int start, int end)
+            {
+                for (; start <= end; start++)
+                {
+                    if (!char.IsWhiteSpace(String[start])) break;
+                }
+
+                for (; end >= start; end--)
+                {
+                    if (!char.IsWhiteSpace(String[end])) break;
+                }
+
+                return new StringSegment
+                {
+                    Start = start,
+                    Length = end - start + 1,
+                    String = String
+                };
+            }
+
+            public int Start;
+            public int Length;
+            public string String;
         }
     }
 }


### PR DESCRIPTION
Saves 209MB of allocations

#### Before

Running `nuget restore Roslyn.sln -NoCache` allocates 209 MB in Parse converting string to enum
```
  100%   Parse  •  209 MB  •  NuGet.LibraryModel.LibraryDependencyTargetUtils.Parse(String)
  ► 33.8%   ToList  •  71 MB  •  System.Linq.Enumerable.ToList(IEnumerable)
  ► 27.8%   Select  •  58 MB  •  System.Linq.Enumerable.Select(IEnumerable, Func)
    12.1%   clr.dll  •  25 MB
  ► 10.4%   SplitInternal  •  22 MB  •  System.String.SplitInternal(Char[], Int32, StringSplitOptions)
  ► 8.52%   Any  •  18 MB  •  System.Linq.Enumerable.Any(IEnumerable)
  ► 7.38%   Where  •  15 MB  •  System.Linq.Enumerable+WhereSelectArrayIterator`2.Where(Func)
```

Time
```
  100%   Parse  •  633 ms  •  NuGet.LibraryModel.LibraryDependencyTargetUtils.Parse(String)
  ► 30.9%   ToList  •  196 ms  •  System.Linq.Enumerable.ToList(IEnumerable)
    28.1%   [Unknown]  •  178 ms
  ► 14.3%   Select  •  91 ms  •  System.Linq.Enumerable.Select(IEnumerable, Func)
  ► 11.7%   SplitInternal  •  74 ms  •  System.String.SplitInternal(Char[], Int32, StringSplitOptions)
  ► 7.05%   Any  •  45 ms  •  System.Linq.Enumerable.Any(IEnumerable)
  ► 3.97%   clr.dll  •  25 ms
  ► 3.38%   Where  •  21 ms  •  System.Linq.Enumerable+WhereSelectArrayIterator`2.Where(Func)
  ► 0.39%   Where  •  2.5 ms  •  System.Linq.Enumerable.Where(IEnumerable, Func)
    0.02%   [CPU Ready]  •  0.1 ms

```

#### After
```
No allocations
```

Time
```
  100%   Parse  •  65 ms  •  NuGet.LibraryModel.LibraryDependencyTargetUtils.Parse(String)
  ► 63.0%   clr.dll  •  41 ms (**GC time)
  ► 23.0%   ParseSingleFlag  •  15 ms  •  NuGet.LibraryModel.LibraryDependencyTargetUtils.ParseSingleFlag(StringSegment)
  ► 8.76%   CreateTrimmed  •  5.7 ms  •  NuGet.LibraryModel.LibraryDependencyTargetUtils+StringSegment.CreateTrimmed(String, Int32, Int32)
    0.14%   [Unknown]  •  0.09 ms
```

Resolves https://github.com/NuGet/Home/issues/5677