### PR TITLE
Enforce naming styles in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,3 +85,52 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+; Naming styles
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+; Naming rule: async methods end in Async
+dotnet_naming_style.async_method_style.capitalization  = pascal_case
+dotnet_naming_style.async_method_style.required_suffix = Async
+dotnet_naming_symbols.async_method_symbols.applicable_kinds = method
+dotnet_naming_symbols.async_method_symbols.required_modifiers = async
+dotnet_naming_rule.async_methods_rule.severity = suggestion
+dotnet_naming_rule.async_methods_rule.symbols = async_method_symbols
+dotnet_naming_rule.async_methods_rule.style = async_method_style
+
+; Naming rule: Interfaces must be pascal-cased prefixed with I
+dotnet_naming_style.interface_style.capitalization = pascal_case
+dotnet_naming_style.interface_style.required_prefix = I
+dotnet_naming_symbols.interface_symbols.applicable_kinds = interface
+dotnet_naming_symbols.interface_symbols.applicable_accessibilities = *
+dotnet_naming_rule.interfaces_rule.severity = warning
+dotnet_naming_rule.interfaces_rule.symbols  = interface_symbols
+dotnet_naming_rule.interfaces_rule.style = interface_style
+
+; Naming rule: All methods and properties must be pascal-cased
+dotnet_naming_symbols.method_and_property_symbols.applicable_kinds = method,property,class,struct,enum:property,namespace
+dotnet_naming_symbols.method_and_property_symbols.applicable_accessibilities = *
+dotnet_naming_rule.methods_and_properties_rule.severity = warning
+dotnet_naming_rule.methods_and_properties_rule.symbols  = method_and_property_symbols
+dotnet_naming_rule.methods_and_properties_rule.style = pascal_case_style
+
+; Naming rule: Static fields must be pascal-cased
+dotnet_naming_symbols.static_member_symbols.applicable_kinds = field
+dotnet_naming_symbols.static_member_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.static_member_symbols.required_modifiers = static
+dotnet_naming_symbols.const_member_symbols.applicable_kinds = field
+dotnet_naming_symbols.const_member_symbols.applicable_accessibilities = *
+dotnet_naming_symbols.const_member_symbols.required_modifiers = const
+dotnet_naming_rule.static_fields_rule.severity = warning
+dotnet_naming_rule.static_fields_rule.symbols  = static_member_symbols
+dotnet_naming_rule.static_fields_rule.style = pascal_case_style
+
+; Naming rule: Private members must be camel-cased and prefixed with underscore
+dotnet_naming_style.private_member_style.capitalization = camel_case
+dotnet_naming_style.private_member_style.required_prefix = _
+dotnet_naming_symbols.private_field_symbols.applicable_kinds = field,event
+dotnet_naming_symbols.private_field_symbols.applicable_accessibilities = private,protected,internal
+dotnet_naming_rule.private_field_rule.severity = warning
+dotnet_naming_rule.private_field_rule.symbols  = private_field_symbols
+dotnet_naming_rule.private_field_rule.style = private_member_style


### PR DESCRIPTION
This change updates `.editorconfig` with common naming styles for:
- Types, methods, and properties
- Private members
- Const and static members
- Async methods.

New rules will generate "naming violation" warnings when editing code in
IDE. These rules don't impact a build process.