### PR TITLE
Virtualized directory methods on folder/package path resolvers

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagePathResolver.cs
@@ -34,7 +34,7 @@ namespace NuGet.Packaging
             get { return _rootDirectory; }
         }
 
-        public string GetPackageDirectoryName(PackageIdentity packageIdentity)
+        public virtual string GetPackageDirectoryName(PackageIdentity packageIdentity)
         {
             var directory = GetPathBase(packageIdentity);
 
@@ -77,7 +77,7 @@ namespace NuGet.Packaging
             return string.IsNullOrEmpty(installedPackageFilePath) ? null : Path.GetDirectoryName(installedPackageFilePath);
         }
 
-        public string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
+        public virtual string GetInstalledPackageFilePath(PackageIdentity packageIdentity)
         {
             return PackagePathHelper.GetInstalledPackageFilePath(packageIdentity, this);
         }

--- a/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
+++ b/src/NuGet.Core/NuGet.Packaging/VersionFolderPathResolver.cs
@@ -123,7 +123,7 @@ namespace NuGet.Packaging
         /// </summary>
         /// <param name="packageId">The package ID.</param>
         /// <returns>The version list directory.</returns>
-        public string GetVersionListDirectory(string packageId)
+        public virtual string GetVersionListDirectory(string packageId)
         {
             return Normalize(packageId);
         }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5700#issuecomment-319696868

The following methods are made virtual:

- PackagePathResolver.GetPackageDirectoryName
- PackagePathResolver.GetInstalledPackageFilePath
- VersionFolderPathResolver.GetVersionListDirectory