### PR TITLE
When resolving MsBuild consider the case that some SKUs don't ship with MsBuild

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildToolset.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -64,6 +64,8 @@ namespace NuGet.CommandLine
                 return _parsedToolsVersion;
             }
         }
+
+        public bool IsValid => Path != null;
 
         public string Version { get; private set; }
 
@@ -148,6 +150,11 @@ namespace NuGet.CommandLine
             }
 
             return FileVersionInfo.GetVersionInfo(msBuildPath)?.FileVersion;
+        }
+
+        public override string ToString()
+        {
+            return $"Version: {Version} Path: {Path}";
         }
     }
 }

--- a/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/MsBuildUtility.cs
@@ -524,14 +524,17 @@ namespace NuGet.CommandLine
             Func<string> getMsBuildPathInPathVar)
         {
             MsBuildToolset toolset;
+
+            var toolsetsContainingMSBuild = GetToolsetsContainingValidMSBuildInstallation(installedToolsets);
+
             if (string.IsNullOrEmpty(userVersion))
             {
                 var msbuildPathInPath = getMsBuildPathInPathVar();
-                toolset = GetToolsetFromPath(msbuildPathInPath, installedToolsets);
+                toolset = GetToolsetFromPath(msbuildPathInPath, toolsetsContainingMSBuild);
             }
             else
             {
-                toolset = GetToolsetFromUserVersion(userVersion, installedToolsets);
+                toolset = GetToolsetFromUserVersion(userVersion, toolsetsContainingMSBuild);
             }
 
             if (toolset == null)
@@ -541,6 +544,11 @@ namespace NuGet.CommandLine
 
             LogToolsetToConsole(console, toolset);
             return toolset.Path;
+        }
+
+        private static IEnumerable<MsBuildToolset> GetToolsetsContainingValidMSBuildInstallation(IEnumerable<MsBuildToolset> installedToolsets)
+        {
+            return installedToolsets.Where(e => e.IsValid);
         }
 
         /// <summary>

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
@@ -31,6 +31,23 @@ namespace NuGet.CommandLine.Test
         [Theory]
         [MemberData("PathMatchData", MemberType = typeof(ToolsetDataSource))]
         public void VersionSelectedThatMatchesPathMsBuildVersion(List<MsBuildToolset> toolsets, string expectedPath)
+        {
+            // Arrange
+            // Act
+            var directory = MsBuildUtility.GetMsBuildDirectoryInternal(
+                userVersion: null,
+                console: null,
+                installedToolsets: toolsets.OrderByDescending(t => t),
+                getMsBuildPathInPathVar: () => expectedPath);
+
+            // Assert
+            Assert.Equal(expectedPath, directory);
+        }
+
+        // Test that GetMsBuildDirectoryInternal deals with invalid toolsets (for example ones created from SKUs that don't ship MSBuild like VS Test Agent SKU) See https://github.com/NuGet/Home/issues/5840 for more info
+        [Theory]
+        [MemberData("InvalidToolsetData", MemberType = typeof(ToolsetDataSource))]
+        public void HandlesToolsetsWithInvalidPaths(List<MsBuildToolset> toolsets, string expectedPath)
         {
             // Arrange
             // Act
@@ -214,6 +231,10 @@ namespace NuGet.CommandLine.Test
                 version: "15.1.137.25382",
                 path: @"c:\vs\25557.01",
                 installDate: new DateTime(2016, 9, 17));
+            private static readonly MsBuildToolset InvalidToolsetVSTest = new MsBuildToolset(
+                version: null,
+                path: null,
+                installDate: new DateTime(2017, 9, 7));
 
             // Toolset collections
 
@@ -275,6 +296,11 @@ namespace NuGet.CommandLine.Test
                 Toolset14,
                 Toolset12,
                 Toolset4
+            };
+
+            private static List<MsBuildToolset> CombinedToolsets_MsBuild15AndVSTestToolsets = new List<MsBuildToolset> {
+                Toolset15_Wed_LongVersion,
+                InvalidToolsetVSTest
             };
 
             // Test data sets
@@ -342,12 +368,20 @@ namespace NuGet.CommandLine.Test
                     new object[] { LegacyToolsets_NonNumericVersion, "0" },
                 };
 
+            private static readonly List<object[]> _invalidToolsetData
+                = new List<object[]>
+                {
+                    new object[] { CombinedToolsets_MsBuild15AndVSTestToolsets, Toolset15_Wed_LongVersion.Path}
+                };
+
             public static IEnumerable<object[]> HighestPathData => _highestPathData;
             public static IEnumerable<object[]> PathMatchData => _pathMatchData;
             public static IEnumerable<object[]> VersionMatchData => _versionMatchData;
             public static IEnumerable<object[]> IntegerVersionMatchData => _integerVersionMatchData;
             public static IEnumerable<object[]> NonNumericVersionMatchData => _nonNumericVersionMatchData;
             public static IEnumerable<object[]> NonNumericVersionMatchFailureData => _nonNumericVersionMatchFailureData;
+            public static IEnumerable<object[]> InvalidToolsetData => _invalidToolsetData;
+
         }
     }
 }


### PR DESCRIPTION
## Bug
Link: Fixes https://github.com/NuGet/Home/issues/5840
Regression: Yes, 15.1
If Regression then when did it last work:  Never truly worked, shipped broken in 15.1
If Regression then how are we preventing it in future:   Adding automated tests for that

## Fix
Details: Some SKUs don't ship with MsBuild such as the VS Test Agent SKU. When evaluating these SKUs we didn't consider the fact that the path could be null and we hit an NPE.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  Automated tests and manual validation
