### PR TITLE
add version-suffix to P2P references for dotnet pack

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/IPackTaskRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Build.Framework;
@@ -59,5 +59,6 @@ namespace NuGet.Build.Tasks.Pack
         string[] TargetFrameworks { get; }
         TItem[] TargetPathsToSymbols { get; }
         string Title { get; }
+        string VersionSuffix { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -207,6 +207,7 @@ Copyright (c) .NET Foundation. All rights reserved.
               PackageVersion="$(PackageVersion)"
               PackageId="$(PackageId)"
               Title="$(Title)"
+              VersionSuffix="$(VersionSuffix)"
               Authors="$(Authors)"
               Description="$(PackageDescription)"
               Copyright="$(Copyright)"

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTask.cs
@@ -22,6 +22,7 @@ namespace NuGet.Build.Tasks.Pack
         public ITaskItem[] BuildOutputInPackage { get; set; }
         public string PackageId { get; set; }
         public string PackageVersion { get; set; }
+        public string VersionSuffix { get; set; }
         public string Title { get; set; }
         public string[] Authors { get; set; }
         public string Description { get; set; }
@@ -164,7 +165,8 @@ namespace NuGet.Build.Tasks.Pack
                 Tags = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(Tags),
                 TargetFrameworks = MSBuildStringUtility.TrimAndExcludeNullOrEmpty(TargetFrameworks),
                 TargetPathsToSymbols = MSBuildUtility.WrapMSBuildItem(TargetPathsToSymbols),
-                Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title)
+                Title = MSBuildStringUtility.TrimAndGetNullForEmpty(Title),
+                VersionSuffix = MSBuildStringUtility.TrimAndGetNullForEmpty(VersionSuffix)
             };
         }
     }

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -183,7 +183,7 @@ namespace NuGet.Build.Tasks.Pack
                     assetsFilePath));
             }
 
-            PopulateProjectAndPackageReferences(builder, assetsFile);
+            PopulateProjectAndPackageReferences(builder, assetsFile, request.VersionSuffix);
             PopulateFrameworkAssemblyReferences(builder, request);
             return builder;
         }
@@ -570,11 +570,11 @@ namespace NuGet.Build.Tasks.Pack
             return sourceFiles;
         }
 
-        private void PopulateProjectAndPackageReferences(PackageBuilder packageBuilder, LockFile assetsFile)
+        private void PopulateProjectAndPackageReferences(PackageBuilder packageBuilder, LockFile assetsFile, string versionSuffix)
         {
             var dependenciesByFramework = new Dictionary<NuGetFramework, HashSet<LibraryDependency>>();
 
-            InitializeProjectDependencies(assetsFile, dependenciesByFramework);
+            InitializeProjectDependencies(assetsFile, dependenciesByFramework, versionSuffix);
             InitializePackageDependencies(assetsFile, dependenciesByFramework);
 
             foreach (var pair in dependenciesByFramework)
@@ -585,7 +585,8 @@ namespace NuGet.Build.Tasks.Pack
 
         private static void InitializeProjectDependencies(
             LockFile assetsFile,
-            Dictionary<NuGetFramework, HashSet<LibraryDependency>> dependenciesByFramework)
+            Dictionary<NuGetFramework, HashSet<LibraryDependency>> dependenciesByFramework,
+            string versionSuffix)
         {
             // From the package spec, all we know is each absolute path to the project reference the the target
             // framework that project reference applies to.
@@ -640,6 +641,10 @@ namespace NuGet.Build.Tasks.Pack
                         continue;
                     }
 
+                    if(!string.IsNullOrEmpty(versionSuffix) && !string.Equals(versionSuffix, targetLibrary.Version.Release, StringComparison.Ordinal))
+                    {
+                        targetLibrary.Version = new NuGetVersion(targetLibrary.Version.Version, versionSuffix);
+                    }
                     // TODO: Implement <TreatAsPackageReference>false</TreatAsPackageReference>
                     //   https://github.com/NuGet/Home/issues/3891
                     //

--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -53,5 +53,6 @@ namespace NuGet.Build.Tasks.Pack
         public string[] TargetFrameworks { get; set; }
         public IMSBuildItem[] TargetPathsToSymbols { get; set; }
         public string Title { get; set; }
+        public string VersionSuffix { get; set; }
     }
 }


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/4337
Regression: No  
If Regression then when did it last work:  N/A  
If Regression then how are we preventing it in future:   N/A

## Fix
Details: This fix adds the passed in version suffix to the project references if they don't already have it. These project references get added to the resulting nupkg as package references with the given version suffix.

## Testing/Validation
Tests Added: Yes 
Reason for not adding tests:  Tests added
Validation done:  Added automated functional tests, and verified locally.
