### PR TITLE
allow a way to specify allowed extensions in build output folder

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -15,6 +15,8 @@ namespace NuGet.Build.Tasks.Pack
     /// </typeparam>
     public interface IPackTaskRequest<TItem>
     {
+        string[] AllowedOutputExtensionsInPackageBuildOutputFolder { get; }
+        string[] AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get; }
         string AssemblyName { get; }
         string[] Authors { get; }
         TItem[] BuildOutputInPackage { get; }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -39,6 +39,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <AddPriFileDependsOn Condition="'$(MicrosoftPortableCurrentVersionPropsHasBeenImported)' == 'true'">DeterminePortableBuildCapabilities</AddPriFileDependsOn>
     <NuspecOutputPath Condition="'$(NuspecOutputPath)' == ''">$(BaseIntermediateOutputPath)$(Configuration)\</NuspecOutputPath>
     <ImportNuGetBuildTasksPackTargetsFromSdk Condition="'$(ImportNuGetBuildTasksPackTargetsFromSdk)' == ''">false</ImportNuGetBuildTasksPackTargetsFromSdk>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>.dll; .exe; .winmd; .json; .pri; .xml; $(AllowedOutputExtensionsInPackageBuildOutputFolder)</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>.pdb; .mdb; $(AllowedOutputExtensionsInPackageBuildOutputFolder); $(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)</AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder>
   </PropertyGroup>
   <PropertyGroup Condition="'$(NoBuild)' == 'true' ">
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
@@ -239,7 +241,9 @@ Copyright (c) .NET Foundation. All rights reserved.
               RestoreOutputPath="$(RestoreOutputAbsolutePath)"
               NuspecFile="$(NuspecFileAbsolutePath)"
               NuspecBasePath="$(NuspecBasePath)"
-              NuspecProperties="$(NuspecProperties)"/>
+              NuspecProperties="$(NuspecProperties)"
+              AllowedOutputExtensionsInPackageBuildOutputFolder="$(AllowedOutputExtensionsInPackageBuildOutputFolder)"
+              AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder="$(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder)"/>
   </Target>
 
   <!--
@@ -279,7 +283,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     </MSBuild>
 
     <MSBuild
-      Condition="'$(IncludeSymbols)' == 'true' OR '$(IncludeSource)' == 'true'"
+      Condition="'$(IncludeBuildOutput)' == 'true'"
       Projects="$(MSBuildProjectFullPath)"
       Targets="_GetDebugSymbolsWithTfm"
       Properties="TargetFramework=%(_TargetFrameworks.Identity);">

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -55,6 +55,8 @@ namespace NuGet.Build.Tasks.Pack
         public string[] ContentTargetFolders { get; set; }
         public string[] NuspecProperties { get; set; }
         public string NuspecBasePath { get; set; }
+        public string[] AllowedOutputExtensionsInPackageBuildOutputFolder { get; set; }
+        public string[] AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get; set; }
 
         public ILogger Logger => new MSBuildLogger(Log);
 
@@ -119,6 +121,8 @@ namespace NuGet.Build.Tasks.Pack
         {
             return new PackTaskRequest
             {
+                AllowedOutputExtensionsInPackageBuildOutputFolder = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(AllowedOutputExtensionsInPackageBuildOutputFolder),
+                AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder),
                 AssemblyName = MSBuildStringUtility.TrimAndGetNullForEmpty(AssemblyName),
                 Authors = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Authors),
                 BuildOutputInPackage = MSBuildUtility.WrapMSBuildItem(BuildOutputInPackage),

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -33,6 +33,8 @@ namespace NuGet.Build.Tasks.Pack
                 NoPackageAnalysis = request.NoPackageAnalysis,
                 PackTargetArgs = new MSBuildPackTargetArgs
                 {
+                    AllowedOutputExtensionsInPackageBuildOutputFolder = InitOutputExtensions(request.AllowedOutputExtensionsInPackageBuildOutputFolder),
+                    AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = InitOutputExtensions(request.AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder),
                     TargetPathsToAssemblies = InitLibFiles(request.BuildOutputInPackage),
                     TargetPathsToSymbols = InitLibFiles(request.TargetPathsToSymbols),
                     AssemblyName = request.AssemblyName,
@@ -719,6 +721,11 @@ namespace NuGet.Build.Tasks.Pack
             }
 
             return dictionary;
+        }
+
+        private HashSet<string> InitOutputExtensions(IEnumerable<string> outputExtensions)
+        {
+            return new HashSet<string>(outputExtensions.Distinct(StringComparer.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -9,6 +9,8 @@ namespace NuGet.Build.Tasks.Pack
 {
     public class PackTaskRequest : IPackTaskRequest<IMSBuildItem>
     {
+        public string[] AllowedOutputExtensionsInPackageBuildOutputFolder { get; set; }
+        public string[] AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get; set; }
         public string AssemblyName { get; set; }
         public string[] Authors { get; set; }
         public IMSBuildItem[] BuildOutputInPackage { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildPackTargetArgs.cs
@@ -11,6 +11,8 @@ namespace NuGet.Commands
     {
         public IEnumerable<OutputLibFile> TargetPathsToSymbols { get; set; } 
         public IEnumerable<OutputLibFile> TargetPathsToAssemblies { get; set; }
+        public HashSet<string> AllowedOutputExtensionsInPackageBuildOutputFolder { get; set; }
+        public HashSet<string> AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder { get; set; }
         public string AssemblyName { get; set; }
         public string NuspecOutputPath { get; set; }
         public Dictionary<string, IEnumerable<ContentMetadata>> ContentFiles { get; set; }

--- a/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
+++ b/src/NuGet.Core/NuGet.Commands/MSBuildProjectFactory.cs
@@ -22,32 +22,6 @@ namespace NuGet.Commands
         private static readonly string ReferenceFolder = PackagingConstants.Folders.Lib;
         private static readonly string ToolsFolder = PackagingConstants.Folders.Tools;
         private static readonly string SourcesFolder = PackagingConstants.Folders.Source;
-        
-        // List of extensions to allow in the output path
-        private static readonly HashSet<string> _allowedOutputExtensions
-            = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ".dll",
-            ".exe",
-            ".xml",
-            ".json",
-            ".winmd",
-            ".pri"
-        };
-
-        // List of extensions to allow in the output path if IncludeSymbols is set
-        private static readonly HashSet<string> _allowedOutputExtensionsForSymbols
-            = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ".dll",
-            ".exe",
-            ".xml",
-            ".winmd",
-            ".json",
-            ".pri",
-            ".pdb",
-            ".mdb"
-        };
 
         private MSBuildPackTargetArgs PackTargetArgs { get; set; }
         private PackArgs PackArgs { get; set; }
@@ -142,13 +116,9 @@ namespace NuGet.Commands
         {
             if (PackTargetArgs.IncludeBuildOutput)
             {
-                if (IncludeSymbols)
-                {
-                    // Include pdbs for symbol packages
-                    AddOutputLibFiles(PackTargetArgs.TargetPathsToSymbols, _allowedOutputExtensionsForSymbols);
-                }
+                AddOutputLibFiles(PackTargetArgs.TargetPathsToSymbols, IncludeSymbols ? PackTargetArgs.AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder : PackTargetArgs.AllowedOutputExtensionsInPackageBuildOutputFolder);
 
-                AddOutputLibFiles(PackTargetArgs.TargetPathsToAssemblies, _allowedOutputExtensions);
+                AddOutputLibFiles(PackTargetArgs.TargetPathsToAssemblies, PackTargetArgs.AllowedOutputExtensionsInPackageBuildOutputFolder);
             }
         }
 

--- a/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Build.Tasks.Pack.Test/PackTaskTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -264,6 +264,8 @@ namespace NuGet.Build.Tasks.Pack.Test
                 AssemblyName = "AssemblyName",
                 FrameworkAssemblyReferences = new ITaskItem[0],
                 Authors = new string[0],
+                AllowedOutputExtensionsInPackageBuildOutputFolder = new string[0],
+                AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder = new string[0],
                 BuildOutputFolder = "BuildOutputFolder",
                 ContentTargetFolders = new string[] { "ContentTargetFolders" } ,
                 ContinuePackingAfterGeneratingNuspec = true,


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Home/issues/5810

This fix enables package authors to add custom content to the build output target folder and also control what extensions are allowed to go into that folder. Currently, there is an extension point ```TargetsForTfmSpecificBuildOutput``` , however, if someone tries to add a file that is not in the list of allowed extensions , then the target doesn't work.

This customization will allow package authors to control the allowed extensions using ```AllowedOutputExtensionsInPackageBuildOutputFolder ``` for the main package and ```AllowedOutputExtensionsInSymbolsPackageBuildOutputFolder ``` for the symbols package