### PR TITLE
Change class library template tfm to net46

### DIFF
--- a/test/EndToEnd/ProjectTemplates/ClassLibrary.zip/classlibrary.csproj
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary.zip/classlibrary.csproj
@@ -10,7 +10,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
-		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/EndToEnd/ProjectTemplates/ClassLibrary.zip/classlibrary.csproj
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary.zip/classlibrary.csproj
@@ -10,7 +10,7 @@
 		<AppDesignerFolder>Properties</AppDesignerFolder>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<AssemblyName>$safeprojectname$</AssemblyName>
-		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/assemblyinfo.cs
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/assemblyinfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("$projectname$")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("$guid1$")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/class1.cs
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/class1.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+$if$ ($targetframeworkversion$ >= 3.5)using System.Linq;
+$endif$using System.Text;
+
+namespace $safeprojectname$
+{
+	public class Class1
+	{
+	}
+}

--- a/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/classlibrary.csproj
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/classlibrary.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>$guid1$</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>$safeprojectname$</RootNamespace>
+		<AssemblyName>$safeprojectname$</AssemblyName>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+ 		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System"/>
+		$if$ ($targetframeworkversion$ >= 3.5)
+		<Reference Include="System.Core"/>
+		<Reference Include="System.Xml.Linq"/>
+		<Reference Include="System.Data.DataSetExtensions"/>
+		$endif$
+		$if$ ($targetframeworkversion$ >= 4.0)
+		<Reference Include="Microsoft.CSharp"/>
+ 		$endif$
+		<Reference Include="System.Data"/>
+		<Reference Include="System.Xml"/>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="Class1.cs" />
+
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+
+ </Project>

--- a/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/csClassLibrary.vstemplate
+++ b/test/EndToEnd/ProjectTemplates/ClassLibrary46.zip/csClassLibrary.vstemplate
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005">
+  <TemplateData>
+    <Name Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2322" />
+    <Description Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="2323" />
+    <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4547" />
+    <TemplateID>Microsoft.CSharp.ClassLibrary</TemplateID>
+    <ProjectType>CSharp</ProjectType>
+    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
+    <SortOrder>20</SortOrder>
+    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <CreateNewFolder>true</CreateNewFolder>
+    <DefaultName>ClassLibrary</DefaultName>
+    <ProvideDefaultName>true</ProvideDefaultName>
+  </TemplateData>
+  <TemplateContent>
+    <Project File="ClassLibrary.csproj" ReplaceParameters="true">
+      <ProjectItem ReplaceParameters="true" TargetFileName="Properties\AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
+      <ProjectItem ReplaceParameters="true">Class1.cs</ProjectItem>
+    </Project>
+  </TemplateContent>
+</VSTemplate>

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -346,7 +346,7 @@ function Test-BuildIntegratedTransitiveProjectJsonRestores {
 
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
-    $project2 = New-ClassLibrary46
+    $project2 = New-ClassLibraryNET46
     $project3 = New-Project BuildIntegratedClassLibrary
 
     Add-ProjectReference $project2 $project1
@@ -465,7 +465,7 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTr
 
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
-    $project2 = New-ClassLibrary46 ClassLib2
+    $project2 = New-ClassLibraryNET46 ClassLib2
     $project3 = New-Project BuildIntegratedClassLibrary
 
     Add-ProjectReference $project1 $project2

--- a/test/EndToEnd/tests/BuildIntegratedTest.ps1
+++ b/test/EndToEnd/tests/BuildIntegratedTest.ps1
@@ -346,7 +346,7 @@ function Test-BuildIntegratedTransitiveProjectJsonRestores {
 
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
-    $project2 = New-ClassLibrary
+    $project2 = New-ClassLibrary46
     $project3 = New-Project BuildIntegratedClassLibrary
 
     Add-ProjectReference $project2 $project1
@@ -465,7 +465,7 @@ function Test-BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTr
 
     # Arrange
     $project1 = New-Project BuildIntegratedClassLibrary
-    $project2 = New-ClassLibrary ClassLib2
+    $project2 = New-ClassLibrary46 ClassLib2
     $project3 = New-Project BuildIntegratedClassLibrary
 
     Add-ProjectReference $project1 $project2

--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -303,7 +303,7 @@ function New-ClassLibrary {
     New-Project ClassLibrary $ProjectName $SolutionFolderName
 }
 
-function New-ClassLibrary46 {
+function New-ClassLibraryNET46 {
     param(
         [string]$ProjectName,
         [string]$SolutionFolderName

--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -303,6 +303,15 @@ function New-ClassLibrary {
     New-Project ClassLibrary $ProjectName $SolutionFolderName
 }
 
+function New-ClassLibrary46 {
+    param(
+        [string]$ProjectName,
+        [string]$SolutionFolderName
+    )
+
+    New-Project ClassLibrary46 $ProjectName $SolutionFolderName
+}
+
 function New-LightSwitchApplication
 {
     param(


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5778
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Changing the template so that the test have compatible frameworks
Fixes E2E tests 
BuildIntegratedParentProjectIsRestoredAfterInstallWithClassLibInTree & 
BuildIntegratedTransitiveProjectJsonRestores

## Testing/Validation
Tests Added: No  
Reason for not adding tests: The changes itself pertains to a test  
Validation done:  Run E2E on a private machine, run through automation

PS:
Waiting on the E2E tests to complete before merging. 
