### PR TITLE
Disabled sources are not considered

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -107,6 +108,7 @@ namespace NuGet.Build.Tasks
                     return false;
                 }
 
+                Debugger.Launch();
                 // Settings
                 var settings = RestoreSettingsUtils.ReadSettings(RestoreSolutionDirectory, Path.GetDirectoryName(ProjectUniqueName), RestoreConfigFile, _machineWideSettings);
                 OutputConfigFilePaths = SettingsUtility.GetConfigFilePaths(settings).ToArray();
@@ -122,7 +124,7 @@ namespace NuGet.Build.Tasks
                     () => RestoreSourcesOverride?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePath(MSBuildStartupDirectory, e)).ToArray(),
                     () => MSBuildRestoreUtility.ContainsClearKeyword(RestoreSources) ? new string[0] : null,
                     () => RestoreSources?.Select(MSBuildRestoreUtility.FixSourcePath).Select(e => UriUtility.GetAbsolutePathFromFile(ProjectUniqueName, e)).ToArray(),
-                    () => (new PackageSourceProvider(settings)).LoadPackageSources().Select(e => e.Source).ToArray());
+                    () => (new PackageSourceProvider(settings)).LoadPackageSources().Where(e => e.IsEnabled).Select(e => e.Source).ToArray());
 
                 // Append additional sources
                 // Escape strings to avoid xplat path issues with msbuild.

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreSettingsTask.cs
@@ -108,7 +108,6 @@ namespace NuGet.Build.Tasks
                     return false;
                 }
 
-                Debugger.Launch();
                 // Settings
                 var settings = RestoreSettingsUtils.ReadSettings(RestoreSolutionDirectory, Path.GetDirectoryName(ProjectUniqueName), RestoreConfigFile, _machineWideSettings);
                 OutputConfigFilePaths = SettingsUtility.GetConfigFilePaths(settings).ToArray();

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -5442,8 +5442,6 @@ namespace NuGet.CommandLine.Test
                 brokenSource.Add(new XAttribute(XName.Get("value"), pathContext.PackageSource + "brokenLocalSource"));
                 packageSources.Add(brokenSource);
 
-                File.WriteAllText(configPath, doc.ToString());
-
                 // Disable that config
                 var disabledPackageSources = new XElement(XName.Get("disabledPackageSources"));
                 var disabledBrokenSource = new XElement(XName.Get("add"));

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -413,11 +413,11 @@ namespace NuGet.Build.Tasks.Test
              <configuration>
               <packageSources>
                 <Clear/>
-                <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" />
-                <add key=""NuGet.org.v2"" value=""https://nuget.org/v2/api"" />
+                <add key=""NuGet"" value=""https://api.nuget.org/v3/index.json"" />
+                <add key=""NuGet.v2"" value=""https://nuget.org/v2/api"" />
               </packageSources>
               <disabledPackageSources>
-                 <add key=""NuGet.org"" value=""true"" />
+                 <add key=""NuGet"" value=""true"" />
               </disabledPackageSources>
             </configuration>";
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -417,6 +417,7 @@ namespace NuGet.Build.Tasks.Test
                 <add key=""NuGet.v2"" value=""https://nuget.org/v2/api"" />
               </packageSources>
               <disabledPackageSources>
+                 <Clear/>
                  <add key=""NuGet"" value=""true"" />
               </disabledPackageSources>
             </configuration>";

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Test/GetRestoreSettingTaskTests.cs
@@ -352,6 +352,42 @@ namespace NuGet.Build.Tasks.Test
             }
         }
 
+
+        [Fact]
+        public void GetRestoreSettingsTask_VerifyDisabledSourcesAreExcluded()
+        {
+
+            using (var testDir = TestDirectory.Create())
+            {
+                // Arrange
+                var buildEngine = new TestBuildEngine();
+                var testLogger = buildEngine.TestLogger;
+
+
+                var configFile = Path.Combine(testDir, Settings.DefaultSettingsFileName);
+
+                var projectDirectory = Path.GetDirectoryName(configFile);
+                Directory.CreateDirectory(projectDirectory);
+
+                File.WriteAllText(configFile, DisableSourceConfig);
+
+                var task = new GetRestoreSettingsTask()
+                {
+                    BuildEngine = buildEngine,
+                    ProjectUniqueName = Path.Combine(testDir, "a.csproj"),
+                    RestoreFallbackFolders = new[] { Path.Combine(testDir, "base") },
+                    RestoreSettingsPerFramework = new ITaskItem[0]
+                };
+
+                // Act
+                var result = task.Execute();
+
+                // Assert
+                result.Should().BeTrue();
+                task.OutputSources.ShouldBeEquivalentTo(new[] { @"https://nuget.org/v2/api" });
+            }
+        }
+
         private static string machineWideSettingsConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
                 <configuration>
                 </configuration>";
@@ -371,5 +407,19 @@ namespace NuGet.Build.Tasks.Test
                   <add key=""outer-key"" value=""outer-value"" />
                 </SectionName>
               </configuration>";
+
+        private static string DisableSourceConfig =
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+             <configuration>
+              <packageSources>
+                <Clear/>
+                <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" />
+                <add key=""NuGet.org.v2"" value=""https://nuget.org/v2/api"" />
+              </packageSources>
+              <disabledPackageSources>
+                 <add key=""NuGet.org"" value=""true"" />
+              </disabledPackageSources>
+            </configuration>";
+
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5704

In 4.3 we introduced a regression where disabled sources are not considered by NuGet.exe/MSBuild.exe/dotnet.exe

I have fixed and added both a test for the restore settings evaluation and a general E2E exe restore test. 

//cc @rrelyea 
We should consider taking this in 4.3 for nuget.exe, and discuss what the plan is for dotnet.exe

**VS is NOT affected**