### PR TITLE
NU1608 warning for packages above dependency upper bounds

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/IndexedRestoreTargetGraph.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/IndexedRestoreTargetGraph.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using NuGet.DependencyResolver;
+using NuGet.LibraryModel;
+
+namespace NuGet.Commands
+{
+    /// <summary>
+    /// Contains a RestoreTargetGraph with the flattened graph indexed on id.
+    /// </summary>
+    public class IndexedRestoreTargetGraph
+    {
+        private readonly Dictionary<string, GraphItem<RemoteResolveResult>> _lookup
+            = new Dictionary<string, GraphItem<RemoteResolveResult>>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly HashSet<string> _idsWithErrors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// RestoreTargetGraph
+        /// </summary>
+        public IRestoreTargetGraph Graph { get; }
+
+        private IndexedRestoreTargetGraph(IRestoreTargetGraph graph)
+        {
+            Graph = graph ?? throw new ArgumentNullException(nameof(graph));
+
+            // Id -> Node
+            foreach (var node in graph.Flattened)
+            {
+                var id = node.Key.Name;
+                if (!_lookup.ContainsKey(id))
+                {
+                    _lookup.Add(id, node);
+                }
+            }
+
+            // Index NU1607 version conflict errors
+            var versionConflicts = graph.AnalyzeResult?.VersionConflicts;
+            if (versionConflicts != null)
+            {
+                foreach (var node in versionConflicts)
+                {
+                    // Selected and conflicting will have the same name.
+                    _idsWithErrors.Add(node.Conflicting.Key.Name);
+                }
+            }
+
+            // Index cycles
+            var cycles = graph.AnalyzeResult?.Cycles;
+            if (cycles != null)
+            {
+                foreach (var node in cycles)
+                {
+                    _idsWithErrors.Add(node.Key.Name);
+                }
+            }
+        }
+
+        public static IndexedRestoreTargetGraph Create(IRestoreTargetGraph graph)
+        {
+            return new IndexedRestoreTargetGraph(graph);
+        }
+
+        /// <summary>
+        /// Returns the item or null if the id does not exist.
+        /// </summary>
+        public GraphItem<RemoteResolveResult> GetItemById(string id)
+        {
+            if (_lookup.TryGetValue(id, out var node))
+            {
+                return node;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the item or null if the id does not exist or does not match the type.
+        /// </summary>
+        public GraphItem<RemoteResolveResult> GetItemById(string id, LibraryType libraryType)
+        {
+            if (_lookup.TryGetValue(id, out var node)
+                && node.Key.Type == libraryType)
+            {
+                return node;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// True if an id has a conflict or cycle error associated with it.
+        /// </summary>
+        public bool HasErrors(string id)
+        {
+            return _idsWithErrors.Contains(id);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Diagnostics/UnexpectedDependencyMessages.cs
@@ -1,13 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Common;
-using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.ProjectModel;
 using NuGet.Shared;
@@ -28,6 +28,9 @@ namespace NuGet.Commands
             var ignoreIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var graphList = graphs.AsList();
 
+            // Index the flattened graph for faster lookups.
+            var indexedGraphs = graphList.Select(IndexedRestoreTargetGraph.Create).ToList();
+
             // 1. Detect project dependency authoring issues in the current project.
             //    The user can fix these themselves.
             var projectMissingLowerBounds = GetProjectDependenciesMissingLowerBounds(project);
@@ -43,8 +46,12 @@ namespace NuGet.Commands
 
             // 3. Detect top level dependencies that have a version different from the specified version.
             //    Ignore packages already logged in #1 and #2 since those errors are more specific.
-            var bumpedUp = GetBumpedUpDependencies(graphList, project, ignoreIds);
+            var bumpedUp = GetBumpedUpDependencies(indexedGraphs, project, ignoreIds);
             await logger.LogMessagesAsync(DiagnosticUtility.MergeOnTargetGraph(bumpedUp));
+
+            // 4. Detect dependencies that are higher than the upper bound of a version range.
+            var aboveUpperBounds = GetDependenciesAboveUpperBounds(indexedGraphs, logger);
+            await logger.LogMessagesAsync(aboveUpperBounds);
         }
 
         /// <summary>
@@ -111,14 +118,14 @@ namespace NuGet.Commands
         /// Warn for dependencies that have been bumped up.
         /// </summary>
         public static IEnumerable<RestoreLogMessage> GetBumpedUpDependencies(
-            IEnumerable<IRestoreTargetGraph> graphs,
+            List<IndexedRestoreTargetGraph> graphs,
             PackageSpec project,
             ISet<string> ignoreIds)
         {
             var messages = new List<RestoreLogMessage>();
 
             // Group by framework to get project dependencies, then check each graph.
-            foreach (var frameworkGroup in graphs.GroupBy(e => e.Framework))
+            foreach (var frameworkGroup in graphs.GroupBy(e => e.Graph.Framework))
             {
                 // Get dependencies from the project
                 var dependencies = project.GetPackageDependenciesForFramework(frameworkGroup.Key)
@@ -128,24 +135,27 @@ namespace NuGet.Commands
                 foreach (var dependency in dependencies)
                 {
                     // Graphs may have different versions of the resolved package
-                    foreach (var graph in frameworkGroup)
+                    foreach (var indexedGraph in frameworkGroup)
                     {
-                        // Ignore floating or version-less (project) dependencies
-                        // Avoid warnings for non-packages
-                        var match = graph.Flattened.GetItemById(dependency.Name);
-
-                        if (match != null
-                            && LibraryType.Package == match.Key.Type
-                            && dependency.LibraryRange.VersionRange.IsMinInclusive
-                            && match.Key.Version > dependency.LibraryRange.VersionRange.MinVersion)
+                        var minVersion = dependency.LibraryRange.VersionRange?.MinVersion;
+                        if (minVersion != null && dependency.LibraryRange.VersionRange.IsMinInclusive)
                         {
-                            var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
-                                dependency.LibraryRange.Name,
-                                dependency.LibraryRange.VersionRange.PrettyPrint(),
-                                match.Key.Name,
-                                match.Key.Version);
+                            // Ignore floating or version-less (project) dependencies
+                            // Avoid warnings for non-packages
+                            var match = indexedGraph.GetItemById(dependency.Name, LibraryType.Package);
 
-                            messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, message, match.Key.Name, graph.TargetGraphName));
+                            if (match != null && match.Key.Version > minVersion)
+                            {
+                                var message = string.Format(CultureInfo.CurrentCulture, Strings.Log_DependencyBumpedUp,
+                                    dependency.LibraryRange.Name,
+                                    dependency.LibraryRange.VersionRange.PrettyPrint(),
+                                    match.Key.Name,
+                                    match.Key.Version);
+
+                                var graphName = indexedGraph.Graph.TargetGraphName;
+
+                                messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1601, message, match.Key.Name, graphName));
+                            }
                         }
                     }
                 }
@@ -207,6 +217,68 @@ namespace NuGet.Commands
             }
 
             return !range.IsMinInclusive || !range.HasLowerBound;
+        }
+
+        /// <summary>
+        /// Log upgrade warnings from the graphs.
+        /// </summary>
+        public static IEnumerable<RestoreLogMessage> GetDependenciesAboveUpperBounds(List<IndexedRestoreTargetGraph> graphs, ILogger logger)
+        {
+            var messages = new List<RestoreLogMessage>();
+
+            foreach (var indexedGraph in graphs)
+            {
+                var graph = indexedGraph.Graph;
+
+                foreach (var node in graph.Flattened)
+                {
+                    var dependencies = node.Data?.Dependencies ?? Enumerable.Empty<LibraryDependency>();
+
+                    foreach (var dependency in dependencies)
+                    {
+                        // Check if the dependency has an upper bound
+                        var dependencyRange = dependency.LibraryRange.VersionRange;
+                        var upperBound = dependencyRange?.MaxVersion;
+                        if (upperBound != null)
+                        {
+                            var dependencyId = dependency.Name;
+
+                            // If the version does not exist then it was not resolved or is a project and should be skipped.
+                            var match = indexedGraph.GetItemById(dependencyId, LibraryType.Package);
+                            if (match != null)
+                            {
+                                var actualVersion = match.Key.Version;
+
+                                // If the upper bound is included then require that the version be higher than the upper bound to fail
+                                // If the upper bound is not included, then an exact match on the upperbound is a failure
+                                var compare = dependencyRange.IsMaxInclusive ? 1 : 0;
+
+                                if (VersionComparer.VersionRelease.Compare(actualVersion, upperBound) >= compare)
+                                {
+                                    // True if the package already has an NU1607 error, NU1608 would be redundant here.
+                                    if (!indexedGraph.HasErrors(dependencyId))
+                                    {
+                                        var parent = DiagnosticUtility.FormatIdentity(node.Key);
+                                        var child = DiagnosticUtility.FormatDependency(dependencyId, dependencyRange);
+                                        var actual = DiagnosticUtility.FormatIdentity(match.Key);
+
+                                        var message = string.Format(CultureInfo.CurrentCulture,
+                                            Strings.Warning_VersionAboveUpperBound,
+                                            parent,
+                                            child,
+                                            actual);
+
+                                        messages.Add(RestoreLogMessage.CreateWarning(NuGetLogCode.NU1608, message, dependencyId, graph.TargetGraphName));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Merge log messages
+            return DiagnosticUtility.MergeOnTargetGraph(messages);
         }
 
         private static bool IsNonFloatingPackageDependency(this LibraryDependency dependency)

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.Commands {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1427,6 +1427,15 @@ namespace NuGet.Commands {
         internal static string Warning_UnspecifiedField {
             get {
                 return ResourceManager.GetString("Warning_UnspecifiedField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Detected package version outside of dependency constraint: {0} requires {1} but version {2} was resolved..
+        /// </summary>
+        internal static string Warning_VersionAboveUpperBound {
+            get {
+                return ResourceManager.GetString("Warning_VersionAboveUpperBound", resourceCulture);
             }
         }
     }

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -600,4 +600,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Error_EmptySourceFileProjectDirectory" xml:space="preserve">
     <value>The project directory for the source file '{0}' could not be found.</value>
   </data>
+  <data name="Warning_VersionAboveUpperBound" xml:space="preserve">
+    <value>Detected package version outside of dependency constraint: {0} requires {1} but version {2} was resolved.</value>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
+++ b/src/NuGet.Core/NuGet.Commands/Utility/Extensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,14 +32,6 @@ namespace NuGet.Commands
             return new HashSet<LibraryDependency>(
                 project.Dependencies.Concat(project.GetTargetFramework(framework).Dependencies)
                                     .Where(e => e.LibraryRange.TypeConstraintAllows(LibraryDependencyTarget.Package)));
-        }
-
-        /// <summary>
-        /// Search on Key.Name for the given package/project id.
-        /// </summary>
-        public static GraphItem<RemoteResolveResult> GetItemById(this IEnumerable<GraphItem<RemoteResolveResult>> items, string id)
-        {
-            return items.FirstOrDefault(e => e.Key.Name.Equals(id, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -169,6 +169,11 @@ namespace NuGet.Common
         NU1607 = 1607,
 
         /// <summary>
+        /// Version is higher than upper bound.
+        /// </summary>
+        NU1608 = 1608,
+
+        /// <summary>
         /// Fallback framework used.
         /// </summary>
         NU1701 = 1701,


### PR DESCRIPTION
Warns when the flattened graph contains a version higher than an allowed upper bound version. This is essentially the reverse of a downgrade warning.

Example:
```
Detected package version outside of dependency constraint: x 1.0.0 requires y (= 1.0.0) but version y 2.0.0 was resolved.
```

Fixes https://github.com/NuGet/Home/issues/2358