### PR TITLE
change absolute path tests in pack to output to temp directory

### DIFF
--- a/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
+++ b/test/NuGet.Core.FuncTests/Dotnet.Integration.Test/PackCommandTests.cs
@@ -575,7 +575,7 @@ namespace Dotnet.Integration.Test
         [InlineData("folderA/folderB/abc.txt", null,
             "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
         [InlineData("../abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", null, "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         [InlineData("abc.txt", "folderA/", "folderA/abc.txt")]
         [InlineData("abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
         [InlineData("abc.txt", "", "abc.txt")]
@@ -595,15 +595,15 @@ namespace Dotnet.Integration.Test
         [InlineData("folderA/abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
         [InlineData("folderA/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         [InlineData("folderA/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
-        [InlineData("C:/abc.txt", "folderA/", "folderA/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
-        [InlineData("C:/abc.txt", "", "abc.txt")]
-        [InlineData("C:/abc.txt", "/", "abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
-        [InlineData("C:/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA/", "folderA/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "", "abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "/", "abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA;folderB", "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA;contentFiles", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA;contentFiles\\", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA;contentFiles/", "folderA/abc.txt;contentFiles/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt", "folderA;contentFiles/folderA", "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         [InlineData("../abc.txt", "folderA/", "folderA/abc.txt")]
         [InlineData("../abc.txt", "folderA/xyz.txt", "folderA/xyz.txt")]
         [InlineData("../abc.txt", "", "abc.txt")]
@@ -636,6 +636,10 @@ namespace Dotnet.Integration.Test
                 if (sourcePath.StartsWith("##"))
                 {
                     sourcePath = sourcePath.Replace("##", workingDirectory);
+                }
+                else if(sourcePath.StartsWith("{AbsolutePath}"))
+                {
+                    sourcePath.Replace("{AbsolutePath}", Environment.GetEnvironmentVariable("temp").Replace('\\','/'));
                 }
 
                 // Create the subdirectory structure for testing possible source paths for the content file
@@ -1295,7 +1299,7 @@ namespace Dotnet.Integration.Test
         [InlineData("folderA/abc.txt",          null,                               "content/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
         [InlineData("folderA/folderB/abc.txt",  null,                               "content/folderA/folderB/abc.txt;contentFiles/any/netstandard1.4/folderA/folderB/abc.txt")]
         [InlineData("../abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               null,                               "content/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
         [InlineData("abc.txt",                  "folderA/",                         "folderA/abc.txt")]
         [InlineData("abc.txt",                  "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
         [InlineData("abc.txt",                  "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
@@ -1311,13 +1315,13 @@ namespace Dotnet.Integration.Test
         [InlineData("folderA/abc.txt",          "folderA;contentFiles/",            "folderA/folderA/abc.txt;contentFiles/any/netstandard1.4/folderA/abc.txt")]
         [InlineData("folderA/abc.txt",          "folderA;contentFiles/folderA",     "folderA/folderA/abc.txt;contentFiles/folderA/folderA/abc.txt")]
         [InlineData("folderA/abc.txt",          "folderA/xyz.txt",                  "folderA/xyz.txt/folderA/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA/",                         "folderA/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles",             "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles\\",           "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles/",            "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
-        [InlineData("C:/abc.txt",               "folderA;contentFiles/folderA",     "folderA/abc.txt;contentFiles/folderA/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA/",                         "folderA/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA;contentFiles",             "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA;contentFiles\\",           "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA;contentFiles/",            "folderA/abc.txt;contentFiles/any/netstandard1.4/abc.txt")]
+        [InlineData("{AbsolutePath}/abc.txt",               "folderA;contentFiles/folderA",     "folderA/abc.txt;contentFiles/folderA/abc.txt")]
         [InlineData("../abc.txt",               "folderA/",                         "folderA/abc.txt")]
         [InlineData("../abc.txt",               "folderA/xyz.txt",                  "folderA/xyz.txt/abc.txt")]
         [InlineData("../abc.txt",               "folderA;folderB",                  "folderA/abc.txt;folderB/abc.txt")]
@@ -1346,6 +1350,10 @@ namespace Dotnet.Integration.Test
                 if (sourcePath.StartsWith("##"))
                 {
                     sourcePath = sourcePath.Replace("##", workingDirectory);
+                }
+                else if (sourcePath.StartsWith("{AbsolutePath}"))
+                {
+                    sourcePath.Replace("{AbsolutePath}", Environment.GetEnvironmentVariable("temp").Replace('\\', '/'));
                 }
 
                 // Create the subdirectory structure for testing possible source paths for the content file


### PR DESCRIPTION
this is just a test maintenance fix where pack tests were writing out to C:\ to test out absolute paths outside of project directory. Now it writes out to %temp% folder instead.