### PR TITLE
make pack task read target frameworks same way as restore

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Compile Include="..\NuGet.Build.Tasks\Common\MSBuildLogger.cs" />
+    <Compile Include="..\NuGet.Build.Tasks\GetProjectTargetFrameworksTask.cs" />
     <Content Include="Pack.targets">
        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -51,21 +52,15 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <Target Name="PublishAndMergePackNupkg"  AfterTargets="AfterBuild" Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' == 'false' AND '$(BuildingInsideVisualStudio)' != 'true'">
-    <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="Publish;ILMergeNuGetPack"/>
+  <Target Name="PublishAndMergePackNupkg" AfterTargets="AfterBuild" Condition="'$(TargetFramework)' != '' AND '$(IsXPlat)' == 'false' AND '$(BuildingInsideVisualStudio)' != 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish;ILMergeNuGetPack" />
   </Target>
 
   <Target Name="ILMergeNuGetPackResourcesPerCulture" DependsOnTargets="Publish">
     <ItemGroup>
-      <_PackResourceDlls Include="$(OutputPath)**\$(AssemblyName).resources.dll"/>
+      <_PackResourceDlls Include="$(OutputPath)**\$(AssemblyName).resources.dll" />
     </ItemGroup>
-    <MSBuild
-      Projects="$(MSBuildProjectFullPath)"
-      Targets="ILMergeNuGetPackResources"
-      Properties="CurrentCulture=%(_PackResourceDlls.RecursiveDir);
-                  BuildProjectReferences=false">
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="ILMergeNuGetPackResources" Properties="CurrentCulture=%(_PackResourceDlls.RecursiveDir);&#xD;&#xA;                  BuildProjectReferences=false">
     </MSBuild>
   </Target>
 
@@ -73,7 +68,7 @@
     <PropertyGroup>
       <ILMergeResultDir>$(OutputPath)ilmerge</ILMergeResultDir>
     </PropertyGroup>
-    <MakeDir Directories="$(ILMergeResultDir)"/>
+    <MakeDir Directories="$(ILMergeResultDir)" />
     <ItemGroup>
       <BuildArtifacts Include="$(OutputPath)*.dll" Exclude="$(OutputPath)*Pack.dll" />
     </ItemGroup>
@@ -89,7 +84,7 @@
     <PropertyGroup>
       <ILMergeResultDir>$(OutputPath)ilmerge\$(CurrentCulture)</ILMergeResultDir>
     </PropertyGroup>
-    <MakeDir Directories="$(ILMergeResultDir)"/>
+    <MakeDir Directories="$(ILMergeResultDir)" />
     <ItemGroup>
       <ResourceArtifacts Include="$(OutputPath)$(CurrentCulture)NuGet*.resources.dll" Exclude="$(OutputPath)$(CurrentCulture)*Pack.resources.dll" />
     </ItemGroup>

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
 ***********************************************************************************************
 NuGet.targets
 
@@ -10,20 +10,21 @@ Copyright (c) .NET Foundation. All rights reserved.
 ***********************************************************************************************
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NugetTaskAssemblyFile) -->
-  <PropertyGroup Condition="$(NugetTaskAssemblyFile) == ''">
-    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
-    <NugetTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NugetTaskAssemblyFile>
+  <!-- Load NuGet.Build.Tasks.Pack.dll, this can be overridden to use a different version with $(NuGetPackTaskAssemblyFile) -->
+  <PropertyGroup Condition="$(NuGetPackTaskAssemblyFile) == ''">
+    <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' == 'Core'">..\CoreCLR\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
+    <NuGetPackTaskAssemblyFile Condition="'$(MSBuildRuntimeType)' != 'Core'">..\Desktop\NuGet.Build.Tasks.Pack.dll</NuGetPackTaskAssemblyFile>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NugetTaskAssemblyFile)" />
-  <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NugetTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.Pack.PackTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.Pack.GetPackOutputItemsTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
 
   <PropertyGroup>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
-    <GenerateNuspecDependsOn>_LoadPackInputItems; _WalkEachTargetPerFramework; _GetPackageFiles; $(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
+    <GenerateNuspecDependsOn>_LoadPackInputItems; _GetTargetFrameworksOutput; _WalkEachTargetPerFramework; _GetPackageFiles; $(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
     <Description Condition="'$(Description)'==''">Package Description</Description>
     <IsPackable Condition="'$(IsPackable)'=='' AND '$(IsTestProject)'=='true'">false</IsPackable>
     <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
@@ -45,8 +46,6 @@ Copyright (c) .NET Foundation. All rights reserved.
   </PropertyGroup>
   <ItemGroup>
     <ProjectCapability Include="Pack"/>
-    <_TargetFrameworks Condition="'$(TargetFramework)' == ''" Include="$(TargetFrameworks.Split(';'))"/>
-    <_TargetFrameworks Condition="'$(TargetFramework)' != ''" Include="$(TargetFramework)"/>
   </ItemGroup>
   <ItemDefinitionGroup>
     <BuildOutputInPackage>
@@ -80,6 +79,37 @@ Copyright (c) .NET Foundation. All rights reserved.
         TaskParameter="OutputPackItems"
         ItemName="_OutputPackItems" />
     </GetPackOutputItemsTask>
+  </Target>
+
+  <!--
+    ============================================================
+    _GetTargetFrameworksOutput
+    Read target frameworks from the project.
+    ============================================================
+  -->
+  <Target Name="_GetTargetFrameworksOutput"
+    Returns="@(_TargetFrameworks)">
+
+    <PropertyGroup>
+      <_ProjectFrameworks></_ProjectFrameworks>
+    </PropertyGroup>
+
+      <GetProjectTargetFrameworksTask
+      ProjectPath="$(MSBuildProjectFullPath)"
+      TargetFrameworks="$(TargetFrameworks)"
+      TargetFramework="$(TargetFramework)"
+      TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+      TargetPlatformIdentifier="$(TargetPlatformIdentifier)"
+      TargetPlatformVersion="$(TargetPlatformVersion)"
+      TargetPlatformMinVersion="$(TargetPlatformMinVersion)">
+      <Output
+        TaskParameter="ProjectTargetFrameworks"
+        PropertyName="_ProjectFrameworks" />
+    </GetProjectTargetFrameworksTask>
+
+    <ItemGroup Condition=" '$(_ProjectFrameworks)' != '' ">
+      <_TargetFrameworks Include="$(_ProjectFrameworks.Split(';'))" />
+    </ItemGroup>
   </Target>
 
   <!--

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetProjectTargetFrameworksTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
@@ -12,7 +12,7 @@ namespace NuGet.Build.Tasks
     /// Determine the project's targetframework(s) based
     /// on the available properties.
     /// </summary>
-    public class GetRestoreProjectFrameworks : Task
+    public class GetProjectTargetFrameworksTask : Task
     {
         /// <summary>
         /// Full path to the msbuild project.

--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -77,7 +77,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestorePackageReferencesTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreDotnetCliToolsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
-  <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreProjectFrameworks" AssemblyFile="$(RestoreTaskAssemblyFile)" />
+  <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSolutionProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.GetRestoreSettingsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
   <UsingTask TaskName="NuGet.Build.Tasks.WarnForInvalidProjectsTask" AssemblyFile="$(RestoreTaskAssemblyFile)" />
@@ -397,7 +397,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </PropertyGroup>
 
     <!-- For project.json projects target frameworks will be read from project.json. -->
-    <GetRestoreProjectFrameworks
+    <GetProjectTargetFrameworksTask
       Condition=" '$(RestoreProjectStyle)' != 'ProjectJson' "
       ProjectPath="$(MSBuildProjectFullPath)"
       TargetFrameworks="$(TargetFrameworks)"
@@ -409,7 +409,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output
         TaskParameter="ProjectTargetFrameworks"
         PropertyName="_RestoreProjectFramework" />
-    </GetRestoreProjectFrameworks>
+    </GetProjectTargetFrameworksTask>
 
     <ItemGroup Condition=" '$(_RestoreProjectFramework)' != '' ">
       <_RestoreTargetFrameworksOutputFiltered Include="$(_RestoreProjectFramework.Split(';'))" />


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5168
already have enough tests to verify we didn't break any existing scenario with this change.
i will see if i can easily add tests for packing legacy projects , otherwise will open up an engineering issue to build the infra.
