### PR TITLE
Let any feed have prefix id reservation

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/PackageItemLoader.cs
@@ -35,7 +35,6 @@ namespace NuGet.PackageManagement.UI
         public IItemLoaderState State => _state;
 
         public bool IsMultiSource => _packageFeed.IsMultiSource;
-        public bool IsOnlyLoadingFromNuGetOrg => _packageFeed.IsOnlyLoadingFromNuGetOrg;
 
         private class PackageFeedSearchState : IItemLoaderState
         {
@@ -316,7 +315,7 @@ namespace NuGet.PackageManagement.UI
                         Summary = metadata.Summary,
                         Versions = AsyncLazy.New(() => metadata.GetVersionsAsync()),
                         AllowedVersions = allowedVersions,
-                        PrefixReserved = metadata.PrefixReserved && IsOnlyLoadingFromNuGetOrg
+                        PrefixReserved = metadata.PrefixReserved && !IsMultiSource
                     };
                     listItem.UpdatePackageStatus(_installedPackages);
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1541,7 +1541,7 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The identity of this package has been verified by nuget.org.
+        ///   Looks up a localized string similar to The ID prefix of this package has been reserved for the owner of the package by the currently selected feed.
         /// </summary>
         public static string Tooltip_PrefixReserved {
             get {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -679,7 +679,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
     <value>Uncheck</value>
   </data>
   <data name="Tooltip_PrefixReserved" xml:space="preserve">
-    <value>The identity of this package has been verified by nuget.org</value>
+    <value>The ID prefix of this package has been reserved for the owner of the package by the currently selected feed</value>
   </data>
   <data name="RefreshButtonLabel" xml:space="preserve">
     <value>Refresh</value>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/IPackageFeed.cs
@@ -15,8 +15,6 @@ namespace NuGet.PackageManagement.VisualStudio
     {
         bool IsMultiSource { get; }
 
-        bool IsOnlyLoadingFromNuGetOrg { get; }
-
         /// <summary>
         /// Starts new search.
         /// </summary>

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/MultiSourcePackageFeed.cs
@@ -28,8 +28,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         public bool IsMultiSource => _sourceRepositories.Length > 1;
 
-        public bool IsOnlyLoadingFromNuGetOrg => !IsMultiSource && StringComparer.OrdinalIgnoreCase.Equals(_sourceRepositories.First<SourceRepository>().ToString(), NuGetConstants.FeedName);
-
         private class AggregatedContinuationToken : ContinuationToken
         {
             public string SearchString { get; set; }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/PlainPackageFeedBase.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/PackageFeeds/PlainPackageFeedBase.cs
@@ -26,7 +26,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         // No, it's not.
         public bool IsMultiSource => false;
-        public bool IsOnlyLoadingFromNuGetOrg => false;
 
         public Task<SearchResult<IPackageSearchMetadata>> SearchAsync(string searchText, SearchFilter searchFilter, CancellationToken cancellationToken)
         {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/NuGet.PackageManagement.UI.Test.csproj
@@ -29,6 +29,7 @@
     <Compile Include="ConverterTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="PackageItemLoaderTests.cs" />
+    <Compile Include="PackageManagerListItemsTest.cs" />
     <Compile Include="PackageManagerProviderTest.cs" />
     <Compile Include="TestPackageManagerProviders.cs" />
     <Compile Include="WpfFactAttribute.cs" />
@@ -52,6 +53,9 @@
     <Content Include="Resources\packageicon.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="compiler\resources\EntityFrameworkSearch.json" />
   </ItemGroup>
   <ItemGroup>
     <None Include="xunit.runner.json">

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -130,7 +130,6 @@ namespace NuGet.PackageManagement.UI.Test
         private class TestPackageFeed : IPackageFeed
         {
             public bool IsMultiSource => false;
-            public bool IsOnlyLoadingFromNuGetOrg => false;
 
             public Task<SearchResult<IPackageSearchMetadata>> ContinueSearchAsync(ContinuationToken continuationToken, CancellationToken cancellationToken)
             {

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageItemLoaderTests.cs
@@ -59,6 +59,12 @@ namespace NuGet.PackageManagement.UI.Test
                 }
             } 
 
+            // All items should not have a prefix reserved because the feed is multisource
+            foreach (var item in loaded)
+            {
+                Assert.False(item.PrefixReserved);
+            }
+
             Assert.NotEmpty(loaded);
         }
 

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerListItemsTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/PackageManagerListItemsTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NuGet.PackageManagement.VisualStudio;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.PackageManagement.UI.Test
+{
+    public class PackageManagerListItemsTest
+    {
+
+        [Fact]
+        public async Task PackagePrefixReservation_FromOneSource()
+        {
+            var solutionManager = Mock.Of<IVsSolutionManager>();
+            var uiContext = Mock.Of<INuGetUIContext>();
+            Mock.Get(uiContext)
+                .Setup(x => x.SolutionManager)
+                .Returns(solutionManager);
+
+            // Arrange
+            var responses = new Dictionary<string, string>
+            {
+                {
+                    "https://api-v3search-0.nuget.org/query?q=EntityFramework&skip=0&take=26&prerelease=false&semVerLevel=2.0.0",
+                    ProtocolUtility.GetResource("NuGet.PackageManagement.UI.Test.compiler.resources.EntityFrameworkSearch.json", GetType())
+                },
+                { "http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer }
+            };
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var repositories = new List<SourceRepository>
+            {
+                repo
+            };
+
+            var context = new PackageLoadContext(repositories, false, uiContext);
+
+            var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
+            var loader = new PackageItemLoader(context, packageFeed, "EntityFramework", false);
+
+            var loaded = new List<PackageItemListViewModel>();
+            foreach (var page in Enumerable.Range(0, 5))
+            {
+                await loader.LoadNextAsync(null, CancellationToken.None);
+                while (loader.State.LoadingStatus == LoadingStatus.Loading)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    await loader.UpdateStateAsync(null, CancellationToken.None);
+                }
+
+                var items = loader.GetCurrent();
+                loaded.AddRange(items);
+
+                if (loader.State.LoadingStatus != LoadingStatus.Ready)
+                {
+                    break;
+                }
+            }
+
+            // Resource only has one item
+            var item = loaded.First();
+            Assert.True(item.PrefixReserved);
+        }
+
+        [Fact]
+        public async Task PackagePrefixReservation_FromMultiSource()
+        {
+            var solutionManager = Mock.Of<IVsSolutionManager>();
+            var uiContext = Mock.Of<INuGetUIContext>();
+            Mock.Get(uiContext)
+                .Setup(x => x.SolutionManager)
+                .Returns(solutionManager);
+
+            // Arrange
+            var responses = new Dictionary<string, string>
+            {
+                {
+                    "https://api-v3search-0.nuget.org/query?q=EntityFramework&skip=0&take=26&prerelease=false&semVerLevel=2.0.0",
+                    ProtocolUtility.GetResource("NuGet.PackageManagement.UI.Test.compiler.resources.EntityFrameworkSearch.json", GetType())
+                },
+                { "http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer },
+                { "http://othersource.com/v3/index.json", JsonData.IndexWithoutFlatContainer }
+            };
+
+            var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+            var repo1 = StaticHttpHandler.CreateSource("http://othersource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
+
+            var repositories = new List<SourceRepository>
+            {
+                repo,
+                repo1
+            };
+
+            var context = new PackageLoadContext(repositories, false, uiContext);
+
+            var packageFeed = new MultiSourcePackageFeed(repositories, logger: null);
+            var loader = new PackageItemLoader(context, packageFeed, "EntityFramework", false);
+
+            var loaded = new List<PackageItemListViewModel>();
+            foreach (var page in Enumerable.Range(0, 5))
+            {
+                await loader.LoadNextAsync(null, CancellationToken.None);
+                while (loader.State.LoadingStatus == LoadingStatus.Loading)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                    await loader.UpdateStateAsync(null, CancellationToken.None);
+                }
+
+                var items = loader.GetCurrent();
+                loaded.AddRange(items);
+
+                if (loader.State.LoadingStatus != LoadingStatus.Ready)
+                {
+                    break;
+                }
+            }
+
+            // Resource only has one item
+            var item = loaded.First();
+            Assert.False(item.PrefixReserved);
+        }
+    }
+}

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/compiler/resources/EntityFrameworkSearch.json
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.UI.Test/compiler/resources/EntityFrameworkSearch.json
@@ -1,0 +1,100 @@
+﻿{
+  "@context": {
+    "@vocab": "http://schema.nuget.org/schema#",
+    "@base": "http://api.nuget.org/v3/registration0/"
+  },
+  "totalHits": 972,
+  "lastReopen": "2017-03-22T23:58:15.5787510Z",
+  "index": "v3-lucene0-v2v3-20170110",
+  "data": [
+    {
+      "@id": "http://api.nuget.org/v3/registration0/entityframework/index.json",
+      "@type": "Package",
+      "registration": "http://api.nuget.org/v3/registration0/entityframework/index.json",
+      "id": "EntityFramework",
+      "version": "6.1.3",
+      "description": "Entity Framework is Microsoft's recommended data access technology for new applications.",
+      "summary": "Entity Framework is Microsoft's recommended data access technology for new applications.",
+      "title": "EntityFramework",
+      "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=386613",
+      "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=320539",
+      "projectUrl": "http://go.microsoft.com/fwlink/?LinkID=320540",
+      "tags": [ "Microsoft", "EF", "Database", "Data", "O/RM", "ADO.NET" ],
+      "authors": [ "Microsoft" ],
+      "totalDownloads": 28390569,
+      "verified": true,
+      "versions": [
+        {
+          "version": "4.1.10311",
+          "downloads": 64099,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.1.10311.json"
+        },
+        {
+          "version": "4.1.10331",
+          "downloads": 612084,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.1.10331.json"
+        },
+        {
+          "version": "4.1.10715",
+          "downloads": 763125,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.1.10715.json"
+        },
+        {
+          "version": "4.2.0",
+          "downloads": 392907,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.2.0.json"
+        },
+        {
+          "version": "4.3.0",
+          "downloads": 89777,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.3.0.json"
+        },
+        {
+          "version": "4.3.1",
+          "downloads": 465884,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/4.3.1.json"
+        },
+        {
+          "version": "5.0.0",
+          "downloads": 6798521,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/5.0.0.json"
+        },
+        {
+          "version": "6.0.0",
+          "downloads": 1841069,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.0.0.json"
+        },
+        {
+          "version": "6.0.1",
+          "downloads": 1010303,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.0.1.json"
+        },
+        {
+          "version": "6.0.2",
+          "downloads": 1659310,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.0.2.json"
+        },
+        {
+          "version": "6.1.0",
+          "downloads": 1614353,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.1.0.json"
+        },
+        {
+          "version": "6.1.1",
+          "downloads": 2548547,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.1.1.json"
+        },
+        {
+          "version": "6.1.2",
+          "downloads": 1367762,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.1.2.json"
+        },
+        {
+          "version": "6.1.3",
+          "downloads": 8211011,
+          "@id": "http://api.nuget.org/v3/registration0/entityframework/6.1.3.json"
+        }
+      ]
+    }
+  ]
+}

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -19,11 +19,11 @@ namespace NuGet.Protocol.Tests
         public async Task AutoCompleteResourceV2Feed_IdStartsWith()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "package-ids?partialId=Azure&includePrerelease=False&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureAutoComplete.json", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureAutoComplete.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -41,11 +41,11 @@ namespace NuGet.Protocol.Tests
         public async Task AutoCompleteResourceV2Feed_VersionStartsWith()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "package-versions/xunit?includePrerelease=False&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitVersionAutoComplete.json", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitVersionAutoComplete.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -63,7 +63,7 @@ namespace NuGet.Protocol.Tests
         public async Task AutoCompleteResourceV2Feed_VersionStartsWithInvalidId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "package-versions/azure?includePrerelease=False&semVerLevel=2.0.0", "[]");

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -21,11 +21,11 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfoResourceV2Feed_GetDependencyInfoById()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -46,13 +46,13 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfoResourceV2Feed_GetDependencyInfoByPackageIdentity()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -75,11 +75,11 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfo_RetrieveExactVersion()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='2.1.0-beta1-build2945')",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.Xunit.2.1.0-beta1-build2945GetPackages.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.Xunit.2.1.0-beta1-build2945GetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -104,11 +104,11 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfo_RetrieveDependencies()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -138,16 +138,16 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfo_RetrieveExactVersion_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
@@ -164,11 +164,11 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfo_RetrieveDependencies_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -186,11 +186,11 @@ namespace NuGet.Protocol.Tests
         public async Task DependencyInfo_GetNearestFramework()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='DotNetOpenAuth.Core',Version='4.3.2.13293')",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.DotNetOpenAuth.Core.4.3.2.13293GetPackages.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.DotNetOpenAuth.Core.4.3.2.13293GetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DownloadResourceV2FeedTests.cs
@@ -20,16 +20,16 @@ namespace NuGet.Protocol.Tests
         public async Task DownloadResourceFromIdentityInvalidId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             var downloadResource = await repo.GetResourceAsync<DownloadResource>();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/JsonExtensionsTest.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Newtonsoft.Json.Linq;
+using Test.Utility;
 using Xunit;
 
 namespace NuGet.Protocol.Tests

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LegacyCapabilityResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LegacyCapabilityResourceTests.cs
@@ -24,11 +24,11 @@ namespace NuGet.Protocol.Tests
         public async Task LegacyResourceNuGetOrg()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -46,11 +46,11 @@ namespace NuGet.Protocol.Tests
         public async Task LegacyResourceSearchNoAbsoluteLatestVersion()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTF.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTF.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -68,11 +68,11 @@ namespace NuGet.Protocol.Tests
         public async Task LegacyResourceNoSearchAbsoluteLatestVersion()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataFT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataFT.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -90,11 +90,11 @@ namespace NuGet.Protocol.Tests
         public async Task LegacyResourceNoSearchNoAbsoluteLatestVersion()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataFF.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataFF.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
@@ -21,11 +21,11 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetLatestVersion()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -43,11 +43,11 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetLatestVersionStable()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -65,11 +65,11 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetVersionsStable()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -87,11 +87,11 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -109,11 +109,11 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceIdExist()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -131,12 +131,12 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceIdentityExist()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -156,15 +156,15 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetLatestVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -187,12 +187,12 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetLatestVersionInvalidId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -210,12 +210,12 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceGetVersionsInvalidId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -232,17 +232,17 @@ namespace NuGet.Protocol.Tests
         [Fact]
         public async Task MetaDataResourceIdentityExistInvalidIdentity()
         {
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses,
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
@@ -259,12 +259,12 @@ namespace NuGet.Protocol.Tests
         public async Task MetaDataResourceIdExistNotFoundId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/ODataServiceDocumentV2Tests.cs
@@ -17,7 +17,7 @@ namespace NuGet.Protocol.Tests
         public async Task DefaultBaseAddressIsServiceAddressWithTrimmedSlash()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + '/';
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + '/';
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress, string.Empty);
@@ -37,10 +37,10 @@ namespace NuGet.Protocol.Tests
         public async Task IgnoresXmlBase()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
-            responses.Add(serviceAddress, TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.ODataServiceDocument.xml", GetType()));
+            responses.Add(serviceAddress, ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.ODataServiceDocument.xml", GetType()));
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
 
@@ -58,7 +58,7 @@ namespace NuGet.Protocol.Tests
         public async Task IgnoresInvalidXml()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress, "[1, 2, \"not XML\"]");
@@ -76,7 +76,7 @@ namespace NuGet.Protocol.Tests
         public async Task FollowsRedirect()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress, "301 https://bringing/it/all/back/home");
@@ -96,7 +96,7 @@ namespace NuGet.Protocol.Tests
         public async Task FollowsRedirectAndTrimsQueryStringAndSlashes()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress, "301 https://bringing/it/all/back/home//?foo=bar");
@@ -116,7 +116,7 @@ namespace NuGet.Protocol.Tests
         public async Task FollowsRedirectToJustDomainName()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress, "301 https://bringing");

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -21,11 +21,11 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResource_Basic()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -64,11 +64,11 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResource_UsesReferenceCache()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='afine'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.FindPackagesByIdWithDuplicateBesidesVersion.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.FindPackagesByIdWithDuplicateBesidesVersion.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -89,11 +89,11 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResource_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='not-found'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -111,11 +111,11 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResource_PackageIdentity()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -136,13 +136,13 @@ namespace NuGet.Protocol.Tests
         public async Task PackageMetadataResource_PackageIdentity_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='0.0.0')",
-                 TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
+                 ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NotFoundFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV2FeedTests.cs
@@ -19,13 +19,13 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSearchResourceV2Feed_Basic()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
                 "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);
@@ -64,13 +64,13 @@ namespace NuGet.Protocol.Tests
         public async Task PackageSearchResourceV2Feed_Search100()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
                 "&includePrerelease=false&$skip=0&$top=100&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch100.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch100.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var repo = StaticHttpHandler.CreateSource(serviceAddress, Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageSearchResourceV3Tests.cs
@@ -20,7 +20,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EntityFrameworkSearch.json", GetType()));
             responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
@@ -54,7 +54,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("https://api-v3search-0.nuget.org/query?q=entityframework&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchV3WithDuplicateBesidesVersion.json", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchV3WithDuplicateBesidesVersion.json", GetType()));
             responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);
@@ -83,7 +83,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             var responses = new Dictionary<string, string>();
             responses.Add("https://api-v3search-0.nuget.org/query?q=yabbadabbadoo&skip=0&take=1&prerelease=false&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EmptySearchResponse.json", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.EmptySearchResponse.json", GetType()));
             responses.Add("http://testsource.com/v3/index.json", JsonData.IndexWithoutFlatContainer);
 
             var repo = StaticHttpHandler.CreateSource("http://testsource.com/v3/index.json", Repository.Provider.GetCoreV3(), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RawSearchResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RawSearchResourceTests.cs
@@ -20,13 +20,13 @@ namespace NuGet.Protocol.Tests
         public async Task RawSearchResource_SearchEncoding()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false" +
                 "&supportedFramework=.NETFramework,Version=v4.5&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -51,13 +51,13 @@ namespace NuGet.Protocol.Tests
         public async Task RawSearchResource_VerifyReadSyncIsNotUsed()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "?q=azure%20b&skip=0&take=1&prerelease=false" +
                 "&supportedFramework=.NETFramework,Version=v4.5&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.V3Search.json", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV2FindPackageByIdResourceTests.cs
@@ -198,7 +198,7 @@ namespace NuGet.Protocol.Tests
         public async Task GetAllVersionsAsync_NoErrorsOnNoContent()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
@@ -330,7 +330,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             using (var workingDir = TestDirectory.Create())
             {
-                var serviceAddress = TestUtility.CreateServiceAddress();
+                var serviceAddress = ProtocolUtility.CreateServiceAddress();
                 var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "xunit", "2.2.0-beta1-build3239");
                 var packageBytes = File.ReadAllBytes(package.FullName);
 
@@ -347,7 +347,7 @@ namespace NuGet.Protocol.Tests
                         serviceAddress + "FindPackagesById()?id='XUNIT'",
                         _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
-                            Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()))
+                            Content = new TestContent(ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()))
                         })
                     },
                     {
@@ -388,7 +388,7 @@ namespace NuGet.Protocol.Tests
             // Arrange
             using (var workingDir = TestDirectory.Create())
             {
-                var serviceAddress = TestUtility.CreateServiceAddress();
+                var serviceAddress = ProtocolUtility.CreateServiceAddress();
                 var package = SimpleTestPackageUtility.CreateFullPackage(workingDir, "WindowsAzure.Storage", "6.2.2-preview");
                 var packageBytes = File.ReadAllBytes(package.FullName);
 
@@ -405,7 +405,7 @@ namespace NuGet.Protocol.Tests
                         serviceAddress + "FindPackagesById()?id='WINDOWSAZURE.STORAGE'",
                         _ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
-                            Content = new TestContent(TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()))
+                            Content = new TestContent(ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()))
                         })
                     },
                     {
@@ -727,7 +727,7 @@ namespace NuGet.Protocol.Tests
 
             internal static RemoteV2FindPackageByIdResourceTest Create()
             {
-                var serviceAddress = TestUtility.CreateServiceAddress();
+                var serviceAddress = ProtocolUtility.CreateServiceAddress();
                 var packageIdentity = new PackageIdentity(
                     id: "xunit",
                     version: NuGetVersion.Parse("2.2.0-beta1-build3239"));
@@ -753,7 +753,7 @@ namespace NuGet.Protocol.Tests
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
-                                TestUtility.GetResource(
+                                ProtocolUtility.GetResource(
                                     "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
                                     typeof(RemoteV2FindPackageByIdResourceTest)))
                         })
@@ -763,7 +763,7 @@ namespace NuGet.Protocol.Tests
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
-                                TestUtility.GetResource(
+                                ProtocolUtility.GetResource(
                                     "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
                                     typeof(RemoteV2FindPackageByIdResourceTest)))
                         })

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -155,7 +155,7 @@ namespace NuGet.Protocol.Tests
         public async Task GetAllVersionsAsync_NoErrorsOnNoContent()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='a'", "204");
@@ -624,7 +624,7 @@ namespace NuGet.Protocol.Tests
 
             internal static RemoteV3FindPackageByIdResourceTest Create()
             {
-                var serviceAddress = TestUtility.CreateServiceAddress();
+                var serviceAddress = ProtocolUtility.CreateServiceAddress();
                 var packageIdentity = new PackageIdentity(
                     id: "xunit",
                     version: NuGetVersion.Parse("2.2.0-beta1-build3239"));
@@ -680,7 +680,7 @@ namespace NuGet.Protocol.Tests
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
-                                TestUtility.GetResource(
+                                ProtocolUtility.GetResource(
                                     "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
                                     typeof(RemoteV3FindPackageByIdResourceTest)))
                         })
@@ -690,7 +690,7 @@ namespace NuGet.Protocol.Tests
                         request => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                         {
                             Content = new TestContent(
-                                TestUtility.GetResource(
+                                ProtocolUtility.GetResource(
                                     "NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml",
                                     typeof(RemoteV3FindPackageByIdResourceTest)))
                         })

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedListResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedListResourceTests.cs
@@ -19,17 +19,17 @@ namespace NuGet.Protocol.Tests
         public async Task TestListDelistedNoPrereleaseNotAllVersionsDelistedOnlyResponse()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
                 "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -66,17 +66,17 @@ namespace NuGet.Protocol.Tests
         public async Task TestListNoDelistedNoPrereleaseNotAllVersionsDelistedOnlyResponse()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
                 "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.6DelistedEntries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -113,21 +113,21 @@ namespace NuGet.Protocol.Tests
         public async Task TestListNoDelistedNoPrereleaseNotAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
                 "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NewtonSearch30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NewtonSearch30Entries.xml", GetType()));
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsLatestVersion&$orderby=Id&searchTerm='newton'" +
                 "&targetFramework=''&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NewtonSearch3Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NewtonSearch3Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -164,17 +164,17 @@ namespace NuGet.Protocol.Tests
         public async Task TestListNoDelistedPrereleaseNotAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='NuGet.Exe'" +
                 "&targetFramework=''&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -211,21 +211,21 @@ namespace NuGet.Protocol.Tests
         public async Task TestListDelistedPrereleaseNoAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'" +
                 "&targetFramework=''&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
             responses.Add(
                 serviceAddress + "/Search()?$filter=IsAbsoluteLatestVersion&$orderby=Id&searchTerm='Windows.AzureStorage'" +
                 "&targetFramework=''&includePrerelease=true&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -263,17 +263,17 @@ namespace NuGet.Protocol.Tests
         public async Task TestListNoDelistedPrereleaseAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='NuGet.Exe'&targetFramework=''" +
                 "&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NuGetExeSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -310,21 +310,21 @@ namespace NuGet.Protocol.Tests
         public async Task TestListDelistedPrereleaseAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
                 "&includePrerelease=true&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
                 "&includePrerelease=true&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -362,21 +362,21 @@ namespace NuGet.Protocol.Tests
         public async Task TestListNoDelistedNoPrereleaseAllVersions()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
                 "&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='Windows.AzureStorage'&targetFramework=''" +
                 "&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -413,17 +413,17 @@ namespace NuGet.Protocol.Tests
         public async Task TestUsesReferenceCache()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress() + "api/v2";
+            var serviceAddress = ProtocolUtility.CreateServiceAddress() + "api/v2";
 
             var responses = new Dictionary<string, string>();
 
             responses.Add(
                 serviceAddress + "/Search()?$orderby=Id&searchTerm='afine'" +
                 "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchV2WithDuplicateBesidesVersion.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchV2WithDuplicateBesidesVersion.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(serviceAddress + "/$metadata",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.MetadataTT.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/V2FeedParserTests.cs
@@ -24,11 +24,11 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Basic()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -49,17 +49,17 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_FollowNextLinks()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='ravendb.client'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','1.2.2067-Unstable'",
-               TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesByIdPage1.xml", GetType()));
+               ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesByIdPage1.xml", GetType()));
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','2.0.2183-Unstable'",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesByIdPage2.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.RavendbFindPackagesByIdPage2.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -76,11 +76,11 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_FindPackagesByIdAsync()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -120,11 +120,11 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_UsesReferenceCache()
         {
             //// Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='afine'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.FindPackagesByIdWithDuplicateBesidesVersion.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.FindPackagesByIdWithDuplicateBesidesVersion.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -145,17 +145,17 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_DownloadFromIdentityInvalidId()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
             // Act
@@ -179,13 +179,13 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Search()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
                 "&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -228,13 +228,13 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Search_OrderById()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$orderby=Id&searchTerm=''&targetFramework=''&includePrerelease=false" +
                 "&$skip=0&$top=5&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchOrderById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.SearchOrderById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -265,13 +265,13 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_SearchEncoding()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'" + 
                 "&targetFramework='portable-net45%2Bwin8'&includePrerelease=false&$skip=0&$top=1&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -294,18 +294,18 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_SearchTop100()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure'&targetFramework='net40-client'" +
                 "&includePrerelease=false&$skip=0&$top=100&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch100.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch100.xml", GetType()));
             responses.Add(
                 "https://www.nuget.org/api/v2/Search?searchTerm='azure'&targetFramework='net40-client'" +
                 "&includePrerelease=false&$filter=IsLatestVersion" +
                 "&$skiptoken='Haven.ServiceBus.Azure.ServiceBus.Publisher','1.0.5835.19676',100",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearchNext100.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearchNext100.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -326,7 +326,7 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Search_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
@@ -363,7 +363,7 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Search_InternalServerError()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
@@ -400,11 +400,11 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackage()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -442,16 +442,16 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnPackages()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.XunitFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
@@ -466,12 +466,12 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnPackagesFoundOnFindPackagesById()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')", string.Empty);
             responses.Add(serviceAddress + "FindPackagesById()?id='WindowsAzure.Storage'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -510,7 +510,7 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackage_NotFoundOnBoth()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-notfound')", string.Empty);
@@ -518,7 +518,7 @@ namespace NuGet.Protocol.Tests
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var packageIdentity = new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound"));
@@ -540,14 +540,14 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackage_InternalServerError()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='xunit',Version='1.0.0-InternalServerError')", null);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
             var packageIdentity = new PackageIdentity("xunit", new NuGetVersion("1.0.0-InternalServerError"));
@@ -567,14 +567,14 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_FindPackagesById_NotFound()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0", string.Empty);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
@@ -594,14 +594,14 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_FindPackagesById_InternalServerError()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='xunit'&semVerLevel=2.0.0", null);
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses,
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.500Error.xml", GetType()));
 
             V2FeedParser parser = new V2FeedParser(httpSource, serviceAddress);
 
@@ -621,12 +621,12 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_NexusFindPackagesByIdNullDependencyRange()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "FindPackagesById()?id='PackageA'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NexusFindPackagesById.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.NexusFindPackagesById.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -660,16 +660,16 @@ namespace NuGet.Protocol.Tests
             // Arrange
             var dupUrl =
                 "https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','1.2.2067-Unstable'";
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "FindPackagesById()?id='ravendb.client'&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependency.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependency.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
             responses.Add(dupUrl,
-               TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependencyPage1.xml", GetType()));
+               ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependencyPage1.xml", GetType()));
             responses.Add("https://www.nuget.org/api/v2/FindPackagesById?id='ravendb.client'&$skiptoken='RavenDB.Client','2.0.2183-Unstable'",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependencyPage2.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.CyclicDependencyPage2.xml", GetType()));
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
 
@@ -696,14 +696,14 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_Search_MultipleSupportedFramework()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='azure%20%2B''%20b%20'" +
                 "&targetFramework='portable45-net45%2Bwin8%2Bwpa81%7Cwpa81%7Cmonoandroid60'&includePrerelease=false" +
                 "&$skip=0&$top=1&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.AzureSearch.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -732,17 +732,17 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetSearchPage()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'" +
                 "&targetFramework=''&includePrerelease=false&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
             responses.Add(
                 serviceAddress + "Search()?$filter=IsLatestVersion&searchTerm='WindowsAzure.Storage'" +
                 "&targetFramework=''&includePrerelease=false&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -767,18 +767,18 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_GetPackagesPage()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages()?$filter=((((Id%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Id)))"+
                 "%20or%20((Description%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Description))))%20or%20((Tags%20ne%20null)"+
                 "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=0&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage30Entries.xml", GetType()));
 
             responses.Add(serviceAddress +"Packages()?$filter=((((Id%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Id)))" +
                 "%20or%20((Description%20ne%20null)%20and%20substringof('WindowsAzure.Storage',tolower(Description))))%20or%20((Tags%20ne%20null)" +
                 "%20and%20substringof('%20WindowsAzure.Storage%20',tolower(Tags))))%20and%20IsLatestVersion&$skip=30&$top=30&semVerLevel=2.0.0",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageSearchPackage17Entries.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);
@@ -803,11 +803,11 @@ namespace NuGet.Protocol.Tests
         public async Task V2FeedParser_VerifySyncReadIsNotUsed()
         {
             // Arrange
-            var serviceAddress = TestUtility.CreateServiceAddress();
+            var serviceAddress = ProtocolUtility.CreateServiceAddress();
 
             var responses = new Dictionary<string, string>();
             responses.Add(serviceAddress + "Packages(Id='WindowsAzure.Storage',Version='4.3.2-preview')",
-                TestUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
+                ProtocolUtility.GetResource("NuGet.Protocol.Tests.compiler.resources.WindowsAzureStorageGetPackages.xml", GetType()));
             responses.Add(serviceAddress, string.Empty);
 
             var httpSource = new TestHttpSource(new PackageSource(serviceAddress), responses);

--- a/test/TestUtilities/Test.Utility/JsonData.cs
+++ b/test/TestUtilities/Test.Utility/JsonData.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace NuGet.Protocol.Tests
+namespace Test.Utility
 {
     public static class JsonData
     {

--- a/test/TestUtilities/Test.Utility/ProtocolUtility.cs
+++ b/test/TestUtilities/Test.Utility/ProtocolUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -12,9 +12,9 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Reflection;
 
-namespace NuGet.Protocol.Tests
+namespace Test.Utility
 {
-    public static class TestUtility
+    public static class ProtocolUtility
     {
         public static string GetResource(string name, Type type)
         {


### PR DESCRIPTION
After testing out an end to end scenario of the Prefix Id Reservation in the client UI, @diverdan92 suggested that every feed should be able to show the checkmark, except the feeds that have more than one source (e.g. "All"). This PR addresses that suggestion.