### PR TITLE
added solutionDir property during getProjectReferences

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -257,6 +257,7 @@ namespace NuGet.CommandLine
             AddPropertyIfHasValue(args, "RestoreSolutionDirectory", solutionDirectory);
             AddPropertyIfHasValue(args, "RestoreConfigFile", restoreConfigFile);
             AddPropertyIfHasValue(args, "RestorePackagesPath", packagesDirectory);
+            AddPropertyIfHasValue(args, "SolutionDir", solutionDirectory);
 
             // Add additional args to msbuild if needed
             var msbuildAdditionalArgs = Environment.GetEnvironmentVariable("NUGET_RESTORE_MSBUILD_ARGS");

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -2152,5 +2152,80 @@ EndProject");
                 Assert.Contains(globalPackagesFolder, match.Groups[1].Value);
             }
         }
+
+        [Fact]
+        public void RestoreCommand_ProjectContainsSolutionDirs()
+        {
+            using (var randomRepositoryPath = TestDirectory.Create())
+            using (var randomSolutionFolder = TestDirectory.Create())
+            {
+                // Arrange
+                var nugetexe = Util.GetNuGetExePath();
+                Util.CreateTestPackage("packageA", "1.1.0", randomRepositoryPath);
+
+                Util.CreateFile(randomSolutionFolder, "nuget.config",
+$@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <config>
+    <add key=""globalPackagesFolder"" value=""GlobalPackages"" />
+  </config>
+</configuration>");
+
+                var solutionFile = Path.Combine(randomSolutionFolder, "A.sln");
+                var targetFile = Path.Combine(randomSolutionFolder, "MSBuild.Community.Tasks.Targets");
+                var solutionFileContents
+                    = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") " +
+@"= ""proj"", ""proj\proj.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
+EndProject";
+                var targetFileContents
+                    = @"
+<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<Target Name=""test"">  
+    <Message Text = ""test"" />
+</Target>
+</Project>";
+
+                File.WriteAllText(solutionFile, solutionFileContents);
+                File.WriteAllText(targetFile, targetFileContents);
+
+                var projectDirectory = Path.Combine(randomSolutionFolder, "proj");
+                Directory.CreateDirectory(projectDirectory);
+
+                File.WriteAllText(
+                    Path.Combine(projectDirectory, "proj.csproj"),
+@"<Project ToolsVersion='15.0' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+<Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props""
+ Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
+  <PropertyGroup>
+    <ProjectGuid>{AA9CA553-8E25-477C-824F-0E5DFE3703DC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+   <ItemGroup>
+    <PackageReference Include=""packageA"">
+      <Version>1.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project=""$(SolutionDir)\MSBuild.Community.Tasks.Targets"" />
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+</Project>");
+
+                // Act
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    randomSolutionFolder,
+                    "restore  -Source " + randomRepositoryPath,
+                    waitForExit: true);
+
+                // Assert
+                Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);               
+                var packageFileA = Path.Combine(randomSolutionFolder, "GlobalPackages", "packagea","1.1.0", "packageA.1.1.0.nupkg");
+                Assert.True(File.Exists(packageFileA));
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/5649

the issue here is 
during nuget.exe restoring sln file, nuget try to start msbuild target on csproj for fetching projectReferences, if SolutionDir is used in csproj, it will point to the driver root.

the fix is set right path for SolutionDir 