### PR TITLE
Dev zhi osx check

### DIFF
--- a/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
+++ b/src/NuGet.Core/NuGet.Common/RuntimeEnvironmentHelper.cs
@@ -1,13 +1,17 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace NuGet.Common
 {
     public static class RuntimeEnvironmentHelper
     {
         private static Lazy<bool> _isMono = new Lazy<bool>(() => Type.GetType("Mono.Runtime") != null);
+
+        [DllImport("libc")]
+        static extern int uname(IntPtr buf);
 
         public static bool IsDev14 { get; set; }
 
@@ -48,8 +52,35 @@ namespace NuGet.Common
 
                 return false;
 #else
-                var platform = (int)Environment.OSVersion.Platform;
-                return platform == 6;
+                var buf = IntPtr.Zero;
+
+                try
+                {
+                    buf = Marshal.AllocHGlobal(8192);
+
+                    // This is a hacktastic way of getting sysname from uname ()
+                    if (uname(buf) == 0)
+                    {
+                        var os = Marshal.PtrToStringAnsi(buf);
+
+                        if (os == "Darwin")
+                        {
+                            return true;
+                        }
+                    }
+                }
+                catch
+                {
+                }
+                finally
+                {
+                    if (buf != IntPtr.Zero)
+                    {
+                        Marshal.FreeHGlobal(buf);
+                    }
+                }
+
+                return false;
 #endif
             }
         }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -3629,7 +3629,7 @@ namespace Proj2
     }
 }");
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }
@@ -3758,7 +3758,7 @@ namespace Proj2
     }
 }");
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -481,7 +481,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 
 
             var msbuildPath = Util.GetMsbuildPathOnWindows();
-            if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+            if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
             {
                 msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
             }
@@ -539,7 +539,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 
 
             var msbuildPath = Util.GetMsbuildPathOnWindows();
-            if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+            if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
             {
                 msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -71,7 +71,7 @@ namespace NuGet.CommandLine
 
                 // Act
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }
@@ -145,7 +145,7 @@ namespace NuGet.CommandLine
                 File.WriteAllText(projectPath, projectXml);
 
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }
@@ -219,7 +219,7 @@ namespace NuGet.CommandLine
                 File.WriteAllText(projectPath, projectXml);
 
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }
@@ -293,7 +293,7 @@ namespace NuGet.CommandLine
                 File.WriteAllText(projectPath, projectXml);
 
                 var msbuildPath = Util.GetMsbuildPathOnWindows();
-                if (RuntimeEnvironmentHelper.IsMono && Util.IsRunningOnMac())
+                if (RuntimeEnvironmentHelper.IsMono && RuntimeEnvironmentHelper.IsMacOSX)
                 {
                     msbuildPath = @"/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/msbuild/15.0/bin/";
                 }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Globalization;
@@ -23,9 +23,6 @@ namespace NuGet.CommandLine.Test
     public static class Util
     {
         private static readonly string NupkgFileFormat = "{0}.{1}.nupkg";
-
-        [DllImport("libc")]
-        static extern int uname(IntPtr buf);
 
         public static string GetMockServerResource()
         {
@@ -1159,47 +1156,6 @@ EndProject");
         public static string GetHintPath(string path)
         {
             return @"<HintPath>.." + Path.DirectorySeparatorChar + path + @"</HintPath>";
-        }
-
-        public static bool IsRunningOnMac()
-        {
-
-            IntPtr buf = IntPtr.Zero;
-
-            try
-            {
-
-                buf = Marshal.AllocHGlobal(8192);
-
-                // This is a hacktastic way of getting sysname from uname ()
-
-                if (uname(buf) == 0)
-                {
-
-                    string os = Marshal.PtrToStringAnsi(buf);
-
-                    if (os == "Darwin")
-
-                        return true;
-
-                }
-
-            }
-            catch
-            {
-
-            }
-            finally
-            {
-
-                if (buf != IntPtr.Zero)
-
-                    Marshal.FreeHGlobal(buf);
-
-            }
-
-            return false;
-
         }
 
         private static bool IsProjectJson(string configFileName)


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/4648

"The RuntimeEnvironmentHelper.IsLinux helper should be improved to properly detect OSX when running on Mono.
Currently this method returns true when on OSX. In many scenarios this method is used to check if the file system is case sensitive. We should fix up any areas where this is being used incorrectly"

the "Environment.OSVersion.Platform == 4" check is actually Unix check, so RuntimeEnvironmentHelper.IsLinux return true on OSX.

the issue here is OSX check return false on OSX, talked with mono guys, they will not fix this and provided the "uname" workaround.

