### PR TITLE
fix pack to always have files target with directory separator

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestFile.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackageCreation/Authoring/ManifestFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using NuGet.Common;
 using NuGet.Packaging.PackageCreation.Resources;
 
 namespace NuGet.Packaging
@@ -20,9 +21,19 @@ namespace NuGet.Packaging
         internal static readonly char[] ReferenceFileInvalidCharacters = _invalidSourceCharacters.Concat(new[] { ':', '*', '?', '\\', '/' }).ToArray();
         private static readonly char[] _invalidTargetChars = ReferenceFileInvalidCharacters.Except(new[] { '\\', '/' }).ToArray();
 
+        private string _target;
         public string Source { get; set; }
 
-        public string Target { get; set; }
+        public string Target {
+            get
+            {
+                return _target;
+            }
+            set
+            {
+                _target = string.IsNullOrEmpty(value) ? value : PathUtility.GetPathWithDirectorySeparator(value);
+            }
+        }
 
         public string Exclude { get; set; }
 


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5655

This fixes a wider problem in pack where directory separator characters were arbitrary. This PR makes sure that target path for package files has only the directory separator char as specified by  Path.DirectorySeparatorChar