### PR TITLE
throw error for PC and PJ when projectRef is not resolved

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemReferenceReader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsCoreProjectSystemReferenceReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -64,10 +64,8 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     var reference3 = childReference as Reference3;
 
-                    // Set missing reference if
-                    // 1. reference is null OR
-                    // 2. reference is not resolved which means project is not loaded or assembly not found.
-                    if (reference3 == null || !reference3.Resolved)
+                    // Set missing reference if reference is null 
+                    if (reference3 == null)
                     {
                         // Skip missing references and show a warning
                         hasMissingReferences = true;

--- a/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/BuildIntegratedClassLibrary.csproj
+++ b/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/BuildIntegratedClassLibrary.csproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>$guid1$</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>$safeprojectname$</RootNamespace>
+		<AssemblyName>$safeprojectname$</AssemblyName>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+    <ResolveNuGetPackages>true</ResolveNuGetPackages>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+ 		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System"/>
+		$if$ ($targetframeworkversion$ >= 3.5)
+		<Reference Include="System.Core"/>
+		<Reference Include="System.Xml.Linq"/>
+		<Reference Include="System.Data.DataSetExtensions"/>
+		$endif$
+		$if$ ($targetframeworkversion$ >= 4.0)
+		<Reference Include="Microsoft.CSharp"/>
+ 		$endif$
+		<Reference Include="System.Data"/>
+		<Reference Include="System.Xml"/>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="Class1.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+    <None Include="project.json" />
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/assemblyinfo.cs
+++ b/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/assemblyinfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("$projectname$")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("$guid1$")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/class1.cs
+++ b/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/class1.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+$if$ ($targetframeworkversion$ >= 3.5)using System.Linq;
+$endif$using System.Text;
+
+namespace $safeprojectname$
+{
+	public class Class1
+	{
+	}
+}

--- a/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/csClassLibrary.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/csClassLibrary.vstemplate
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name Package="{CAE03EC1-301F-11d3-BF4B-00C349EFBC}" ID="2322" />
+    <Description Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2323" />
+    <Icon Package="{CAE03EC1-301F-11d3-BF4B-00C349EFBC}" ID="4547" />
+    <TemplateID>Microsoft.CSharp.ClassLibrary</TemplateID>
+    <ProjectType>CSharp</ProjectType>
+    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
+    <SortOrder>20</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <CreateNewFolder>true</CreateNewFolder>
+    <DefaultName>ClassLibrary</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+  </TemplateData>
+  <TemplateContent>
+    <Project File="BuildIntegratedClassLibrary.csproj" ReplaceParameters="true">
+      <ProjectItem ReplaceParameters="true" TargetFileName="Properties\AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true">Class1.cs</ProjectItem>
+      <ProjectItem>project.json</ProjectItem>
+    </Project>
+  </TemplateContent>
+</VSTemplate>

--- a/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/project.json
+++ b/test/EndToEnd/ProjectTemplates/Net45BuildIntegratedClassLibrary.zip/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "frameworks": {
+    "net45": {}
+  },
+  "runtimes": {
+    "win-anycpu": {},
+    "win": {},
+    "win-x86": {}
+  }
+}

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -117,6 +117,31 @@ function Assert-ProjectJsonLockFilePackage {
     Assert-True $found "Package $Id $Version was not found in the lock file for $($Project.Name)"    
 }
 
+function Assert-ProjectJsonLockFileErrorCode {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project,
+        [parameter(Mandatory = $true)]
+        [string]$errorCode
+    )
+
+    $lockFile = Get-ProjectJsonLockFile $Project
+
+    Assert-NotNull $lockFile
+
+    $found = $false
+
+    foreach ($log in $lockFile.logs) {
+        
+        if ($log.Code.ToUpperInvariant().Equals($errorCode.ToUpperInvariant()))
+        {
+            $found = $true;
+        }
+    }
+
+     Assert-True $found "Error Code $errorCode was not found in the lock file for $($Project.Name)"
+}
+
 function Assert-ProjectCacheFileExists {
     param(
         [parameter(Mandatory = $true)]

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -131,7 +131,7 @@ function Assert-ProjectJsonLockFileErrorCode {
 
     $found = $false
 
-    foreach ($log in $lockFile.logs) {
+    foreach ($log in $lockFile.LogMessages) {
         
         if ($log.Code.ToUpperInvariant().Equals($errorCode.ToUpperInvariant()))
         {

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -597,7 +597,6 @@ function Test-BuildIntegratedGetIncompatibleError {
     $projectT = New-Project PackageReferenceClassLibrary
 
     $projectR | Add-ProjectReference -ProjectTo $projectT
-    $projectR | Install-Package NuGet.Versioning -Version 1.0.7
 
     Clean-Solution
 

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -589,3 +589,22 @@ function Test-BuildIntegratedLegacyRebuildDoesNotDeleteCacheFile {
     #Assert
     Assert-ProjectCacheFileExists $project
 }
+
+function Test-BuildIntegratedGetIncompatibleError {
+    [SkipTestForVS14()]
+
+    $projectR = New-Project Net45BuildIntegratedClassLibrary
+    $projectT = New-Project PackageReferenceClassLibrary
+
+    $projectR | Add-ProjectReference -ProjectTo $projectT
+    $projectR | Install-Package NuGet.Versioning -Version 1.0.7
+
+    Clean-Solution
+
+    $projectT = $projectT | Select-Object UniqueName, ProjectName, FullName
+
+    # Act (Restore)
+    Build-Solution
+
+    Assert-ProjectJsonLockFileErrorCode $projectR NU1201
+}


### PR DESCRIPTION
https://github.com/NuGet/Home/issues/5777

For netcore project and package reference, NuGet always pass project reference path to restore, let restore throw error.

But Project.json and packages.config will skip unresolved project reference, let restore succeed, but fail during build.

the fix is let PJ and PC also throw during restore if project reference is not resolved.

we should have test infrastructure for error/warning code, filed a bug: https://github.com/NuGet/Home/issues/5792