### PR TITLE
change nuget.exe logging to output file version

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/Command.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 extern alias CoreV2;
 
@@ -139,11 +139,13 @@ namespace NuGet.CommandLine
             if (ShouldOutputNuGetVersion)
             {
                 var assemblyName = Assembly.GetExecutingAssembly().GetName();
+                var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(assemblyLocation).FileVersion;
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     LocalizedResourceManager.GetString("OutputNuGetVersion"),
                     assemblyName.Name,
-                    assemblyName.Version);
+                    version);
                 Console.WriteLine(message);
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5746

Changes nuget.exe logging to output file version instead of the assembly version.

Context: When NuGet.exe runs any command, the first line printed out is the NuGet Version.

This currently prints out the assembly version but that has changed recently and now the exe ends up printing something like 4.3.0.6 rather than 4.3.0.4300ish.