### PR TITLE
Adding mapping from uap10.0.15064.0 to .NET Standard 2.0

### DIFF
--- a/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
+++ b/src/NuGet.Core/NuGet.Frameworks/DefaultFrameworkMappings.cs
@@ -349,6 +349,11 @@ namespace NuGet.Frameworks
                             FrameworkConstants.CommonFrameworks.Tizen4,
                             FrameworkConstants.CommonFrameworks.NetStandard20),
 
+                        // UAP 10.0.15064.0 projects support NETStandard2.0
+                        CreateStandardMapping(
+                            new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.UAP, new Version(10, 0, 15064, 0)),
+                            FrameworkConstants.CommonFrameworks.NetStandard20),
+
                         // NetCoreApp1.0 projects support NetStandard1.6
                         CreateStandardMapping(
                             FrameworkConstants.CommonFrameworks.NetCoreApp10,

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityListProviderTests.cs
@@ -91,6 +91,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v3.0", actual);
+            Assert.Contains("UAP,Version=v10.0.15064", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -98,7 +99,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain(".NETPlatform,Version=v5.6", actual); // frameworks with no relationship are not returned
 
             // count
-            Assert.Equal(19, actual.Length);
+            Assert.Equal(20, actual.Length);
         }
 
         [Fact]
@@ -133,6 +134,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v3.0", actual);
+            Assert.Contains("UAP,Version=v10.0.15064", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -141,7 +143,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(18, actual.Length);
+            Assert.Equal(19, actual.Length);
         }
 
         [Fact]
@@ -176,6 +178,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v4.0", actual);
+            Assert.Contains("UAP,Version=v10.0.15064", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -184,7 +187,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(18, actual.Length);
+            Assert.Equal(19, actual.Length);
         }
 
         [Fact]
@@ -218,6 +221,7 @@ namespace NuGet.Frameworks.Test
             Assert.Contains("Xamarin.Xbox360,Version=v0.0", actual);
             Assert.Contains("Xamarin.XboxOne,Version=v0.0", actual);
             Assert.Contains("Tizen,Version=v4.0", actual);
+            Assert.Contains("UAP,Version=v10.0.15064", actual);
 
             // negative
             Assert.DoesNotContain(".NETFramework,Version=v4.7", actual); // only the minimum support version is returned
@@ -226,7 +230,7 @@ namespace NuGet.Frameworks.Test
             Assert.DoesNotContain("DNXCore,Version=v5.0", actual);
 
             // count
-            Assert.Equal(18, actual.Length);
+            Assert.Equal(19, actual.Length);
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -599,6 +599,19 @@ namespace NuGet.Test
         [InlineData("netcoreapp1.0", "net451", false)]
         [InlineData("netcoreapp1.0", "net4", false)]
         [InlineData("netcoreapp1.0", "win8", false)]
+
+        // UAP 10.0.15064.0 is compatible with netstandard2.0 
+        // Reference - https://devdiv.visualstudio.com/DevDiv/_queries?id=469873 
+        [InlineData("uap10.0.15064.0", "netstandard2.0", true)]
+        [InlineData("uap10.0.15064.0", "netcoreapp2.0", false)]
+        [InlineData("uap10.0.15064.0", "netcoreapp1.0", false)]
+        [InlineData("uap10.0.15064.0", "net45", false)]
+        [InlineData("uap10.0.15064.0", "net46", false)]
+        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
+        [InlineData("uap10.0.15064.0", "dotnet", false)]
+        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
+        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
+        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
         public void Compatibility_FrameworksAreCompatible(string project, string package, bool compatible)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -603,12 +603,12 @@ namespace NuGet.Test
         // UAP 10.0.15064.0 is compatible with netstandard2.0 
         // Reference - https://devdiv.visualstudio.com/DevDiv/_queries?id=469873 
         [InlineData("uap10.0.15064.0", "netstandard2.0", true)]
+        [InlineData("uap10.0.15064.0", "dotnet", true)]
         [InlineData("uap10.0.15064.0", "netcoreapp2.0", false)]
         [InlineData("uap10.0.15064.0", "netcoreapp1.0", false)]
         [InlineData("uap10.0.15064.0", "net45", false)]
         [InlineData("uap10.0.15064.0", "net46", false)]
         [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
-        [InlineData("uap10.0.15064.0", "dotnet", false)]
         [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
         [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
         [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/CompatibilityTests.cs
@@ -601,17 +601,17 @@ namespace NuGet.Test
         [InlineData("netcoreapp1.0", "win8", false)]
 
         // UAP 10.0.15064.0 is compatible with netstandard2.0 
-        // Reference - https://devdiv.visualstudio.com/DevDiv/_queries?id=469873 
         [InlineData("uap10.0.15064.0", "netstandard2.0", true)]
+        [InlineData("uap10.0.15064.0", "netstandard1.9", true)]
+        [InlineData("uap10.0.15064.0", "netstandard1.5", true)]
+        [InlineData("uap10.0.15064.0", "netstandard1.0", true)]
         [InlineData("uap10.0.15064.0", "dotnet", true)]
         [InlineData("uap10.0.15064.0", "netcoreapp2.0", false)]
         [InlineData("uap10.0.15064.0", "netcoreapp1.0", false)]
         [InlineData("uap10.0.15064.0", "net45", false)]
         [InlineData("uap10.0.15064.0", "net46", false)]
         [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
-        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
-        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
-        [InlineData("uap10.0.15064.0", "netstandardapp1.5", false)]
+        [InlineData("uap10.0.15064.0", "netstandard2.1", false)]
         public void Compatibility_FrameworksAreCompatible(string project, string package, bool compatible)
         {
             // Arrange

--- a/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Frameworks.Test/FrameworkReducerTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using NuGet.Frameworks;
 using Xunit;
@@ -35,6 +36,9 @@ namespace NuGet.Test
         [InlineData("uap10.0", "dotnet5.2,portable-win81+net45", "dotnet5.2")]
         [InlineData("uap10.0", "wpa81,dotnet5.2,portable-win81+net45", "wpa81")]
         [InlineData("uap10.0", "dotnet5.2,portable-win81+net45", "dotnet5.2")]
+        [InlineData("uap10.0.15064.0", "netcore50,win81,wpa81,dotnet5.4,portable-win81+net45,netstandard2.0", "netcore50")]
+        [InlineData("uap10.0.15064.0", "netstandard2.0, netstandard2.1, netstandard1.9, net45, net461", "netstandard2.0")]
+        [InlineData("uap10.0.15064.0", "netstandard2.0, netcoreapp1.0, netcore2.0", "netstandard2.0")]
         // Take the most specific PCL profile
         [InlineData("uap10.0", "dotnet6.0,portable-win81+net45", "portable-win81+net45")]
         [InlineData("uap10.0", "dotnet6.0,portable-win81+net45+sl5,portable-win81+net45", "portable-win81+net45")]


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5684 and internal bug 469873

Adding a compatibility mapping from uap10.0.15064.0 to .NET Standard 2.0 and some test cases around that.
