### PR TITLE
Use TopologicalSortUtility for DependencyGraphSpec sort

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
+++ b/src/NuGet.Core/NuGet.Packaging/TopologicalSortUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,36 +11,109 @@ namespace NuGet.Packaging
 {
     public static class TopologicalSortUtility
     {
-        private static readonly PackageInfoComparer DefaultComparer = new PackageInfoComparer();
+        /// <summary>
+        /// Order dependencies by children first.
+        /// </summary>
+        /// <param name="items">Items to sort.</param>
+        /// <param name="comparer">Comparer for Ids.</param>
+        /// <param name="getId">Retrieve the id of the item.</param>
+        /// <param name="getDependencies">Retrieve dependency ids.</param>
+        /// <returns></returns>
+        public static IReadOnlyList<T> SortPackagesByDependencyOrder<T>(
+            IEnumerable<T> items,
+            StringComparer comparer,
+            Func<T, string> getId,
+            Func<T, string[]> getDependencies) where T : class
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            if (comparer == null)
+            {
+                throw new ArgumentNullException(nameof(comparer));
+            }
+
+            if (getId == null)
+            {
+                throw new ArgumentNullException(nameof(getId));
+            }
+
+            if (getDependencies == null)
+            {
+                throw new ArgumentNullException(nameof(getDependencies));
+            }
+
+            // De-dupe and create a lookup table for mapping items back after sorting
+            var lookup = new Dictionary<string, T>(comparer);
+            var itemInfos = new List<ItemDependencyInfo>();
+
+            foreach (var item in items)
+            {
+                var id = getId(item);
+                var deps = getDependencies(item);
+
+                if (!lookup.ContainsKey(id))
+                {
+                    lookup.Add(id, item);
+                    itemInfos.Add(new ItemDependencyInfo(id, deps));
+                }
+            }
+
+            // Sort
+            var sortedInfos = SortPackagesByDependencyOrder(itemInfos, comparer);
+
+            // ItemInfo -> Original item
+            var sorted = new List<T>(sortedInfos.Count);
+            foreach (var item in sortedInfos)
+            {
+                sorted.Add(lookup[item.Id]);
+            }
+
+            return sorted;
+        }
+
         /// <summary>
         /// Order dependencies by children first.
         /// </summary>
         public static IReadOnlyList<PackageDependencyInfo> SortPackagesByDependencyOrder(
             IEnumerable<PackageDependencyInfo> packages)
         {
-            var lookup = new Dictionary<string, PackageInfo>(StringComparer.OrdinalIgnoreCase);
+            return SortPackagesByDependencyOrder(
+                packages,
+                StringComparer.OrdinalIgnoreCase,
+                GetPackageDependencyInfoId,
+                GetPackageDependencyInfoDependencies);
+        }
+
+        /// <summary>
+        /// Order dependencies by children first.
+        /// </summary>
+        private static List<ItemDependencyInfo> SortPackagesByDependencyOrder(List<ItemDependencyInfo> items, StringComparer comparer)
+        {
+            var lookup = new Dictionary<string, ItemDependencyInfo>(comparer);
+            var itemComparer = new PackageInfoComparer(comparer);
+
             //Deduplicate references
-            foreach (var package in packages)
+            foreach (var item in items)
             {
-                var id = package.Id;
-                if (!lookup.ContainsKey(id))
-                {
-                    lookup.Add(id, new PackageInfo(package));
-                }
+                // These are deduped before they are added here
+                lookup.Add(item.Id, item);
             }
 
             // Extract the deduplicated values
             var toSort = lookup.Values.ToArray();
-            var sorted = new List<PackageDependencyInfo>(toSort.Length);
+            var sorted = new List<ItemDependencyInfo>(toSort.Length);
 
             CalculateRelationships(toSort, lookup);
 
             for (var i = 0; i < toSort.Length; i++)
             {
-                Array.Sort(toSort, i, toSort.Length - i, DefaultComparer);
+                Array.Sort(toSort, i, toSort.Length - i, itemComparer);
                 // take the child with the lowest number of children
                 var package = toSort[i];
-                sorted.Add(package.Package);
+                sorted.Add(package);
                 UpdateChildCounts(package);
             }
 
@@ -50,7 +123,7 @@ namespace NuGet.Packaging
             return sorted;
         }
 
-        private static void UpdateChildCounts(PackageInfo package)
+        private static void UpdateChildCounts(ItemDependencyInfo package)
         {
             // Decrement the parent count for each child of this package.
             var children = package.Children;
@@ -64,23 +137,21 @@ namespace NuGet.Packaging
             }
         }
 
-        private static void CalculateRelationships(PackageInfo[] packages, Dictionary<string, PackageInfo> lookup)
+        private static void CalculateRelationships(ItemDependencyInfo[] packages, Dictionary<string, ItemDependencyInfo> lookup)
         {
             foreach (var package in packages)
             {
-                var deps = package.Package.Dependencies;
-                var dependencies = deps as PackageDependency[] ?? deps.ToArray();
+                var dependencies = package.DependencyIds ?? new string[0];
 
-                foreach (var dependency in dependencies)
+                foreach (var id in dependencies)
                 {
-                    var id = dependency.Id;
                     if (lookup.TryGetValue(id, out var dependencyPackage))
                     {
                         // Mark the current package as a parent
                         var parents = dependencyPackage.Parents;
                         if (parents == null)
                         {
-                            parents = new List<PackageInfo>();
+                            parents = new List<ItemDependencyInfo>();
                             dependencyPackage.Parents = parents;
                         }
                         parents.Add(package);
@@ -89,7 +160,7 @@ namespace NuGet.Packaging
                         var packageChildren = package.Children;
                         if (packageChildren == null)
                         {
-                            packageChildren = new List<PackageInfo>();
+                            packageChildren = new List<ItemDependencyInfo>();
                             package.Children = packageChildren;
                         }
                         packageChildren.Add(dependencyPackage);
@@ -103,9 +174,27 @@ namespace NuGet.Packaging
             }
         }
 
-        private class PackageInfoComparer : IComparer<PackageInfo>
+
+        private static string GetPackageDependencyInfoId(PackageDependencyInfo info)
         {
-            public int Compare(PackageInfo x, PackageInfo y)
+            return info.Id;
+        }
+
+        private static string[] GetPackageDependencyInfoDependencies(PackageDependencyInfo info)
+        {
+            return info.Dependencies.Select(e => e.Id).ToArray();
+        }
+
+        private class PackageInfoComparer : IComparer<ItemDependencyInfo>
+        {
+            private readonly StringComparer _comparer;
+
+            public PackageInfoComparer(StringComparer comparer)
+            {
+                _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+            }
+
+            public int Compare(ItemDependencyInfo x, ItemDependencyInfo y)
             {
                 // Order packages by parent count
                 if (x.ActiveParents < y.ActiveParents)
@@ -116,23 +205,27 @@ namespace NuGet.Packaging
                 {
                     return 1;
                 }
-                return StringComparer.OrdinalIgnoreCase.Compare(x.Package.Id, y.Package.Id);
+
+                return _comparer.Compare(x.Id, y.Id);
             }
         }
 
         [DebuggerDisplay("{Package.Id} Active: {ActiveParents}")]
-        private sealed class PackageInfo
+        private sealed class ItemDependencyInfo
         {
-            public PackageInfo(PackageDependencyInfo package)
+            public ItemDependencyInfo(string id, string[] dependencyIds)
             {
-                Package = package;
                 ActiveParents = 0;
+                Id = id;
+                DependencyIds = dependencyIds;
             }
 
-            public PackageDependencyInfo Package;
+            public string Id;
+            public string[] DependencyIds;
+
             public int ActiveParents;
-            public List<PackageInfo> Parents;
-            public List<PackageInfo> Children;
+            public List<ItemDependencyInfo> Parents;
+            public List<ItemDependencyInfo> Children;
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.ProjectModel.Test/DependencyGraphSpecTests.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -47,14 +48,14 @@ namespace NuGet.ProjectModel.Test
             // Act
             var dg = DependencyGraphSpec.Load(json);
 
-            var xClosure = dg.GetClosure("A55205E7-4D08-4672-8011-0925467CC45F").ToList();
-            var yClosure = dg.GetClosure("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F").ToList();
-            var zClosure = dg.GetClosure("44B29B8D-8413-42D2-8DF4-72225659619B").ToList();
+            var xClosure = dg.GetClosure("A55205E7-4D08-4672-8011-0925467CC45F").OrderBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal).ToList();
+            var yClosure = dg.GetClosure("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F").OrderBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal).ToList();
+            var zClosure = dg.GetClosure("44B29B8D-8413-42D2-8DF4-72225659619B").OrderBy(e => e.RestoreMetadata.ProjectUniqueName, StringComparer.Ordinal).ToList();
 
             // Assert
             Assert.Equal(3, xClosure.Count);
-            Assert.Equal("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F", xClosure[0].RestoreMetadata.ProjectUniqueName);
-            Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B", xClosure[1].RestoreMetadata.ProjectUniqueName);
+            Assert.Equal("44B29B8D-8413-42D2-8DF4-72225659619B", xClosure[0].RestoreMetadata.ProjectUniqueName);
+            Assert.Equal("78A6AD3F-9FA5-47F6-A54E-84B46A48CB2F", xClosure[1].RestoreMetadata.ProjectUniqueName);
             Assert.Equal("A55205E7-4D08-4672-8011-0925467CC45F", xClosure[2].RestoreMetadata.ProjectUniqueName);
 
             Assert.Equal(1, yClosure.Count);


### PR DESCRIPTION
Use TopologicalSortUtility for DependencyGraphSpec sort

* Removing unneeded sorting when finding the dgspec project closure, every place that GetClosure was called it was re-sorting afterwards.
* Moving DependencyGraphSpec.SortPackagesByDependencyOrder to use TopologicalSortUtility which is dramatically faster. This is still used for installs/updates from the VS UI.

A test solution with 130 interlinked projects went from 43s to 5s for restore time of the dg spec directly  (no msbuild time).

✔️ Sort behavior is covered by existing unit tests and the results are the same.

Fixes https://github.com/NuGet/Home/issues/5814