### PR TITLE
Net standard 2.0 support for VS2015

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -217,6 +217,21 @@ namespace NuGet.Common
             return Task.FromResult(0);
         }
 
+        public bool IsNetStandardMSINeeded()
+        {
+            var result = false;
+
+            // check for ImplicitlyExpandNETStandardFacades build property, if this exists, then it means, MSI is already installed.
+            var propertyValue = GetPropertyValue(ProjectManagement.Constants.ImplicitlyExpandNETStandardFacades);
+
+            if (string.IsNullOrEmpty(propertyValue))
+            {
+                result = true;
+            }
+
+            return result;
+        }
+
         public bool FileExistsInProject(string path)
         {
             // some ItemTypes which starts with _ are added by various MSBuild tasks for their own purposes

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/ProjectSystems/VSMSBuildNuGetProjectSystem.cs
@@ -929,5 +929,26 @@ namespace NuGet.PackageManagement.VisualStudio
                        select p.Name;
             });
         }
+
+        public bool IsNetStandardMSINeeded()
+        {
+            var result = false;
+
+            // Get the msbuild project for this project
+            var buildProject = EnvDTEProjectUtility.AsMicrosoftBuildEvaluationProject(EnvDTEProject.FullName);
+
+            if (buildProject != null)
+            {
+                // check for ImplicitlyExpandNETStandardFacades build property, if this exists, then it means, MSI is already installed.
+                var propertyValue = MicrosoftBuildEvaluationProjectUtility.GetPropertyValue(buildProject, Constants.ImplicitlyExpandNETStandardFacades);
+
+                if (string.IsNullOrEmpty(propertyValue))
+                {
+                    result = true;
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/MicrosoftBuildEvaluationProjectUtility.cs
+++ b/src/NuGet.Clients/PackageManagement.VisualStudio/Utility/MicrosoftBuildEvaluationProjectUtility.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Microsoft;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using NuGet.ProjectManagement;
@@ -39,6 +40,22 @@ namespace NuGet.PackageManagement.VisualStudio
                     yield return Tuple.Create(referenceProjectItem, assemblyName);
                 }
             }
+        }
+
+        internal static string GetPropertyValue(MicrosoftBuildEvaluationProject msBuildProject, string propertyName)
+        {
+            Assumes.NotNull(msBuildProject);
+
+            string value = null;
+
+            var property = msBuildProject.GetProperty(propertyName);
+
+            if (property != null)
+            {
+                value = property.EvaluatedValue;
+            }
+
+            return value;
         }
 
         internal static void AddImportStatement(MicrosoftBuildEvaluationProject msBuildProject, string targetsPath, ImportLocation location)

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.Designer.cs
@@ -222,6 +222,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to To reference a library that targets .NET Standard 1.5 or higher, you need to install the .NET Standard Build Support extension for the .NET Framework from https://aka.ms/netstandard-build-support-netfx.
+        /// </summary>
+        public static string MissingNetStandard20MSI {
+            get {
+                return ResourceManager.GetString("MissingNetStandard20MSI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to When updating multiple packages, dependency behavior has to be DependencyBehavior.Highest.
         /// </summary>
         public static string MultiplePackageInstallOrUpdateHasToBeAnUpdate {

--- a/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
+++ b/src/NuGet.Core/NuGet.PackageManagement/Strings.resx
@@ -332,4 +332,7 @@
     <value>Source '{0}' not found. Please provide an HTTP or local source.</value>
     <comment>{0} is the source</comment>
   </data>
+  <data name="MissingNetStandard20MSI" xml:space="preserve">
+    <value>To reference a library that targets .NET Standard 1.5 or higher, you need to install the .NET Standard Build Support extension for the .NET Framework from https://aka.ms/netstandard-build-support-netfx</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.PackageManagement/Utility/NetStandardCompatibilityUtil.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Utility/NetStandardCompatibilityUtil.cs
@@ -1,0 +1,44 @@
+﻿using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NuGet.PackageManagement
+{
+    internal static class NetStandardCompatibilityUtil
+    {
+        internal static bool DoesProjectTargetsNet461ORGreater(NuGetFramework currentProjectFramework)
+        {
+            if (currentProjectFramework == null)
+            {
+                throw new ArgumentNullException(nameof(currentProjectFramework));
+            }
+
+            if (currentProjectFramework.IsDesktop()
+                && currentProjectFramework.Version >= FrameworkConstants.CommonFrameworks.Net461.Version)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool IsNearestFrameworkNetStandard20OrGreater(NuGetFramework currentProjectFramework,
+            IEnumerable<NuGetFramework> supportedFrameworks)
+        {
+            // we look at target frameworks supported by the package and determine if the nearest framework is netstandard2.0,
+            var frameworkReducer = new FrameworkReducer();
+            var nearestFramework = frameworkReducer.GetNearest(currentProjectFramework, supportedFrameworks);
+            if (nearestFramework != null
+                && string.Equals(nearestFramework.Framework, FrameworkConstants.FrameworkIdentifiers.NetStandard, StringComparison.OrdinalIgnoreCase)
+                    && nearestFramework.Version >= FrameworkConstants.CommonFrameworks.NetStandard20.Version)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+    }
+}

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/IMSBuildNuGetProjectSystem.cs
@@ -72,6 +72,12 @@ namespace NuGet.ProjectManagement
         /// <returns>The list of subdirectories in relative path.</returns>
         IEnumerable<string> GetDirectories(string path);
 
+        /// <summary>
+        /// Check if MSI to support net standard 2.0 is installed from build evaluated project.
+        /// </summary>
+        /// <returns>true, if MSI is installed</returns>
+        bool IsNetStandardMSINeeded();
+
         // LIKELY, THERE HAS TO MORE STUFF HERE like 'IsSupportedFile' and 'IsBindingRedirectsEnabled'
         // IMO, there are hacks introduced to special case based on project systems like 'websites' and 'silverlight'
     }

--- a/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Projects/MSBuildNuGetProject.cs
@@ -103,6 +103,11 @@ namespace NuGet.ProjectManagement
             MSBuildNuGetProjectSystem.AddBindingRedirects();
         }
 
+        public bool IsNetStandardMSINeeded()
+        {
+            return MSBuildNuGetProjectSystem.IsNetStandardMSINeeded();
+        }
+
         private static bool IsBindingRedirectsDisabled(INuGetProjectContext nuGetProjectContext)
         {
             var msBuildNuGetProjectContext = nuGetProjectContext as IMSBuildNuGetProjectContext;

--- a/src/NuGet.Core/NuGet.ProjectManagement/Utility/Constants.cs
+++ b/src/NuGet.Core/NuGet.ProjectManagement/Utility/Constants.cs
@@ -42,5 +42,6 @@ namespace NuGet.ProjectManagement
         public static readonly string TargetPlatformIdentifier = "TargetPlatformIdentifier";
         public static readonly string TargetPlatformVersion = "TargetPlatformVersion";
         public static readonly string TargetFrameworkMoniker = "TargetFrameworkMoniker";
+        public static readonly string ImplicitlyExpandNETStandardFacades = "ImplicitlyExpandNETStandardFacades";
     }
 }

--- a/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
+++ b/src/NuGet.Core/Test.Utility/ProjectManagement/TestMSBuildNuGetProjectSystem.cs
@@ -175,6 +175,11 @@ namespace Test.Utility
         {
         }
 
+        public bool IsNetStandardMSINeeded()
+        {
+            return true;
+        }
+
         public void RegisterProcessedFiles(IEnumerable<string> files)
         {
             if (FilesInProcessing == null)


### PR DESCRIPTION
This PR is to support net standard 2.0 for VS2015. There is a new .net standard support extension for the .net frameworks so if this MSI is not installed and user tries to install a net standard 2.0 package into net461 project, then we will throw a error asking user to install this MSI in order to install this package.

Fixes https://github.com/NuGet/Home/issues/5325

@rrelyea 