### PR TITLE
Change template to net46, add non lsl tests as well

### DIFF
--- a/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/BuildIntegratedClassLibrary.csproj
+++ b/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/BuildIntegratedClassLibrary.csproj
@@ -11,7 +11,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/csClassLibrary.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/csClassLibrary.vstemplate
@@ -6,7 +6,7 @@
     <Icon Package="{CAE03EC1-301F-11d3-BF4B-00C349EFBC}" ID="4547" />
     <TemplateID>Microsoft.CSharp.ClassLibrary</TemplateID>
     <ProjectType>CSharp</ProjectType>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
+    <RequiredFrameworkVersion>4.6</RequiredFrameworkVersion>
     <SortOrder>20</SortOrder>
     <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
     <CreateNewFolder>true</CreateNewFolder>

--- a/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/project.json
+++ b/test/EndToEnd/ProjectTemplates/BuildIntegratedClassLibrary.zip/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "frameworks": {
-    "net45": {}
+    "net46": {}
   },
   "runtimes": {
     "win-anycpu": {},

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -589,3 +589,26 @@ function Test-BuildIntegratedLegacyRebuildDoesNotDeleteCacheFile {
     #Assert
     Assert-ProjectCacheFileExists $project
 }
+
+function Test-BuildIntegratedProjectGetPackageTransitive {
+    [SkipTestForVS14()]
+    param($Context, $TestCase)
+
+    $projectR = New-Project $TestCase.ProjectTemplate
+    $projectT = New-Project BuildIntegratedClassLibrary
+
+    $projectT | Add-ProjectReference -ProjectTo $projectR
+    $projectR | Install-Package NuGet.Versioning -Version 1.0.7
+    Clean-Solution
+
+    $projectT = $projectT | Select-Object UniqueName, ProjectName, FullName
+
+    # Act (Restore)
+    Build-Solution
+
+    Assert-ProjectJsonLockFilePackage $projectT NuGet.Versioning 1.0.7
+}
+
+function TestCases-BuildIntegratedProjectGetPackageTransitive{
+    BuildProjectTemplateTestCases 'PackageReferenceClassLibrary', 'BuildIntegratedClassLibrary'
+}

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -612,3 +612,26 @@ function Test-BuildIntegratedProjectGetPackageTransitive {
 function TestCases-BuildIntegratedProjectGetPackageTransitive{
     BuildProjectTemplateTestCases 'PackageReferenceClassLibrary', 'BuildIntegratedClassLibrary'
 }
+
+function Test-PackageReferenceProjectGetPackageTransitive {
+    [SkipTestForVS14()]
+    param($Context, $TestCase)
+
+    $projectR = New-Project $TestCase.ProjectTemplate
+    $projectT = New-Project PackageReferenceClassLibrary
+
+    $projectT | Add-ProjectReference -ProjectTo $projectR
+    $projectR | Install-Package NuGet.Versioning -Version 1.0.7
+    Clean-Solution
+
+    $projectT = $projectT | Select-Object UniqueName, ProjectName, FullName
+
+    # Act (Restore)
+    Build-Solution
+
+    Assert-NetCorePackageInLockFile $projectT NuGet.Versioning 1.0.7
+}
+
+function TestCases-PackageReferenceProjectGetPackageTransitive{
+    BuildProjectTemplateTestCases 'ClassLibrary' , 'PackageReferenceClassLibrary', 'BuildIntegratedClassLibrary'
+}


### PR DESCRIPTION
This fix addresses part of https://github.com/NuGet/Home/issues/5778


Copying the text from there:

While investigating EndToEnd failures for the following PR NuGet/NuGet.Client#1652 where I move the top level dependencies of Legacy Package Reference to per tfm, I have discovered some weirdness in our test setup.

LSL tests specifically.
In particular the following set of tests:
DeferredBuildIntegratedProjectGetPackageTransitive (2 tests cases, so counts as 2 tests).

This setup has a Project Json net45 reference a Legacy Package Reference net46 and then verify that the dependencies from the legacy project flow.

Of course the issue here is that this is incompatible, however due to the following bug: #5777 the dependencies acutally end up flowing in LSL mode.

Note if you test this in non-LSL mode this will NOT work.
**end**

So what I'm doing here is changing the template so the tests have compatible frameworks and no surprises between LSL and non-LSL scenarios. 

Adding non-LSL equivalents of the LSL transitive tests. 

Once this is merged, I think merging #1652 is safe, and #1659 after that. 

I don't think issue  NuGet/Home#5777 should stop these 2(or 3) PRs from going in as the behavior without the fix will be the same as the 15.3 one. 
