### PR TITLE
Fix LSL hangs part3 for right click context menu

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -170,6 +170,11 @@ namespace NuGet.PackageManagement.UI
 
         protected virtual void OnCurrentPackageChanged()
         {
+        }
+
+        public virtual void CreateProjectLists()
+        {
+            // by default do nothing, since it's only applicable at solution level.
         }
 
         public virtual void OnFilterChanged(ItemFilter? previousFilter, ItemFilter currentFilter)

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/PackageDetailControlModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,8 +23,6 @@ namespace NuGet.PackageManagement.UI
             IEnumerable<NuGetProject> nugetProjects)
             : base(nugetProjects)
         {
-            Debug.Assert(nugetProjects.Count() == 1);
-
             _solutionManager = solutionManager;
             _solutionManager.NuGetProjectUpdated += NuGetProjectChanged;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/NuGet.PackageManagement.UI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -108,6 +108,9 @@
     <Compile Include="Xamls\InfiniteScrollListBoxAutomationPeer.cs" />
     <Compile Include="Xamls\PackageManagementFormatWindow.xaml.cs">
       <DependentUpon>PackageManagementFormatWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Xamls\PackagesErrorBar.xaml.cs">
+      <DependentUpon>PackagesErrorBar.xaml</DependentUpon>
     </Compile>
     <Compile Include="Xamls\RestartRequestBar.xaml.cs">
       <DependentUpon>RestartRequestBar.xaml</DependentUpon>
@@ -275,6 +278,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Xamls\PrefixReservedIndicator.xaml">
+	  <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Xamls\PackagesErrorBar.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -241,6 +241,14 @@ namespace NuGet.PackageManagement.UI
 
         public async Task<SearchResult<IPackageSearchMetadata>> SearchAsync(ContinuationToken continuationToken, CancellationToken cancellationToken)
         {
+            // check if there is already a running initialization task for SolutionManager. If yes,
+            // search should wait until this is completed. This would usually happen when opening manager
+            //ui is the first nuget operation under LSL mode where it might take some time to initialize.
+            if (_context.SolutionManager.InitializationTask != null && !_context.SolutionManager.InitializationTask.IsCompleted)
+            {
+                await _context.SolutionManager.InitializationTask;
+            }
+
             if (continuationToken != null)
             {
                 return await _packageFeed.ContinueSearchAsync(continuationToken, cancellationToken);

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLoadContext.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageLoadContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,6 +31,8 @@ namespace NuGet.PackageManagement.UI
 
         public PackageSearchMetadataCache CachedPackages { get; set; }
 
+        public IVsSolutionManager SolutionManager { get; private set; }
+
         public PackageLoadContext(
             IEnumerable<SourceRepository> sourceRepositories,
             bool isSolution,
@@ -41,6 +43,7 @@ namespace NuGet.PackageManagement.UI
             PackageManager = uiContext.PackageManager;
             Projects = (uiContext.Projects ?? Enumerable.Empty<NuGetProject>()).ToArray();
             PackageManagerProviders = uiContext.PackageManagerProviders;
+            SolutionManager = uiContext.SolutionManager;
 
             _installedPackagesTask = PackageCollection.FromProjectsAsync(Projects, CancellationToken.None);
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -999,6 +999,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Refresh.
+        /// </summary>
+        public static string RefreshButtonLabel {
+            get {
+                return ResourceManager.GetString("RefreshButtonLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Multiple packages failed to uninstall. Restart Visual Studio to finish the process..
         /// </summary>
         public static string RequestRestartToCompleteUninstallMultiplePackages {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -680,5 +680,8 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   </data>
   <data name="Tooltip_PrefixReserved" xml:space="preserve">
     <value>The identity of this package has been verified by nuget.org</value>
+  </data>
+  <data name="RefreshButtonLabel" xml:space="preserve">
+    <value>Refresh</value>
   </data>
 </root>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackagesErrorBar.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackagesErrorBar.xaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="NuGet.PackageManagement.UI.PackagesErrorBar"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:resx="clr-namespace:NuGet.PackageManagement.UI">
+  <Border x:Name="ErrorBar" VerticalAlignment="Center" Visibility="Collapsed" BorderThickness="0,0,0,1">
+    <Grid Margin="0,4,0,6">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <TextBlock Name="ErrorMessage"
+                       VerticalAlignment="Center"
+                       TextWrapping="WrapWithOverflow" />
+      <Button
+                x:Name="RefreshButton"
+                VerticalAlignment="Center"
+                Grid.Column="1"
+                Content="{x:Static resx:Resources.RefreshButtonLabel}"
+                Click="ExecuteRefresh"
+                Margin="5,0,3,0"
+                Padding="8,2,8,2" />
+    </Grid>
+  </Border>
+</UserControl>

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackagesErrorBar.xaml.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/PackagesErrorBar.xaml.cs
@@ -1,0 +1,126 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Windows;
+using System.Windows.Controls;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.Shell;
+using NuGet.Packaging;
+using NuGet.ProjectManagement;
+using NuGet.VisualStudio;
+using Task = System.Threading.Tasks.Task;
+
+namespace NuGet.PackageManagement.UI
+{
+    [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "NuGet/Home#4833 Baseline")]
+    public partial class PackagesErrorBar : UserControl, INuGetProjectContext
+    {
+        private readonly ISolutionManager _solutionManager;
+
+        public event EventHandler RefreshUI;
+
+        public event EventHandler InitializationCompleted;
+
+        public PackageExtractionContext PackageExtractionContext { get; set; }
+
+        public ISourceControlManagerProvider SourceControlManagerProvider { get; }
+
+        public ProjectManagement.ExecutionContext ExecutionContext { get; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
+
+        public NuGetActionType ActionType { get; set; }
+
+        public TelemetryServiceHelper TelemetryService { get; set; }
+
+        public PackagesErrorBar(ISolutionManager solutionManager)
+        {
+            InitializeComponent();
+
+            _solutionManager = solutionManager;
+
+            // Start a task to check for all the project's packages file and accordingly update error bar.
+            // this would also be initlize VSSolutionManager first time, if it hasn't been initialized yet.
+            Task.Run(UpdateErrorBarAsync);
+
+            ErrorMessage.SetResourceReference(TextBlock.ForegroundProperty, VsBrushes.InfoTextKey);
+            ErrorBar.SetResourceReference(Border.BackgroundProperty, VsBrushes.InfoBackgroundKey);
+            ErrorBar.SetResourceReference(Border.BorderBrushProperty, VsBrushes.ActiveBorderKey);
+        }
+
+        private async Task UpdateErrorBarAsync()
+        {
+            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            try
+            {
+                var projects = await _solutionManager.GetNuGetProjectsAsync();
+                foreach (var project in projects)
+                {
+                    await project.GetInstalledPackagesAsync(CancellationToken.None);
+                }
+
+                ErrorBar.Visibility = Visibility.Collapsed;
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage.Text = ex.Message;
+                ErrorBar.Visibility = Visibility.Visible;
+            }
+            finally
+            {
+                InitializationCompleted?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private void ExecuteRefresh(object sender, EventArgs e)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.Run(UpdateErrorBarAsync);
+
+            // raise RefreshUI event to refresh the manager ui
+            RefreshUI?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void Log(MessageLevel level, string message, params object[] args)
+        {
+            if (args.Length > 0)
+            {
+                message = string.Format(CultureInfo.CurrentCulture, message, args);
+            }
+
+            ShowMessage(message);
+        }
+
+        public void CleanUp()
+        {
+            // for now, there is nothing to be cleaned but we might need it in future so it's already
+            // been called from main component.
+        }
+
+        public void ReportError(string message)
+        {
+            ShowMessage(message);
+        }
+
+        public FileConflictAction ResolveFileConflict(string message)
+        {
+            return FileConflictAction.IgnoreAll;
+        }
+
+        private void ShowMessage(string message)
+        {
+            NuGetUIThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            {
+                await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                ErrorMessage.Text = message;
+            });
+        }
+    }
+}

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/IVsProjectAdapterProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -12,6 +12,13 @@ namespace NuGet.PackageManagement.VisualStudio
     /// </summary>
     public interface IVsProjectAdapterProvider
     {
+        /// <summary>
+        /// Check if given file path exists from AnyCode api in LSL mode.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns>true, if file path exists</returns>
+        Task<bool> EntityExistsAsync(string filePath);
+
         /// <summary>
         /// Creates a project adapter for fully loaded project represented by DTE object.
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/VsProjectAdapterProvider.cs
@@ -45,6 +45,11 @@ namespace NuGet.PackageManagement.VisualStudio
             _vsSolution = new Lazy<IVsSolution>(() => serviceProvider.GetService<SVsSolution, IVsSolution>());
         }
 
+        public async Task<bool> EntityExistsAsync(string filePath)
+        {
+            return await _workspaceService.Value.EntityExistsAsync(filePath);
+        }
+
         public IVsProjectAdapter CreateAdapterForFullyLoadedProject(EnvDTE.Project dteProject)
         {
             return _threadingService.ExecuteSynchronously(

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Services/DeferredProjectWorkspaceService.cs
@@ -44,6 +44,14 @@ namespace NuGet.PackageManagement.VisualStudio
                 NuGetUIThreadHelper.JoinableTaskFactory);
         }
 
+        public async Task<bool> EntityExistsAsync(string filePath)
+        {
+            var workspace = SolutionWorkspaceService.CurrentWorkspace;
+            var indexService = workspace.GetIndexWorkspaceService();
+            var filePathExists = await indexService.EntityExists(filePath);
+            return filePathExists;
+        }
+
         public async Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath)
         {
             var workspace = SolutionWorkspaceService.CurrentWorkspace;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGet.PackageManagement.VisualStudio {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Strings {

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Telemetry/NuGetProjectTelemetryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/SolutionRestoreCommand.cs
@@ -147,7 +147,7 @@ namespace NuGet.SolutionRestoreManager
                     _restoreTask.IsCompleted &&
                     !ConsoleStatus.Value.IsBusy &&
                     !SolutionRestoreWorker.Value.IsBusy &&
-                    (await SolutionManager.Value.GetNuGetProjectsAsync()).Any();
+                    await SolutionManager.Value.DoesNuGetSupportsAnyProjectAsync();
             });
         }
 

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -582,30 +582,46 @@ namespace NuGetVSExtension
                 (uint)_VSRDTFLAGS.RDT_DontAddToMRU |
                 (uint)_VSRDTFLAGS.RDT_DontSaveAs;
 
-            if (!await SolutionManager.IsSolutionAvailableAsync())
+            if (await SolutionManager.SolutionHasDeferredProjectsAsync() && !SolutionManager.IsInitialized)
             {
-                throw new InvalidOperationException(Resources.SolutionIsNotSaved);
+                // when VSSolutionManager is not yet initialized, then do a quick pre-condition checks without initializing it fully
+                // which might take some time so we'll initialize it after showing the manager ui window.
+                var preCheckResult = await SolutionManager.CheckSolutionUIPreConditionsAsync();
+
+                // key represent if solution is available or not.
+                if (!preCheckResult.Key)
+                {
+                    throw new InvalidOperationException(Resources.SolutionIsNotSaved);
+                }
+
+                // value represent if there is any project in the solution which NuGet supports.
+                if (!preCheckResult.Value)
+                {
+                    // NOTE: The menu 'Manage NuGet Packages For Solution' will be disabled in this case.
+                    // But, it is possible, that, before NuGetPackage is loaded in VS, the menu is enabled and used.
+                    // For once, this message will be shown. Once the package is loaded, the menu will get disabled as appropriate
+                    MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
+                    return null;
+                }
+            }
+            else
+            {
+                // when VSSolutionManager is already initialized, then use the existing APIs to check pre-conditions.
+                if (!await SolutionManager.IsSolutionAvailableAsync())
+                {
+                    throw new InvalidOperationException(Resources.SolutionIsNotSaved);
+                }
+
+                var projects = await SolutionManager.GetNuGetProjectsAsync();
+                if (!projects.Any())
+                {
+                    MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
+                    return null;
+                }
             }
 
-            var projects = await SolutionManager.GetNuGetProjectsAsync();
-            if (!projects.Any())
-            {
-                // NOTE: The menu 'Manage NuGet Packages For Solution' will be disabled in this case.
-                // But, it is possible, that, before NuGetPackage is loaded in VS, the menu is enabled and used.
-                // For once, this message will be shown. Once the package is loaded, the menu will get disabled as appropriate
-                MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
-                return null;
-            }
-
-            // load packages.config. This makes sure that an exception will get thrown if there
-            // are problems with packages.config, such as duplicate packages. When an exception
-            // is thrown, an error dialog will pop up and this doc window will not be created.
-            foreach (var project in projects)
-            {
-                await project.GetInstalledPackagesAsync(CancellationToken.None);
-            }
-
-            var uiController = UIFactory.Create(projects.ToArray());
+            // pass empty array of NuGetProject
+            var uiController = UIFactory.Create(new NuGetProject[0]);
 
             var solutionName = (string)_dte.Solution.Properties.Item("Name").Value;
 
@@ -764,7 +780,7 @@ namespace NuGetVSExtension
                 command.Enabled =
                     IsSolutionExistsAndNotDebuggingAndNotBuilding() &&
                     !ConsoleStatus.Value.IsBusy &&
-                    (await SolutionManager.GetNuGetProjectsAsync()).Any();
+                    await SolutionManager.DoesNuGetSupportsAnyProjectAsync();
             });
         }
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NuGet.ProjectManagement;
@@ -23,6 +24,16 @@ namespace NuGet.PackageManagement.VisualStudio
         /// in the IDE.
         /// </summary>
         string DefaultNuGetProjectName { get; set; }
+
+        /// <summary>
+        /// Get the initialization status of SolutionManager
+        /// </summary>
+        bool IsInitialized { get; }
+
+        /// <summary>
+        /// Gets the SolutionManager initialization task, if there is one running.
+        /// </summary>
+        Task InitializationTask { get; set; }
 
         /// <summary>
         /// Retrieves <see cref="NuGetProject"/> instance associated with VS project.
@@ -74,5 +85,17 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return collection of safe name for all supported projects in solution.
         /// </summary>
         Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync();
+
+        /// <summary>
+        /// Check for all the pre-conditions before showing manager ui at solution level. And
+        /// return KeyValuePair, where key represents if solution is available to work. And
+        /// value represents if solution has any project which NuGet supports.
+        /// </summary>
+        Task<KeyValuePair<bool, bool>> CheckSolutionUIPreConditionsAsync();
+
+        /// <summary>
+        /// Returns true if solution has any deferred project.
+        /// </summary>
+        Task<bool> SolutionHasDeferredProjectsAsync();
     }
 }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Services/IDeferredProjectWorkspaceService.cs
@@ -9,6 +9,8 @@ namespace NuGet.VisualStudio
 {
     public interface IDeferredProjectWorkspaceService
     {
+        Task<bool> EntityExistsAsync(string filePath);
+
         Task<IEnumerable<string>> GetProjectReferencesAsync(string projectFilePath);
 
         Task<IMSBuildProjectDataService> GetMSBuildProjectDataServiceAsync(string projectFilePath, string targetFramework = null);

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/ISolutionManager.cs
@@ -91,6 +91,12 @@ namespace NuGet.PackageManagement
         /// This will only be applicable for VS15 and will do nothing for VS14.
         /// </summary>
         void EnsureSolutionIsLoaded();
+
+        /// <summary>
+        /// It's a quick check to know if NuGet supports any prokect of current solution
+        /// without initializing whole VSSolutionManager.
+        /// </summary>
+        Task<bool> DoesNuGetSupportsAnyProjectAsync();
     }
 
     public class NuGetProjectEventArgs : EventArgs

--- a/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/IDE/PackageRestoreManager.cs
@@ -168,17 +168,24 @@ namespace NuGet.PackageManagement
                     continue;
                 }
 
-                var nuGetProjectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
-                var installedPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
-                foreach (var installedPackageReference in installedPackageReferences)
+                try
                 {
-                    List<string> projectNames = null;
-                    if (!packageReferencesDict.TryGetValue(installedPackageReference, out projectNames))
+                    var nuGetProjectName = NuGetProject.GetUniqueNameOrName(nuGetProject);
+                    var installedPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
+                    foreach (var installedPackageReference in installedPackageReferences)
                     {
-                        projectNames = new List<string>();
-                        packageReferencesDict.Add(installedPackageReference, projectNames);
+                        List<string> projectNames = null;
+                        if (!packageReferencesDict.TryGetValue(installedPackageReference, out projectNames))
+                        {
+                            projectNames = new List<string>();
+                            packageReferencesDict.Add(installedPackageReference, projectNames);
+                        }
+                        projectNames.Add(nuGetProjectName);
                     }
-                    projectNames.Add(nuGetProjectName);
+                }
+                catch (Exception)
+                {
+                    // ignore failed projects, and continue with other projects
                 }
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -23,7 +23,11 @@ namespace NuGet.PackageManagement.UI.Test
         [Fact]
         public async Task MultipleSources_Works()
         {
+            var solutionManager = Mock.Of<IVsSolutionManager>();
             var uiContext = Mock.Of<INuGetUIContext>();
+            Mock.Get(uiContext)
+                .Setup(x => x.SolutionManager)
+                .Returns(solutionManager);
 
             var source1 = new Configuration.PackageSource("https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json", "NuGetVolatile");
             var source2 = new Configuration.PackageSource("https://api.nuget.org/v3/index.json", "NuGet.org");
@@ -32,6 +36,7 @@ namespace NuGet.PackageManagement.UI.Test
             var repositories = sourceRepositoryProvider.GetRepositories();
 
             var context = new PackageLoadContext(repositories, false, uiContext);
+
             var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
             var loader = new PackageItemLoader(context, packageFeed, "nuget");
 
@@ -60,7 +65,11 @@ namespace NuGet.PackageManagement.UI.Test
         [Fact]
         public async Task GetTotalCountAsync_Works()
         {
+            var solutionManager = Mock.Of<IVsSolutionManager>();
             var uiContext = Mock.Of<INuGetUIContext>();
+            Mock.Get(uiContext)
+                .Setup(x => x.SolutionManager)
+                .Returns(solutionManager);
 
             var source1 = new Configuration.PackageSource("https://dotnet.myget.org/F/nuget-volatile/api/v3/index.json", "NuGetVolatile");
             var source2 = new Configuration.PackageSource("https://api.nuget.org/v3/index.json", "NuGet.org");
@@ -69,6 +78,7 @@ namespace NuGet.PackageManagement.UI.Test
             var repositories = sourceRepositoryProvider.GetRepositories();
 
             var context = new PackageLoadContext(repositories, false, uiContext);
+
             var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
             var loader = new PackageItemLoader(context, packageFeed, "nuget");
 
@@ -80,9 +90,13 @@ namespace NuGet.PackageManagement.UI.Test
         [Fact]
         public async Task LoadNextAsync_Works()
         {
+            var solutionManager = Mock.Of<IVsSolutionManager>();
             var uiContext = Mock.Of<INuGetUIContext>();
-            var context = new PackageLoadContext(null, false, uiContext);
+            Mock.Get(uiContext)
+                .Setup(x => x.SolutionManager)
+                .Returns(solutionManager);
 
+            var context = new PackageLoadContext(null, false, uiContext);
             var packageFeed = new TestPackageFeed();
             var loader = new PackageItemLoader(context, packageFeed, TestSearchTerm, true);
 

--- a/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
+++ b/test/TestUtilities/Test.Utility/PackageManagement/TestSolutionManager.cs
@@ -153,6 +153,11 @@ namespace Test.Utility
             // do nothing
         }
 
+        public Task<bool> DoesNuGetSupportsAnyProjectAsync()
+        {
+            return Task.FromResult(true);
+        }
+
 #pragma warning disable 0067
 
         public event EventHandler<NuGetProjectEventArgs> NuGetProjectAdded;


### PR DESCRIPTION
This PR primarily fix LSL hangs issues for solution right click to see context menu and also when clicked manager ui option. But along with that, it also changes some of the existing UI behavior. Below is the complete summary of current vs new behavior.

Current Behavior:
1.	When you right click on solution, NuGet is initialized and all NuGet projects are created based of dte (which is typically very fast).
2.	You click “Manage NuGet Packages for Solution”,
a.	It first check 3 pre-conditions
i.	Check if Solution is available like opened or saved, etc…
ii.	Check if there is any project in solution which is supported by NuGet.
iii.	Try loading all the packages.config files to see all are valid to read all package references.
b.	Any failure of any condition, will result into an error dialog with appropriate message. And it will not launch manager ui.
c.	If all checks passed, then pops up the Manager UI and show “loading…” in scroll list until packages are available to be shown. 

New Behavior (with or without LSL mode):
1.	When you right click on solution, we do a quick check to see if NuGet options (Manage NuGet packages for solution, and Restore NuGet packages) are enabled or disabled. And accordingly show their status on context menu. It will be a fast check without initializing NuGet (if it hasn’t been initialized so far).
2.	You click “Manage NuGet packages for solution”,
a.	It checks for 2 pre-conditions (since these two checks are quick and won’t delay anything to either show manager ui or pop up error dialog in case any of the check fails)
i.	Check if Solution is available like opened or saved, etc… (Fast check)
ii.	Check if there is any project in solution which is supported by NuGet. (Fast check)
b.	Any failure of either condition, will result into an error dialog with appropriate message. And it will not launch manager ui.
c.	Pop-up Manage UI, which show “loading...” in scroll list until NuGet is initialized and packages are available to be shown.
i.	During loading, it now execute third check “try loading all the packages.config files to see all are valid”. And if there is any failure, then it will show a yellow bar (similar to missing packages one) with appropriate message and refresh button to reload the UI after fixing the issue.

Fixes https://github.com/NuGet/Home/issues/5723 

@rrelyea 