### PR TITLE
Preserve Formatting While adding package through dotnet add package command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -329,7 +329,7 @@ namespace NuGet.CommandLine.XPlat
             {
                 // There is ProjectRootElement.TryOpen but it does not work as expected
                 // I.e. it returns null for some valid projects
-                return ProjectRootElement.Open(filename);
+                return ProjectRootElement.Open(filename, ProjectCollection.GlobalProjectCollection, preserveFormatting: true);
             }
             catch (Microsoft.Build.Exceptions.InvalidProjectFileException)
             {


### PR DESCRIPTION
Fixing: https://github.com/NuGet/Home/issues/5697

Adding a `bool? preserveFormatting` to `ProjectRootElement.Open` call. This preserves the existing formatting in the csproj file - 

Original - 
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>



  <!--extra spacing-->

  
</Project>
```

Current behavior on add package - 
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="nuget.versioning" Version="4.2.0" />
  </ItemGroup>
  <!--extra spacing-->
</Project>
```


Fixed behavior on add package - 
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>netcoreapp2.0</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="nuget.versioning" Version="4.2.0" />
  </ItemGroup>



  <!--extra spacing-->

  
</Project>
```