### PR TITLE
fix package description so it doesn't collide with GenerateAssemblyInfo Task

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -25,7 +25,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
     <GenerateNuspecDependsOn>_LoadPackInputItems; _GetTargetFrameworksOutput; _WalkEachTargetPerFramework; _GetPackageFiles; $(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
-    <Description Condition="'$(Description)'==''">Package Description</Description>
+    <PackageDescription Condition="'$(PackageDescription)'==''">$(Description)</PackageDescription>
+    <PackageDescription Condition="'$(PackageDescription)'==''">Package Description</PackageDescription>
     <IsPackable Condition="'$(IsPackable)'=='' AND '$(IsTestProject)'=='true'">false</IsPackable>
     <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
@@ -201,7 +202,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               PackageId="$(PackageId)"
               Title="$(Title)"
               Authors="$(Authors)"
-              Description="$(Description)"
+              Description="$(PackageDescription)"
               Copyright="$(Copyright)"
               RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
               LicenseUrl="$(PackageLicenseUrl)"


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5374

Pack.targets sets the default value of Description property to "Package Description":

```    <Description Condition="'$(Description)'==''">Package Description</Description>```

If the project doesn't set Description this default value ends up in its AssemblyDescriptionAttribute:

``` <AssemblyAttribute Include="System.Reflection.AssemblyDescriptionAttribute" Condition="'$(Description)' != '' and '$(GenerateAssemblyDescriptionAttribute)' == 'true'"> ```