### PR TITLE
Make ProjectAssetsFile relative in msbuild props

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/BuildAssetsUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -142,7 +142,12 @@ namespace NuGet.Commands
 
             if (firstImport != null)
             {
-                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, assetsFilePath, success);
+                // Write the assets file path relative to the props file.
+                // This allows the project to be moved and avoid a large number of project errors
+                // until restore can run again.
+                var relativeAssetsPath = PathUtility.GetRelativePath(firstImport.Path, assetsFilePath);
+
+                AddNuGetProperties(firstImport.Content, packageFolders, repositoryRoot, projectStyle, relativeAssetsPath, success);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/BuildAssetsUtilsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -49,6 +49,62 @@ namespace NuGet.Commands.Test
 
             // Assert
             Assert.Equal(path, props["ProjectAssetsFile"]);
+        }
+
+        [Fact]
+        public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePath()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var filePath = Path.Combine(workingDir, "obj", "test.props");
+                var assetsPath = Path.Combine(workingDir, "obj", "project.assets.json");
+
+                var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                var file = new MSBuildOutputFile(filePath, doc);
+
+                // Act
+                BuildAssetsUtils.AddNuGetPropertiesToFirstImport(
+                    new[] { file },
+                    Enumerable.Empty<string>(),
+                    string.Empty,
+                    ProjectStyle.PackageReference,
+                    assetsPath,
+                    success: true);
+
+                var props = TargetsUtility.GetMSBuildProperties(doc);
+
+                // Assert
+                Assert.Equal("project.assets.json", props["ProjectAssetsFile"]);
+            }
+        }
+
+        [Fact]
+        public void BuildAssetsUtils_GenerateProjectRelativeAssetsFilePathInOtherDir()
+        {
+            using (var workingDir = TestDirectory.Create())
+            {
+                // Arrange
+                var filePath = Path.Combine(workingDir, "obj", "test.props");
+                var assetsPath = Path.Combine(workingDir, "nuget", "project.assets.json");
+
+                var doc = BuildAssetsUtils.GenerateEmptyImportsFile();
+                var file = new MSBuildOutputFile(filePath, doc);
+
+                // Act
+                BuildAssetsUtils.AddNuGetPropertiesToFirstImport(
+                    new[] { file },
+                    Enumerable.Empty<string>(),
+                    string.Empty,
+                    ProjectStyle.PackageReference,
+                    assetsPath,
+                    success: true);
+
+                var props = TargetsUtility.GetMSBuildProperties(doc);
+
+                // Assert
+                Assert.Equal("../nuget/project.assets.json".Replace('/', Path.DirectorySeparatorChar), props["ProjectAssetsFile"]);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Use the relative path for ProjectAssetsFile instead of the absolute path to allow moving the project.

Fixes https://github.com/NuGet/Home/issues/4582