### PR TITLE
Dev zhi fix restore message

### DIFF
--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.SolutionRestoreManager {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -122,6 +122,15 @@ namespace NuGet.SolutionRestoreManager {
         internal static string PackageNotRestoredBecauseOfNoConsent {
             get {
                 return ResourceManager.GetString("PackageNotRestoredBecauseOfNoConsent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the Package Manager node and check &apos;Allow NuGet to download missing packages during build.&apos; You can also enable it by setting the environment variable &apos;EnableNuGetPackageRestore&apos; to &apos;true&apos;..
+        /// </summary>
+        internal static string PackageRefNotRestoredBecauseOfNoConsent {
+            get {
+                return ResourceManager.GetString("PackageRefNotRestoredBecauseOfNoConsent", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -140,6 +140,9 @@
 
 Missing packages: {0}</value>
   </data>
+  <data name="PackageRefNotRestoredBecauseOfNoConsent" xml:space="preserve">
+    <value>NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the Package Manager node and check 'Allow NuGet to download missing packages during build.' You can also enable it by setting the environment variable 'EnableNuGetPackageRestore' to 'true'.</value>
+  </data>
   <data name="PackageRestoreCanceled" xml:space="preserve">
     <value>NuGet package restore canceled.</value>
   </data>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreJob.cs
@@ -42,6 +42,7 @@ namespace NuGet.SolutionRestoreManager
 
         private RestoreOperationLogger _logger;
         private INuGetProjectContext _nuGetProjectContext;
+        private PackageRestoreConsent _packageRestoreConsent;
 
         private NuGetOperationStatus _status;
         private int _packageCount;
@@ -74,6 +75,7 @@ namespace NuGet.SolutionRestoreManager
             _sourceRepositoryProvider = sourceRepositoryProvider;
             _restoreEventsPublisher = restoreEventsPublisher;
             _settings = settings;
+            _packageRestoreConsent = new PackageRestoreConsent(_settings);
         }
 
         /// <summary>
@@ -165,6 +167,7 @@ namespace NuGet.SolutionRestoreManager
                     await RestorePackagesOrCheckForMissingPackagesAsync(
                         solutionDirectory,
                         isSolutionAvailable,
+                        restoreSource,
                         token);
                 }
 
@@ -176,6 +179,7 @@ namespace NuGet.SolutionRestoreManager
                     dependencyGraphProjects,
                     forceRestore,
                     isSolutionAvailable,
+                    restoreSource,
                     token);
 
 #if !VS14
@@ -195,10 +199,17 @@ namespace NuGet.SolutionRestoreManager
                 _packageRestoreManager.PackageRestoreFailedEvent -= PackageRestoreManager_PackageRestoreFailedEvent;
 
                 TelemetryUtility.StopTimer();
-
                 var duration = TelemetryUtility.GetTimerElapsedTime();
-                await _logger.WriteSummaryAsync(_status, duration);
 
+                // Do not log any restore message if user disabled restore.
+                if (_packageRestoreConsent.IsGranted)
+                {
+                    await _logger.WriteSummaryAsync(_status, duration);
+                }
+                else
+                {
+                    _logger.LogDebug(Resources.PackageRefNotRestoredBecauseOfNoConsent);
+                }
                 // Emit telemetry event for restore operation
                 EmitRestoreTelemetryEvent(
                     projects,
@@ -236,6 +247,7 @@ namespace NuGet.SolutionRestoreManager
             List<IDependencyGraphProject> projects,
             bool forceRestore,
             bool isSolutionAvailable,
+            RestoreOperationSource restoreSource,
             CancellationToken token)
         {
             // Only continue if there are some build integrated type projects.
@@ -244,7 +256,7 @@ namespace NuGet.SolutionRestoreManager
                 return;
             }
 
-            if (IsConsentGranted(_settings))
+            if (_packageRestoreConsent.IsGranted)
             {
                 if (!isSolutionAvailable)
                 {
@@ -321,6 +333,14 @@ namespace NuGet.SolutionRestoreManager
                         token);
                 }
             }
+            else if (restoreSource == RestoreOperationSource.Explicit)
+            {
+                // Log an error when restore is disabled and user explicitly restore.
+                _logger.Do((l, _) =>
+                {
+                    l.ShowError(Resources.PackageRefNotRestoredBecauseOfNoConsent);
+                });
+            }
         }
 
         private bool IsProjectBuildIntegrated(PackageSpec packageSpec)
@@ -393,6 +413,7 @@ namespace NuGet.SolutionRestoreManager
         private async Task RestorePackagesOrCheckForMissingPackagesAsync(
             string solutionDirectory,
             bool isSolutionAvailable,
+            RestoreOperationSource restoreSource,
             CancellationToken token)
         {
             if (string.IsNullOrEmpty(solutionDirectory))
@@ -404,7 +425,7 @@ namespace NuGet.SolutionRestoreManager
             var packages = (await _packageRestoreManager.GetPackagesInSolutionAsync(
                 solutionDirectory, token)).ToList();
 
-            if (IsConsentGranted(_settings))
+            if (_packageRestoreConsent.IsGranted)
             {
                 _currentCount = 0;
 
@@ -444,7 +465,7 @@ namespace NuGet.SolutionRestoreManager
                     _status = NuGetOperationStatus.Succeeded;
                 }
             }
-            else
+            else if (restoreSource == RestoreOperationSource.Explicit)
             {
                 // When the user consent is not granted, missing packages may not be restored.
                 // So, we just check for them, and report them as warning(s) on the error list window
@@ -462,8 +483,10 @@ namespace NuGet.SolutionRestoreManager
         /// Checks if there are missing packages that should be restored. If so, a warning will
         /// be added to the error list.
         /// </summary>
-        private void CheckForMissingPackages(IEnumerable<PackageRestoreData> missingPackages)
+        private void CheckForMissingPackages(IEnumerable<PackageRestoreData> installedPackages)
         {
+            var missingPackages = installedPackages.Where(p => p.IsMissing);
+
             if (missingPackages.Any())
             {
                 _logger.Do((l, _) =>
@@ -471,7 +494,7 @@ namespace NuGet.SolutionRestoreManager
                     var errorText = string.Format(
                         CultureInfo.CurrentCulture,
                         Resources.PackageNotRestoredBecauseOfNoConsent,
-                        string.Join(", ", missingPackages.Select(p => p.ToString())));
+                        string.Join(", ", missingPackages.Select(p => p.PackageReference.PackageIdentity.ToString())));
                     l.ShowError(errorText);
                 });
             }


### PR DESCRIPTION
Fixed https://github.com/NuGet/Home/issues/5718
https://github.com/NuGet/Home/issues/5659

the main bug is VS show "all packages are installed" if user disabled restore, but packages are not actually restored.

the behavior with this fix will be:

If user disabled restore
auto restore: show nothing

Solution restore:
show error for package ref
show error for package.config if there are some missing packages
