### PR TITLE
Moving NetworkProtocolUtilityTests to NuGet.Common.FuncTests

### DIFF
--- a/NuGet.sln
+++ b/NuGet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26726.0
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BD1946CE-5544-4F28-A04A-9C3D51113E1A}"
 EndProject
@@ -207,7 +207,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Build.Tasks.Test", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetConsole.Host.PowerShell.Test", "test\NuGet.Clients.Tests\NuGetConsole.Host.PowerShell.Test\NuGetConsole.Host.PowerShell.Test.csproj", "{96E9B926-60A1-48BD-9EC8-8ED1F6746ECD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGet.Localization", "src\NuGet.Core\NuGet.Localization\NuGet.Localization.csproj", "{B1BE7458-1A1B-4C38-B99B-08301A6D5A70}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Localization", "src\NuGet.Core\NuGet.Localization\NuGet.Localization.csproj", "{B1BE7458-1A1B-4C38-B99B-08301A6D5A70}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGet.Common.FuncTest", "test\NuGet.Core.FuncTests\NuGet.Common.FuncTest\NuGet.Common.FuncTest.csproj", "{57FB5B86-E5F9-46A1-B019-2A62C974C088}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -491,6 +493,10 @@ Global
 		{B1BE7458-1A1B-4C38-B99B-08301A6D5A70}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1BE7458-1A1B-4C38-B99B-08301A6D5A70}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1BE7458-1A1B-4C38-B99B-08301A6D5A70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57FB5B86-E5F9-46A1-B019-2A62C974C088}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57FB5B86-E5F9-46A1-B019-2A62C974C088}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57FB5B86-E5F9-46A1-B019-2A62C974C088}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57FB5B86-E5F9-46A1-B019-2A62C974C088}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -575,6 +581,7 @@ Global
 		{F813268A-1EA1-41E6-A42C-01E7F937E257} = {7323F93B-D141-4001-BB9E-7AF14031143E}
 		{96E9B926-60A1-48BD-9EC8-8ED1F6746ECD} = {01BC4531-1E25-48D7-A8FD-A47D6FEC47FB}
 		{B1BE7458-1A1B-4C38-B99B-08301A6D5A70} = {506AF844-92E0-4404-BBFC-0AB073890A72}
+		{57FB5B86-E5F9-46A1-B019-2A62C974C088} = {BB63CACA-866F-454F-BA4C-78B788D032BB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3747A66A-00D1-41B8-A9C5-ED0D7BEA9D25}

--- a/test/NuGet.Core.FuncTests/NuGet.Common.FuncTest/NetworkProtocolUtilityTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Common.FuncTest/NetworkProtocolUtilityTests.cs
@@ -6,7 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace NuGet.Common.Test
+namespace NuGet.Common.FuncTest
 {
     public class NetworkProtocolUtilityTests
     {

--- a/test/NuGet.Core.FuncTests/NuGet.Common.FuncTest/NuGet.Common.FuncTest.csproj
+++ b/test/NuGet.Core.FuncTests/NuGet.Common.FuncTest/NuGet.Common.FuncTest.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.test.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsXPlat)' == 'true' ">netcoreapp1.0</TargetFrameworks>
+    <TestProject>true</TestProject>
+    <UseParallelXunit>true</UseParallelXunit>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(TestUtilitiesDirectory)Test.Utility\Test.Utility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.0.1" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <Import Project="$(BuildCommonDirectory)common.targets" />
+</Project>


### PR DESCRIPTION
The tests in `NetworkProtocolUtilityTests` connect to an external source. We should not have external dependencies in unit tests. So i am moving the tests into `NuGet.Common.FuncTests`