### PR TITLE
Support for numeric only release labels with floating ranges

### DIFF
--- a/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
+++ b/src/NuGet.Core/NuGet.DependencyResolver.Core/Remote/RemoteDependencyWalker.cs
@@ -220,7 +220,7 @@ namespace NuGet.DependencyResolver
                     }
 
                     nearMinVersion = GetReleaseLabelFreeVersion(nearVersion);
-                    nearRelease = nearVersion.Float.MinVersion.Release;
+                    nearRelease = nearVersion.Float.OriginalReleasePrefix;
                 }
                 else
                 {
@@ -237,7 +237,7 @@ namespace NuGet.DependencyResolver
                     }
 
                     farMinVersion = GetReleaseLabelFreeVersion(farVersion);
-                    farRelease = farVersion.Float.MinVersion.Release;
+                    farRelease = farVersion.Float.OriginalReleasePrefix;
                 }
                 else
                 {
@@ -251,8 +251,6 @@ namespace NuGet.DependencyResolver
                     return result > 0;
                 }
 
-                nearRelease = nearRelease?.Trim('-');
-                farRelease = farRelease?.Trim('-');
                 if (string.IsNullOrEmpty(nearRelease))
                 {
                     // near is 1.0.0-*

--- a/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/FloatRange.cs
@@ -59,26 +59,21 @@ namespace NuGet.Versioning
         /// <summary>
         /// True if a min range exists.
         /// </summary>
-        public bool HasMinVersion
-        {
-            get { return _minVersion != null; }
-        }
-
+        public bool HasMinVersion => _minVersion != null;
         /// <summary>
         /// The minimum version of the float range. This is null for cases such as *
         /// </summary>
-        public NuGetVersion MinVersion
-        {
-            get { return _minVersion; }
-        }
+        public NuGetVersion MinVersion => _minVersion;
 
         /// <summary>
         /// Defined float behavior
         /// </summary>
-        public NuGetVersionFloatBehavior FloatBehavior
-        {
-            get { return _floatBehavior; }
-        }
+        public NuGetVersionFloatBehavior FloatBehavior => _floatBehavior;
+
+        /// <summary>
+        /// The original release label. Invalid labels are allowed here.
+        /// </summary>
+        public string OriginalReleasePrefix => _releasePrefix;
 
         /// <summary>
         /// True if the given version falls into the floating range.
@@ -202,17 +197,16 @@ namespace NuGet.Versioning
                         {
                             releasePrefix = actualVersion.Substring(versionString.LastIndexOf('-') + 1);
 
-                            if (actualVersion.EndsWith("-"))
+                            // For numeric labels 0 is the lowest. For alpha-numeric - is the lowest.
+                            if (releasePrefix.Length == 0 || actualVersion.EndsWith("."))
                             {
-                                // remove the empty release label, the version will be release but
-                                // the behavior will have to account for this
-                                actualVersion += "-";
-                            }
-                            else if (actualVersion.EndsWith("."))
-                            {
-                                // ending with a . is not allowed
-                                // TODO: solve this better
+                                // 1.0.0-* scenario, an empty label is not a valid version.
                                 actualVersion += "0";
+                            }
+                            else if (actualVersion.EndsWith("-"))
+                            {
+                                // Append a dash to allow floating on the next character.
+                                actualVersion += "-";
                             }
                         }
                     }
@@ -251,16 +245,16 @@ namespace NuGet.Versioning
                     result = MinVersion.ToNormalizedString();
                     break;
                 case NuGetVersionFloatBehavior.Prerelease:
-                    result = String.Format(VersionFormatter.Instance, "{0:V}-{1}*", MinVersion, _releasePrefix);
+                    result = string.Format(VersionFormatter.Instance, "{0:V}-{1}*", MinVersion, _releasePrefix);
                     break;
                 case NuGetVersionFloatBehavior.Revision:
-                    result = String.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch);
+                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.*", MinVersion.Major, MinVersion.Minor, MinVersion.Patch);
                     break;
                 case NuGetVersionFloatBehavior.Patch:
-                    result = String.Format(CultureInfo.InvariantCulture, "{0}.{1}.*", MinVersion.Major, MinVersion.Minor);
+                    result = string.Format(CultureInfo.InvariantCulture, "{0}.{1}.*", MinVersion.Major, MinVersion.Minor);
                     break;
                 case NuGetVersionFloatBehavior.Minor:
-                    result = String.Format(CultureInfo.InvariantCulture, "{0}.*", MinVersion.Major);
+                    result = string.Format(CultureInfo.InvariantCulture, "{0}.*", MinVersion.Major);
                     break;
                 case NuGetVersionFloatBehavior.Major:
                     result = "*";

--- a/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
+++ b/src/NuGet.Core/NuGet.Versioning/VersionRange.cs
@@ -317,21 +317,28 @@ namespace NuGet.Versioning
 
             var lastLabel = version.ReleaseLabels.LastOrDefault() ?? string.Empty;
 
-            if (lastLabel.EndsWith("-", StringComparison.Ordinal))
+            var endsWithZero = lastLabel == "0";
+            var endsWithDash = lastLabel.EndsWith("-", StringComparison.Ordinal);
+
+            if (endsWithZero || endsWithDash)
             {
                 var fixedReleaseLabel = string.Empty;
 
-                if (lastLabel.EndsWith("--", StringComparison.Ordinal))
+                if (endsWithDash)
                 {
-                    // For labels such as rc1-* an additional - is added by nuget
-                    fixedReleaseLabel = lastLabel.Substring(0, lastLabel.Length - 2);
-                }
-                else
-                {
-                    // Remove the - for 1.0.0-* (1.0.0--)
-                    fixedReleaseLabel = lastLabel.Substring(0, lastLabel.Length - 1);
+                    if (lastLabel.EndsWith("--", StringComparison.Ordinal))
+                    {
+                        // For labels such as rc1-* an additional - is added by nuget
+                        fixedReleaseLabel = lastLabel.Substring(0, lastLabel.Length - 2);
+                    }
+                    else
+                    {
+                        // Remove the - for 1.0.0-* (1.0.0--)
+                        fixedReleaseLabel = lastLabel.Substring(0, lastLabel.Length - 1);
+                    }
                 }
 
+                // Remove the last label and add in the fixed label if one exists.
                 var fixedLabels = version.ReleaseLabels.Take(version.ReleaseLabels.Count() - 1).ToList();
 
                 if (!string.IsNullOrEmpty(fixedReleaseLabel))

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/ProjectSystems/ProjectKNuGetProjectTests.cs
@@ -42,7 +42,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                 Assert.Equal(1, actual.Count());
                 var packageReference = actual.First();
                 Assert.Equal("foo", packageReference.PackageIdentity.Id);
-                Assert.Equal(NuGetVersion.Parse("1.0.0--"), packageReference.PackageIdentity.Version);
+                Assert.Equal(NuGetVersion.Parse("1.0.0-0"), packageReference.PackageIdentity.Version);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/FloatingRangeTests.cs
@@ -123,7 +123,7 @@ namespace NuGet.Versioning.Test
         {
             var range = FloatRange.Parse("1.0.0-*");
 
-            Assert.Equal("1.0.0--", range.MinVersion.ToNormalizedString());
+            Assert.Equal("1.0.0-0", range.MinVersion.ToNormalizedString());
             Assert.Equal(NuGetVersionFloatBehavior.Prerelease, range.FloatBehavior);
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Versioning.Test/VersionRangeTests.cs
@@ -172,7 +172,7 @@ namespace NuGet.Versioning.Test
         [InlineData("1.0.0-*", "1.0.0")]
         [InlineData("2.0.0-*", "2.0.0")]
         [InlineData("1.0.0-rc1-*", "1.0.0-rc1")]
-        [InlineData("1.0.0-5.1.*", "1.0.0-5.1.0")]
+        [InlineData("1.0.0-5.1.*", "1.0.0-5.1")]
         [InlineData("1.0.0-5.1.0-*", "1.0.0-5.1.0")]
         [InlineData("1.0.*", "1.0.0")]
         [InlineData("1.*", "1.0.0")]


### PR DESCRIPTION
* Allow 1.0.0-* to float from 1.0.0-0 instead of 1.0.0-- which is a non-numeric label.
* Treat floating labels that end with . in the same way as labels ending in - when converting to non-snapshot versions for display purposes.

For alpha-numeric labels in SemVer `-` is the lowest possible label in lexicographical order. In SemVer 2.0.0 numeric labels are lower than alpha-numeric labels per the rules, which puts `0` before `-` despite the lexicographical order.

When converting `1.0.0-*` to the min version of range a release label is needed to avoid ending up with `1.0.0` which is stable. To handle this NuGet adds the lowest possible release label as a place holder, previously it was incorrectly using `-`, now it will use `0` only when the label is empty.

This extra label is primarily an internal thing, when displayed to users it is removed using ToNonSnapshotVersion, the result of which is only for display, it isn't used for comparing versions.

I've added more tests for this, and there are quite a few existing tests around this already verifying that the behavior is the same.

Fixes https://github.com/NuGet/Home/issues/4513