### PR TITLE
Excluding Apex test project from run test projects

### DIFF
--- a/build/common.project.props
+++ b/build/common.project.props
@@ -243,7 +243,8 @@
   <!-- All projects in the repository -->
   <ItemGroup Condition=" '$(IsXPlat)' != 'true' ">
     <SolutionProjects Include="$(RepositoryRootDirectory)test\*\*\*.csproj"
-                      Exclude="$(RepositoryRootDirectory)test\EndToEnd\*\*.csproj"
+                      Exclude="$(RepositoryRootDirectory)test\EndToEnd\*\*.csproj;
+                               $(RepositoryRootDirectory)test\NuGet.Tests.Apex\*\*.csproj"
                       Condition=" '$(ExcludeTestProjects)' != 'true' " />
 
     <SolutionProjects Include="$(RepositoryRootDirectory)src\*\*\*.csproj" />


### PR DESCRIPTION
Excluding Apex test project from run test projects as apex package is not yet available to public and that would break our build during `msbuild build.proj /t:restoreVS15`

Since Apex tests are not being run, this should have no impact over the test pipeline.