### PR TITLE
enable buildAction to be overridden for contentFiles

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -370,46 +370,46 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Include PackageFiles and Content of the project being packed -->
     <ItemGroup>
       <_PackageFiles Include="@(Content)" Condition=" %(Content.Pack) != 'false' ">
-        <BuildAction>Content</BuildAction>
+        <BuildAction Condition = "'%(Content.BuildAction)' == ''">Content</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Compile)" Condition=" %(Compile.Pack) == 'true' ">
-        <BuildAction>Compile</BuildAction>
+        <BuildAction Condition = "'%(Compile.BuildAction)' == ''">Compile</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(None)" Condition=" %(None.Pack) == 'true' ">
-        <BuildAction>None</BuildAction>
+        <BuildAction Condition = "'%(None.BuildAction)' == ''">None</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(EmbeddedResource)" Condition=" %(EmbeddedResource.Pack) == 'true' ">
-        <BuildAction>EmbeddedResource</BuildAction>
+        <BuildAction Condition = "'%(EmbeddedResource.BuildAction)' == ''">EmbeddedResource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(ApplicationDefinition)" Condition=" %(ApplicationDefinition.Pack) == 'true' ">
-        <BuildAction>ApplicationDefinition</BuildAction>
+        <BuildAction Condition = "'%(ApplicationDefinition.BuildAction)' == ''">ApplicationDefinition</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Page)" Condition=" %(Page.Pack) == 'true' ">
-        <BuildAction>Page</BuildAction>
+        <BuildAction Condition = "'%(Page.BuildAction)' == ''">Page</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(Resource)" Condition=" %(Resource.Pack) == 'true' ">
-        <BuildAction>Resource</BuildAction>
+        <BuildAction Condition = "'%(Resource.BuildAction)' == ''">Resource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(SplashScreen)" Condition=" %(SplashScreen.Pack) == 'true' ">
-        <BuildAction>SplashScreen</BuildAction>
+        <BuildAction Condition = "'%(SplashScreen.BuildAction)' == ''">SplashScreen</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(DesignData)" Condition=" %(DesignData.Pack) == 'true' ">
-        <BuildAction>DesignData</BuildAction>
+        <BuildAction Condition = "'%(DesignData.BuildAction)' == ''">DesignData</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(DesignDataWithDesignTimeCreatableTypes)" Condition=" %(DesignDataWithDesignTimeCreatableTypes.Pack) == 'true' ">
-        <BuildAction>DesignDataWithDesignTimeCreatableTypes</BuildAction>
+        <BuildAction Condition = "'%(DesignDataWithDesignTimeCreatableTypes.BuildAction)' == ''">DesignDataWithDesignTimeCreatableTypes</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(CodeAnalysisDictionary)" Condition=" %(CodeAnalysisDictionary.Pack) == 'true' ">
-        <BuildAction>CodeAnalysisDictionary</BuildAction>
+        <BuildAction Condition = "'%(CodeAnalysisDictionary.BuildAction)' == ''">CodeAnalysisDictionary</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(AndroidAsset)" Condition=" %(AndroidAsset.Pack) == 'true' ">
-        <BuildAction>AndroidAsset</BuildAction>
+        <BuildAction Condition = "'%(AndroidAsset.BuildAction)' == ''">AndroidAsset</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(AndroidResource)" Condition=" %(AndroidResource.Pack) == 'true' ">
-        <BuildAction>AndroidResource</BuildAction>
+        <BuildAction Condition = "'%(AndroidResource.BuildAction)' == ''">AndroidResource</BuildAction>
       </_PackageFiles>
       <_PackageFiles Include="@(BundleResource)" Condition=" %(BundleResource.Pack) == 'true' ">
-        <BuildAction>BundleResource</BuildAction>
+        <BuildAction Condition = "'%(BundleResource.BuildAction)' == ''">BundleResource</BuildAction>
       </_PackageFiles>
     </ItemGroup>
   </Target>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1796,6 +1796,68 @@ namespace ClassLibrary
                         var frameworkSpecificGroup = frameworkItems.Where(t => t.TargetFramework.Equals(nugetFramework)).First();
                         Assert.True(frameworkSpecificGroup.Items.Contains(referenceAssembly) == pack);
                     }                    
+                }
+            }
+        }
+
+        [PlatformTheory(Platform.Windows)]
+        [InlineData("Content",                                      "",                                     "Content")]
+        [InlineData("Content",                                      "Page",                                 "Page")]
+        [InlineData("EmbeddedResource",                             "",                                     "EmbeddedResource")]
+        [InlineData("EmbeddedResource",                             "ApplicationDefinition",                "ApplicationDefinition")]
+        public void PackCommand_PackProject_OutputsBuildActionForContentFiles(string itemType, string buildAction, string expectedBuildAction )
+        {
+            // Arrange
+            using (var testDirectory = TestDirectory.Create())
+            {
+                var projectName = "ClassLibrary1";
+                var workingDirectory = Path.Combine(testDirectory, projectName);
+
+                // Create the subdirectory structure for testing possible source paths for the content file
+                var projectFile = Path.Combine(workingDirectory, $"{projectName}.csproj");
+
+                msbuildFixture.CreateDotnetNewProject(testDirectory.Path, projectName, " classlib");
+
+                File.WriteAllBytes(Path.Combine(workingDirectory, "abc.png"), new byte[0]);
+
+                using (var stream = new FileStream(projectFile, FileMode.Open, FileAccess.ReadWrite))
+                {
+                    var xml = XDocument.Load(stream);
+                    
+                    var attributes = new Dictionary<string, string>();
+                    attributes["Pack"] = "true";
+                    var properties = new Dictionary<string, string>();
+                    properties["BuildAction"] = buildAction;
+
+                    ProjectFileUtils.AddItem(
+                        xml,
+                        itemType,
+                        "abc.png",
+                        NuGetFramework.AnyFramework,
+                        properties,
+                        attributes);
+
+                    ProjectFileUtils.WriteXmlToFile(xml, stream);
+                }
+
+                msbuildFixture.RestoreProject(workingDirectory, projectName, string.Empty);
+                var nupkgPath = Path.Combine(workingDirectory, $"{projectName}.1.0.0.nupkg");
+                var nuspecPath = Path.Combine(workingDirectory, "obj", $"{projectName}.1.0.0.nuspec");
+                // Act
+                msbuildFixture.PackProject(workingDirectory, projectName, $"-o {workingDirectory}");
+
+                // Assert
+                Assert.True(File.Exists(nupkgPath), "The output .nupkg is not in the expected place");
+                Assert.True(File.Exists(nuspecPath), "The intermediate nuspec file is not in the expected place");
+
+                using (var nupkgReader = new PackageArchiveReader(nupkgPath))
+                {
+                    var nuspecReader = nupkgReader.NuspecReader;
+                    var contentFiles = nuspecReader.GetContentFiles().ToArray();
+
+                    Assert.True(contentFiles.Count() == 1);
+                    var contentFile = contentFiles[0];
+                    Assert.Equal(expectedBuildAction, contentFile.BuildAction);
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/4166

users can now specify additional metadata on items that go  to package as contentFiles so that the package can be built a certain way but consumed a different way.

>  The content that I want to pack is not going to be of that type in the library itself. For example, in my xUnit for Devices library, I have an App.Xaml.pp that is "Content" in my library, but the buildAction needs to be ApplicationDefinition. It cannot be "ApplicationDefinition" with metadata in the library itself. What it needs is Content or None with a metadata BuildAction where I can specify what it should be in the nuget.