### PR TITLE
add public extension point to execute targets before pack

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -32,7 +32,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>
     <ContentTargetFolders Condition="'$(ContentTargetFolders)' == ''">content;contentFiles</ContentTargetFolders>
-    <PackDependsOn>GenerateNuspec; $(PackDependsOn)</PackDependsOn>
+    <PackDependsOn>$(BeforePack); _IntermediatePack; GenerateNuspec; $(PackDependsOn)</PackDependsOn>
     <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
     <NoBuild Condition="'$(GeneratePackageOnBuild)' == 'true'">true</NoBuild>
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
@@ -183,7 +183,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Main entry point for packing packages
     ============================================================
   -->
-  <Target Name="Pack" DependsOnTargets="_IntermediatePack;$(PackDependsOn)">
+  <Target Name="Pack" DependsOnTargets="$(PackDependsOn)">
   </Target>
   <Target Name="_IntermediatePack">
     <PropertyGroup>

--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/MsbuilldIntegrationTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -90,7 +90,7 @@ namespace Dotnet.Integration.Test
             Assert.True(result.Item3 == "", $"Restore failed with following message in error stream :\n {result.Item3}");
         }
 
-        internal void PackProject(string workingDirectory, string projectName, string args)
+        internal CommandRunnerResult PackProject(string workingDirectory, string projectName, string args)
         {
             var envVar = new Dictionary<string, string>();
             envVar.Add("MSBuildSDKsPath", MsBuildSdksPath);
@@ -101,6 +101,7 @@ namespace Dotnet.Integration.Test
                 environmentVariables: envVar);
             Assert.True(result.Item1 == 0, $"Pack failed with following log information :\n {result.Item3}");
             Assert.True(result.Item3 == "", $"Pack failed with following message in error stream :\n {result.Item3}");
+            return result;
         }
 
         internal void BuildProject(string workingDirectory, string projectName, string args)


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5143

This change basically adds a property ``` $(BeforePack) ```  (much like ```BeforeBuild``` and ```BeforeClean```) that a package author can use to define targets that need to run before pack.