### PR TITLE
Change the consent message log level

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -350,7 +350,7 @@ namespace NuGet.CommandLine
                         LocalizedResourceManager.GetString("RestoreCommandPackageRestoreOptOutMessage"),
                         NuGetResources.PackageRestoreConsentCheckBoxText.Replace("&", ""));
 
-                    Console.LogMinimal(message);
+                    Console.LogInformation(message);
                 }
                 else
                 {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/RestoreOperationLogger.cs
@@ -334,13 +334,13 @@ namespace NuGet.SolutionRestoreManager
                     switch (_operationSource)
                     {
                         case RestoreOperationSource.Implicit:
-                            WriteLine(MSBuildVerbosityLevel.Quiet, Resources.RestoringPackages);
+                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
                             break;
                         case RestoreOperationSource.OnBuild:
-                            WriteLine(MSBuildVerbosityLevel.Quiet, Resources.PackageRestoreOptOutMessage);
+                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.PackageRestoreOptOutMessage);
                             break;
                         case RestoreOperationSource.Explicit:
-                            WriteLine(MSBuildVerbosityLevel.Quiet, Resources.RestoringPackages);
+                            WriteLine(MSBuildVerbosityLevel.Normal, Resources.RestoringPackages);
                             break;
                     }
                 });

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -675,8 +675,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
 
         // Tests that when package restore is enabled and -RequireConsent is specified,
         // the opt out message is displayed.
-        // TODO: renable the test once this is implemented
-        // [Theory]
+        [Theory]
         [InlineData("packages.config")]
         [InlineData("packages.proj1.config")]
         public void RestoreCommand_OptOutMessage(string configFileName)
@@ -687,8 +686,7 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             using (var workingPath = TestDirectory.Create())
             {
                 Util.CreateFile(workingPath, "my.config",
-                    @"
-<?xml version=""1.0"" encoding=""utf-8""?>
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageRestore>
     <add key=""enabled"" value=""True"" />


### PR DESCRIPTION
## Bug
Link: Fixes https://github.com/NuGet/Home/issues/5802
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Change the log level of the package download consent message  

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  There's exisiting infrastructure. Enabled some old disabled tests. 
Validation done: Manual validation, existing automated tests  
