### PR TITLE
[WIP] [Suggestion] Adding the ability to simulate a package update

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class NuGetCommand {
@@ -14492,6 +14492,15 @@ namespace NuGet.CommandLine {
         internal static string UpdateCommandVersionDescription {
             get {
                 return ResourceManager.GetString("UpdateCommandVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shows which packages would be updated, but makes no changes.
+        /// </summary>
+        internal static string WhatIf {
+            get {
+                return ResourceManager.GetString("WhatIf", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetCommand.resx
@@ -5345,4 +5345,7 @@ nuget locals global-packages -list</value>
   <data name="InstallCommandFrameworkDescription" xml:space="preserve">
     <value>Target framework used for selecting dependencies. Defaults to 'Any' if not specified.</value>
   </data>
+  <data name="WhatIf" xml:space="preserve">
+    <value>Shows which packages would be updated, but makes no changes</value>
+  </data>
 </root>

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class NuGetResources {
@@ -15775,6 +15775,24 @@ namespace NuGet.CommandLine {
         public static string UpdateCommandUpdatingNuGet_trk {
             get {
                 return ResourceManager.GetString("UpdateCommandUpdatingNuGet_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos; would be updated from &apos;{1}&apos; to &apos;{2}&apos;.
+        /// </summary>
+        public static string UpdateWhatIf {
+            get {
+                return ResourceManager.GetString("UpdateWhatIf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package &apos;{0}&apos;, version &apos;{1}&apos; would be installed for the first time.
+        /// </summary>
+        public static string UpdateWhatIfNew {
+            get {
+                return ResourceManager.GetString("UpdateWhatIfNew", resourceCulture);
             }
         }
         

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -6133,4 +6133,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="InstallPackageMessage" xml:space="preserve">
     <value>Installing package '{0}' to '{1}'.</value>
   </data>
+  <data name="UpdateWhatIf" xml:space="preserve">
+    <value>Package '{0}' would be updated from '{1}' to '{2}'</value>
+  </data>
+  <data name="UpdateWhatIfNew" xml:space="preserve">
+    <value>Package '{0}', version '{1}' would be installed for the first time</value>
+  </data>
 </root>


### PR DESCRIPTION
**What is this?**

A new command line option for "nuget update", which lets a user simulate rather than actually perform the update. It's similar to the "-whatif" option which is already available in some of the PMC cmdlets. 

When this option is included, nuget will not make any modifications. Instead, it will print the package name, the currently installed version, and the version it would update to (taking into account whether the user has opted into prelease packages). If a package installation brings in any new dependencies, the user will be informed about a new package install rather than a version update.

**Why?**

We have often wanted to be able to run CI tasks that report on packages being out of date, or report on new major version availability, etc. In some cases, we’d even like to fail a build if a package is no longer up to date. We cannot currently do this because the existing cmdlets can only run within the context of Visual Studio’s Package Management Console. 

**Is this PR 100% ready?**

No. While I've scanned the wiki, I'm not very familiar with the codebase, so apologies in advance for violations of style, convention, architecture, etc. 

I really just wanted to show this to determine if there would be an appetite to include this as a feature addition? If so, I can raise an issue to associate it with, write any appropriate tests, refactor, etc.

Thanks for spending the time to read this!
