### PR TITLE
fix pack ilmerge to use older sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ artifacts/
 **/.vscode/
 
 cli/
-cli_test/
+cli1.0.4/
 **/nupkgs/*.nupkg
 packages/
 .nuget/nuget.exe

--- a/build/common.project.props
+++ b/build/common.project.props
@@ -14,7 +14,7 @@
     <ArtifactsDirectory>$(RepositoryRootDirectory)artifacts\</ArtifactsDirectory>
     <DotnetExePath>$(RepositoryRootDirectory)cli\dotnet.exe</DotnetExePath>
     <DotnetExePath Condition=" '$(IsXPlat)' == 'true' ">$(RepositoryRootDirectory)cli\dotnet</DotnetExePath>
-    <DotnetSharedSDKDirectory>$(RepositoryRootDirectory)cli\shared\Microsoft.NETCore.App\2.0.0\</DotnetSharedSDKDirectory>
+    <DotnetSharedSDKDirectory>$(RepositoryRootDirectory)cli1.0.4\shared\Microsoft.NETCore.App\1.0.4\</DotnetSharedSDKDirectory>
     <NuGetExePath>$(RepositoryRootDirectory).nuget\nuget.exe</NuGetExePath>
     <SharedDirectory>$(BuildCommonDirectory)Shared</SharedDirectory>
     <NuGetCoreSrcDirectory>$(RepositoryRootDirectory)src\NuGet.Core\</NuGetCoreSrcDirectory>

--- a/configure.ps1
+++ b/configure.ps1
@@ -50,7 +50,8 @@ Invoke-BuildStep 'Installing NuGet.exe' {
 } -ev +BuildErrors
 
 Invoke-BuildStep 'Installing .NET CLI' {
-    Install-DotnetCLI -Force:$Force
+    Install-DotnetCLIToILMergePack -Force:$Force
+    Install-DotnetCLI -Force:$Force    
 } -ev +BuildErrors
 
 # Restoring tools required for build

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.csproj
@@ -75,7 +75,7 @@
     </ItemGroup>
     <PropertyGroup>
       <PathToMergedNuGetPack>$(ILMergeResultDir)\NuGet.Build.Tasks.Pack.dll</PathToMergedNuGetPack>
-      <DotnetSharedDirectoryArg Condition="'$(TargetFramework)' == 'netstandard1.3'">/lib:$(OutputPath)$(RuntimeIdentifier)\publish\refs</DotnetSharedDirectoryArg>
+      <DotnetSharedDirectoryArg Condition="'$(IsCore)' == 'true'">/lib:$(DotnetSharedSDKDirectory)</DotnetSharedDirectoryArg>
       <IlmergeCommand>$(ILMergeExePath) $(OutputPath)NuGet.Build.Tasks.Pack.dll @(BuildArtifacts, ' ') /out:$(PathToMergedNuGetPack) $(DotnetSharedDirectoryArg) /lib:$(OutputPath)$(RuntimeIdentifier)\publish /internalize /xmldocs /log:$(ILMergeResultDir)\IlMergeLog.txt</IlmergeCommand>
       <IlmergeCommand Condition="Exists($(MS_PFX_PATH))">$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)</IlmergeCommand>
     </PropertyGroup>


### PR DESCRIPTION
this is temporary till we find a better solution to ilmerging pack. i have temporary worked around by additionally downloading an older sdk and passing it as a probing path to ilmerge.