### PR TITLE
Share NuspecReaders across resources during restore

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProviders.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,36 +23,19 @@ namespace NuGet.Commands
         /// <param name="fallbackPackageFolders">Path to any fallback package folders.</param>
         /// <param name="localProviders">This is typically just a provider for the global packages folder.</param>
         /// <param name="remoteProviders">All dependency providers.</param>
+        /// <param name="nuspecCache">Nuspec cache.</param>
         public RestoreCommandProviders(
             NuGetv3LocalRepository globalPackages,
             IReadOnlyList<NuGetv3LocalRepository> fallbackPackageFolders,
             IReadOnlyList<IRemoteDependencyProvider> localProviders,
-            IReadOnlyList<IRemoteDependencyProvider> remoteProviders)
+            IReadOnlyList<IRemoteDependencyProvider> remoteProviders,
+            LocalNuspecCache nuspecCache)
         {
-            if (globalPackages == null)
-            {
-                throw new ArgumentNullException(nameof(globalPackages));
-            }
-
-            if (fallbackPackageFolders == null)
-            {
-                throw new ArgumentNullException(nameof(fallbackPackageFolders));
-            }
-
-            if (localProviders == null)
-            {
-                throw new ArgumentNullException(nameof(localProviders));
-            }
-
-            if (remoteProviders == null)
-            {
-                throw new ArgumentNullException(nameof(remoteProviders));
-            }
-
-            GlobalPackages = globalPackages;
-            LocalProviders = localProviders;
-            RemoteProviders = remoteProviders;
-            FallbackPackageFolders = fallbackPackageFolders;
+            GlobalPackages = globalPackages ?? throw new ArgumentNullException(nameof(globalPackages));
+            LocalProviders = localProviders ?? throw new ArgumentNullException(nameof(localProviders));
+            RemoteProviders = remoteProviders ?? throw new ArgumentNullException(nameof(remoteProviders));
+            FallbackPackageFolders = fallbackPackageFolders ?? throw new ArgumentNullException(nameof(fallbackPackageFolders));
+            NuspecCache = nuspecCache ?? throw new ArgumentNullException(nameof(nuspecCache));
         }
 
         /// <summary>
@@ -68,14 +51,17 @@ namespace NuGet.Commands
 
         public IReadOnlyList<IRemoteDependencyProvider> RemoteProviders { get; }
 
+        public LocalNuspecCache NuspecCache { get; }
+
         public static RestoreCommandProviders Create(
             string globalFolderPath,
             IEnumerable<string> fallbackPackageFolderPaths,
             IEnumerable<SourceRepository> sources,
             SourceCacheContext cacheContext,
+            LocalNuspecCache nuspecCache,
             ILogger log)
         {
-            var globalPackages = new NuGetv3LocalRepository(globalFolderPath);
+            var globalPackages = new NuGetv3LocalRepository(globalFolderPath, nuspecCache);
             var globalPackagesSource = Repository.Factory.GetCoreV3(globalFolderPath, FeedType.FileSystemV3);
 
             var localProviders = new List<IRemoteDependencyProvider>()
@@ -86,7 +72,8 @@ namespace NuGet.Commands
                     log,
                     cacheContext,
                     ignoreFailedSources: true,
-                    ignoreWarning: true)
+                    ignoreWarning: true,
+                    nuspecCache: nuspecCache)
             };
 
             // Add fallback sources as local providers also
@@ -94,7 +81,7 @@ namespace NuGet.Commands
 
             foreach (var path in fallbackPackageFolderPaths)
             {
-                var fallbackRepository = new NuGetv3LocalRepository(path);
+                var fallbackRepository = new NuGetv3LocalRepository(path, nuspecCache);
                 var fallbackSource = Repository.Factory.GetCoreV3(path, FeedType.FileSystemV3);
 
                 var provider = new SourceRepositoryDependencyProvider(
@@ -102,7 +89,8 @@ namespace NuGet.Commands
                     log,
                     cacheContext,
                     ignoreFailedSources: false,
-                    ignoreWarning: false);
+                    ignoreWarning: false,
+                    nuspecCache: nuspecCache);
 
                 fallbackPackageFolders.Add(fallbackRepository);
                 localProviders.Add(provider);
@@ -117,7 +105,8 @@ namespace NuGet.Commands
                     log,
                     cacheContext,
                     cacheContext.IgnoreFailedSources,
-                    ignoreWarning: false);
+                    ignoreWarning: false,
+                    nuspecCache: nuspecCache);
 
                 remoteProviders.Add(provider);
             }
@@ -126,7 +115,8 @@ namespace NuGet.Commands
                 globalPackages,
                 fallbackPackageFolders,
                 localProviders,
-                remoteProviders);
+                remoteProviders,
+                nuspecCache);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/RestoreCommandProvidersCache.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,18 +17,16 @@ namespace NuGet.Commands
     /// </summary>
     public class RestoreCommandProvidersCache
     {
-        // Paths are case insensitive on windows
-        private static readonly StringComparer _comparer 
-            = RuntimeEnvironmentHelper.IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-
         private readonly ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider> _remoteProviders
             = new ConcurrentDictionary<SourceRepository, IRemoteDependencyProvider>();
 
         private readonly ConcurrentDictionary<string, IRemoteDependencyProvider> _localProvider
-            = new ConcurrentDictionary<string, IRemoteDependencyProvider>(_comparer);
+            = new ConcurrentDictionary<string, IRemoteDependencyProvider>(PathUtility.GetStringComparerBasedOnOS());
 
         private readonly ConcurrentDictionary<string, NuGetv3LocalRepository> _globalCache
-            = new ConcurrentDictionary<string, NuGetv3LocalRepository>(_comparer);
+            = new ConcurrentDictionary<string, NuGetv3LocalRepository>(PathUtility.GetStringComparerBasedOnOS());
+
+        private readonly LocalNuspecCache _nuspecCache = new LocalNuspecCache();
 
         public RestoreCommandProviders GetOrCreate(
             string globalPackagesPath,
@@ -37,7 +35,7 @@ namespace NuGet.Commands
             SourceCacheContext cacheContext,
             ILogger log)
         {
-            var globalCache = _globalCache.GetOrAdd(globalPackagesPath, (path) => new NuGetv3LocalRepository(path));
+            var globalCache = _globalCache.GetOrAdd(globalPackagesPath, (path) => new NuGetv3LocalRepository(path, _nuspecCache));
 
             var local = _localProvider.GetOrAdd(globalPackagesPath, (path) =>
             {
@@ -50,7 +48,8 @@ namespace NuGet.Commands
                     log,
                     cacheContext,
                     ignoreFailedSources: true,
-                    ignoreWarning: true);
+                    ignoreWarning: true,
+                    nuspecCache: _nuspecCache);
             });
 
             var localProviders = new List<IRemoteDependencyProvider>() { local };
@@ -58,7 +57,7 @@ namespace NuGet.Commands
 
             foreach (var fallbackPath in fallbackPackagesPaths)
             {
-                var cache = _globalCache.GetOrAdd(fallbackPath, (path) => new NuGetv3LocalRepository(path));
+                var cache = _globalCache.GetOrAdd(fallbackPath, (path) => new NuGetv3LocalRepository(path, _nuspecCache));
                 fallbackFolders.Add(cache);
 
                 var localProvider = _localProvider.GetOrAdd(fallbackPath, (path) =>
@@ -72,7 +71,8 @@ namespace NuGet.Commands
                         log,
                         cacheContext,
                         ignoreFailedSources: false,
-                        ignoreWarning: false);
+                        ignoreWarning: false,
+                        nuspecCache: _nuspecCache);
                 });
 
                 localProviders.Add(localProvider);
@@ -87,12 +87,13 @@ namespace NuGet.Commands
                     log,
                     cacheContext,
                     cacheContext.IgnoreFailedSources,
-                    ignoreWarning: false));
+                    ignoreWarning: false,
+                    nuspecCache: _nuspecCache));
 
                 remoteProviders.Add(remoteProvider);
             }
 
-            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders);
+            return new RestoreCommandProviders(globalCache, fallbackFolders, localProviders, remoteProviders, _nuspecCache);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/SourceRepositoryDependencyProvider.cs
@@ -29,6 +29,7 @@ namespace NuGet.Commands
         private readonly SourceRepository _sourceRepository;
         private readonly ILogger _logger;
         private readonly SourceCacheContext _cacheContext;
+        private readonly LocalNuspecCache _nuspecCache;
         private FindPackageByIdResource _findPackagesByIdResource;
         private bool _ignoreFailedSources;
         private bool _ignoreWarning;
@@ -67,6 +68,30 @@ namespace NuGet.Commands
             SourceCacheContext cacheContext,
             bool ignoreFailedSources,
             bool ignoreWarning)
+            : this(sourceRepository, logger, cacheContext, ignoreFailedSources, ignoreWarning, nuspecCache: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="SourceRepositoryDependencyProvider" /> class.
+        /// </summary>
+        /// <param name="sourceRepository">A source repository.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="cacheContext">A source cache context.</param>
+        /// <param name="ignoreFailedSources"><c>true</c> to ignore failed sources; otherwise <c>false</c>.</param>
+        /// <param name="ignoreWarning"><c>true</c> to ignore warnings; otherwise <c>false</c>.</param>
+        /// <param name="nuspecCache">Optional nuspec cache.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="sourceRepository" />
+        /// is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="logger" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="cacheContext" /> is <c>null</c>.</exception>
+        public SourceRepositoryDependencyProvider(
+        SourceRepository sourceRepository,
+        ILogger logger,
+        SourceCacheContext cacheContext,
+        bool ignoreFailedSources,
+        bool ignoreWarning,
+        LocalNuspecCache nuspecCache)
         {
             if (sourceRepository == null)
             {
@@ -88,6 +113,7 @@ namespace NuGet.Commands
             _cacheContext = cacheContext;
             _ignoreFailedSources = ignoreFailedSources;
             _ignoreWarning = ignoreWarning;
+            _nuspecCache = nuspecCache;
         }
 
         /// <summary>
@@ -454,8 +480,23 @@ namespace NuGet.Commands
                 {
                     if (_findPackagesByIdResource == null)
                     {
+                        AddNuspecCache(resource);
+
                         _findPackagesByIdResource = resource;
                     }
+                }
+            }
+        }
+
+        private void AddNuspecCache(FindPackageByIdResource resource)
+        {
+            // Link the nuspec cache to the new resource if it exists.
+            if (_nuspecCache != null)
+            {
+                var localV3 = resource as LocalV3FindPackageByIdResource;
+                if (localV3 != null)
+                {
+                    localV3.NuspecCache = _nuspecCache;
                 }
             }
         }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalV3FindPackageByIdResource.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -30,6 +29,28 @@ namespace NuGet.Protocol
 
         private readonly string _source;
         private readonly VersionFolderPathResolver _resolver;
+        private LocalNuspecCache _nuspecCache;
+        private readonly Lazy<bool> _rootExists;
+
+        /// <summary>
+        /// Nuspec files read from disk.
+        /// This is exposed to allow sharing the cache with other components
+        /// that are reading the same files.
+        /// </summary>
+        public LocalNuspecCache NuspecCache
+        {
+            get
+            {
+                if (_nuspecCache == null)
+                {
+                    _nuspecCache = new LocalNuspecCache();
+                }
+
+                return _nuspecCache;
+            }
+
+            set => _nuspecCache = value;
+        }
 
         /// <summary>
         /// Initializes a new <see cref="LocalV3FindPackageByIdResource" /> class.
@@ -48,6 +69,7 @@ namespace NuGet.Protocol
 
             _source = rootDirInfo.FullName;
             _resolver = new VersionFolderPathResolver(_source);
+            _rootExists = new Lazy<bool>(() => Directory.Exists(_source));
         }
 
         /// <summary>
@@ -89,7 +111,7 @@ namespace NuGet.Protocol
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return Task.FromResult(GetVersions(id, cacheContext, logger).AsEnumerable());
+            return Task.FromResult<IEnumerable<NuGetVersion>>(GetVersions(id, cacheContext, logger));
         }
 
         /// <summary>
@@ -282,34 +304,43 @@ namespace NuGet.Protocol
         private T ProcessNuspecReader<T>(string id, NuGetVersion version, Func<NuspecReader, T> process)
         {
             var nuspecPath = _resolver.GetManifestFilePath(id, version);
-            using (var stream = File.OpenRead(nuspecPath))
+            var expandedPath = _resolver.GetInstallPath(id, version);
+
+            NuspecReader nuspecReader;
+            try
             {
-                NuspecReader nuspecReader;
-                try
-                {
-                    nuspecReader = new NuspecReader(stream);
-                }
-                catch (XmlException ex)
-                {
-                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Protocol_PackageMetadataError, id + "." + version, _source);
-                    var inner = new PackagingException(message, ex);
-
-                    throw new FatalProtocolException(message, inner);
-                }
-                catch (PackagingException ex)
-                {
-                    var message = string.Format(CultureInfo.CurrentCulture, Strings.Protocol_PackageMetadataError, id + "." + version, _source);
-
-                    throw new FatalProtocolException(message, ex);
-                }
-
-                return process(nuspecReader);
+                // Read the nuspec
+                nuspecReader = NuspecCache.GetOrAdd(nuspecPath, expandedPath).Value;
             }
+            catch (XmlException ex)
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Protocol_PackageMetadataError, id + "." + version, _source);
+                var inner = new PackagingException(message, ex);
+
+                throw new FatalProtocolException(message, inner);
+            }
+            catch (PackagingException ex)
+            {
+                var message = string.Format(CultureInfo.CurrentCulture, Strings.Protocol_PackageMetadataError, id + "." + version, _source);
+
+                throw new FatalProtocolException(message, ex);
+            }
+
+            // Process nuspec
+            return process(nuspecReader);
         }
 
         private NuGetVersion GetVersion(string id, NuGetVersion version, SourceCacheContext cacheContext, ILogger logger)
         {
-            return GetVersions(id, cacheContext, logger).FirstOrDefault(v => v == version);
+            foreach (var currentVersion in GetVersions(id, cacheContext, logger))
+            {
+                if (version == currentVersion)
+                {
+                    return currentVersion;
+                }
+            }
+
+            return null;
         }
 
         private List<NuGetVersion> GetVersions(string id, SourceCacheContext cacheContext, ILogger logger)
@@ -334,17 +365,6 @@ namespace NuGet.Protocol
         {
             var versions = new List<NuGetVersion>();
             var idDir = new DirectoryInfo(_resolver.GetVersionListPath(id));
-
-            if (!Directory.Exists(_source))
-            {
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    Strings.Log_FailedToRetrievePackage,
-                    id,
-                    _source);
-
-                throw new FatalProtocolException(message);
-            }
 
             if (idDir.Exists)
             {
@@ -376,6 +396,17 @@ namespace NuGet.Protocol
 
                     versions.Add(version);
                 }
+            }
+            else if (!_rootExists.Value)
+            {
+                // Fail if the root directory does not exist at all.
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.Log_FailedToRetrievePackage,
+                    id,
+                    _source);
+
+                throw new FatalProtocolException(message);
             }
 
             return versions;

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalNuspecCache.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/LocalNuspecCache.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using NuGet.Common;
+using NuGet.Packaging;
+
+namespace NuGet.Protocol
+{
+    /// <summary>
+    /// Allow .nuspec files on disk to be cached across v3 folder readers.
+    /// </summary>
+    /// <remarks>Nuspecs that do not exist are returned as null. It is expected that the caller has already verified
+    /// the that folder and paths are valid.</remarks>
+    public class LocalNuspecCache
+    {
+        // Expanded path -> NuspecReader
+        private readonly ConcurrentDictionary<string, Lazy<NuspecReader>> _cache
+            = new ConcurrentDictionary<string, Lazy<NuspecReader>>(PathUtility.GetStringComparerBasedOnOS());
+
+        public LocalNuspecCache()
+        {
+        }
+
+        /// <summary>
+        /// Read a nuspec file from disk. The nuspec is expected to exist.
+        /// </summary>
+        public Lazy<NuspecReader> GetOrAdd(string manifestPath, string expandedPath)
+        {
+            return _cache.GetOrAdd(expandedPath,
+                e => new Lazy<NuspecReader>(() => GetNuspec(manifestPath, expandedPath)));
+        }
+
+        /// <summary>
+        /// Search for a nuspec using the given path, or by the expanded folder path.
+        /// The manifest path here is a shortcut to use the already constructed well
+        /// known location, if this doesn't exist the folder reader will find the nuspec
+        /// if it exists.
+        /// </summary>
+        private static NuspecReader GetNuspec(string manifestPath, string expandedPath)
+        {
+            NuspecReader nuspec = null;
+
+            // Verify that the nuspec has the correct name before opening it
+            if (File.Exists(manifestPath))
+            {
+                nuspec = new NuspecReader(File.OpenRead(manifestPath));
+            }
+            else
+            {
+                // Scan the folder for the nuspec
+                var folderReader = new PackageFolderReader(expandedPath);
+
+                // This will throw if the nuspec is not found
+                nuspec = new NuspecReader(folderReader.GetNuspec());
+            }
+
+            return nuspec;
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepositoryUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/PackagesFolder/NuGetv3LocalRepositoryUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -18,8 +18,10 @@ namespace NuGet.Repositories
         {
             LocalPackageInfo package = null;
 
-            foreach (var repository in repositories)
+            for (var i=0; i < repositories.Count; i++)
             {
+                var repository = repositories[i];
+
                 package = repository.FindPackage(id, version);
 
                 if (package != null)

--- a/src/NuGet.Core/NuGet.Versioning/SemanticVersion.cs
+++ b/src/NuGet.Core/NuGet.Versioning/SemanticVersion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -194,7 +194,16 @@ namespace NuGet.Versioning
             {
                 if (_releaseLabels != null)
                 {
-                    return string.Join(".", _releaseLabels);
+                    if (_releaseLabels.Length == 1)
+                    {
+                        // There is exactly 1 label
+                        return _releaseLabels[0];
+                    }
+                    else
+                    {
+                        // Join all labels
+                        return string.Join(".", _releaseLabels);
+                    }
                 }
 
                 return string.Empty;

--- a/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Commands.FuncTest/RestoreCommandTests.cs
@@ -1963,7 +1963,7 @@ namespace NuGet.Commands.FuncTest
                     context.IgnoreFailedSources = true;
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
-                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
+                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalNuspecCache(), logger);
                     var request = new RestoreRequest(spec, provider, context, logger);
 
                     request.LockFilePath = Path.Combine(projectDir, "project.lock.json");
@@ -2012,7 +2012,7 @@ namespace NuGet.Commands.FuncTest
                     context.IgnoreFailedSources = true;
                     var cachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(NullSettings.Instance));
 
-                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, logger);
+                    var provider = RestoreCommandProviders.Create(packagesDir, new List<string>(), sources.Select(p => cachingSourceProvider.CreateRepository(p)), context, new LocalNuspecCache(), logger);
                     var request = new RestoreRequest(spec, provider, context, logger);
 
                     request.LockFilePath = Path.Combine(projectDir, "project.lock.json");

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalNuspecCacheTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalNuspecCacheTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Test.Utility;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class LocalNuspecCacheTests
+    {
+        [Fact]
+        public async Task LocalNuspecCache_GetNuspecTwiceVerifySameInstance()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var cache = new LocalNuspecCache();
+                var pathResolver = new VersionFolderPathResolver(pathContext.PackageSource);
+
+                var identity = new PackageIdentity("X", NuGetVersion.Parse("1.0.0"));
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    identity);
+
+                var nuspec = pathResolver.GetManifestFilePath(identity.Id, identity.Version);
+                var expanded = pathResolver.GetInstallPath(identity.Id, identity.Version);
+
+                var result1 = cache.GetOrAdd(nuspec, expanded);
+                var result2 = cache.GetOrAdd(nuspec, expanded);
+
+                Assert.Same(result1.Value, result2.Value);
+                result1.Value.GetIdentity().Should().Be(identity);
+            }
+        }
+
+        [Fact]
+        public async Task LocalNuspecCache_FallbackToFolderReaderVerifyResult()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var cache = new LocalNuspecCache();
+                var pathResolver = new VersionFolderPathResolver(pathContext.PackageSource);
+
+                var identity = new PackageIdentity("X", NuGetVersion.Parse("1.0.0"));
+
+                await SimpleTestPackageUtility.CreateFolderFeedV3(
+                    pathContext.PackageSource,
+                    identity);
+
+                var nuspec = pathResolver.GetManifestFilePath(identity.Id, identity.Version) + "invalid.nuspec";
+                var expanded = pathResolver.GetInstallPath(identity.Id, identity.Version);
+
+                var result = cache.GetOrAdd(nuspec, expanded);
+
+                result.Value.GetIdentity().Should().Be(identity);
+            }
+        }
+
+        [Fact]
+        public void LocalNuspecCache_NuspecNotFoundVerifyFailure()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var cache = new LocalNuspecCache();
+                var pathResolver = new VersionFolderPathResolver(pathContext.PackageSource);
+
+                var identity = new PackageIdentity("X", NuGetVersion.Parse("1.0.0"));
+
+                var nuspec = pathResolver.GetManifestFilePath(identity.Id, identity.Version);
+                var expanded = pathResolver.GetInstallPath(identity.Id, identity.Version);
+                Directory.CreateDirectory(expanded);
+
+                // Verify does not throw
+                var result = cache.GetOrAdd(nuspec, expanded);
+
+                // This should throw
+                Assert.Throws<PackagingException>(() => result.Value);
+            }
+        }
+
+        [Fact]
+        public void LocalNuspecCache_DirNotFoundVerifyFailure()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var cache = new LocalNuspecCache();
+                var pathResolver = new VersionFolderPathResolver(pathContext.PackageSource);
+
+                var identity = new PackageIdentity("X", NuGetVersion.Parse("1.0.0"));
+
+                var nuspec = pathResolver.GetManifestFilePath(identity.Id, identity.Version);
+                var expanded = pathResolver.GetInstallPath(identity.Id, identity.Version);
+
+                // Verify does not throw
+                var result = cache.GetOrAdd(nuspec, expanded);
+
+                // This should throw
+                Assert.Throws<DirectoryNotFoundException>(() => result.Value);
+            }
+        }
+    }
+}

--- a/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
+++ b/test/TestUtilities/Test.Utility/Commands/TestRestoreRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -105,6 +105,7 @@ namespace NuGet.Commands.Test
                     fallbackPackageFolderPaths: fallbackPackageFolders,
                     sources: sources,
                     cacheContext: cacheContext,
+                    nuspecCache: new LocalNuspecCache(),
                     log: log),
                 cacheContext,
                 log)


### PR DESCRIPTION
Share NuspecReaders across resources during restore 

* Adds LocalNuspecCache to ensure that a nuspec is only read once between the dependency info and local folder resources
* Fixing several perf issues found when profiling restore

All behaviors are the same, which is verified by existing tests.

Fixes https://github.com/NuGet/Home/issues/5735

### Before
![before](https://user-images.githubusercontent.com/6381138/29154827-2000f87a-7d4c-11e7-8648-ce70c85584e0.PNG)

### After
![after](https://user-images.githubusercontent.com/6381138/29154828-22bce9ac-7d4c-11e7-983d-157ad426720b.PNG)

