### PR TITLE
fix inclusion of src files across different OS

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -263,7 +263,7 @@ namespace NuGet.Commands
             if (sourcePath.Contains(projectDirectory))
             {
                 var relativePath = Path.GetDirectoryName(sourcePath).Replace(projectDirectory, string.Empty);
-                if (PathUtility.IsDirectorySeparatorChar(relativePath[0]))
+                if (!string.IsNullOrEmpty(relativePath) && PathUtility.IsDirectorySeparatorChar(relativePath[0]))
                 {
                     relativePath = relativePath.Substring(1, relativePath.Length - 1);
                 }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -256,7 +256,7 @@ namespace NuGet.Commands
         {
             if(string.IsNullOrEmpty(sourcePath))
             {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptySourcePath));
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptySourceFilePath));
             }
 
             if (string.IsNullOrEmpty(projectDirectory))
@@ -272,7 +272,10 @@ namespace NuGet.Commands
             var targetPath = Path.Combine(SourcesFolder, projectName);
             if (sourcePath.Contains(projectDirectory))
             {
-                var relativePath = Path.GetDirectoryName(sourcePath).Replace(projectDirectory, string.Empty);
+                // This is needed because Path.GetDirectoryName returns a path with Path.DirectorySepartorChar
+                var projectDirectoryWithSeparatorChar = PathUtility.GetPathWithDirectorySeparator(projectDirectory);
+
+                var relativePath = Path.GetDirectoryName(sourcePath).Replace(projectDirectoryWithSeparatorChar, string.Empty);
                 if (!string.IsNullOrEmpty(relativePath) && PathUtility.IsDirectorySeparatorChar(relativePath[0]))
                 {
                     relativePath = relativePath.Substring(1, relativePath.Length - 1);

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -254,6 +254,16 @@ namespace NuGet.Commands
 
         public static string GetTargetPathForSourceFile(string sourcePath, string projectDirectory)
         {
+            if(string.IsNullOrEmpty(sourcePath))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptySourcePath));
+            }
+
+            if (string.IsNullOrEmpty(projectDirectory))
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Error_EmptySourceFileProjectDirectory, sourcePath));
+            }
+
             if (PathUtility.HasTrailingDirectorySeparator(projectDirectory))
             {
                 projectDirectory = projectDirectory.Substring(0, projectDirectory.Length - 1);

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -103,6 +103,24 @@ namespace NuGet.Commands {
         internal static string Error_CannotFindMsbuild {
             get {
                 return ResourceManager.GetString("Error_CannotFindMsbuild", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A source file was added with an empty path..
+        /// </summary>
+        internal static string Error_EmptySourceFilePath {
+            get {
+                return ResourceManager.GetString("Error_EmptySourceFilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project directory for the source file &apos;{0}&apos; could not be found..
+        /// </summary>
+        internal static string Error_EmptySourceFileProjectDirectory {
+            get {
+                return ResourceManager.GetString("Error_EmptySourceFileProjectDirectory", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -594,4 +594,10 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="UnsupportedProject" xml:space="preserve">
     <value>Skipping restore for project '{0}'. The project file may be invalid or missing targets required for restore.</value>
   </data>
+  <data name="Error_EmptySourceFilePath" xml:space="preserve">
+    <value>A source file was added with an empty path.</value>
+  </data>
+  <data name="Error_EmptySourceFileProjectDirectory" xml:space="preserve">
+    <value>The project directory for the source file '{0}' could not be found.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -121,16 +121,21 @@ namespace NuGet.Common
             }
             else
             {
-                if (RuntimeEnvironmentHelper.IsWindows)
-                {
-                    // Windows has both '/' and '\' as valid directory separators.
-                    return (path[path.Length - 1] == Path.DirectorySeparatorChar ||
-                            path[path.Length - 1] == Path.AltDirectorySeparatorChar);
-                }
-                else
-                {
-                    return path[path.Length - 1] == Path.DirectorySeparatorChar;
-                }
+                return IsDirectorySeparatorChar(path[path.Length - 1]);
+            }
+        }
+
+        public static bool IsDirectorySeparatorChar(char ch)
+        {
+            if (RuntimeEnvironmentHelper.IsWindows)
+            {
+                // Windows has both '/' and '\' as valid directory separators.
+                return (ch == Path.DirectorySeparatorChar ||
+                        ch == Path.AltDirectorySeparatorChar);
+            }
+            else
+            {
+                return ch == Path.DirectorySeparatorChar;
             }
         }
         

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -10,9 +10,35 @@ namespace NuGet.Commands.Test
 {
     public class MSBuildProjectFactoryTests
     {
-        [PlatformTheory(Platform.Linux)]
+        [PlatformTheory(Platform.Windows)]
         [InlineData("D:\\temp\\project1\\source.cs",                            "D:\\temp\\project1",                           "src\\project1\\source.cs")]
-        public void MSBuildProjectFactory_GetTargetPathForSourceFiles(string sourcePath, string projectDirectory, string expectedResult)
+        [InlineData("D:\\temp\\project1\\folder1\\source.cs",                   "D:\\temp\\project1",                           "src\\project1\\folder1\\source.cs")]
+        [InlineData("D:\\temp\\project1\\folder1\\folder2\\source.cs",          "D:\\temp\\project1",                           "src\\project1\\folder1\\folder2\\source.cs")]
+        [InlineData("D:\\temp\\source.cs",                                      "D:\\temp\\project1",                           "src\\project1\\source.cs")]
+        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Windows(string sourcePath, string projectDirectory, string expectedResult)
+        {
+            var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [PlatformTheory(Platform.Linux)]
+        [InlineData("/mnt/d/temp/project1/source.cs",                           "/mnt/d/temp/project1",                         "src/project1/source.cs")]
+        [InlineData("/mnt/d/temp/project1/folder1/source.cs",                   "/mnt/d/temp/project1",                         "src/project1/folder1/source.cs")]
+        [InlineData("/mnt/d/temp/project1/folder1/folder2/source.cs",           "/mnt/d/temp/project1",                         "src/project1/folder1/folder2/source.cs")]
+        [InlineData("/mnt/d/temp/source.cs",                                    "/mnt/d/temp/project1",                         "src/project1/source.cs")]
+
+        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Linux(string sourcePath, string projectDirectory, string expectedResult)
+        {
+            var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
+            Assert.Equal(expectedResult, result);
+        }
+
+        [PlatformTheory(Platform.Darwin)]
+        [InlineData("/mnt/d/temp/project1/source.cs",                           "/mnt/d/temp/project1",                         "src/project1/source.cs")]
+        [InlineData("/mnt/d/temp/project1/folder1/source.cs",                   "/mnt/d/temp/project1",                         "src/project1/folder1/source.cs")]
+        [InlineData("/mnt/d/temp/project1/folder1/folder2/source.cs",           "/mnt/d/temp/project1",                         "src/project1/folder1/folder2/source.cs")]
+        [InlineData("/mnt/d/temp/source.cs",                                    "/mnt/d/temp/project1",                         "src/project1/source.cs")]
+        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Darwin(string sourcePath, string projectDirectory, string expectedResult)
         {
             var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
             Assert.Equal(expectedResult, result);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
@@ -15,7 +15,11 @@ namespace NuGet.Commands.Test
         [InlineData("D:\\temp\\project1\\folder1\\source.cs",                   "D:\\temp\\project1",                           "src\\project1\\folder1\\source.cs")]
         [InlineData("D:\\temp\\project1\\folder1\\folder2\\source.cs",          "D:\\temp\\project1",                           "src\\project1\\folder1\\folder2\\source.cs")]
         [InlineData("D:\\temp\\source.cs",                                      "D:\\temp\\project1",                           "src\\project1\\source.cs")]
-        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Windows(string sourcePath, string projectDirectory, string expectedResult)
+        [InlineData("D:/temp/project1/source.cs",                               "D:/temp/project1",                             "src\\project1\\source.cs")]
+        [InlineData("D:/temp/project1/folder1/source.cs",                       "D:/temp/project1",                             "src\\project1\\folder1\\source.cs")]
+        [InlineData("D:/temp/project1/folder1/folder2/source.cs",               "D:/temp/project1",                             "src\\project1\\folder1\\folder2\\source.cs")]
+        [InlineData("D:/temp/source.cs",                                        "D:/temp/project1",                             "src\\project1\\source.cs")]
+        public void GetTargetPathForSourceFiles_Windows(string sourcePath, string projectDirectory, string expectedResult)
         {
             var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
             Assert.Equal(expectedResult, result);
@@ -27,7 +31,7 @@ namespace NuGet.Commands.Test
         [InlineData("/mnt/d/temp/project1/folder1/folder2/source.cs",           "/mnt/d/temp/project1",                         "src/project1/folder1/folder2/source.cs")]
         [InlineData("/mnt/d/temp/source.cs",                                    "/mnt/d/temp/project1",                         "src/project1/source.cs")]
 
-        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Linux(string sourcePath, string projectDirectory, string expectedResult)
+        public void GetTargetPathForSourceFiles_Linux(string sourcePath, string projectDirectory, string expectedResult)
         {
             var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
             Assert.Equal(expectedResult, result);
@@ -38,7 +42,7 @@ namespace NuGet.Commands.Test
         [InlineData("/mnt/d/temp/project1/folder1/source.cs",                   "/mnt/d/temp/project1",                         "src/project1/folder1/source.cs")]
         [InlineData("/mnt/d/temp/project1/folder1/folder2/source.cs",           "/mnt/d/temp/project1",                         "src/project1/folder1/folder2/source.cs")]
         [InlineData("/mnt/d/temp/source.cs",                                    "/mnt/d/temp/project1",                         "src/project1/source.cs")]
-        public void MSBuildProjectFactory_GetTargetPathForSourceFiles_Darwin(string sourcePath, string projectDirectory, string expectedResult)
+        public void GetTargetPathForSourceFiles_Darwin(string sourcePath, string projectDirectory, string expectedResult)
         {
             var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
             Assert.Equal(expectedResult, result);

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/MSBuildProjectFactoryTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using NuGet.Commands;
+using NuGet.Test.Utility;
+using Xunit;
+
+namespace NuGet.Commands.Test
+{
+    public class MSBuildProjectFactoryTests
+    {
+        [PlatformTheory(Platform.Linux)]
+        [InlineData("D:\\temp\\project1\\source.cs",                            "D:\\temp\\project1",                           "src\\project1\\source.cs")]
+        public void MSBuildProjectFactory_GetTargetPathForSourceFiles(string sourcePath, string projectDirectory, string expectedResult)
+        {
+            var result = MSBuildProjectFactory.GetTargetPathForSourceFile(sourcePath, projectDirectory);
+            Assert.Equal(expectedResult, result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4719

The code was written keeping windows in mind- i have now adapted it so it works across different platforms and with different directory separators characters. 