### PR TITLE
Fix regex performance

### DIFF
--- a/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
+++ b/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs
@@ -61,7 +61,7 @@ namespace NuGet.Common
                 // regex wildcard adjustments for *nix-style file systems
                 pattern = pattern
                     .Replace(@"\.\*\*", @"\.[^/.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*/", "(.+/)*") //For recursive wildcards /**/, include the current directory.
+                    .Replace(@"\*\*/", "(?>.+/)*") //For recursive wildcards /**/, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^/]*(/)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character
@@ -72,7 +72,7 @@ namespace NuGet.Common
                 pattern = pattern
                     .Replace("/", @"\\") // On Windows, / is treated the same as \.
                     .Replace(@"\.\*\*", @"\.[^\\.]*") // .** should not match on ../file or ./file but will match .file
-                    .Replace(@"\*\*\\", @"(.+\\)*") //For recursive wildcards \**\, include the current directory.
+                    .Replace(@"\*\*\\", @"(?>.+\\)*") //For recursive wildcards \**\, include the current directory.
                     .Replace(@"\*\*", ".*") // For recursive wildcards that don't end in a slash e.g. **.txt would be treated as a .txt file at any depth
                     .Replace(@"\*", @"[^\\]*(\\)?") // For non recursive searches, limit it any character that is not a directory separator
                     .Replace(@"\?", "."); // ? translates to a single any character


### PR DESCRIPTION
Resolve https://github.com/NuGet/Home/issues/5016.

Use atomic grouping to disable backtracking.

Using the repro in https://github.com/NuGet/Home/issues/5016 and testing each NuGet.exe version 100 times, I see an improvement over 3.5.0 of ~10%.

![image](https://user-images.githubusercontent.com/12734758/29253852-912e54d2-803c-11e7-9691-eea430f23ddd.png)

CC @rohit21agrawal, @jussimattila