### PR TITLE
Improvements for nuget.exe install

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -44,6 +44,11 @@ namespace NuGet.CommandLine
 
         [Option(typeof(NuGetCommand), "CommandPackageSaveMode")]
         public string PackageSaveMode { get; set; }
+
+        /// <summary>
+        /// If true the global packages folder NOT will be added as a source.
+        /// </summary>
+        internal bool ExcludeCacheAsSource { get; set; }
 
         internal void CalculateEffectivePackageSaveMode()
         {
@@ -117,7 +122,7 @@ namespace NuGet.CommandLine
             var availableSources = SourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
             var packageSources = new List<Configuration.PackageSource>();
 
-            if (!NoCache)
+            if (!NoCache && !ExcludeCacheAsSource)
             {
                 // Add the v3 global packages folder
                 var globalPackageFolder = SettingsUtility.GetGlobalPackagesFolder(settings);

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
 using System.IO;
@@ -10,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
@@ -36,6 +39,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "InstallCommandDependencyVersion")]
         public string DependencyVersion { get; set; }
 
+        [Option(typeof(NuGetCommand), "InstallCommandFrameworkDescription")]
+        public string Framework { get; set; }
+
         [Option(typeof(NuGetCommand), "InstallCommandExcludeVersionDescription", AltName = "x")]
         public bool ExcludeVersion { get; set; }
 
@@ -51,13 +57,14 @@ namespace NuGet.CommandLine
         [ImportingConstructor]
         protected internal InstallCommand()
         {
-            // On mono, parallel builds are broken for some reason. See https://gist.github.com/4201936 for the errors
-            // That are thrown.
-            DisableParallelProcessing = RuntimeEnvironmentHelper.IsMono;
         }
 
         public override Task ExecuteCommandAsync()
         {
+            // On mono, parallel builds are broken for some reason. See https://gist.github.com/4201936 for the errors
+            // That are thrown.
+            DisableParallelProcessing |= RuntimeEnvironmentHelper.IsMono;
+
             if (DisableParallelProcessing)
             {
                 HttpSourceResourceProvider.Throttle = SemaphoreSlimThrottle.CreateBinarySemaphore();
@@ -65,10 +72,10 @@ namespace NuGet.CommandLine
 
             CalculateEffectivePackageSaveMode();
             CalculateEffectiveSettings();
-            string installPath = ResolveInstallPath();
+            var installPath = ResolveInstallPath();
 
-            string configFilePath = Path.GetFullPath(Arguments.Count == 0 ? Constants.PackageReferenceFile : Arguments[0]);
-            string configFileName = Path.GetFileName(configFilePath);
+            var configFilePath = Path.GetFullPath(Arguments.Count == 0 ? Constants.PackageReferenceFile : Arguments[0]);
+            var configFileName = Path.GetFileName(configFilePath);
 
             // If the first argument is a packages.xxx.config file, install everything it lists
             // Otherwise, treat the first argument as a package Id
@@ -80,27 +87,27 @@ namespace NuGet.CommandLine
                 if (Console != null && RequireConsent &&
                     new PackageRestoreConsent(Settings).IsGranted)
                 {
-                    string message = String.Format(
+                    var message = string.Format(
                         CultureInfo.CurrentCulture,
                         LocalizedResourceManager.GetString("RestoreCommandPackageRestoreOptOutMessage"),
                         NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
                     Console.WriteLine(message);
                 }
 
-                return PerformV2Restore(configFilePath, installPath);
+                return PerformV2RestoreAsync(configFilePath, installPath);
             }
             else
             {
                 var packageId = Arguments[0];
                 var version = Version != null ? new NuGetVersion(Version) : null;
-                return InstallPackage(packageId, version, installPath);
+                return InstallPackageAsync(packageId, version, installPath);
             }
         }
 
         private void CalculateEffectiveSettings()
         {
             // If the SolutionDir is specified, use the .nuget directory under it to determine the solution-level settings
-            if (!String.IsNullOrEmpty(SolutionDirectory))
+            if (!string.IsNullOrEmpty(SolutionDirectory))
             {
                 var path = Path.Combine(SolutionDirectory.TrimEnd(Path.DirectorySeparatorChar), NuGetConstants.NuGetSolutionSettingsFolder);
 
@@ -119,20 +126,20 @@ namespace NuGet.CommandLine
 
         internal string ResolveInstallPath()
         {
-            if (!String.IsNullOrEmpty(OutputDirectory))
+            if (!string.IsNullOrEmpty(OutputDirectory))
             {
                 // Use the OutputDirectory if specified.
                 return OutputDirectory;
             }
 
-            string installPath = SettingsUtility.GetRepositoryPath(Settings);
-            if (!String.IsNullOrEmpty(installPath))
+            var installPath = SettingsUtility.GetRepositoryPath(Settings);
+            if (!string.IsNullOrEmpty(installPath))
             {
                 // If a value is specified in config, use that.
                 return installPath;
             }
 
-            if (!String.IsNullOrEmpty(SolutionDirectory))
+            if (!string.IsNullOrEmpty(SolutionDirectory))
             {
                 // For package restore scenarios, deduce the path of the packages directory from the solution directory.
                 return Path.Combine(SolutionDirectory, CommandLineConstants.PackagesDirectoryName);
@@ -142,7 +149,7 @@ namespace NuGet.CommandLine
             return CurrentDirectory;
         }
 
-        private async Task PerformV2Restore(string packagesConfigFilePath, string installPath)
+        private async Task PerformV2RestoreAsync(string packagesConfigFilePath, string installPath)
         {
             var sourceRepositoryProvider = GetSourceRepositoryProvider();
             var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, installPath, ExcludeVersion);
@@ -158,15 +165,17 @@ namespace NuGet.CommandLine
                     isMissing: true));
 
             var packageSources = GetPackageSources(Settings);
-            
+
             Console.PrintPackageSources(packageSources);
+
+            var failedEvents = new ConcurrentQueue<PackageRestoreFailedEventArgs>();
 
             var packageRestoreContext = new PackageRestoreContext(
                 nuGetPackageManager,
                 packageRestoreData,
                 CancellationToken.None,
                 packageRestoredEvent: null,
-                packageRestoreFailedEvent: null,
+                packageRestoreFailedEvent: (sender, args) => { failedEvents.Enqueue(args); },
                 sourceRepositories: packageSources.Select(sourceRepositoryProvider.CreateRepository),
                 maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism);
 
@@ -189,7 +198,7 @@ namespace NuGet.CommandLine
 
                 var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload);
 
-                await PackageRestoreManager.RestoreMissingPackagesAsync(
+                var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                     packageRestoreContext,
                     new ConsoleProjectContext(Console),
                     downloadContext);
@@ -197,6 +206,17 @@ namespace NuGet.CommandLine
                 if (downloadContext.DirectDownload)
                 {
                     GetDownloadResultUtility.CleanUpDirectDownloads(downloadContext);
+                }
+
+                if (!result.Restored || failedEvents.Count > 0)
+                {
+                    // Log errors if they exist
+                    foreach (var message in failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message)))
+                    {
+                        await Console.LogAsync(message);
+                    }
+
+                    throw new ExitCodeException(1);
                 }
             }
         }
@@ -221,9 +241,9 @@ namespace NuGet.CommandLine
         private DependencyBehavior GetDependencyBehavior()
         {
             // If dependencyVersion is not set by either the config or commandline, default dependency behavior is 'Lowest'.
-            DependencyBehavior dependencyBehavior = DependencyBehavior.Lowest;
+            var dependencyBehavior = DependencyBehavior.Lowest;
 
-            string settingsDependencyVersion = SettingsUtility.GetConfigValue(Settings, "dependencyVersion");
+            var settingsDependencyVersion = SettingsUtility.GetConfigValue(Settings, "dependencyVersion");
 
             // Check to see if commandline flag is set. Else check for dependencyVersion in .config.
             if (!string.IsNullOrEmpty(DependencyVersion))
@@ -238,28 +258,33 @@ namespace NuGet.CommandLine
             return dependencyBehavior;
         }
 
-        private async Task InstallPackage(
+        private async Task InstallPackageAsync(
             string packageId,
             NuGetVersion version,
             string installPath)
         {
             if (version == null)
             {
-                NoCache = true;
+                // Avoid searching for the highest version in the global packages folder,
+                // it needs to come from the feeds instead. Once found it may come from
+                // the global packages folder unless NoCache is true.
+                ExcludeCacheAsSource = true;
             }
 
-            var folderProject = new FolderNuGetProject(
-                installPath,
-                new PackagePathResolver(installPath, !ExcludeVersion));
+            var framework = GetTargetFramework();
+
+            // Create the project and set the framework if available.
+            var project = new InstallCommandProject(
+                root: installPath,
+                packagePathResolver: new PackagePathResolver(installPath, !ExcludeVersion),
+                targetFramework: framework);
 
             var sourceRepositoryProvider = GetSourceRepositoryProvider();
             var packageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, installPath);
 
             var packageSources = GetPackageSources(Settings);
-
-            Console.PrintPackageSources(packageSources);
-
             var primaryRepositories = packageSources.Select(sourceRepositoryProvider.CreateRepository);
+            Console.PrintPackageSources(packageSources);
 
             var allowPrerelease = Prerelease || (version != null && version.IsPrerelease);
 
@@ -273,10 +298,15 @@ namespace NuGet.CommandLine
 
             if (version == null)
             {
+                // Write out a helpful message before the http messages are shown
+                Console.Log(LogLevel.Minimal, string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("InstallPackageMessage"), packageId, installPath));
+
                 // Find the latest version using NuGetPackageManager
                 var resolvePackage = await NuGetPackageManager.GetLatestVersionAsync(
                     packageId,
-                    folderProject,
+                    project,
                     resolutionContext,
                     primaryRepositories,
                     Console,
@@ -295,9 +325,23 @@ namespace NuGet.CommandLine
                 version = resolvePackage.LatestVersion;
             }
 
+            // Get a list of packages already in the folder.
+            var installedPackages = await project.GetFolderPackagesAsync(CancellationToken.None);
+
+            // Find existing versions of the package
+            var alreadyInstalledVersions = new HashSet<NuGetVersion>(installedPackages
+                .Where(e => StringComparer.OrdinalIgnoreCase.Equals(packageId, e.PackageIdentity.Id))
+                .Select(e => e.PackageIdentity.Version));
+
             var packageIdentity = new PackageIdentity(packageId, version);
 
-            if (folderProject.PackageExists(packageIdentity))
+            // Check if the package already exists or a higher version exists already.
+            var skipInstall = project.PackageExists(packageIdentity);
+
+            // For SxS allow other versions to install. For non-SxS skip if a higher version exists.
+            skipInstall |= (ExcludeVersion && alreadyInstalledVersions.Any(e => e >= version));
+
+            if (skipInstall)
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -318,7 +362,7 @@ namespace NuGet.CommandLine
                     projectContext.PackageExtractionContext.PackageSaveMode = EffectivePackageSaveMode;
                 }
 
-                using(var cacheContext = new SourceCacheContext())
+                using (var cacheContext = new SourceCacheContext())
                 {
                     cacheContext.NoCache = NoCache;
                     cacheContext.DirectDownload = DirectDownload;
@@ -326,7 +370,7 @@ namespace NuGet.CommandLine
                     var downloadContext = new PackageDownloadContext(cacheContext, installPath, DirectDownload);
 
                     await packageManager.InstallPackageAsync(
-                        folderProject,
+                        project,
                         packageIdentity,
                         resolutionContext,
                         projectContext,
@@ -341,6 +385,31 @@ namespace NuGet.CommandLine
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Parse the Framework parameter or use Any as the default framework.
+        /// </summary>
+        private NuGetFramework GetTargetFramework()
+        {
+            var targetFramework = NuGetFramework.AnyFramework;
+
+            if (!string.IsNullOrEmpty(Framework))
+            {
+                targetFramework = NuGetFramework.Parse(Framework);
+            }
+
+            if (targetFramework.IsUnsupported)
+            {
+                // Fail with a helpful message if the user provided an invalid framework.
+                var message = string.Format(CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("UnsupportedFramework"),
+                    Framework);
+
+                throw new ArgumentException(message);
+            }
+
+            return targetFramework;
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -333,7 +333,7 @@ namespace NuGet.CommandLine
                     Settings.Priority.Select(x => Path.Combine(x.Root, x.FileName)),
                     packageSources.Select(x => x.Source),
                     installCount,
-                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, e.Exception.Message))));
+                    collectorLogger.Errors.Concat(failedEvents.Select(e => new RestoreLogMessage(LogLevel.Error, NuGetLogCode.Undefined, e.Exception.Message))));
             }
         }
 

--- a/src/NuGet.Clients/NuGet.CommandLine/Common/InstallCommandProject.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Common/InstallCommandProject.cs
@@ -1,0 +1,110 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
+using NuGet.Protocol;
+
+namespace NuGet.CommandLine
+{
+    /// <summary>
+    /// Project used for nuget.exe install
+    /// </summary>
+    internal class InstallCommandProject : FolderNuGetProject
+    {
+        private readonly NuGetFramework _framework;
+        private readonly PackagePathResolver _packagePathResolver;
+
+        public InstallCommandProject(string root, PackagePathResolver packagePathResolver, NuGetFramework targetFramework)
+            : base(root, packagePathResolver, targetFramework)
+        {
+            _packagePathResolver = packagePathResolver;
+            _framework = targetFramework;
+        }
+
+        /// <summary>
+        /// Asynchronously gets installed packages.
+        /// </summary>
+        /// <remarks>This is used only for the install command, not in PM.</remarks>
+        /// <param name="token">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{PackageReference}" />.</returns>
+        public Task<IEnumerable<PackageReference>> GetFolderPackagesAsync(CancellationToken token)
+        {
+            var packages = Enumerable.Empty<LocalPackageInfo>();
+
+            if (Directory.Exists(Root))
+            {
+                if (_packagePathResolver.UseSideBySidePaths)
+                {
+                    // Id.Version
+                    packages = LocalFolderUtility.GetPackagesConfigFolderPackages(Root, NullLogger.Instance);
+                }
+                else
+                {
+                    // Id
+                    packages = LocalFolderUtility.GetPackagesV2(Root, NullLogger.Instance);
+                }
+            }
+
+            return Task.FromResult<IEnumerable<PackageReference>>(
+                LocalFolderUtility.GetDistinctPackages(packages)
+                    .Select(e => new PackageReference(e.Identity, _framework))
+                    .ToList());
+        }
+
+        /// <summary>
+        /// Asynchronously gets installed packages.
+        /// </summary>
+        /// <param name="token">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns an
+        /// <see cref="IEnumerable{PackageReference}" />.</returns>
+        public override Task<IEnumerable<PackageReference>> GetInstalledPackagesAsync(CancellationToken token)
+        {
+            if (!_packagePathResolver.UseSideBySidePaths)
+            {
+                // Without versions packages must be uninstalled to update them.
+                return GetFolderPackagesAsync(token);
+            }
+
+            // For SxS scenarios PackageManagement should not read these references, this would cause uninstalls.
+            return Task.FromResult(Enumerable.Empty<PackageReference>());
+        }
+
+        /// <summary>
+        /// Asynchronously uninstalls a package.
+        /// </summary>
+        /// <param name="packageIdentity">A package identity.</param>
+        /// <param name="nuGetProjectContext">A NuGet project context.</param>
+        /// <param name="token">A cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation.
+        /// The task result (<see cref="Task{TResult}.Result" />) returns a <see cref="bool" />
+        /// indication successfulness of the operation.</returns>
+        public override async Task<bool> UninstallPackageAsync(
+            PackageIdentity packageIdentity,
+            INuGetProjectContext nuGetProjectContext,
+            CancellationToken token)
+        {
+            var installedPackagesList = await GetInstalledPackagesAsync(token);
+            var packageReference = installedPackagesList.Where(p => p.PackageIdentity.Equals(packageIdentity)).FirstOrDefault();
+            if (packageReference == null)
+            {
+                // Package does not exist
+                return false;
+            }
+
+            // Delete the package for nuget.exe install/update scenarios
+            return await DeletePackage(packageIdentity, nuGetProjectContext, token);
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props" />
-  <Import Project="ilmerge.props"/>
+  <Import Project="ilmerge.props" />
 
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
@@ -57,7 +57,8 @@
       <DependentUpon>NuGetCommand.resx</DependentUpon>
     </Compile>
     <EmbeddedResource Update="NuGetResources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <!-- Strings are shared by other projects, use public strings. -->
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>NuGetResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <Compile Update="NuGetResources.Designer.cs">
@@ -76,19 +77,16 @@
 
   <Target Name="ILMergeNuGetExe" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)\*.dll" Exclude="@(MergeExclude)"/>
+      <BuildArtifacts Include="$(OutputPath)\*.dll" Exclude="@(MergeExclude)" />
     </ItemGroup>
-    <Error Text="Build dependencies are inconsistent with mergeinclude specified in ilmerge.props"
-             Condition="'@(BuildArtifacts->Count())' != '@(MergeInclude->Count())'"/>
+    <Error Text="Build dependencies are inconsistent with mergeinclude specified in ilmerge.props" Condition="'@(BuildArtifacts-&gt;Count())' != '@(MergeInclude-&gt;Count())'" />
     <PropertyGroup>
       <PathToBuiltNuGetExe>$(OutputPath)NuGet.exe</PathToBuiltNuGetExe>
       <IlmergeCommand>$(ILMergeExePath) $(PathToBuiltNuGetExe) /lib:$(OutputPath) @(BuildArtifacts->'%(filename)%(extension)', ' ') /out:$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe @(MergeAllowDup -> '/allowdup:%(Identity)', ' ')</IlmergeCommand>
       <IlmergeCommand Condition="Exists($(MS_PFX_PATH))">$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)</IlmergeCommand>
     </PropertyGroup>
-    <MakeDir  
-            Directories="$(ArtifactsDirectory)$(VsixOutputDirName)"/>
-    <Exec Command="$(IlmergeCommand)"
-          ContinueOnError="false" />
+    <MakeDir Directories="$(ArtifactsDirectory)$(VsixOutputDirName)" />
+    <Exec Command="$(IlmergeCommand)" ContinueOnError="false" />
   </Target>
   
   <PropertyGroup>
@@ -110,8 +108,8 @@
 
   <Target Name="GetSymbolsToIndex" Returns="@(SymbolsToIndex)">
     <ItemGroup>
-      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"/>
-      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb"/>
+      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" />
+      <SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -3602,6 +3602,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Target framework used for selecting dependencies. Defaults to &apos;Any&apos; if not specified..
+        /// </summary>
+        internal static string InstallCommandFrameworkDescription {
+            get {
+                return ResourceManager.GetString("InstallCommandFrameworkDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 禁止使用计算机缓存作为第一个程序包源。.
         /// </summary>
         internal static string InstallCommandNoCache_chs {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5342,4 +5342,7 @@ nuget locals global-packages -list</value>
   <data name="InstallCommandDependencyVersion" xml:space="preserve">
     <value>Overrides the default dependency resolution behavior.</value>
   </data>
+  <data name="InstallCommandFrameworkDescription" xml:space="preserve">
+    <value>Target framework used for selecting dependencies. Defaults to 'Any' if not specified.</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -4813,6 +4813,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installing package &apos;{0}&apos; to &apos;{1}&apos;..
+        /// </summary>
+        public static string InstallPackageMessage {
+            get {
+                return ResourceManager.GetString("InstallPackageMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: invalid arguments..
         /// </summary>
         public static string InvalidArguments {
@@ -14875,6 +14884,15 @@ namespace NuGet.CommandLine {
         public static string UnknownOptionError_trk {
             get {
                 return ResourceManager.GetString("UnknownOptionError_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid target framework..
+        /// </summary>
+        public static string UnsupportedFramework {
+            get {
+                return ResourceManager.GetString("UnsupportedFramework", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6127,4 +6127,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>Invalid value given for 'DependencyVersion': "{0}".</value>
     <comment>Please don't localize "DependencyVersion".</comment>
   </data>
+  <data name="UnsupportedFramework" xml:space="preserve">
+    <value>'{0}' is not a valid target framework.</value>
+  </data>
+  <data name="InstallPackageMessage" xml:space="preserve">
+    <value>Installing package '{0}' to '{1}'.</value>
+  </data>
 </root>

--- a/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTests.cs
+++ b/test/NuGet.Clients.FuncTests/NuGet.CommandLine.FuncTest/Caching/CachingTests.cs
@@ -81,12 +81,12 @@ namespace NuGet.CommandLine.Test.Caching
         [Theory]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.Default, ServerType.V3, true, true)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, true, false)] // Should either fail or install?
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, true, false)] // Should either fail or install?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V2, false, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache, ServerType.V3, false, false)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V2, true, true)]
         [InlineData(typeof(InstallPackagesConfigCommand), CachingType.DirectDownload, ServerType.V3, true, true)]
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, true, false)] // Should either fail or install?
-        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, true, false)] // Should either fail or install?
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V2, false, false)]
+        [InlineData(typeof(InstallPackagesConfigCommand), CachingType.NoCache | CachingType.DirectDownload, ServerType.V3, false, false)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V2, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.Default, ServerType.V3, true, true)]
         [InlineData(typeof(InstallSpecificVersionCommand), CachingType.NoCache, ServerType.V2, false, false)]

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -5,9 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Xml.Linq;
+using FluentAssertions;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.Test.Utility;
+using NuGet.Versioning;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -15,11 +21,267 @@ namespace NuGet.CommandLine.Test
     public class NuGetInstallCommandTest
     {
         [Fact]
+        public void InstallCommand_UpdatePackageWithExcludeVersionVerifyPackageReplaced()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA1 = new SimpleTestPackageContext("a", "1.0.0");
+                var packageA2 = new SimpleTestPackageContext("a", "2.0.0");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA1, packageA2);
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                var r1 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                // Act
+                var r2 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "2.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                var nupkgPath = pathResolver.GetInstalledPackageFilePath(new PackageIdentity("a", NuGetVersion.Parse("2.0.0")));
+
+                // Assert
+                r1.Success.Should().BeTrue();
+                r2.Success.Should().BeTrue();
+                File.Exists(nupkgPath).Should().BeTrue();
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("2.0.0");
+                }
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_DependencyFailsToInstallVerifyFailure()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA = new SimpleTestPackageContext("a", "1.0.0");
+                var packageB = new SimpleTestPackageContext("b", "1.0.0");
+                packageA.Dependencies.Add(packageB);
+
+                // Only create A
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA);
+
+                File.Delete(Directory.GetFiles(pathContext.PackageSource).Single(e => e.EndsWith("b.1.0.0.nupkg")));
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                // Act
+                var r1 = RunInstall(pathContext, "a", 1, "-ExcludeVersion", "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot, "-Source", pathContext.PackageSource);
+
+                // Assert
+                r1.Success.Should().BeFalse();
+                r1.Errors.Should().Contain("Unable to resolve dependency");
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_PackageFailsToInstallVerifyFailure()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Act
+                var r1 = RunInstall(pathContext, "a", 1, "-ExcludeVersion", "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot, "-Source", pathContext.PackageSource);
+
+                // Assert
+                r1.Success.Should().BeFalse();
+                r1.Errors.Should().Contain("Package 'a 1.0.0' is not found in the following");
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_UpdatePackageWithExcludeVersionVerifyFilesRemoved()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA1 = new SimpleTestPackageContext("a", "1.0.0");
+                packageA1.AddFile("data/1.txt");
+
+                var packageA2 = new SimpleTestPackageContext("a", "2.0.0");
+                packageA2.AddFile("data/2.txt");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA1, packageA2);
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                var r1 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                // Act
+                var r2 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "2.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                var nupkgPath = pathResolver.GetInstalledPackageFilePath(new PackageIdentity("a", NuGetVersion.Parse("2.0.0")));
+                var installDir = Path.GetDirectoryName(nupkgPath);
+
+                // Assert
+                r1.Success.Should().BeTrue();
+                r2.Success.Should().BeTrue();
+                File.Exists(nupkgPath).Should().BeTrue();
+                File.Exists(Path.Combine(installDir, "data", "1.txt")).Should().BeFalse("this package was uninstalled");
+                File.Exists(Path.Combine(installDir, "data", "2.txt")).Should().BeTrue("this package was installed");
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("2.0.0");
+                }
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_DowngradePackageWithExcludeVersionVerifyPackageReplaced()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA1 = new SimpleTestPackageContext("a", "1.0.0");
+                var packageA2 = new SimpleTestPackageContext("a", "2.0.0");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA1, packageA2);
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                var r1 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "2.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                // Act
+                var r2 = RunInstall(pathContext, "a", 0, "-ExcludeVersion", "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                var nupkgPath = pathResolver.GetInstalledPackageFilePath(new PackageIdentity("a", NuGetVersion.Parse("2.0.0")));
+
+                // Assert
+                r1.Success.Should().BeTrue();
+                r2.Success.Should().BeTrue();
+                File.Exists(nupkgPath).Should().BeTrue();
+
+                using (var reader = new PackageArchiveReader(nupkgPath))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("2.0.0");
+                }
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_InstallTwoVersionsOfAPackageVerifySxS()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA1 = new SimpleTestPackageContext("a", "1.0.0");
+                var packageA2 = new SimpleTestPackageContext("a", "2.0.0");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA1, packageA2);
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                // Act
+                var r2 = RunInstall(pathContext, "a", 0, "-Version", "2.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+                var r1 = RunInstall(pathContext, "a", 0, "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot);
+
+                var nupkgPath2 = pathResolver.GetInstalledPackageFilePath(new PackageIdentity("a", NuGetVersion.Parse("2.0.0")));
+                var nupkgPath1 = pathResolver.GetInstalledPackageFilePath(new PackageIdentity("a", NuGetVersion.Parse("1.0.0")));
+
+                // Assert
+                r1.Success.Should().BeTrue();
+                r2.Success.Should().BeTrue();
+                File.Exists(nupkgPath1).Should().BeTrue();
+                File.Exists(nupkgPath2).Should().BeTrue();
+            }
+        }
+
+        [Theory]
+        [InlineData("net461", "c")]
+        [InlineData("sl7", "b")]
+        [InlineData("any", "b")]
+        [InlineData("net451", "f")]
+        [InlineData("native", "e")]
+        [InlineData("netcoreapp2.0", "d")]
+        public void InstallCommand_InstallWithFrameworkFlagVerifyDependencies(string tfm, string expectedId)
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA = new SimpleTestPackageContext("a", "1.0.0")
+                {
+                    Nuspec = XDocument.Parse($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <package>
+                        <metadata>
+                            <id>a</id>
+                            <version>1.0.0</version>
+                            <title />
+                            <dependencies>
+                                <group>
+                                    <dependency id=""b"" version=""1.0.0"" />
+                                </group>
+                                <group targetFramework=""net46"">
+                                    <dependency id=""c"" version=""1.0.0"" />
+                                </group>
+                                <group targetFramework=""netstandard1.0"">
+                                    <dependency id=""d"" version=""1.0.0"" />
+                                </group>
+                                <group targetFramework=""native"">
+                                    <dependency id=""e"" version=""1.0.0"" />
+                                </group>
+                                <group targetFramework=""net45"">
+                                    <dependency id=""f"" version=""1.0.0"" />
+                                </group>
+                            </dependencies>
+                        </metadata>
+                        </package>")
+                };
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource,
+                    packageA,
+                    new SimpleTestPackageContext("b"),
+                    new SimpleTestPackageContext("c"),
+                    new SimpleTestPackageContext("d"),
+                    new SimpleTestPackageContext("e"),
+                    new SimpleTestPackageContext("f"));
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                // Act
+                var r = RunInstall(pathContext, "a", 0, "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot, "-Framework", tfm);
+
+                var nupkgPath = pathResolver.GetInstalledPackageFilePath(new PackageIdentity(expectedId, NuGetVersion.Parse("1.0.0")));
+
+                // Assert
+                r.Success.Should().BeTrue();
+                File.Exists(nupkgPath).Should().BeTrue();
+                Directory.GetDirectories(pathContext.SolutionRoot).Length.Should().Be(2, "No other packages should be included");
+            }
+        }
+
+        [Fact]
+        public void InstallCommand_InstallWithUnsupportedFrameworkVerifyFailure()
+        {
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Arrange
+                var packageA = new SimpleTestPackageContext("a", "1.0.0");
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, packageA);
+
+                var pathResolver = new PackagePathResolver(pathContext.SolutionRoot, useSideBySidePaths: false);
+
+                // Act
+                var r = RunInstall(pathContext, "a", 1, "-Version", "1.0.0", "-OutputDirectory", pathContext.SolutionRoot, "-Framework", "blaah999");
+
+                // Assert
+                r.Success.Should().BeFalse();
+                r.AllOutput.Should().Contain("'blaah999' is not a valid target framework.");
+            }
+        }
+
+        [Fact]
         public void InstallCommand_FromPackagesConfigFileWithExcludeVersion()
         {
             // Arrange
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var nugetexe = Util.GetNuGetExePath();
 
@@ -37,11 +299,7 @@ namespace NuGet.CommandLine.Test
 </packages>");
 
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    $"install -OutputDirectory outputDir -Source {repositoryPath} -ExcludeVersion",
-                    waitForExit: true);
+                var r = RunInstall(pathContext, string.Empty, 0, $"-OutputDirectory outputDir -Source {repositoryPath} -ExcludeVersion");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
@@ -53,29 +311,27 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
-        public async Task InstallCommand_WithExcludeVersion()
+        public void InstallCommand_WithExcludeVersion()
         {
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
-                    "testPackage1", "1.1.0", source);
+                    "testPackage1", "1.1.0", pathContext.PackageSource);
 
                 // Act
-                string[] args = new string[] {
-                    "install", "testPackage1",
-                    "-OutputDirectory", outputDirectory,
-                    "-Source", source,
+                var args = new string[] {
+                    "-OutputDirectory", pathContext.SolutionRoot,
+                    "-Source", pathContext.PackageSource,
                     "-ExcludeVersion" };
 
-                int r = await Task.Run(() => Program.Main(args));
+                var r = RunInstall(pathContext, "testPackage1", 0, args);
 
                 // Assert
-                Assert.Equal(0, r);
-
                 var packageDir = Path.Combine(
-                    outputDirectory,
+                    pathContext.SolutionRoot,
                     @"testPackage1");
 
                 Assert.True(Directory.Exists(packageDir));
@@ -86,10 +342,10 @@ namespace NuGet.CommandLine.Test
         public void InstallCommand_FromPackagesConfigFile()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+
                 var repositoryPath = Path.Combine(workingPath, "Repository");
 
                 // Add a nuget.config to clear out sources and set the global packages folder
@@ -104,9 +360,8 @@ namespace NuGet.CommandLine.Test
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
-                string[] args = new string[]
+                var args = new string[]
                 {
-                    "install",
                     "-OutputDirectory",
                     "outputDir",
                     "-Source",
@@ -114,11 +369,7 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    string.Join(" ", args),
-                    waitForExit: true);
+                var r = RunInstall(pathContext, "", 0, args);
 
                 // Assert
                 Assert.Equal(0, r.Item1);
@@ -130,13 +381,55 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void InstallCommand_FromPackagesConfigFileFailsVerifyCode()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                var workingPath = pathContext.WorkingDirectory;
+
+                var repositoryPath = Path.Combine(workingPath, "Repository");
+
+                // Add a nuget.config to clear out sources and set the global packages folder
+                Util.CreateConfigForGlobalPackagesFolder(workingPath);
+
+                Directory.CreateDirectory(repositoryPath);
+
+                // Incorrect versions
+                Util.CreateTestPackage("packageA", "1.0.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.0.0", repositoryPath);
+
+                Util.CreateFile(workingPath, "packages.config",
+    @"<packages>
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+</packages>");
+
+                var args = new string[]
+                {
+                    "-OutputDirectory",
+                    "outputDir",
+                    "-Source",
+                    repositoryPath
+                };
+
+                // Act
+                var r = RunInstall(pathContext, "", 1, args);
+
+                // Assert
+                Assert.Equal(1, r.Item1);
+                r.AllOutput.Should().NotContain("NU1000");
+                r.Errors.Should().Contain("Unable to find version");
+            }
+        }
+
+        [Fact]
         public void InstallCommand_ShowsAlreadyInstalledMessageWhenAllPackagesArePresent()
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var packagesConfig = Path.Combine(workingPath, "packages.config");
 
@@ -149,10 +442,8 @@ namespace NuGet.CommandLine.Test
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
-                string[] args = new string[]
+                var args = new string[]
                 {
-                    "install",
-                    packagesConfig,
                     "-OutputDirectory",
                     "outputDir",
                     "-Source",
@@ -160,11 +451,7 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    string.Join(" ", args),
-                    waitForExit: true);
+                var r = RunInstall(pathContext, packagesConfig, 0, args);
 
                 // Assert
                 Assert.Equal(0, r.Item1);
@@ -174,25 +461,19 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(packageFileB));
 
                 //Act (Install a second time)
-                string[] args2 = new string[]
+                var args2 = new string[]
                 {
-                    "install",
-                    packagesConfig,
                     "-OutputDirectory",
                     "outputDir",
                     "-Source",
                     repositoryPath
                 };
 
-                var r1 = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    string.Join(" ", args2),
-                    waitForExit: true);
+                var r1 = RunInstall(pathContext, packagesConfig, 1, args2);
 
-                //Assert
+                // Assert
                 var message = r1.Item2;
-                string alreadyInstalledMessage = String.Format("All packages listed in {0} are already installed.", packagesConfig);
+                var alreadyInstalledMessage = string.Format("All packages listed in {0} are already installed.", packagesConfig);
                 Assert.Contains(alreadyInstalledMessage, message, StringComparison.OrdinalIgnoreCase);
             }
         }
@@ -204,8 +485,9 @@ namespace NuGet.CommandLine.Test
             var currentDirectory = Directory.GetCurrentDirectory();
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -221,9 +503,8 @@ namespace NuGet.CommandLine.Test
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
-                string[] args = new string[]
+                var args = new string[]
                 {
-                    "install",
                     "-SolutionDir",
                     $"\"{workingPath}\"",
                     "-OutputDirectory",
@@ -233,11 +514,7 @@ namespace NuGet.CommandLine.Test
                 };
 
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    workingPath,
-                    string.Join(" ", args),
-                    waitForExit: true);
+                var r = RunInstall(pathContext, "", 0, args);
 
                 // Assert
                 Assert.True(0 == r.Item1, $"{r.Item2} {r.Item3}");
@@ -255,12 +532,13 @@ namespace NuGet.CommandLine.Test
             var currentDirectory = Directory.GetCurrentDirectory();
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
-                string folderName = Path.GetFileName(workingPath);
+                var folderName = Path.GetFileName(workingPath);
 
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var relativeFolderPath = $"..\\{folderName}";
@@ -274,7 +552,7 @@ namespace NuGet.CommandLine.Test
   <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
 </packages>");
 
-                string[] args = new string[]
+                var args = new string[]
                 {
                     "install",
                     "-SolutionDir",
@@ -292,6 +570,7 @@ namespace NuGet.CommandLine.Test
                     workingPath,
                     string.Join(" ", args),
                     waitForExit: true);
+
                 Environment.SetEnvironmentVariable("PATH", path);
 
                 // Assert
@@ -305,24 +584,25 @@ namespace NuGet.CommandLine.Test
 
         public void InstallCommand_PackageSaveModeNuspec()
         {
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
+
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source);
 
                 // Act
-                string[] args = new string[] {
-                    "install", "testPackage1",
+                var args = new string[] {
                     "-OutputDirectory", outputDirectory,
                     "-Source", source,
                     "-PackageSaveMode", "nuspec" };
-                int r = Program.Main(args);
+
+                var r = RunInstall(pathContext, "testPackage1", 0, args);
 
                 // Assert
-                Assert.Equal(0, r);
-
                 var nuspecFile = Path.Combine(
                     outputDirectory,
                     "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
@@ -335,24 +615,24 @@ namespace NuGet.CommandLine.Test
 
         public void InstallCommand_PackageSaveModeNupkg()
         {
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source);
 
                 // Act
-                string[] args = new string[] {
-                    "install", "testPackage1",
+                var args = new string[] {
                     "-OutputDirectory", outputDirectory,
                     "-Source", source,
                     "-PackageSaveMode", "nupkg" };
-                int r = Program.Main(args);
+
+                var r = RunInstall(pathContext, "testPackage1", 0, args);
 
                 // Assert
-                Assert.Equal(0, r);
-
                 var nupkgFile = Path.Combine(
                     outputDirectory,
                     "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
@@ -365,24 +645,24 @@ namespace NuGet.CommandLine.Test
 
         public void InstallCommand_PackageSaveModeNuspecNupkg()
         {
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source);
 
                 // Act
-                string[] args = new string[] {
-                    "install", "testPackage1",
+                var args = new string[] {
                     "-OutputDirectory", outputDirectory,
                     "-Source", source,
                     "-PackageSaveMode", "nupkg;nuspec" };
-                int r = Program.Main(args);
+
+                var r = RunInstall(pathContext, "testPackage1", 0, args);
 
                 // Assert
-                Assert.Equal(0, r);
-
                 var nupkgFile = Path.Combine(
                     outputDirectory,
                     "testPackage1.1.1.0", "testPackage1.1.1.0.nuspec");
@@ -398,29 +678,24 @@ namespace NuGet.CommandLine.Test
         // package.
         public void InstallCommand_PackageSaveModeNuspecReinstall()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source);
 
-                string[] args = new string[] {
-                    "install", "testPackage1",
+                var args = new string[] {
                     "-OutputDirectory", outputDirectory,
                     "-Source", source,
                     "-PackageSaveMode", "nuspec" };
-                int r = Program.Main(args);
+                var r = Program.Main(args);
                 Assert.Equal(0, r);
 
                 // Act
-                var result = CommandRunner.Run(
-                    nugetexe,
-                    Directory.GetCurrentDirectory(),
-                    string.Join(" ", args),
-                    waitForExit: true);
+                var result = RunInstall(pathContext, "testPackage1", 0, args);
 
                 var output = result.Item2;
 
@@ -434,19 +709,21 @@ namespace NuGet.CommandLine.Test
         // Test that PackageSaveMode specified in nuget.config file is used.
         public void InstallCommand_PackageSaveModeInConfigFile()
         {
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
                 // Arrange
                 var packageFileName = Util.CreateTestPackage(
                     "testPackage1", "1.1.0", source);
 
                 var configFile = Path.Combine(source, "nuget.config");
                 Util.CreateFile(Path.GetDirectoryName(configFile), Path.GetFileName(configFile), "<configuration/>");
-                string[] args = new string[] {
+                var args = new string[] {
                     "config", "-Set", "PackageSaveMode=nuspec",
                     "-ConfigFile", configFile };
-                int r = Program.Main(args);
+                var r = Program.Main(args);
                 Assert.Equal(0, r);
 
                 // Act
@@ -478,10 +755,10 @@ namespace NuGet.CommandLine.Test
         public void InstallCommand_OptOutMessage(string configFileName)
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -519,15 +796,11 @@ namespace NuGet.CommandLine.Test
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    proj1Directory,
-                    "install " + configFileName + " -Source " + repositoryPath + $@" -ConfigFile ..{Path.DirectorySeparatorChar}my.config -RequireConsent -Verbosity detailed",
-                    waitForExit: true);
+                var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config -RequireConsent");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
-                string optOutMessage = String.Format(
+                var optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGet.CommandLine.NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGet.Resources.NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
@@ -543,10 +816,10 @@ namespace NuGet.CommandLine.Test
         public void InstallCommand_NoOptOutMessage(string configFileName)
         {
             // Arrange
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -584,15 +857,11 @@ namespace NuGet.CommandLine.Test
   <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
 </packages>");
                 // Act
-                var r = CommandRunner.Run(
-                    nugetexe,
-                    proj1Directory,
-                    "install " + configFileName + " -Source " + repositoryPath + $@" -ConfigFile ..{Path.DirectorySeparatorChar}my.config",
-                    waitForExit: true);
+                var r = RunInstall(pathContext, configFileName, 0, " -Source " + repositoryPath + $@" -ConfigFile my.config");
 
                 // Assert
                 Assert.Equal(0, r.Item1);
-                string optOutMessage = String.Format(
+                var optOutMessage = string.Format(
                     CultureInfo.CurrentCulture,
                     NuGetResources.RestoreCommandPackageRestoreOptOutMessage,
                     NuGet.Resources.NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
@@ -605,11 +874,11 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_GetLastestReleaseVersion()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
+
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -624,6 +893,7 @@ namespace NuGet.CommandLine.Test
                 var package1 = new ZipPackage(packageFileName);
                 packageFileName = Util.CreateTestPackage("testPackage1", "1.2.0", packageDirectory);
                 var package2 = new ZipPackage(packageFileName);
+                var nugetexe = Util.GetNuGetExePath();
 
                 using (var server = Util.CreateMockServer(new[] { package1, package2 }))
                 {
@@ -651,11 +921,12 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_GetLastestPrereleaseVersion()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
+                var nugetexe = Util.GetNuGetExePath();
+
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -690,11 +961,12 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_WithPrereleaseVersionSpecified()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
+                var nugetexe = Util.GetNuGetExePath();
+
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -730,11 +1002,10 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_WithVersionSpecified()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
                 // Add a nuget.config to clear out sources and set the global packages folder
                 Util.CreateConfigForGlobalPackagesFolder(workingPath);
 
@@ -747,8 +1018,8 @@ namespace NuGet.CommandLine.Test
 
                 using (var server = new MockServer())
                 {
-                    bool getPackageByVersionIsCalled = false;
-                    bool packageDownloadIsCalled = false;
+                    var getPackageByVersionIsCalled = false;
+                    var packageDownloadIsCalled = false;
 
                     server.Get.Add("/nuget/$metadata", r =>
                        Util.GetMockServerResource());
@@ -776,6 +1047,7 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r => "OK");
 
                     server.Start();
+                    var nugetexe = Util.GetNuGetExePath();
 
                     // Act
                     var args = "install testPackage1 -Version 1.1.0 -Source " + server.Uri + "nuget";
@@ -793,59 +1065,15 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        // Tests that when -Version is specified, if the specified version cannot be found,
-        // nuget will retry with new version numbers by appending 0's to the specified version.
-        [Fact(Skip = "Exact packages are no longer requested")]
-        public void InstallCommand_WillTryNewVersionsByAppendingZeros()
-        {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            {
-                // Arrange
-                using (var server = new MockServer())
-                {
-                    List<string> requests = new List<string>();
-                    server.Get.Add("/nuget/$metadata", r =>
-                       Util.GetMockServerResource());
-                    server.Get.Add("/nuget/Packages", r =>
-                    {
-                        requests.Add(r.Url.ToString());
-                        return HttpStatusCode.NotFound;
-                    });
-                    server.Get.Add("/nuget", r => "OK");
-
-                    server.Start();
-
-                    // Act
-                    var args = "install testPackage1 -Version 1.1 -Source " + server.Uri + "nuget";
-                    var r1 = CommandRunner.Run(
-                        nugetexe,
-                        workingPath,
-                        args,
-                        waitForExit: true);
-
-                    // Assert
-                    Assert.True(1 == r1.Item1, r1.Item2 + " " + r1.Item3);
-
-                    Assert.Equal(3, requests.Count);
-                    Assert.True(requests[0].EndsWith("Packages(Id='testPackage1',Version='1.1')"));
-                    Assert.True(requests[1].EndsWith("Packages(Id='testPackage1',Version='1.1.0')"));
-                    Assert.True(requests[2].EndsWith("Packages(Id='testPackage1',Version='1.1.0.0')"));
-                }
-            }
-        }
-
         // Tests that nuget will NOT download package from http source if the package on the server
         // has the same hash value as the cached version.
-        [Fact(Skip = "Failing on CI Build need to investigate the reason")]
-        public void InstallCommand_WillUseCachedFile()
+        [Fact]
+        public async Task InstallCommand_WillUseCachedFile()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var packageDirectory = pathContext.PackageSource;
                 var repositoryPath = Path.Combine(workingPath, "Repository");
                 var proj1Directory = Path.Combine(workingPath, "proj1");
 
@@ -854,13 +1082,12 @@ namespace NuGet.CommandLine.Test
                 var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
                 var package = new ZipPackage(packageFileName);
 
-                // add the package to machine cache
-                MachineCache.Default.AddPackage(package);
+                await SimpleTestPackageUtility.CreateFolderFeedV3(pathContext.UserPackagesFolder, PackageSaveMode.Defaultv3, new PackageIdentity("testPackage1", NuGetVersion.Parse("1.1.0")));
 
                 using (var server = new MockServer())
                 {
-                    string findPackagesByIdRequest = string.Empty;
-                    bool packageDownloadIsCalled = false;
+                    var findPackagesByIdRequest = string.Empty;
+                    var packageDownloadIsCalled = false;
 
                     server.Get.Add("/nuget/$metadata", r =>
                        Util.GetMockServerResource());
@@ -869,7 +1096,7 @@ namespace NuGet.CommandLine.Test
                         {
                             findPackagesByIdRequest = r.Url.ToString();
                             response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
-                            string feed = server.ToODataFeed(new[] { package }, "FindPackagesById");
+                            var feed = server.ToODataFeed(new[] { package }, "FindPackagesById");
                             MockServer.SetResponseContent(response, feed);
                         }));
 
@@ -898,103 +1125,14 @@ namespace NuGet.CommandLine.Test
                     server.Start();
 
                     // Act
-                    var args = "install testPackage1 -Source " + server.Uri + "nuget";
-                    var r1 = CommandRunner.Run(
-                        nugetexe,
-                        workingPath,
-                        args,
-                        waitForExit: true);
+                    var args = "-Source " + server.Uri + "nuget";
+
+                    var r1 = RunInstall(pathContext, "testPackage1", 0, args);
 
                     // Assert
-                    Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-
                     // verifies that package is NOT downloaded from server since nuget uses
                     // the file in machine cache.
                     Assert.False(packageDownloadIsCalled);
-                }
-            }
-        }
-
-        // Tests that nuget will download package from http source if the package on the server
-        // has a different hash value from the cached version.
-        [Fact(Skip = "Hashes are no longer checked on download")]
-        public void InstallCommand_DownloadPackageWhenHashChanges()
-        {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var workingPath = TestDirectory.Create())
-            using (var packageDirectory = TestDirectory.Create())
-            {
-                // Arrange
-                var repositoryPath = Path.Combine(workingPath, "Repository");
-                var proj1Directory = Path.Combine(workingPath, "proj1");
-
-                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
-                var package = new ZipPackage(packageFileName);
-                MachineCache.Default.RemovePackage(package);
-
-                // add the package to machine cache
-                MachineCache.Default.AddPackage(package);
-
-                // create a new package. Now this package has different hash value from the package in
-                // the machine cache.
-                packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
-                package = new ZipPackage(packageFileName);
-
-                using (var server = new MockServer())
-                {
-                    string findPackagesByIdRequest = string.Empty;
-                    bool packageDownloadIsCalled = false;
-
-                    server.Get.Add("/nuget/$metadata", r =>
-                       Util.GetMockServerResource());
-                    server.Get.Add("/nuget/FindPackagesById()", r =>
-                        new Action<HttpListenerResponse>(response =>
-                        {
-                            findPackagesByIdRequest = r.Url.ToString();
-                            response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
-                            string feed = server.ToODataFeed(new[] { package }, "FindPackagesById");
-                            MockServer.SetResponseContent(response, feed);
-                        }));
-
-                    server.Get.Add("/nuget/Packages(Id='testPackage1',Version='1.1.0')", r =>
-                        new Action<HttpListenerResponse>(response =>
-                        {
-                            response.ContentType = "application/atom+xml;type=entry;charset=utf-8";
-                            var p1 = server.ToOData(package);
-                            MockServer.SetResponseContent(response, p1);
-                        }));
-
-                    server.Get.Add("/package/testPackage1", r =>
-                        new Action<HttpListenerResponse>(response =>
-                        {
-                            packageDownloadIsCalled = true;
-                            response.ContentType = "application/zip";
-                            using (var stream = package.GetStream())
-                            {
-                                var content = stream.ReadAllBytes();
-                                MockServer.SetResponseContent(response, content);
-                            }
-                        }));
-
-                    server.Get.Add("/nuget", r => "OK");
-
-                    server.Start();
-
-                    // Act
-                    var args = "install testPackage1 -Source " + server.Uri + "nuget";
-                    var r1 = CommandRunner.Run(
-                        nugetexe,
-                        workingPath,
-                        args,
-                        waitForExit: true);
-
-                    // Assert
-                    Assert.Equal(0, r1.Item1);
-
-                    // verifies that package is downloaded from server since the cached version has
-                    // a different hash from the package on the server.
-                    Assert.True(packageDownloadIsCalled);
                 }
             }
         }
@@ -1004,19 +1142,22 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_PreferNonSymbolPackage()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
+
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source);
                 var symbolPackageFileName = PackageCreater.CreateSymbolPackage(
                     "testPackage1", "1.1.0", source);
 
+                var nugetexe = Util.GetNuGetExePath();
+
                 // Act
-                string[] args = new string[] {
+                var args = new string[] {
                     "install", "testPackage1",
                     "-OutputDirectory", outputDirectory,
                     "-Source", source };
@@ -1024,7 +1165,7 @@ namespace NuGet.CommandLine.Test
                 var r = CommandRunner.Run(
                     nugetexe,
                     Directory.GetCurrentDirectory(),
-                    String.Join(" ", args),
+                    string.Join(" ", args),
                     waitForExit: true);
 
                 // Assert
@@ -1044,11 +1185,12 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_DependencyResolutionFailure()
         {
-            var nugetexe = Util.GetNuGetExePath();
-
-            using (var source = TestDirectory.Create())
-            using (var outputDirectory = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var workingPath = pathContext.WorkingDirectory;
+                var source = pathContext.PackageSource;
+                var outputDirectory = pathContext.SolutionRoot;
+
                 // Arrange
                 var packageFileName = PackageCreater.CreatePackage(
                     "testPackage1", "1.1.0", source,
@@ -1063,8 +1205,10 @@ namespace NuGet.CommandLine.Test
                         builder.DependencySets.Add(dependencySet);
                     });
 
+                var nugetexe = Util.GetNuGetExePath();
+
                 // Act
-                var args = String.Format(
+                var args = string.Format(
                     CultureInfo.InvariantCulture,
                     "install testPackage1 -OutputDirectory {0} -Source {1}", outputDirectory, source);
                 var r = CommandRunner.Run(
@@ -1095,11 +1239,14 @@ namespace NuGet.CommandLine.Test
                 {"HighestPatch", "1.1", "1.1.1" }
             };
 
-            for (int i = 0; i < variations.GetLength(0); i++)
+            for (var i = 0; i < variations.GetLength(0); i++)
             {
-                using (var source = TestDirectory.Create())
-                using (var outputDirectory = TestDirectory.Create())
+                using (var pathContext = new SimpleTestPathContext())
                 {
+                    var workingPath = pathContext.WorkingDirectory;
+                    var source = pathContext.PackageSource;
+                    var outputDirectory = pathContext.SolutionRoot;
+
                     // Arrange
                     Util.CreateTestPackage("depPackage", "1.1.0", source);
                     Util.CreateTestPackage("depPackage", "1.1.1", source);
@@ -1129,13 +1276,13 @@ namespace NuGet.CommandLine.Test
                     string cmd;
                     if (variations[i, 0] == null)
                     {
-                        cmd = String.Format(
+                        cmd = string.Format(
                             CultureInfo.InvariantCulture,
                             "install testPackage -OutputDirectory {0} -Source {1}", outputDirectory, source);
                     }
                     else
                     {
-                        cmd = String.Format(
+                        cmd = string.Format(
                             CultureInfo.InvariantCulture,
                             "install testPackage -OutputDirectory {0} -Source {1} -DependencyVersion {2}", outputDirectory, source, variations[i, 0]);
                     }
@@ -1148,7 +1295,7 @@ namespace NuGet.CommandLine.Test
                     // Assert
                     Assert.Equal(0, r.Item1);
                     // verify nuget grabs the earliest by default
-                    string depPackageFile = outputDirectory + @"\depPackage." + variations[i, 2] + @"\depPackage." + variations[i, 2] + ".nupkg";
+                    var depPackageFile = outputDirectory + @"\depPackage." + variations[i, 2] + @"\depPackage." + variations[i, 2] + ".nupkg";
                     Assert.True(File.Exists(depPackageFile));
                 }
             }
@@ -1163,9 +1310,11 @@ namespace NuGet.CommandLine.Test
         {
             var nugetexe = Util.GetNuGetExePath();
 
-            using (var randomTestFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
-                bool credentialsPassedToRegistrationEndPoint = false;
+                var randomTestFolder = pathContext.WorkingDirectory;
+
+                var credentialsPassedToRegistrationEndPoint = false;
 
                 // Server setup
                 using (var serverV3 = new MockServer())
@@ -1177,7 +1326,7 @@ namespace NuGet.CommandLine.Test
                     serverV3.Get.Add("/a/b/c/index.json", r =>
                     {
                         var h = r.Headers["Authorization"];
-                        var credential = String.IsNullOrEmpty(h) ?
+                        var credential = string.IsNullOrEmpty(h) ?
                             null :
                             System.Text.Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
 
@@ -1203,7 +1352,7 @@ namespace NuGet.CommandLine.Test
                     serverV3.Get.Add("/reg/test_package/index.json", r =>
                     {
                         var h = r.Headers["Authorization"];
-                        var credential = String.IsNullOrEmpty(h) ?
+                        var credential = string.IsNullOrEmpty(h) ?
                             null :
                             System.Text.Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
 
@@ -1249,7 +1398,7 @@ namespace NuGet.CommandLine.Test
                     File.WriteAllText(configFileName, config);
 
                     // Act
-                    string[] args = new string[]
+                    var args = new string[]
                     {
                         "install test_package",
                         "-Source ",
@@ -1273,9 +1422,10 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void TestInstallWhenNoFeedAvailable()
         {
-            var nugetexe = Util.GetNuGetExePath();
-            using (var randomTestFolder = TestDirectory.Create())
+            using (var pathContext = new SimpleTestPathContext())
             {
+                var randomTestFolder = pathContext.SolutionRoot;
+
                 // Create an empty config file and pass it as -ConfigFile switch.
                 // This imitates the scenario where there is a machine without a default nuget.config under %APPDATA%
                 // In this case, nuget will not create default nuget.config for user.
@@ -1286,7 +1436,8 @@ namespace NuGet.CommandLine.Test
                 var configFileName = Path.Combine(randomTestFolder, "nuget.config");
                 File.WriteAllText(configFileName, config);
 
-                string[] args = new string[]
+                var nugetexe = Util.GetNuGetExePath();
+                var args = new string[]
                 {
                         "install Newtonsoft.Json",
                         "-version",
@@ -1308,6 +1459,39 @@ namespace NuGet.CommandLine.Test
 
                 Assert.False(File.Exists(expectedPath), "nuget.exe installed Newtonsoft.Json.7.0.1");
             }
+        }
+
+        public static CommandRunnerResult RunInstall(SimpleTestPathContext pathContext, string input, int expectedExitCode = 0, params string[] additionalArgs)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Store the dg file for debugging
+            var envVars = new Dictionary<string, string>()
+            {
+                { "NUGET_HTTP_CACHE_PATH", pathContext.HttpCacheFolder }
+            };
+
+            var args = new string[] {
+                    "install",
+                    input,
+                    "-Verbosity",
+                    "detailed"
+                };
+
+            args = args.Concat(additionalArgs).ToArray();
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                pathContext.WorkingDirectory,
+                string.Join(" ", args),
+                waitForExit: true,
+                environmentVariables: envVars);
+
+            // Assert
+            Assert.True(expectedExitCode == r.Item1, r.Item3 + "\n\n" + r.Item2);
+
+            return r;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ProjectManagement/FolderNuGetProjectTests.cs
@@ -25,9 +25,9 @@ namespace NuGet.ProjectManagement.Test
         [Fact]
         public void Constructor_String_ThrowsForNullRoot()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new FolderNuGetProject(root: null));
+            var exception = Assert.Throws<ArgumentException>(() => new FolderNuGetProject(root: null));
 
-            Assert.Equal("root", exception.ParamName);
+            Assert.Equal("rootDirectory", exception.ParamName);
         }
 
         [Fact]


### PR DESCRIPTION
Improvements for nuget.exe install
    
* Allow updating packages when -ExcludeVersion is used
* Improved detection of already installed packages when -ExcludeVersion is used
* Adding -Framework switch to allow setting the target framework used when resolving dependencies.
* Remove NU1000 code from packages.config restore errors.
* Avoid unneeded downloads when a version is not given and the package is cached.
* Disable parallel for mono
* Display errors and return a non-zero exit when install on packages.config fails
* Remove old files during upgrades with -ExcludeVersion
* Adding tests for nuget.exe install -ExcludeVersion scenarios and failure cases.
* Improving current nuget.exe install tests to avoid packages getting shared through the global packages folder.
* Removing old skipped install command tests that no longer apply
* Re-enabling caching test for install

Fixes https://github.com/NuGet/Home/issues/5743
Fixes https://github.com/NuGet/Home/issues/5737
Fixes https://github.com/NuGet/Home/issues/5736
Fixes https://github.com/NuGet/Home/issues/5741
Fixes https://github.com/NuGet/Home/issues/5017
Fixes https://github.com/NuGet/Home/issues/3957
Fixes https://github.com/NuGet/Home/issues/2405
Partial fix for https://github.com/NuGet/Home/issues/3244