### PR TITLE
 Fix bug in the unique name generation for tools in the commandline clients

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -103,7 +103,7 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
 
                 properties.TryGetValue("Version", out string value);
-                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : null);
+                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : VersionRange.All);
                 properties.Add("ProjectUniqueName", uniqueName);
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -103,7 +103,7 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
 
                 properties.TryGetValue("Version", out string value);
-                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, VersionRange.Parse(value));
+                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : null);
                 properties.Add("ProjectUniqueName", uniqueName);
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -14,6 +14,8 @@ namespace NuGet.Commands
 {
     public static class ToolRestoreUtility
     {
+
+        private static string NoVersion = nameof(NoVersion);
         /// <summary>
         /// Build a package spec in memory to execute the tool restore as if it were
         /// its own project. For now, we always restore for a null runtime and a single
@@ -64,9 +66,9 @@ namespace NuGet.Commands
 
         public static string GetUniqueName(string id, string framework, VersionRange versionRange)
         {
-            return $"{id}-{framework}-{versionRange.ToNormalizedString()}".ToLowerInvariant();
+            var version = versionRange!=null?versionRange.ToNormalizedString():NoVersion;
+            return $"{id}-{framework}-{version}".ToLowerInvariant(); 
         }
-
         
         /// <summary>
         /// Only one output can win per packages folder/version range. Between colliding requests take

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -24,7 +24,7 @@ namespace NuGet.Commands
         public static PackageSpec GetSpec(string projectFilePath, string id, VersionRange versionRange, NuGetFramework framework, string packagesPath, IList<string> fallbackFolders, IList<PackageSource> sources, WarningProperties projectWideWarningProperties)
 
         {
-            var name = GetUniqueName(id,framework,versionRange);
+            var name = GetUniqueName(id, framework.Framework, versionRange);
 
             return new PackageSpec()
             {
@@ -59,14 +59,9 @@ namespace NuGet.Commands
             };
         }
 
-        public static string GetUniqueName(string id, NuGetFramework framework, VersionRange versionRange)
-        {
-            return GetUniqueName(id, framework.Framework, versionRange);
-        }
-
         public static string GetUniqueName(string id, string framework, VersionRange versionRange)
         {
-            var version = versionRange!=null?versionRange.ToNormalizedString():NoVersion;
+            var version = versionRange != null ? versionRange.ToNormalizedString() : NoVersion;
             return $"{id}-{framework}-{version}".ToLowerInvariant(); 
         }
         

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -14,8 +14,6 @@ namespace NuGet.Commands
 {
     public static class ToolRestoreUtility
     {
-
-        private static string NoVersion = nameof(NoVersion);
         /// <summary>
         /// Build a package spec in memory to execute the tool restore as if it were
         /// its own project. For now, we always restore for a null runtime and a single
@@ -61,8 +59,7 @@ namespace NuGet.Commands
 
         public static string GetUniqueName(string id, string framework, VersionRange versionRange)
         {
-            var version = versionRange != null ? versionRange.ToNormalizedString() : NoVersion;
-            return $"{id}-{framework}-{version}".ToLowerInvariant(); 
+            return $"{id}-{framework}-{versionRange.ToNormalizedString()}".ToLowerInvariant(); 
         }
         
         /// <summary>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -320,9 +320,9 @@ namespace NuGet.Commands.Test
         }
 
         [Theory]
-        [InlineData("tool","netcoreapp1.0","1.0.0", "tool-netcoreapp1.0-1.0.0")]
-        [InlineData("Tool", "netcoreapp1.0", "1.0.0", "tool-netcoreapp1.0-1.0.0")]
-        [InlineData("tOOl", "NetCoreapp1.0", "1.0.0", "tool-netcoreapp1.0-1.0.0")]
+        [InlineData("tool","netcoreapp1.0","1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
+        [InlineData("Tool", "netcoreapp1.0", "1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
+        [InlineData("tOOl", "NetCoreapp1.0", "1.0.0", "tool-netcoreapp1.0-[1.0.0, )")]
         public void DotnetCliTool_TestGetUniqueName(string name, string framework, string version, string expected)
         {
             Assert.Equal(expected, ToolRestoreUtility.GetUniqueName(name, framework, VersionRange.Parse(version)));

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -329,9 +329,9 @@ namespace NuGet.Commands.Test
         }
 
         [Fact] 
-        public void DotnetCliTool_TestGetUniqueName_NoVersion()
+        public void DotnetCliTool_TestGetUniqueName_VersionRangeAll()
         {
-            Assert.Equal("tool-netcoreapp1.0-noversion", ToolRestoreUtility.GetUniqueName("tool", "netcoreapp1.0", null));
+            Assert.Equal("tool-netcoreapp1.0-(, )", ToolRestoreUtility.GetUniqueName("tool", "netcoreapp1.0", VersionRange.All));
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/DotnetCliToolTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -260,11 +260,9 @@ namespace NuGet.Commands.Test
         [Fact]
         public async Task DotnetCliTool_BasicToolRestore_DifferentVersionRanges()
         {
-
             // Arrange
             using (var pathContext = new SimpleTestPathContext())
             {
-//                Debugger.Launch();
                 var logger = new TestLogger();
                 var dgFile = new DependencyGraphSpec();
 
@@ -319,6 +317,21 @@ namespace NuGet.Commands.Test
                     Assert.True(File.Exists(path), $"{path} does not exist!");
                 }
             }
+        }
+
+        [Theory]
+        [InlineData("tool","netcoreapp1.0","1.0.0", "tool-netcoreapp1.0-1.0.0")]
+        [InlineData("Tool", "netcoreapp1.0", "1.0.0", "tool-netcoreapp1.0-1.0.0")]
+        [InlineData("tOOl", "NetCoreapp1.0", "1.0.0", "tool-netcoreapp1.0-1.0.0")]
+        public void DotnetCliTool_TestGetUniqueName(string name, string framework, string version, string expected)
+        {
+            Assert.Equal(expected, ToolRestoreUtility.GetUniqueName(name, framework, VersionRange.Parse(version)));
+        }
+
+        [Fact] 
+        public void DotnetCliTool_TestGetUniqueName_NoVersion()
+        {
+            Assert.Equal("tool-netcoreapp1.0-noversion", ToolRestoreUtility.GetUniqueName("tool", "netcoreapp1.0", null));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/5716

Fix bug in the unique name generation for tools in the commandline clients
Align the tool restore experience when a version is not specified among VS and CLIs. 