### PR TITLE
add discovery of nuget.core.functests.config based on env variable on vsts ci machines

### DIFF
--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -90,7 +90,7 @@ namespace NuGet.XPlat.FuncTest
 
         public static string ReadApiKey(string feedName)
         {
-            var testSettingsFolder = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            var testSettingsFolder = TestSources.GetConfigFileRoot();
             var protocolConfigPath = Path.Combine(testSettingsFolder, ProtocolConfigFileName);
 
             var fullPath = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);

--- a/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.XPlat.FuncTest/XPlatTestUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -78,7 +78,7 @@ namespace NuGet.XPlat.FuncTest
         /// </summary>
         public static string CopyFuncTestConfig(string destinationFolder)
         {
-            var testSettingsFolder = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            var testSettingsFolder = TestSources.GetConfigFileRoot();
             var funcTestConfigPath = Path.Combine(testSettingsFolder, TestSources.ConfigFile);
 
             var destConfigFile = Path.Combine(destinationFolder, "NuGet.Config");

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
@@ -81,7 +81,7 @@ namespace NuGet.Test.Utility
     public sealed class PackageSourceDataDiscoverer : IDataDiscoverer
     {
         private readonly ConcurrentDictionary<string, PackageSource[]> _cachedSources = new ConcurrentDictionary<string, PackageSource[]>();
-        private readonly string _root = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+        private readonly string _root = TestSources.GetConfigFileRoot();
 
         public IEnumerable<object[]> GetData(IAttributeInfo dataAttribute, IMethodInfo testMethod)
         {

--- a/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
+++ b/test/TestUtilities/Test.Utility/PlatformXunitAttributes/PackageSourceTheoryAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,7 +23,7 @@ namespace NuGet.Test.Utility
 
         public string ConfigFile { get; set; } = TestSources.ConfigFile;
 
-        public string Root { get; } = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+        public string Root { get; } = TestSources.GetConfigFileRoot();
 
         public override string Skip
         {
@@ -39,8 +39,8 @@ namespace NuGet.Test.Utility
                     }
                     else
                     {
+                        
                         var fullPath = Path.Combine(Root, ConfigFile);
-
                         // Skip if a file does not exist, otherwise run the test.
                         if (!File.Exists(fullPath))
                         {

--- a/test/TestUtilities/Test.Utility/TestSources.cs
+++ b/test/TestUtilities/Test.Utility/TestSources.cs
@@ -1,5 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
 
 namespace NuGet.Test.Utility
 {
@@ -16,5 +19,11 @@ namespace NuGet.Test.Utility
         public const string ProGet = nameof(ProGet);
         public const string TeamCity = nameof(TeamCity);
         public const string VSTS = nameof(VSTS);
+
+        public static string GetConfigFileRoot()
+        {
+            var fullPath = Environment.GetEnvironmentVariable("NuGet_Core_FuncTests_Config");
+            return string.IsNullOrEmpty(fullPath) ? NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory) : fullPath;
+        }
     }
 }

--- a/test/TestUtilities/Test.Utility/TestSources.cs
+++ b/test/TestUtilities/Test.Utility/TestSources.cs
@@ -22,7 +22,11 @@ namespace NuGet.Test.Utility
 
         public static string GetConfigFileRoot()
         {
-            var fullPath = Environment.GetEnvironmentVariable("NuGet_Core_FuncTests_Config");
+            // The below environment variable is set on VSTS CI machines and the value is
+            // equal to the root of the repository where the config files are copied as part of
+            // a build step before the tests are run. If the environment variable is not set, the behavior
+            // is the same as on TeamCity - this will ensure both CI's will be happy.
+            var fullPath = Environment.GetEnvironmentVariable("NuGet_FuncTests_Config");
             return string.IsNullOrEmpty(fullPath) ? NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory) : fullPath;
         }
     }


### PR DESCRIPTION
This change is required to differentiate between TeamCity and VSTS CI - we don't want to copy files to UserProfile folder on VSTS CI machines as those machines are shared by other teams too. For VSTS, a build step adds those config files to the build repository root- the path of the repository is the value of the env variable NuGet_Core_FuncTests_Config