### PR TITLE
engineering fix to enable linux/mac testing in vsts

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+env
 while true ; do
 	case "$1" in
 		-c|--clear-cache) CLEAR_CACHE=1 ; shift ;;

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -82,7 +82,7 @@ XunitConsole="$DIR/packages/xunit.runner.console.2.2.0/tools/xunit.console.exe"
 NuGetExe="$DIR/.nuget/nuget.exe"
 
 #Get NuGet.exe
-wget -O $NuGetExe https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe
+curl -o $NuGetExe https://dist.nuget.org/win-x86-commandline/latest-prerelease/nuget.exe
 
 #restore solution packages
 mono $NuGetExe restore  "$DIR/.nuget/packages.config" -SolutionDirectory "$DIR"

--- a/test/TestUtilities/Test.Utility/TestSources.cs
+++ b/test/TestUtilities/Test.Utility/TestSources.cs
@@ -26,7 +26,7 @@ namespace NuGet.Test.Utility
             // equal to the root of the repository where the config files are copied as part of
             // a build step before the tests are run. If the environment variable is not set, the behavior
             // is the same as on TeamCity - this will ensure both CI's will be happy.
-            var fullPath = Environment.GetEnvironmentVariable("NuGet_FuncTests_Config");
+            var fullPath = Environment.GetEnvironmentVariable("NUGET_FUNCTESTS_CONFIG");
             return string.IsNullOrEmpty(fullPath) ? NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory) : fullPath;
         }
     }


### PR DESCRIPTION
- uppercase environment variable so it works on all three platforms (env variables are case sensitive on unix, but not on windows)
- print env variables in linux for debugging purpose
- use curl instead of wget as wget is not included by default on mac