### PR TITLE
remaking methods virtual in PackagePathResolver

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,14 +34,14 @@ namespace NuGet.Packaging
             get { return _rootDirectory; }
         }
 
-        public string GetPackageDirectoryName(PackageIdentity packageIdentity)
+        public virtual string GetPackageDirectoryName(PackageIdentity packageIdentity)
         {
             var directory = GetPathBase(packageIdentity);
 
             return directory.ToString();
         }
 
-        public string GetPackageFileName(PackageIdentity packageIdentity)
+        public virtual string GetPackageFileName(PackageIdentity packageIdentity)
         {
             var fileNameBase = GetPathBase(packageIdentity);
 
@@ -65,19 +65,19 @@ namespace NuGet.Packaging
             return GetId(packageIdentity) + PackagingCoreConstants.NuspecExtension;
         }
 
-        public string GetInstallPath(PackageIdentity packageIdentity)
+        public virtual string GetInstallPath(PackageIdentity packageIdentity)
         {
             return Path.Combine(_rootDirectory, GetPackageDirectoryName(packageIdentity));
         }
 
-        public string GetInstalledPath(PackageIdentity packageIdentity)
+        public virtual string GetInstalledPath(PackageIdentity packageIdentity)
         {
             var installedPackageFilePath = GetInstalledPackageFilePath(packageIdentity);
 
             return string.IsNullOrEmpty(installedPackageFilePath) ? null : Path.GetDirectoryName(installedPackageFilePath);
         }
 
-        public string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
+        public virtual string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
         {
             return PackagePathHelper.GetInstalledPackageFilePath(packageIdentity, this);
         }

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -48,7 +48,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">The package ID.</param>
         /// <param name="version">The package version.</param>
         /// <returns>The package install path.</returns>
-        public string GetInstallPath(string packageId, NuGetVersion version)
+        public virtual string GetInstallPath(string packageId, NuGetVersion version)
         {
             return Path.Combine(
                 RootPath,
@@ -123,7 +123,7 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="packageId">The package ID.</param>
         /// <returns>The version list directory.</returns>
-        public string GetVersionListDirectory(string packageId)
+        public virtual string GetVersionListDirectory(string packageId)
         {
             return Normalize(packageId);
         }
@@ -134,7 +134,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">The package ID.</param>
         /// <param name="version">The package version.</param>
         /// <returns>The package directory.</returns>
-        public string GetPackageDirectory(string packageId, NuGetVersion version)
+        public virtual string GetPackageDirectory(string packageId, NuGetVersion version)
         {
             return Path.Combine(
                 GetVersionListDirectory(packageId),
@@ -147,7 +147,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">The package ID.</param>
         /// <param name="version">The package version.</param>
         /// <returns>The package file name.</returns>
-        public string GetPackageFileName(string packageId, NuGetVersion version)
+        public virtual string GetPackageFileName(string packageId, NuGetVersion version)
         {
             return $"{Normalize(packageId)}.{Normalize(version)}{PackagingCoreConstants.NupkgExtension}";
         }
@@ -168,7 +168,7 @@ namespace NuGet.Packaging
         /// <param name="packageId">The package ID.</param>
         /// <param name="version">The package version.</param>
         /// <returns>The manifest file name.</returns>
-        public string GetManifestFileName(string packageId, NuGetVersion version)
+        public virtual string GetManifestFileName(string packageId, NuGetVersion version)
         {
             return $"{Normalize(packageId)}{PackagingCoreConstants.NuspecExtension}";
         }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagePathResolverTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -184,6 +184,123 @@ namespace NuGet.Packaging.Test
 
                 Assert.Equal(expectedFilePath, actualFilePath);
             }
+        }
+
+        [Fact]
+        public void GetPackageDirectoryName_ReturnsOverridenValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedFilePath = Path.Combine(testDirectory.Path, "abc.txt");
+
+                File.WriteAllText(expectedFilePath, string.Empty);
+
+                var target = new PackagePathResolverExtended(testDirectory.Path, useSideBySidePaths: true);
+
+                var actualFilePath = target.GetPackageDirectoryName(PackageIdentity);
+
+                Assert.Equal("", actualFilePath);
+            }
+        }
+
+        [Fact]
+        public void GetPackageFileName_ReturnsOverridenValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedFilePath = Path.Combine(testDirectory.Path, "abc.txt");
+
+                File.WriteAllText(expectedFilePath, string.Empty);
+
+                var target = new PackagePathResolverExtended(testDirectory.Path, useSideBySidePaths: true);
+
+                var actualFilePath = target.GetPackageFileName(PackageIdentity);
+
+                Assert.Equal("", actualFilePath);
+            }
+        }
+
+        [Fact]
+        public void GetInstallPath_ReturnsOverridenValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedFilePath = Path.Combine(testDirectory.Path, "abc.txt");
+
+                File.WriteAllText(expectedFilePath, string.Empty);
+
+                var target = new PackagePathResolverExtended(testDirectory.Path, useSideBySidePaths: true);
+
+                var actualFilePath = target.GetInstallPath(PackageIdentity);
+
+                Assert.Equal("", actualFilePath);
+            }
+        }
+
+        [Fact]
+        public void GetInstalledPath_ReturnsOverridenValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedFilePath = Path.Combine(testDirectory.Path, "abc.txt");
+
+                File.WriteAllText(expectedFilePath, string.Empty);
+
+                var target = new PackagePathResolverExtended(testDirectory.Path, useSideBySidePaths: true);
+
+                var actualFilePath = target.GetInstalledPath(PackageIdentity);
+
+                Assert.Equal("", actualFilePath);
+            }
+        }
+
+        [Fact]
+        public void GetInstalledPackageFilePath_ReturnsOverridenValue()
+        {
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var expectedFilePath = Path.Combine(testDirectory.Path, "abc.txt");
+
+                File.WriteAllText(expectedFilePath, string.Empty);
+
+                var target = new PackagePathResolverExtended(testDirectory.Path, useSideBySidePaths: true);
+
+                var actualFilePath = target.GetInstalledPackageFilePath(PackageIdentity);
+
+                Assert.Equal("", actualFilePath);
+            }
+        }
+    }
+
+    internal class PackagePathResolverExtended : PackagePathResolver
+    {
+        public PackagePathResolverExtended(string rootDirectory, bool useSideBySidePaths = true) : base(rootDirectory, useSideBySidePaths)
+        {
+        }
+
+        public override string GetPackageDirectoryName(PackageIdentity packageIdentity)
+        {
+            return string.Empty;
+        }
+
+        public override string GetPackageFileName(PackageIdentity packageIdentity)
+        {
+            return string.Empty;
+        }
+
+        public override string GetInstallPath(PackageIdentity packageIdentity)
+        {
+            return string.Empty;
+        }
+
+        public override string GetInstalledPath(PackageIdentity packageIdentity)
+        {
+            return string.Empty;
+        }
+
+        public override string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
+        {
+            return string.Empty;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/VersionFolderPathResolverTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.IO;
@@ -192,8 +192,60 @@ namespace NuGet.Packaging.Test
             Assert.Equal(expectedFileName, actualFileName);
         }
 
+        [Fact]
+        public void GetInstallPath_ReturnsOverridenValue()
+        {
+            var context = new TestContext(useExtendedResolver: true);
+
+            var actualFileName = context.Target.GetInstallPath(context.Id, context.Version);
+
+            Assert.Equal(string.Empty, actualFileName);
+        }
+
+        [Fact]
+        public void GetPackageFileName_ReturnsOverridenValue()
+        {
+            var context = new TestContext(useExtendedResolver: true);
+
+            var actualFileName = context.Target.GetPackageFileName(context.Id, context.Version);
+
+            Assert.Equal(string.Empty, actualFileName);
+        }
+
+        [Fact]
+        public void GetVersionListDirectory_ReturnsOverridenValue()
+        {
+            var context = new TestContext(useExtendedResolver: true);
+
+            var actualFileName = context.Target.GetVersionListDirectory(context.Id);
+
+            Assert.Equal(string.Empty, actualFileName);
+        }
+
+        [Fact]
+        public void GetManifestFileName_ReturnsOverridenValue()
+        {
+            var context = new TestContext(useExtendedResolver: true);
+
+            var actualFileName = context.Target.GetManifestFileName(context.Id, context.Version);
+
+            Assert.Equal(string.Empty, actualFileName);
+        }
+
+        [Fact]
+        public void GetPackageDirectory_ReturnsOverridenValue()
+        {
+
+            var context = new TestContext(useExtendedResolver: true);
+
+            var actualFileName = context.Target.GetPackageDirectory(context.Id, context.Version);
+
+            Assert.Equal(string.Empty, actualFileName);
+        }
+
         private class TestContext
         {
+            private bool _useExtendedResolver;
             public TestContext()
             {
                 // data
@@ -203,14 +255,56 @@ namespace NuGet.Packaging.Test
                 IsLowercase = true;
             }
 
+            public TestContext(bool useExtendedResolver) : base()
+            {
+                _useExtendedResolver = useExtendedResolver;
+            }
+
             public string Id { get; private set; }
             public string PackagesPath { get; set; }
             public NuGetVersion Version { get; set; }
             public bool IsLowercase { get; set; }
             public VersionFolderPathResolver Target
             {
-                get { return new VersionFolderPathResolver(PackagesPath, IsLowercase); }
+                get
+                {
+                    return _useExtendedResolver ? 
+                        new VersionFolderPathResolverExtended(PackagesPath) :
+                        new VersionFolderPathResolver(PackagesPath, IsLowercase);
+                }
             }
+        }
+    }
+
+    internal class VersionFolderPathResolverExtended : VersionFolderPathResolver
+    {
+        public VersionFolderPathResolverExtended(string rootPath) : base(rootPath)
+        {
+
+        }
+        public override string GetInstallPath(string packageId, NuGetVersion version)
+        {
+            return string.Empty;
+        }
+
+        public override string GetPackageFileName(string packageId, NuGetVersion version)
+        {
+            return string.Empty;
+        }
+
+        public override string GetVersionListDirectory(string packageId)
+        {
+            return string.Empty;
+        }
+
+        public override string GetManifestFileName(string packageId, NuGetVersion version)
+        {
+            return string.Empty;
+        }
+
+        public override string GetPackageDirectory(string packageId, NuGetVersion version)
+        {
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5700

CC: @joelverhagen - the methods ceased to be virtual as part of your changeset for https://github.com/NuGet/NuGet.Client/commit/b8372bbc3720b08b08337122d3e5569df3cf7c6c .. any particular reason why?