### PR TITLE
Implemented HTTP cache for packages.config based projects for V2/V3 sources

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.PowerShellCmdlets/PackageActionBaseCommand.cs
@@ -146,7 +146,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 else
                 {
                     NuGetPackageManager.SetDirectInstall(identity, projectContext);
-                    await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, CancellationToken.None);
+                    await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, resolutionContext.SourceCacheContext, CancellationToken.None);
                     NuGetPackageManager.ClearDirectInstall(projectContext);
                 }
             }
@@ -217,7 +217,7 @@ namespace NuGet.PackageManagement.PowerShellCmdlets
                 {
                     var identity = actions.Select(v => v.PackageIdentity).Where(p => p.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                     NuGetPackageManager.SetDirectInstall(identity, projectContext);
-                    await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, CancellationToken.None);
+                    await PackageManager.ExecuteNuGetProjectActionsAsync(project, actions, this, resolutionContext.SourceCacheContext, CancellationToken.None);
                     NuGetPackageManager.ClearDirectInstall(projectContext);
                 }
             }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Implementation/Extensibility/VsPackageInstaller.cs
@@ -390,39 +390,42 @@ namespace NuGet.VisualStudio
             // find the highest version within the ranges
             var idToIdentity = new Dictionary<string, PackageIdentity>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var dep in packages)
+            using (var sourceCacheContext = new SourceCacheContext())
             {
-                NuGetVersion highestVersion = null;
-
-                if (dep.VersionRange != null
-                    && VersionComparer.Default.Equals(dep.VersionRange.MinVersion, dep.VersionRange.MaxVersion)
-                    && dep.VersionRange.MinVersion != null)
+                foreach (var dep in packages)
                 {
-                    // this is a single version, not a range
-                    highestVersion = dep.VersionRange.MinVersion;
-                }
-                else
-                {
-                    var tasks = new List<Task<IEnumerable<NuGetVersion>>>();
+                    NuGetVersion highestVersion = null;
 
-                    foreach (var resource in metadataResources)
+                    if (dep.VersionRange != null
+                        && VersionComparer.Default.Equals(dep.VersionRange.MinVersion, dep.VersionRange.MaxVersion)
+                        && dep.VersionRange.MinVersion != null)
                     {
-                        tasks.Add(resource.GetVersions(dep.Id, NullLogger.Instance, token));
+                        // this is a single version, not a range
+                        highestVersion = dep.VersionRange.MinVersion;
+                    }
+                    else
+                    {
+                        var tasks = new List<Task<IEnumerable<NuGetVersion>>>();
+
+                        foreach (var resource in metadataResources)
+                        {
+                            tasks.Add(resource.GetVersions(dep.Id, sourceCacheContext, NullLogger.Instance, token));
+                        }
+
+                        var versions = await Task.WhenAll(tasks.ToArray());
+
+                        highestVersion = versions.SelectMany(v => v).Where(v => dep.VersionRange.Satisfies(v)).Max();
                     }
 
-                    var versions = await Task.WhenAll(tasks.ToArray());
+                    if (highestVersion == null)
+                    {
+                        throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, VsResources.UnknownPackage, dep.Id));
+                    }
 
-                    highestVersion = versions.SelectMany(v => v).Where(v => dep.VersionRange.Satisfies(v)).Max();
-                }
-
-                if (highestVersion == null)
-                {
-                    throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, VsResources.UnknownPackage, dep.Id));
-                }
-
-                if (!idToIdentity.ContainsKey(dep.Id))
-                {
-                    idToIdentity.Add(dep.Id, new PackageIdentity(dep.Id, highestVersion));
+                    if (!idToIdentity.ContainsKey(dep.Id))
+                    {
+                        idToIdentity.Add(dep.Id, new PackageIdentity(dep.Id, highestVersion));
+                    }
                 }
             }
 
@@ -467,12 +470,6 @@ namespace NuGet.VisualStudio
             try
             {
                 var depBehavior = ignoreDependencies ? DependencyBehavior.Ignore : DependencyBehavior.Lowest;
-
-                var resolution = new ResolutionContext(
-                    depBehavior,
-                    includePrerelease,
-                    includeUnlisted: false,
-                    versionConstraints: VersionConstraints.None);
 
                 var packageManager = CreatePackageManager(repoProvider);
 
@@ -537,21 +534,25 @@ namespace NuGet.VisualStudio
 
             var depBehavior = ignoreDependencies ? DependencyBehavior.Ignore : DependencyBehavior.Lowest;
 
-            var resolution = new ResolutionContext(
-                depBehavior,
-                includePrerelease,
-                includeUnlisted: false,
-                versionConstraints: VersionConstraints.None,
-                gatherCache: gatherCache);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                ResolutionContext resolution = new ResolutionContext(
+                    depBehavior,
+                    includePrerelease,
+                    includeUnlisted: false,
+                    versionConstraints: VersionConstraints.None,
+                    gatherCache: gatherCache,
+                    sourceCacheContext: sourceCacheContext);
 
-            // install the package
-            if (package.Version == null)
-            {
-                await packageManager.InstallPackageAsync(nuGetProject, package.Id, resolution, projectContext, sources, Enumerable.Empty<SourceRepository>(), token);
-            }
-            else
-            {
-                await packageManager.InstallPackageAsync(nuGetProject, package, resolution, projectContext, sources, Enumerable.Empty<SourceRepository>(), token);
+                // install the package
+                if (package.Version == null)
+                {
+                    await packageManager.InstallPackageAsync(nuGetProject, package.Id, resolution, projectContext, sources, Enumerable.Empty<SourceRepository>(), token);
+                }
+                else
+                {
+                    await packageManager.InstallPackageAsync(nuGetProject, package, resolution, projectContext, sources, Enumerable.Empty<SourceRepository>(), token);
+                }
             }
         }
 

--- a/src/NuGet.Core/NuGet.PackageManagement/Context/ResolutionContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Context/ResolutionContext.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 
 namespace NuGet.PackageManagement
@@ -19,7 +20,8 @@ namespace NuGet.PackageManagement
                   includePrelease: false,
                   includeUnlisted: true,
                   versionConstraints: VersionConstraints.None,
-                  gatherCache: new GatherCache())
+                  gatherCache: new GatherCache(),
+                  sourceCacheContext: NullSourceCacheContext.Instance)
         {
         }
 
@@ -35,7 +37,8 @@ namespace NuGet.PackageManagement
                   includePrelease,
                   includeUnlisted,
                   versionConstraints,
-                  new GatherCache())
+                  new GatherCache(),
+                  NullSourceCacheContext.Instance)
         {
         }
 
@@ -47,7 +50,8 @@ namespace NuGet.PackageManagement
             bool includePrelease,
             bool includeUnlisted,
             VersionConstraints versionConstraints,
-            GatherCache gatherCache)
+            GatherCache gatherCache,
+            SourceCacheContext sourceCacheContext)
         {
             if (gatherCache == null)
             {
@@ -59,6 +63,7 @@ namespace NuGet.PackageManagement
             IncludeUnlisted = includeUnlisted;
             VersionConstraints = versionConstraints;
             GatherCache = gatherCache;
+            SourceCacheContext = sourceCacheContext;
         }
 
         /// <summary>
@@ -87,5 +92,10 @@ namespace NuGet.PackageManagement
         /// the gathered packages and re-uses them across all sub operations.
         /// </summary>
         public GatherCache GatherCache { get; }
+
+        /// <summary>
+        /// Http source cache context which will be shared across operations.
+        /// </summary>
+        public SourceCacheContext SourceCacheContext { get; }
     }
 }

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherContext.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/GatherContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/Resolution/ResolverGather.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -282,7 +282,7 @@ namespace NuGet.PackageManagement
                 // Skip installed packages which are targets, this is important for upgrade and reinstall
                 if (!allPrimaryTargets.Contains(installedPackage.Id))
                 {
-                    var packageInfo = await _packagesFolderResource.ResolvePackage(installedPackage, _context.TargetFramework, _context.Log, token);
+                    var packageInfo = await _packagesFolderResource.ResolvePackage(installedPackage, _context.TargetFramework, _context.ResolutionContext.SourceCacheContext, _context.Log, token);
 
                     // Installed packages should exist, but if they do not an attempt will be made to find them in the sources.
                     if (packageInfo != null)
@@ -496,7 +496,7 @@ namespace NuGet.PackageManagement
                 if (version == null)
                 {
                     // find all versions of a package
-                    var packages = await resource.ResolvePackages(packageId, targetFramework, _context.Log, token);
+                    var packages = await resource.ResolvePackages(packageId, targetFramework, _context.ResolutionContext.SourceCacheContext, _context.Log, token);
 
                     results.AddRange(packages);
                 }
@@ -504,7 +504,7 @@ namespace NuGet.PackageManagement
                 {
                     // find a single package id and version
                     var identity = new PackageIdentity(packageId, version);
-                    var package = await resource.ResolvePackage(identity, targetFramework, _context.Log, token);
+                    var package = await resource.ResolvePackage(identity, targetFramework, _context.ResolutionContext.SourceCacheContext, _context.Log, token);
 
                     if (package != null)
                     {

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
@@ -29,14 +32,27 @@ namespace NuGet.Protocol
         public async static Task<IEnumerable<JObject>> LoadRanges(
             HttpSource httpSource,
             Uri registrationUri,
+            string packageId,
             VersionRange range,
+            SourceCacheContext cacheContext,
             ILogger log,
             CancellationToken token)
         {
-            var index = await httpSource.GetJObjectAsync(
-                new HttpSourceRequest(registrationUri, log)
+            var packageIdLowerCase = packageId.ToLowerInvariant();
+
+            var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, 0);
+
+            var index = await httpSource.GetAsync(
+                new HttpSourceCachedRequest(
+                    registrationUri.OriginalString,
+                    $"list_{packageIdLowerCase}_index",
+                    httpSourceCacheContext)
                 {
-                    IgnoreNotFounds = true
+                    IgnoreNotFounds = true,
+                },
+                async httpSourceResult =>
+                {
+                    return await httpSourceResult.Stream.AsJObjectAsync();
                 },
                 log,
                 token);
@@ -59,12 +75,19 @@ namespace NuGet.Protocol
                     JToken items;
                     if (!item.TryGetValue("items", out items))
                     {
-                        var rangeUri = item["@id"].ToObject<Uri>();
+                        var rangeUri = item["@id"].ToString();
 
-                        rangeTasks.Add(httpSource.GetJObjectAsync(
-                            new HttpSourceRequest(rangeUri, log)
+                        rangeTasks.Add(httpSource.GetAsync(
+                            new HttpSourceCachedRequest(
+                                rangeUri,
+                                $"list_{packageIdLowerCase}_range_{lower.ToNormalizedString()}-{upper.ToNormalizedString()}",
+                                httpSourceCacheContext)
                             {
-                                IgnoreNotFounds = true
+                                IgnoreNotFounds = true,
+                            },
+                            async httpSourceResult =>
+                            {
+                                return await httpSourceResult.Stream.AsJObjectAsync();
                             },
                             log,
                             token));

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -29,11 +29,13 @@ namespace NuGet.Protocol
         public static async Task<IEnumerable<RemoteSourceDependencyInfo>> GetDependencies(
             HttpSource httpClient,
             Uri registrationUri,
+            string packageId,
             VersionRange range,
+            SourceCacheContext cacheContext,
             ILogger log,
             CancellationToken token)
         {
-            var ranges = await RegistrationUtility.LoadRanges(httpClient, registrationUri, range, log, token);
+            var ranges = await RegistrationUtility.LoadRanges(httpClient, registrationUri, packageId, range, cacheContext, log, token);
 
             var results = new HashSet<RemoteSourceDependencyInfo>();
             foreach (var rangeObj in ranges)
@@ -115,14 +117,16 @@ namespace NuGet.Protocol
         public static async Task<RegistrationInfo> GetRegistrationInfo(
             HttpSource httpClient,
             Uri registrationUri,
+            string packageId,
             VersionRange range,
+            SourceCacheContext cacheContext,
             NuGetFramework projectTargetFramework,
             ILogger log,
             CancellationToken token)
         {
             var frameworkComparer = new NuGetFrameworkFullComparer();
             var frameworkReducer = new FrameworkReducer();
-            var dependencies = await GetDependencies(httpClient, registrationUri, range, log, token);
+            var dependencies = await GetDependencies(httpClient, registrationUri, packageId, range, cacheContext, log, token);
 
             var result = new HashSet<RegistrationInfo>();
             var registrationInfo = new RegistrationInfo();

--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/AutoCompleteResourceV2Feed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -54,6 +54,7 @@ namespace NuGet.Protocol
             string packageId,
             string versionPrefix,
             bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DependencyInfoResourceV2Feed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,13 +35,14 @@ namespace NuGet.Protocol
         public override async Task<SourcePackageDependencyInfo> ResolvePackage(
             PackageIdentity package,
             NuGetFramework projectFramework,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
             try
             {
-                var packageInfo = await _feedParser.GetPackage(package, log, token);
+                var packageInfo = await _feedParser.GetPackage(package, sourceCacheContext, log, token);
 
                 if (packageInfo == null)
                 {
@@ -62,6 +63,7 @@ namespace NuGet.Protocol
         public override async Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(
             string packageId,
             NuGetFramework projectFramework,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -69,7 +71,7 @@ namespace NuGet.Protocol
 
             try
             {
-                var packages = await _feedParser.FindPackagesByIdAsync(packageId, log, token);
+                var packages = await _feedParser.FindPackagesByIdAsync(packageId, sourceCacheContext, log, token);
 
                 var results = new List<SourcePackageDependencyInfo>();
 
@@ -77,7 +79,6 @@ namespace NuGet.Protocol
                 {
                     results.Add(CreateDependencyInfo(package, projectFramework));
                 }
-
                 return results;
             }
             catch (Exception ex)

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/DownloadResourceV2Feed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -70,13 +70,17 @@ namespace NuGet.Protocol
                 }
                 else
                 {
-                    // Look up the package from the id and version and download it.
-                    return await _feedParser.DownloadFromIdentity(
+                    using (var sourceCacheContext = new SourceCacheContext())
+                    {
+                        // Look up the package from the id and version and download it.
+                        return await _feedParser.DownloadFromIdentity(
                         identity,
                         downloadContext,
                         globalPackagesFolder,
+                        sourceCacheContext,
                         logger,
                         token);
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/IV2FeedParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading;

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/LegacyFeedCapabilityResourceV2Feed.cs
@@ -77,7 +77,9 @@ namespace NuGet.Protocol
             {
                 document = await _feedParser.LoadXmlAsync(
                     metadataUri,
+                    cacheKey: null,
                     ignoreNotFounds: true,
+                    sourceCacheContext: null,
                     log: log,
                     token: token);
 

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2Feed.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/PackageMetadataResourceV2Feed.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -41,10 +41,11 @@ namespace NuGet.Protocol
             string packageId,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token)
         {
-            var packages = await _feedParser.FindPackagesByIdAsync(packageId, includeUnlisted, includePrerelease, log, token);
+            var packages = await _feedParser.FindPackagesByIdAsync(packageId, includeUnlisted, includePrerelease, sourceCacheContext, log, token);
 
             var metadataCache = new MetadataReferenceCache();
             return packages.Select(p => new PackageSearchMetadataV2Feed(p, metadataCache)).ToList();
@@ -52,10 +53,11 @@ namespace NuGet.Protocol
 
         public override async Task<IPackageSearchMetadata> GetMetadataAsync(
             PackageIdentity package,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token)
         {
-            var v2Package = await _feedParser.GetPackage(package, log, token);
+            var v2Package = await _feedParser.GetPackage(package, sourceCacheContext, log, token);
 
             if (v2Package != null)
             {

--- a/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LegacyFeed/V2FeedUtilities.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 using System.Collections.Generic;
 using System.Linq;
@@ -33,30 +33,35 @@ namespace NuGet.Protocol
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            // apply the filters to the version list returned
-            var packages = await feedParser.FindPackagesByIdAsync(
-                package.Id,
-                filter.IncludeDelisted,
-                filter.IncludePrerelease,
-                log,
-                cancellationToken);
 
-            var uniqueVersions = new HashSet<NuGetVersion>();
-            var results = new List<VersionInfo>();
-            
-            foreach (var versionPackage in packages.OrderByDescending(p => p.Version))
+            using (var sourceCacheContext = new SourceCacheContext())
             {
-                if (uniqueVersions.Add(versionPackage.Version))
-                {
-                    var versionInfo = new VersionInfo(versionPackage.Version, versionPackage.DownloadCount)
-                    {
-                        PackageSearchMetadata = new PackageSearchMetadataV2Feed(versionPackage, metadataCache)
-                    };
+                // apply the filters to the version list returned
+                var packages = await feedParser.FindPackagesByIdAsync(
+                    package.Id,
+                    filter.IncludeDelisted,
+                    filter.IncludePrerelease,
+                    sourceCacheContext,
+                    log,
+                    cancellationToken);
 
-                    results.Add(versionInfo);
+                var uniqueVersions = new HashSet<NuGetVersion>();
+                var results = new List<VersionInfo>();
+
+                foreach (var versionPackage in packages.OrderByDescending(p => p.Version))
+                {
+                    if (uniqueVersions.Add(versionPackage.Version))
+                    {
+                        var versionInfo = new VersionInfo(versionPackage.Version, versionPackage.DownloadCount)
+                        {
+                            PackageSearchMetadata = new PackageSearchMetadataV2Feed(versionPackage, metadataCache)
+                        };
+
+                        results.Add(versionInfo);
+                    }
                 }
+                return results;
             }
-            return results;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalAutoCompleteResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalAutoCompleteResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -43,6 +43,7 @@ namespace NuGet.Protocol
             string packageId,
             string versionPrefix,
             bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalDependencyInfoResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalDependencyInfoResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -45,6 +45,7 @@ namespace NuGet.Protocol
         public override Task<SourcePackageDependencyInfo> ResolvePackage(
             PackageIdentity package,
             NuGetFramework projectFramework,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -91,6 +92,7 @@ namespace NuGet.Protocol
         public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(
             string packageId,
             NuGetFramework projectFramework,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalMetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalMetadataResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,6 +32,7 @@ namespace NuGet.Protocol
             IEnumerable<string> packageIds,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -42,7 +43,7 @@ namespace NuGet.Protocol
             // fetch all ids in parallel
             foreach (var id in packageIds)
             {
-                var task = new KeyValuePair<string, Task<IEnumerable<NuGetVersion>>>(id, GetVersions(id, includePrerelease, includeUnlisted, log, token));
+                var task = new KeyValuePair<string, Task<IEnumerable<NuGetVersion>>>(id, GetVersions(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token));
                 tasks.Push(task);
             }
 
@@ -72,6 +73,7 @@ namespace NuGet.Protocol
             string packageId,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -101,6 +103,7 @@ namespace NuGet.Protocol
         public override Task<bool> Exists(
             PackageIdentity identity,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -113,6 +116,7 @@ namespace NuGet.Protocol
             string packageId,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageMetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/LocalRepositories/LocalPackageMetadataResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -30,6 +30,7 @@ namespace NuGet.Protocol
             string packageId,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {
@@ -49,6 +50,7 @@ namespace NuGet.Protocol
 
         public override Task<IPackageSearchMetadata> GetMetadataAsync(
             PackageIdentity package,
+            SourceCacheContext sourceCacheContext,
             ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/NullSourceCacheContext.cs
+++ b/src/NuGet.Core/NuGet.Protocol/NullSourceCacheContext.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NuGet.Protocol.Core.Types
+{
+    public class NullSourceCacheContext : SourceCacheContext
+    {
+        private static SourceCacheContext _instance;
+
+        public static SourceCacheContext Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new NullSourceCacheContext();
+                    _instance.DirectDownload = true;
+                }
+
+                return _instance;
+            }
+        }
+
+        public override string GeneratedTempFolder
+        {
+            get
+            {
+                return string.Empty;
+            }
+        }
+
+        public override SourceCacheContext WithRefreshCacheTrue() { return _instance; }
+
+        public override SourceCacheContext Clone() { return _instance; }
+    }
+}

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/HttpFileSystemBasedFindPackageByIdResource.cs
@@ -339,11 +339,12 @@ namespace NuGet.Protocol
         {
             // Try each base URI 3 times.
             var maxTries = 3 * _baseUris.Count;
+            var packageIdLowerCase = id.ToLowerInvariant();
 
             for (var retry = 0; retry < maxTries; ++retry)
             {
                 var baseUri = _baseUris[retry % _baseUris.Count].OriginalString;
-                var uri = baseUri + id.ToLowerInvariant() + "/index.json";
+                var uri = baseUri + packageIdLowerCase + "/index.json";
                 var httpSourceCacheContext = HttpSourceCacheContext.Create(cacheContext, retry);
 
                 try
@@ -351,7 +352,7 @@ namespace NuGet.Protocol
                     return await _httpSource.GetAsync(
                         new HttpSourceCachedRequest(
                             uri,
-                            $"list_{id}",
+                            $"list_{packageIdLowerCase}",
                             httpSourceCacheContext)
                         {
                             IgnoreNotFounds = true,

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV2FindPackageByIdResource.cs
@@ -363,7 +363,7 @@ namespace NuGet.Protocol
                         paging = await _httpSource.GetAsync(
                             new HttpSourceCachedRequest(
                                 uri,
-                                $"list_{id}_page{page}",
+                                $"list_{id.ToLowerInvariant()}_page{page}",
                                 httpSourceCacheContext)
                             {
                                 AcceptHeaderValues =

--- a/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/RemoteRepositories/RemoteV3FindPackageByIdResource.cs
@@ -313,7 +313,7 @@ namespace NuGet.Protocol
             {
                 if (cacheContext.RefreshMemoryCache || !_packageVersionsCache.TryGetValue(id, out task))
                 {
-                    task = FindPackagesByIdAsyncCore(id, logger, cancellationToken);
+                    task = FindPackagesByIdAsyncCore(id, cacheContext, logger, cancellationToken);
                     _packageVersionsCache[id] = task;
                 }
             }
@@ -323,13 +323,14 @@ namespace NuGet.Protocol
 
         private async Task<IEnumerable<RemoteSourceDependencyInfo>> FindPackagesByIdAsyncCore(
             string id,
+            SourceCacheContext sourceCacheContext,
             ILogger logger,
             CancellationToken cancellationToken)
         {
             // This is invoked from inside a lock.
             await EnsureDependencyProvider(cancellationToken);
 
-            return await _dependencyInfoResource.ResolvePackages(id, logger, cancellationToken);
+            return await _dependencyInfoResource.ResolvePackages(id, sourceCacheContext, logger, cancellationToken);
         }
 
         private async Task EnsureDependencyProvider(CancellationToken cancellationToken)

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -20,6 +20,7 @@ namespace NuGet.Protocol.Core.Types
             string packageId,
             string versionPrefix,
             bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token);
     }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/AutoCompleteResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -82,11 +82,12 @@ namespace NuGet.Protocol
             string packageId,
             string versionPrefix,
             bool includePrerelease,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token)
         {
             //*TODOs : Take prerelease as parameter. Also it should return both listed and unlisted for powershell ?
-            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, Common.NullLogger.Instance, token);
+            var packages = await _regResource.GetPackageMetadata(packageId, includePrerelease, false, sourceCacheContext, Common.NullLogger.Instance, token);
             var versions = new List<NuGetVersion>();
             foreach (var package in packages)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -29,6 +29,7 @@ namespace NuGet.Protocol.Core.Types
         /// </returns>
         public abstract Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package,
             NuGetFramework projectFramework,
+            SourceCacheContext cacheContext,
             ILogger log,
             CancellationToken token);
 
@@ -42,6 +43,7 @@ namespace NuGet.Protocol.Core.Types
         /// <returns>available packages and their dependencies</returns>
         public abstract Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId,
             NuGetFramework projectFramework,
+            SourceCacheContext cacheContext,
             ILogger log,
             CancellationToken token);
 
@@ -53,6 +55,7 @@ namespace NuGet.Protocol.Core.Types
         /// <param name="token">cancellation token</param>
         /// <returns>available packages and their dependencies</returns>
         public virtual Task<IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId,
+            SourceCacheContext cacheContext,
             Common.ILogger log,
             CancellationToken token)
         {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DependencyInfoResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -60,7 +60,7 @@ namespace NuGet.Protocol
         /// Returns dependency info for the given package if it exists. If the package is not found null is
         /// returned.
         /// </returns>
-        public override async Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override async Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             try
             {
@@ -71,7 +71,7 @@ namespace NuGet.Protocol
 
                 // Retrieve the registration blob
                 var singleVersion = new VersionRange(minVersion: package.Version, includeMinVersion: true, maxVersion: package.Version, includeMaxVersion: true);
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, singleVersion, projectFramework, log, token);
+                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, package.Id, singleVersion, cacheContext, projectFramework, log, token);
 
                 // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
                 if (regInfo != null)
@@ -99,7 +99,7 @@ namespace NuGet.Protocol
         /// <param name="projectFramework">project target framework. This is used for finding the dependency group</param>
         /// <param name="token">cancellation token</param>
         /// <returns>available packages and their dependencies</returns>
-        public override async Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override async Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             try
             {
@@ -109,7 +109,7 @@ namespace NuGet.Protocol
                 var uri = _regResource.GetUri(packageId);
 
                 // Retrieve the registration blob
-                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, VersionRange.All, projectFramework, log, token);
+                var regInfo = await ResolverMetadataClient.GetRegistrationInfo(_client, uri, packageId, VersionRange.All, cacheContext, projectFramework, log, token);
 
                 // regInfo is null if the server returns a 404 for the package to indicate that it does not exist
                 if (regInfo != null)
@@ -139,7 +139,7 @@ namespace NuGet.Protocol
         /// <param name="packageId">package Id to search</param>
         /// <param name="token">cancellation token</param>
         /// <returns>available packages and their dependencies</returns>
-        public override Task<IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId, Common.ILogger log, CancellationToken token)
+        public override Task<IEnumerable<RemoteSourceDependencyInfo>> ResolvePackages(string packageId, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
             try
             {
@@ -147,7 +147,7 @@ namespace NuGet.Protocol
                 var uri = _regResource.GetUri(packageId);
 
                 // Retrieve the registration blob
-                return ResolverMetadataClient.GetDependencies(_client, uri, VersionRange.All, log, token);
+                return ResolverMetadataClient.GetDependencies(_client, uri, packageId, VersionRange.All, cacheContext, log, token);
             }
             catch (Exception ex)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/DownloadResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -84,13 +84,16 @@ namespace NuGet.Protocol
             }
             else if (_regResource != null)
             {
-                // Read the url from the registration information
-                var blob = await _regResource.GetPackageMetadata(identity, log, token);
-
-                if (blob != null
-                    && blob["packageContent"] != null)
+                using (var sourceCacheContext = new SourceCacheContext())
                 {
-                    downloadUri = new Uri(blob["packageContent"].ToString());
+                    // Read the url from the registration information
+                    var blob = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
+
+                    if (blob != null
+                        && blob["packageContent"] != null)
+                    {
+                        downloadUri = new Uri(blob["packageContent"].ToString());
+                    }
                 }
             }
 

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -18,42 +18,42 @@ namespace NuGet.Protocol.Core.Types
         /// <summary>
         /// Get all versions of a package
         /// </summary>
-        public async Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, Common.ILogger log, CancellationToken token)
+        public async Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await GetVersions(packageId, true, false, log, token);
+            return await GetVersions(packageId, true, false, sourceCacheContext, log, token);
         }
 
         /// <summary>
         /// Get all versions of a package
         /// </summary>
-        public abstract Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token);
+        public abstract Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
         /// <summary>
         /// True if the package exists in the source
         /// Includes unlisted.
         /// </summary>
-        public async Task<bool> Exists(PackageIdentity identity, Common.ILogger log, CancellationToken token)
+        public async Task<bool> Exists(PackageIdentity identity, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await Exists(identity, true, log, token);
+            return await Exists(identity, true, sourceCacheContext, log, token);
         }
 
         /// <summary>
         /// True if the package exists in the source
         /// </summary>
-        public abstract Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, Common.ILogger log, CancellationToken token);
+        public abstract Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
-        public async Task<bool> Exists(string packageId, Common.ILogger log, CancellationToken token)
+        public async Task<bool> Exists(string packageId, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await Exists(packageId, true, false, log, token);
+            return await Exists(packageId, true, false, sourceCacheContext, log, token);
         }
 
-        public abstract Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token);
+        public abstract Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
-        public abstract Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token);
+        public abstract Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token);
 
-        public async Task<NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public async Task<NuGetVersion> GetLatestVersion(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
-            var results = await GetLatestVersions(new string[] { packageId }, includePrerelease, includeUnlisted, log, token);
+            var results = await GetLatestVersions(new string[] { packageId }, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
             var result = results.SingleOrDefault();
 
             if (!result.Equals(default(KeyValuePair<string, bool>)))

--- a/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/MetadataResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -44,7 +44,13 @@ namespace NuGet.Protocol
         /// </summary>
         /// <param name="includePrerelease">include versions with prerelease labels</param>
         /// <param name="includeUnlisted">not implemented yet</param>
-        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override async Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(
+            IEnumerable<string> packageIds,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
             var results = new List<KeyValuePair<string, NuGetVersion>>();
 
@@ -53,7 +59,7 @@ namespace NuGet.Protocol
                 IEnumerable<NuGetVersion> allVersions;
                 try
                 {
-                    var catalogEntries = await _regResource.GetPackageMetadata(id, includePrerelease, includeUnlisted, log, token);
+                    var catalogEntries = await _regResource.GetPackageMetadata(id, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
                     allVersions = catalogEntries.Select(p => NuGetVersion.Parse(p["version"].ToString()));
                 }
                 catch (Exception ex)
@@ -70,27 +76,44 @@ namespace NuGet.Protocol
             return results;
         }
 
-        public override async Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override async Task<bool> Exists(
+            PackageIdentity identity,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
             // TODO: get the url and just check the headers?
-            var metadata = await _regResource.GetPackageMetadata(identity, log, token);
+            var metadata = await _regResource.GetPackageMetadata(identity, sourceCacheContext, log, token);
 
             // TODO: listed check
             return metadata != null;
         }
 
-        public override async Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override async Task<bool> Exists(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
-            var entries = await GetVersions(packageId, includePrerelease, includeUnlisted, log, token);
+            var entries = await GetVersions(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token);
 
             return entries != null && entries.Any();
         }
 
-        public override async Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override async Task<IEnumerable<NuGetVersion>> GetVersions(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
             var results = new List<NuGetVersion>();
 
-            var entries = await _regResource.GetPackageEntries(packageId, includeUnlisted, log, token);
+            var entries = await _regResource.GetPackageEntries(packageId, includeUnlisted, sourceCacheContext, log, token);
 
             foreach (var catalogEntry in entries)
             {

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResource.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -17,6 +17,7 @@ namespace NuGet.Protocol.Core.Types
             string packageId,
             bool includePrerelease,
             bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token);
 
@@ -25,6 +26,7 @@ namespace NuGet.Protocol.Core.Types
         /// </summary>
         public abstract Task<IPackageSearchMetadata> GetMetadataAsync(
             PackageIdentity package,
+            SourceCacheContext sourceCacheContext,
             Common.ILogger log,
             CancellationToken token);
     }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/PackageMetadataResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -24,12 +24,18 @@ namespace NuGet.Protocol
             _reportAbuseResource = reportAbuseResource;
         }
 
-        public override async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override async Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(
+            string packageId,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
             var metadataCache = new MetadataReferenceCache();
 
             var packages =
-                (await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, log, token))
+                (await _regResource.GetPackageMetadata(packageId, includePrerelease, includeUnlisted, sourceCacheContext, log, token))
                     .Select(ParseMetadata)
                     .Select(m => metadataCache.GetObject(m))
                     .ToArray();
@@ -37,9 +43,13 @@ namespace NuGet.Protocol
             return packages;
         }
 
-        public override async Task<IPackageSearchMetadata> GetMetadataAsync(PackageIdentity package, Common.ILogger log, CancellationToken token)
+        public override async Task<IPackageSearchMetadata> GetMetadataAsync(
+            PackageIdentity package,
+            SourceCacheContext sourceCacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
-            var metadata = await _regResource.GetPackageMetadata(package, log, token);
+            var metadata = await _regResource.GetPackageMetadata(package, sourceCacheContext, log, token);
             if (metadata != null)
             {
                 return ParseMetadata(metadata);

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -95,31 +95,38 @@ namespace NuGet.Protocol
         /// Returns the registration blob for the id and version
         /// </summary>
         /// <remarks>The inlined entries are potentially going away soon</remarks>
-        public virtual async Task<JObject> GetPackageMetadata(PackageIdentity identity, Common.ILogger log, CancellationToken token)
+        public virtual async Task<JObject> GetPackageMetadata(PackageIdentity identity, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
-            return (await GetPackageMetadata(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, log, token)).SingleOrDefault();
+            return (await GetPackageMetadata(identity.Id, new VersionRange(identity.Version, true, identity.Version, true), true, true, cacheContext, log, token)).SingleOrDefault();
         }
 
         /// <summary>
         /// Returns inlined catalog entry items for each registration blob
         /// </summary>
         /// <remarks>The inlined entries are potentially going away soon</remarks>
-        public virtual async Task<IEnumerable<JObject>> GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public virtual async Task<IEnumerable<JObject>> GetPackageMetadata(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
-            return await GetPackageMetadata(packageId, VersionRange.All, includePrerelease, includeUnlisted, log, token);
+            return await GetPackageMetadata(packageId, VersionRange.All, includePrerelease, includeUnlisted, cacheContext, log, token);
         }
 
         /// <summary>
         /// Returns inlined catalog entry items for each registration blob
         /// </summary>
         /// <remarks>The inlined entries are potentially going away soon</remarks>
-        public virtual async Task<IEnumerable<JObject>> GetPackageMetadata(string packageId, VersionRange range, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public virtual async Task<IEnumerable<JObject>> GetPackageMetadata(
+            string packageId,
+            VersionRange range,
+            bool includePrerelease,
+            bool includeUnlisted,
+            SourceCacheContext cacheContext,
+            Common.ILogger log,
+            CancellationToken token)
         {
             var results = new List<JObject>();
 
             var registrationUri = GetUri(packageId);
 
-            var ranges = await RegistrationUtility.LoadRanges(_client, registrationUri, range, log, token);
+            var ranges = await RegistrationUtility.LoadRanges(_client, registrationUri, packageId, range, cacheContext, log, token);
 
             foreach (var rangeObj in ranges)
             {
@@ -155,9 +162,9 @@ namespace NuGet.Protocol
         /// <summary>
         /// Returns all index entries of type Package within the given range and filters
         /// </summary>
-        public virtual Task<IEnumerable<JObject>> GetPackageEntries(string packageId, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public virtual Task<IEnumerable<JObject>> GetPackageEntries(string packageId, bool includeUnlisted, SourceCacheContext cacheContext, Common.ILogger log, CancellationToken token)
         {
-            return GetPackageMetadata(packageId, VersionRange.All, true, includeUnlisted, log, token);
+            return GetPackageMetadata(packageId, VersionRange.All, true, includeUnlisted, cacheContext, log, token);
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.Designer.cs
@@ -323,6 +323,15 @@ namespace NuGet.Protocol {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to fetch results from V2 feed at &apos;{0}&apos; with following message : {1}.
+        /// </summary>
+        internal static string Log_FailedToFetchV2FeedHttp {
+            get {
+                return ResourceManager.GetString("Log_FailedToFetchV2FeedHttp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to load nuspec from package &apos;{0}&apos;..
         /// </summary>
         internal static string Log_FailedToGetNuspecStream {

--- a/src/NuGet.Core/NuGet.Protocol/Strings.resx
+++ b/src/NuGet.Core/NuGet.Protocol/Strings.resx
@@ -469,4 +469,9 @@ The "ms" should be localized to the abbreviation for milliseconds.</comment>
   <data name="Log_LocalSourceNotExist" xml:space="preserve">
     <value>The local source '{0}' doesn't exist.</value>
   </data>
+  <data name="Log_FailedToFetchV2FeedHttp" xml:space="preserve">
+    <value>Failed to fetch results from V2 feed at '{0}' with following message : {1}</value>
+    <comment>{0} is the URL that failed.
+{1} is the message returned from HTTP call.</comment>
+  </data>
 </root>

--- a/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Utility/FindPackagesByIdNupkgDownloader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -263,7 +263,7 @@ namespace NuGet.Protocol
                     return await _httpSource.GetAsync(
                         new HttpSourceCachedRequest(
                             url,
-                            "nupkg_" + identity.Id + "." + identity.Version.ToNormalizedString(),
+                            "nupkg_" + identity.Id.ToLowerInvariant() + "." + identity.Version.ToNormalizedString(),
                             httpSourceCacheContext)
                         {
                             EnsureValidContents = stream => HttpStreamValidation.ValidateNupkg(url, stream),

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/MultiSourcePackageMetadataProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -65,7 +65,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             Mock.Get(_metadataResource).Verify(
-                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -83,7 +83,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             Mock.Get(_metadataResource).Verify(
-                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -102,7 +102,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
 
             // Assert
             Mock.Get(_metadataResource).Verify(
-                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
+                x => x.GetMetadataAsync(testPackageIdentity.Id, true, false, It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
@@ -211,7 +211,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     .Build());
 
             Mock.Get(_metadataResource)
-                .Setup(x => x.GetMetadataAsync(id, true, false, It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMetadataAsync(id, true, false, It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(metadata));
         }
     }

--- a/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.PackageManagement.VisualStudio.Test/Feeds/UpdatePackageFeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -248,7 +248,7 @@ namespace NuGet.PackageManagement.VisualStudio.Test
                     .Build());
 
             Mock.Get(_metadataResource)
-                .Setup(x => x.GetMetadataAsync(id, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
+                .Setup(x => x.GetMetadataAsync(id, It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<SourceCacheContext>(), It.IsAny<Common.ILogger>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(metadata));
         }
     }

--- a/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Protocol.FuncTest/V2FeedParserTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Configuration;
 using NuGet.Packaging.Core;
@@ -93,6 +94,7 @@ namespace NuGet.Protocol.FuncTest
                     new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("6.2.0")),
                     new PackageDownloadContext(cacheContext),
                     packagesFolder,
+                    cacheContext,
                     NullLogger.Instance,
                     CancellationToken.None))
                 {
@@ -115,7 +117,7 @@ namespace NuGet.Protocol.FuncTest
             var parser = new V2FeedParser(httpSource, packageSource);
 
             // Act
-            var package = await parser.GetPackage(new PackageIdentity("owin", new NuGetVersion("1.0")), NullLogger.Instance, CancellationToken.None);
+            var package = await parser.GetPackage(new PackageIdentity("owin", new NuGetVersion("1.0")), NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal("Owin", package.Id);
@@ -141,6 +143,7 @@ namespace NuGet.Protocol.FuncTest
                     new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
                     new PackageDownloadContext(cacheContext),
                     packagesFolder,
+                    cacheContext,
                     NullLogger.Instance,
                     CancellationToken.None))
                 {
@@ -236,7 +239,7 @@ namespace NuGet.Protocol.FuncTest
             var parser = new V2FeedParser(httpSource, packageSource.Source);
 
             // Act
-            var package = await parser.GetPackage(new PackageIdentity("owin", new NuGetVersion("1.0")), NullLogger.Instance, CancellationToken.None);
+            var package = await parser.GetPackage(new PackageIdentity("owin", new NuGetVersion("1.0")), NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal("Owin", package.Id);
@@ -262,6 +265,7 @@ namespace NuGet.Protocol.FuncTest
                     new PackageIdentity("newtonsoft.json", new NuGetVersion("8.0.3")),
                     new PackageDownloadContext(cacheContext),
                     packagesFolder,
+                    cacheContext,
                     NullLogger.Instance,
                     CancellationToken.None))
                 {

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/UnresolvedMessagesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.DependencyResolver.Core.Tests/FindPackageTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -753,6 +753,7 @@ namespace NuGet.Test
                     buildIntegratedProject,
                     actions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     CancellationToken.None);
 
                 var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
@@ -833,6 +834,7 @@ namespace NuGet.Test
                         buildIntegratedProject,
                         actions,
                         new TestNuGetProjectContext(),
+                        NullSourceCacheContext.Instance,
                         CancellationToken.None));
 
                 var rollbackProjectJson = File.ReadAllText(projectJson);
@@ -922,6 +924,7 @@ namespace NuGet.Test
                         buildIntegratedProject,
                         actions,
                         new TestNuGetProjectContext(),
+                        cacheContext,
                         CancellationToken.None);
 
                     var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
@@ -1004,6 +1007,7 @@ namespace NuGet.Test
                         buildIntegratedProject,
                         actions,
                         new TestNuGetProjectContext(),
+                        cacheContext,
                         CancellationToken.None);
 
                     // Act
@@ -1019,6 +1023,7 @@ namespace NuGet.Test
                         buildIntegratedProject,
                         actions,
                         new TestNuGetProjectContext(),
+                        cacheContext,
                         CancellationToken.None);
 
                     var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
@@ -1088,6 +1093,7 @@ namespace NuGet.Test
                     buildIntegratedProject,
                     actions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     CancellationToken.None);
 
                 var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
@@ -1182,6 +1188,7 @@ namespace NuGet.Test
                     buildIntegratedProject,
                     actions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     CancellationToken.None);
 
                 var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
@@ -1262,6 +1269,7 @@ namespace NuGet.Test
                     buildIntegratedProject,
                     actions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     CancellationToken.None);
 
                 var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -3226,7 +3226,7 @@ namespace NuGet.Test
                 Assert.Equal(singlePackageSource, packageActions[5].SourceRepository.PackageSource.Source);
 
                 // Main Act
-                await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(msBuildNuGetProject, packageActions, new TestNuGetProjectContext(), token);
+                await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(msBuildNuGetProject, packageActions, new TestNuGetProjectContext(), NullSourceCacheContext.Instance, token);
 
                 // Check that the packages.config file exists after the installation
                 Assert.True(File.Exists(packagesConfigPath));
@@ -5274,7 +5274,7 @@ namespace NuGet.Test
                     // Main Act
                     await
                         nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, actions,
-                            new TestNuGetProjectContext(), token);
+                            new TestNuGetProjectContext(), NullSourceCacheContext.Instance, token);
 
                     //Assert
                     // Check batch events data
@@ -5410,7 +5410,7 @@ namespace NuGet.Test
                     // Main Act
                     await
                         nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, new List<NuGetProjectAction>(),
-                            new TestNuGetProjectContext(), token);
+                            new TestNuGetProjectContext(), NullSourceCacheContext.Instance, token);
 
                     // Check that the packages.config file exists after the installation
                     Assert.False(File.Exists(projectA.PackagesConfigNuGetProject.FullPath));
@@ -5549,7 +5549,7 @@ namespace NuGet.Test
                     {
                         // Act
                         await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, projectActions,
-                            new TestNuGetProjectContext(), token);
+                            new TestNuGetProjectContext(), NullSourceCacheContext.Instance, token);
                     }
                     catch (Exception ex)
                     {
@@ -5619,7 +5619,7 @@ namespace NuGet.Test
                     {
                         // Act
                         await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(projectA, projectActions,
-                            new TestNuGetProjectContext(), token);
+                            new TestNuGetProjectContext(), NullSourceCacheContext.Instance, token);
                     }
                     catch (Exception ex)
                     {
@@ -5827,6 +5827,7 @@ namespace NuGet.Test
                     new List<NuGetProject>() {buildIntegratedProjectA, buildIntegratedProjectB },
                     projectActions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     token);
 
                 // Assert
@@ -5890,6 +5891,7 @@ namespace NuGet.Test
                     new List<NuGetProject>() { projectA, projectB, projectC },
                     projectActions,
                     new TestNuGetProjectContext(),
+                    NullSourceCacheContext.Instance,
                     token);
 
                 // Assert
@@ -6154,6 +6156,7 @@ namespace NuGet.Test
                     new List<NuGetProject>() { nugetProject },
                     projectActions,
                     nugetProjectContext,
+                    NullSourceCacheContext.Instance,
                     CancellationToken.None);
 
                 // Assert
@@ -6212,6 +6215,7 @@ namespace NuGet.Test
                     new List<NuGetProject>() { buildIntegratedProject },
                     projectActions,
                     nugetProjectContext,
+                    NullSourceCacheContext.Instance,
                     token);
 
                 // Assert

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/ResolverGatherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -410,6 +410,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             var contextAOnly = new GatherContext();
             contextAOnly.PrimaryTargets = targets.ToList();
@@ -418,6 +419,7 @@ namespace NuGet.Test
             contextAOnly.PrimarySources = primaryRepo;
             contextAOnly.AllSources = reposAOnly;
             contextAOnly.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            contextAOnly.ResolutionContext = new ResolutionContext();
 
             // Run the first time
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -473,6 +475,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -587,6 +590,7 @@ namespace NuGet.Test
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
             context.AllowDowngrades = true;
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -644,6 +648,7 @@ namespace NuGet.Test
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
             context.AllowDowngrades = false;
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -695,6 +700,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act and Assert
             await Assert.ThrowsAsync(typeof(InvalidOperationException), async () =>
@@ -746,6 +752,7 @@ namespace NuGet.Test
             context.AllSources = repos;
             context.IsUpdateAll = true;
             context.PackagesFolderSource = CreateRepo("installed", new List<SourcePackageDependencyInfo>());
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -797,6 +804,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -855,6 +863,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -916,6 +925,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -974,6 +984,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1033,6 +1044,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1120,6 +1132,7 @@ namespace NuGet.Test
             context.PrimarySources = primaryRepo;
             context.AllSources = repos;
             context.PackagesFolderSource = CreateRepo("installed", repoInstalled);
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1197,6 +1210,7 @@ namespace NuGet.Test
             context.PrimarySources = repos;
             context.AllSources = repos;
             context.PackagesFolderSource = repos[2];
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1261,6 +1275,7 @@ namespace NuGet.Test
             context.PrimarySources = repos;
             context.AllSources = repos;
             context.PackagesFolderSource = repos[2];
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1324,6 +1339,7 @@ namespace NuGet.Test
             context.PrimarySources = repos;
             context.AllSources = repos;
             context.PackagesFolderSource = repos[2];
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1389,6 +1405,7 @@ namespace NuGet.Test
             context.PrimarySources = repos;
             context.AllSources = repos;
             context.PackagesFolderSource = repos[2];
+            context.ResolutionContext = new ResolutionContext();
 
             // Act
             var results = await ResolverGather.GatherAsync(context, CancellationToken.None);
@@ -1503,12 +1520,12 @@ namespace NuGet.Test
             Exception = ex;
         }
 
-        public override Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             throw Exception;
         }
 
-        public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             throw Exception;
         }
@@ -1524,7 +1541,7 @@ namespace NuGet.Test
 
         }
 
-        public override async Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override async Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             while (true)
             {
@@ -1534,7 +1551,7 @@ namespace NuGet.Test
             }
         }
 
-        public override async Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override async Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             while (true)
             {
@@ -1560,13 +1577,13 @@ namespace NuGet.Test
             Packages = packages;
         }
 
-        public override Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override Task<SourcePackageDependencyInfo> ResolvePackage(PackageIdentity package, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             var matchingPackage = Packages.FirstOrDefault(e => PackageIdentity.Comparer.Equals(e, package));
             return Task.FromResult<SourcePackageDependencyInfo>(ApplySource(matchingPackage));
         }
 
-        public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, Common.ILogger log, CancellationToken token)
+        public override Task<IEnumerable<SourcePackageDependencyInfo>> ResolvePackages(string packageId, NuGetFramework projectFramework, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             var results = new HashSet<SourcePackageDependencyInfo>(
                 Packages.Where(e => StringComparer.OrdinalIgnoreCase.Equals(packageId, e.Id)),
@@ -1623,7 +1640,7 @@ namespace NuGet.Test
             Packages = packages;
         }
 
-        public override Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override Task<IEnumerable<NuGetVersion>> GetVersions(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             return Task.FromResult(Packages
                 .Where(p =>
@@ -1634,7 +1651,7 @@ namespace NuGet.Test
             );
         }
 
-        public override Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override Task<bool> Exists(PackageIdentity identity, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             return Task.FromResult(Packages
                 .Exists(p =>
@@ -1643,7 +1660,7 @@ namespace NuGet.Test
             );
         }
 
-        public override Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public override Task<bool> Exists(string packageId, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             return Task.FromResult(Packages
                 .Exists((p) =>
@@ -1653,13 +1670,13 @@ namespace NuGet.Test
             );
         }
 
-        public async override Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, Common.ILogger log, CancellationToken token)
+        public async override Task<IEnumerable<KeyValuePair<string, NuGetVersion>>> GetLatestVersions(IEnumerable<string> packageIds, bool includePrerelease, bool includeUnlisted, SourceCacheContext sourceCacheContext, Common.ILogger log, CancellationToken token)
         {
             var results = new List<KeyValuePair<string, NuGetVersion>>();
 
             foreach (var id in packageIds)
             {
-                var versions = await GetVersions(id, log, token);
+                var versions = await GetVersions(id, sourceCacheContext, log, token);
                 var latest = versions.OrderByDescending(p => p, VersionComparer.VersionRelease).FirstOrDefault();
 
                 if (latest != null)

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/AutoCompleteResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using Test.Utility;
@@ -53,7 +54,7 @@ namespace NuGet.Protocol.Tests
             var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
 
             // Act
-            var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullLogger.Instance, CancellationToken.None);
+            var result = await autoCompleteResource.VersionStartsWith("xunit", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(6, result.Count());
@@ -74,7 +75,7 @@ namespace NuGet.Protocol.Tests
             var autoCompleteResource = await repo.GetResourceAsync<AutoCompleteResource>();
 
             // Act
-            var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullLogger.Instance, CancellationToken.None);
+            var result = await autoCompleteResource.VersionStartsWith("azure", "1", false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(0, result.Count());

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfoResourceV2FeedTests.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
@@ -35,6 +36,7 @@ namespace NuGet.Protocol.Tests
             // Act
             var dependencyInfoList = await dependencyInfoResource.ResolvePackages("WindowsAzure.Storage",
                                                                             NuGetFramework.Parse("aspnetcore50"),
+                                                                            NullSourceCacheContext.Instance,
                                                                             NullLogger.Instance,
                                                                             CancellationToken.None);
 
@@ -64,6 +66,7 @@ namespace NuGet.Protocol.Tests
             // Act
             var dependencyInfo = await dependencyInfoResource.ResolvePackage(packageIdentity,
                                                                             NuGetFramework.Parse("aspnetcore50"),
+                                                                            NullSourceCacheContext.Instance,
                                                                             NullLogger.Instance,
                                                                             CancellationToken.None);
 
@@ -91,7 +94,7 @@ namespace NuGet.Protocol.Tests
             var dep2 = new PackageIdentity("xunit.assert", NuGetVersion.Parse("2.1.0-beta1-build2945"));
 
             // Act
-            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(package, result, PackageIdentity.Comparer);
@@ -121,7 +124,7 @@ namespace NuGet.Protocol.Tests
             var filterRange = new VersionRange(NuGetVersion.Parse("2.0.0-rc4-build2924"), true, NuGetVersion.Parse("2.1.0-beta1-build2945"), true);
 
             // Act
-            var results = await dependencyInfoResource.ResolvePackages("xunit", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            var results = await dependencyInfoResource.ResolvePackages("xunit", NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
 
             var filtered = results.Where(result => filterRange.Satisfies(result.Version));
 
@@ -154,7 +157,7 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("xunit", NuGetVersion.Parse("1.0.0-notfound"));
 
             // Act
-            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Null(result);
@@ -176,7 +179,7 @@ namespace NuGet.Protocol.Tests
             var dependencyInfoResource = await repo.GetResourceAsync<DependencyInfoResource>();
 
             // Act
-            var results = await dependencyInfoResource.ResolvePackages("not-found", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            var results = await dependencyInfoResource.ResolvePackages("not-found", NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(0, results.Count());
@@ -200,7 +203,7 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("DotNetOpenAuth.Core", NuGetVersion.Parse("4.3.2.13293"));
 
             // Act
-            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            var result = await dependencyInfoResource.ResolvePackage(package, NuGetFramework.Parse("net45"), NullSourceCacheContext.Instance, Common.NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(1, result.Dependencies.Count());

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalAutoCompleteResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalAutoCompleteResourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,8 +7,10 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -172,7 +174,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalAutoCompleteResource(localResource);
 
                 // Act
-                var versions = (await resource.VersionStartsWith("packageA", string.Empty, includePrerelease: true, log: testLogger, token: CancellationToken.None)).ToList();
+                var versions = (await resource.VersionStartsWith("packageA", string.Empty, includePrerelease: true, sourceCacheContext: NullSourceCacheContext.Instance, log: testLogger, token: CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(2, versions.Count);
@@ -200,7 +202,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalAutoCompleteResource(localResource);
 
                 // Act
-                var versions = (await resource.VersionStartsWith("packageA", "1.0", includePrerelease: true, log: testLogger, token: CancellationToken.None)).ToList();
+                var versions = (await resource.VersionStartsWith("packageA", "1.0", includePrerelease: true, sourceCacheContext: NullSourceCacheContext.Instance, log: testLogger, token: CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(1, versions.Count);
@@ -227,7 +229,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalAutoCompleteResource(localResource);
 
                 // Act
-                var versions = (await resource.VersionStartsWith("packageA", "1.1.0-alpha.1.2.3+a.b", includePrerelease: true, log: testLogger, token: CancellationToken.None)).ToList();
+                var versions = (await resource.VersionStartsWith("packageA", "1.1.0-alpha.1.2.3+a.b", includePrerelease: true, sourceCacheContext: NullSourceCacheContext.Instance, log: testLogger, token: CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(1, versions.Count);
@@ -254,7 +256,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalAutoCompleteResource(localResource);
 
                 // Act
-                var versions = (await resource.VersionStartsWith("packageA", "1.1.0-alpha.1.2.3+a.b", includePrerelease: false, log: testLogger, token: CancellationToken.None)).ToList();
+                var versions = (await resource.VersionStartsWith("packageA", "1.1.0-alpha.1.2.3+a.b", includePrerelease: false, sourceCacheContext: NullSourceCacheContext.Instance, log: testLogger, token: CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(0, versions.Count);
@@ -278,7 +280,7 @@ namespace NuGet.Protocol.Tests
 
                 // Act
                 var ids = (await resource.IdStartsWith(string.Empty, includePrerelease: true, log: testLogger, token: CancellationToken.None)).ToList();
-                var versions = (await resource.VersionStartsWith(string.Empty, string.Empty, includePrerelease: true, log: testLogger, token: CancellationToken.None)).ToList();
+                var versions = (await resource.VersionStartsWith(string.Empty, string.Empty, includePrerelease: true, sourceCacheContext: NullSourceCacheContext.Instance, log: testLogger, token: CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(0, ids.Count);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDependencyInfoResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalDependencyInfoResourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -90,9 +91,9 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalDependencyInfoResource(localResource, source);
 
                 // Act
-                var resultsA = (await resource.ResolvePackages("a", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
-                var resultsX = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
-                var resultsY = (await resource.ResolvePackages("y", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var resultsA = (await resource.ResolvePackages("a", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
+                var resultsX = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
+                var resultsY = (await resource.ResolvePackages("y", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(1, resultsA.Count);
@@ -151,7 +152,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalDependencyInfoResource(localResource, source);
 
                 // Act
-                var results = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var results = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 // no dependencies
@@ -189,7 +190,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalDependencyInfoResource(localResource, source);
 
                 // Act
-                var resultsY = (await resource.ResolvePackages("y", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var resultsY = (await resource.ResolvePackages("y", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(0, resultsY.Count);
@@ -209,7 +210,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalDependencyInfoResource(localResource, source);
 
                 // Act
-                var results = (await resource.ResolvePackages("notfound", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var results = (await resource.ResolvePackages("notfound", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(0, results.Count);
@@ -231,7 +232,7 @@ namespace NuGet.Protocol.Tests
                 Directory.Delete(root);
 
                 // Act
-                var results = (await resource.ResolvePackages("notfound", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var results = (await resource.ResolvePackages("notfound", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(0, results.Count);
@@ -280,8 +281,8 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalDependencyInfoResource(localResource, source);
 
                 // Act
-                var results = (await resource.ResolvePackages("a", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
-                var resultsX = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), testLogger, CancellationToken.None)).ToList();
+                var results = (await resource.ResolvePackages("a", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
+                var resultsX = (await resource.ResolvePackages("x", NuGetFramework.Parse("net46"), NullSourceCacheContext.Instance, testLogger, CancellationToken.None)).ToList();
 
                 // Assert
                 Assert.Equal(1, results.Count);
@@ -331,6 +332,7 @@ namespace NuGet.Protocol.Tests
                 var result = (await resource.ResolvePackage(
                     packageA.Identity,
                     NuGetFramework.Parse("net46"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
@@ -380,6 +382,7 @@ namespace NuGet.Protocol.Tests
                 var result = (await resource.ResolvePackage(
                     new PackageIdentity("z", NuGetVersion.Parse("1.0.0")),
                     NuGetFramework.Parse("net46"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
@@ -404,6 +407,7 @@ namespace NuGet.Protocol.Tests
                 var result = (await resource.ResolvePackage(
                     new PackageIdentity("z", NuGetVersion.Parse("1.0.0")),
                     NuGetFramework.Parse("net46"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
@@ -459,18 +463,21 @@ namespace NuGet.Protocol.Tests
                 var resultNet462 = (await resource.ResolvePackage(
                     packageA.Identity,
                     NuGetFramework.Parse("net462"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
                 var resultNet46 = (await resource.ResolvePackage(
                     packageA.Identity,
                     NuGetFramework.Parse("net46"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
                 var resultWin8 = (await resource.ResolvePackage(
                     packageA.Identity,
                     NuGetFramework.Parse("win8"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None));
 
@@ -533,18 +540,21 @@ namespace NuGet.Protocol.Tests
                 var resultNet462 = (await resource.ResolvePackages(
                     "a",
                     NuGetFramework.Parse("net462"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None)).Single();
 
                 var resultNet46 = (await resource.ResolvePackages(
                     "a",
                     NuGetFramework.Parse("net46"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None)).Single();
 
                 var resultWin8 = (await resource.ResolvePackages(
                     "a",
                     NuGetFramework.Parse("win8"),
+                    NullSourceCacheContext.Instance,
                     testLogger,
                     CancellationToken.None)).Single();
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalMetadataResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalMetadataResourceTests.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -33,7 +35,7 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalMetadataResource(localResource);
 
                 // Act
-                var result = (await resource.GetVersions("a", testLogger, CancellationToken.None))
+                var result = (await resource.GetVersions("a", NullSourceCacheContext.Instance, testLogger, CancellationToken.None))
                     .OrderBy(v => v)
                     .ToList();
 
@@ -64,11 +66,11 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalMetadataResource(localResource);
 
                 // Act
-                var resultA = (await resource.GetVersions("a", testLogger, CancellationToken.None))
+                var resultA = (await resource.GetVersions("a", NullSourceCacheContext.Instance, testLogger, CancellationToken.None))
                     .OrderBy(v => v)
                     .ToList();
 
-                var resultB = (await resource.GetVersions("b", testLogger, CancellationToken.None))
+                var resultB = (await resource.GetVersions("b", NullSourceCacheContext.Instance, testLogger, CancellationToken.None))
                     .OrderBy(v => v)
                     .ToList();
 
@@ -103,6 +105,7 @@ namespace NuGet.Protocol.Tests
                     "b",
                     includePrerelease: false,
                     includeUnlisted: false,
+                    sourceCacheContext: NullSourceCacheContext.Instance,
                     log: testLogger,
                     token: CancellationToken.None);
 
@@ -136,6 +139,7 @@ namespace NuGet.Protocol.Tests
                     "b",
                     includePrerelease: true,
                     includeUnlisted: false,
+                    sourceCacheContext: NullSourceCacheContext.Instance,
                     log: testLogger,
                     token: CancellationToken.None);
 
@@ -169,6 +173,7 @@ namespace NuGet.Protocol.Tests
                     new string[] { "a", "b", "c" },
                     includePrerelease: false,
                     includeUnlisted: false,
+                    sourceCacheContext: NullSourceCacheContext.Instance,
                     log: testLogger,
                     token: CancellationToken.None))
                     .OrderBy(e => e.Key)
@@ -204,9 +209,9 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalMetadataResource(localResource);
 
                 // Act
-                var a = await resource.Exists("A", testLogger, CancellationToken.None);
-                var b = await resource.Exists("b", testLogger, CancellationToken.None);
-                var c = await resource.Exists("c", testLogger, CancellationToken.None);
+                var a = await resource.Exists("A", NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var b = await resource.Exists("b", NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var c = await resource.Exists("c", NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
 
                 // Assert
                 Assert.True(a);
@@ -235,11 +240,11 @@ namespace NuGet.Protocol.Tests
                 var resource = new LocalMetadataResource(localResource);
 
                 // Act
-                var b1 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1")), testLogger, CancellationToken.None);
-                var b2 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1+githash.0faef")), testLogger, CancellationToken.None);
-                var b3 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1+githash.aaaa")), testLogger, CancellationToken.None);
-                var b4 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1-githash.0faef")), testLogger, CancellationToken.None);
-                var b5 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.01")), testLogger, CancellationToken.None);
+                var b1 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1")), NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var b2 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1+githash.0faef")), NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var b3 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1+githash.aaaa")), NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var b4 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.1-githash.0faef")), NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
+                var b5 = await resource.Exists(new PackageIdentity("b", NuGetVersion.Parse("2.0.01")), NullSourceCacheContext.Instance, testLogger, CancellationToken.None);
 
                 // Assert
                 Assert.True(b1);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/LocalResourceTests/LocalPackageMetadataResourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Moq;
 using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
 using NuGet.Test.Utility;
 using NuGet.Versioning;
 using Xunit;
@@ -61,6 +63,7 @@ namespace NuGet.Protocol.Tests
                         "A",
                         includePrerelease: false,
                         includeUnlisted: false,
+                        sourceCacheContext: NullSourceCacheContext.Instance,
                         log: testLogger,
                         token: CancellationToken.None))
                         .ToList();
@@ -118,6 +121,7 @@ namespace NuGet.Protocol.Tests
                         "A",
                         includePrerelease: true,
                         includeUnlisted: false,
+                        sourceCacheContext: NullSourceCacheContext.Instance,
                         log: testLogger,
                         token: CancellationToken.None))
                         .ToList();
@@ -175,6 +179,7 @@ namespace NuGet.Protocol.Tests
                         "A",
                         includePrerelease: false,
                         includeUnlisted: false,
+                        sourceCacheContext: NullSourceCacheContext.Instance,
                         log: testLogger,
                         token: CancellationToken.None))
                         .ToList();
@@ -206,6 +211,7 @@ namespace NuGet.Protocol.Tests
                         "A",
                         includePrerelease: false,
                         includeUnlisted: false,
+                        sourceCacheContext: NullSourceCacheContext.Instance,
                         log: testLogger,
                         token: CancellationToken.None))
                         .ToList();
@@ -281,6 +287,7 @@ namespace NuGet.Protocol.Tests
                         "A",
                         includePrerelease: true,
                         includeUnlisted: false,
+                        sourceCacheContext: NullSourceCacheContext.Instance,
                         log: testLogger,
                         token: CancellationToken.None))
                         .OrderByDescending(p => p.Identity.Version)
@@ -343,6 +350,7 @@ namespace NuGet.Protocol.Tests
                 // Act
                 var result = await resource.GetMetadataAsync(
                     new PackageIdentity("A", new NuGetVersion("1.0.0")),
+                    NullSourceCacheContext.Instance,
                     log: testLogger,
                     token: CancellationToken.None);
 
@@ -387,6 +395,7 @@ namespace NuGet.Protocol.Tests
                 // Act
                 var result = await resource.GetMetadataAsync(
                     new PackageIdentity("A", new NuGetVersion("2.0.0")),
+                    NullSourceCacheContext.Instance,
                     log: testLogger,
                     token: CancellationToken.None);
 

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataClientTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -30,14 +31,17 @@ namespace NuGet.Protocol.Tests
             var resource = await repo.GetResourceAsync<DependencyInfoResource>();
 
             // Act
-            var results = await resource.ResolvePackages("deepequal", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var results = await resource.ResolvePackages("deepequal", NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            var target = results.Where(p => p.Version == NuGetVersion.Parse("1.4.0")).Single();
+                var target = results.Where(p => p.Version == NuGetVersion.Parse("1.4.0")).Single();
 
-            // Assert
-            Assert.Equal(19, results.Count());
+                // Assert
+                Assert.Equal(19, results.Count());
 
-            Assert.Equal(0, target.Dependencies.Count());
+                Assert.Equal(0, target.Dependencies.Count());
+            }
         }
 
         [Fact]
@@ -55,10 +59,13 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0"));
 
             // Act
-            var result = await resource.ResolvePackage(package, NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.ResolvePackage(package, NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Equal(result.Version, package.Version);
+                // Assert
+                Assert.Equal(result.Version, package.Version);
+            }
         }
 
         [Fact]
@@ -74,11 +81,14 @@ namespace NuGet.Protocol.Tests
             var resource = await repo.GetResourceAsync<DependencyInfoResource>();
 
             // Act
-            var results = await resource.ResolvePackages("deepequal", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var results = await resource.ResolvePackages("deepequal", NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Equal(19, results.Count());
-            Assert.Equal(1, results.Count(package => package.Version.IsPrerelease));
+                // Assert
+                Assert.Equal(19, results.Count());
+                Assert.Equal(1, results.Count(package => package.Version.IsPrerelease));
+            }
         }
 
         [Fact]
@@ -95,11 +105,14 @@ namespace NuGet.Protocol.Tests
             var resource = await repo.GetResourceAsync<DependencyInfoResource>();
 
             // Act
-            var results = await resource.ResolvePackages("microsoft.owin", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var results = await resource.ResolvePackages("microsoft.owin", NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Equal(14, results.Count());
-            Assert.True(results.All(p => p.Id.Equals("microsoft.owin", StringComparison.OrdinalIgnoreCase)));
+                // Assert
+                Assert.Equal(14, results.Count());
+                Assert.True(results.All(p => p.Id.Equals("microsoft.owin", StringComparison.OrdinalIgnoreCase)));
+            }
         }
 
         [Fact]
@@ -116,10 +129,13 @@ namespace NuGet.Protocol.Tests
             var resource = await repo.GetResourceAsync<DependencyInfoResource>();
 
             // Act
-            var results = await resource.ResolvePackages("owin", NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var results = await resource.ResolvePackages("owin", NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Equal(0, results.Count());
+                // Assert
+                Assert.Equal(0, results.Count());
+            }
         }
 
         [Fact]
@@ -138,10 +154,13 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("owin", NuGetVersion.Parse("1.0.0"));
 
             // Act
-            var result = await resource.ResolvePackage(package, NuGetFramework.Parse("net45"), Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.ResolvePackage(package, NuGetFramework.Parse("net45"), sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Null(result);
+                // Assert
+                Assert.Null(result);
+            }
         }
 
         [Fact]
@@ -162,10 +181,13 @@ namespace NuGet.Protocol.Tests
             var projectFramework = NuGetFramework.Parse("net45");
 
             // Act
-            var result = await resource.ResolvePackage(package, projectFramework, Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.ResolvePackage(package, projectFramework, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.False(result.Listed);
+                // Assert
+                Assert.False(result.Listed);
+            }
         }
 
         [Fact]
@@ -187,10 +209,13 @@ namespace NuGet.Protocol.Tests
             var projectFramework = NuGetFramework.Parse("net45");
 
             // Act
-            var result = await resource.ResolvePackage(package, projectFramework, Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.ResolvePackage(package, projectFramework, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.True(result.Listed);
+                // Assert
+                Assert.True(result.Listed);
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/MetadataResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -33,7 +34,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", true, false, NullLogger.Instance, CancellationToken.None);
+            var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal("6.2.2-preview", latestVersion.ToNormalizedString());
@@ -55,7 +56,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", false, false, NullLogger.Instance, CancellationToken.None);
+            var latestVersion = await metadataResource.GetLatestVersion("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal("6.2.0", latestVersion.ToNormalizedString());
@@ -77,7 +78,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var versions = await metadataResource.GetVersions("WindowsAzure.Storage", false, false, NullLogger.Instance, CancellationToken.None);
+            var versions = await metadataResource.GetVersions("WindowsAzure.Storage", false, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(34, versions.Count());
@@ -99,7 +100,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var versions = await metadataResource.GetVersions("WindowsAzure.Storage", true, false, NullLogger.Instance, CancellationToken.None);
+            var versions = await metadataResource.GetVersions("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(44, versions.Count());
@@ -121,7 +122,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var exist = await metadataResource.Exists("WindowsAzure.Storage", true, false, NullLogger.Instance, CancellationToken.None);
+            var exist = await metadataResource.Exists("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.True(exist);
@@ -146,7 +147,7 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
             // Act
-            var exist = await metadataResource.Exists(package, NullLogger.Instance, CancellationToken.None);
+            var exist = await metadataResource.Exists(package, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.True(exist);
@@ -174,7 +175,7 @@ namespace NuGet.Protocol.Tests
             var packageIdList = new List<string>() { "WindowsAzure.Storage", "xunit" };
 
             // Act
-            var versions = (await metadataResource.GetLatestVersions(packageIdList, true, false, NullLogger.Instance, CancellationToken.None)).ToList();
+            var versions = (await metadataResource.GetLatestVersions(packageIdList, true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None)).ToList();
 
             // Assert
             Assert.Equal("WindowsAzure.Storage", versions[1].Key);
@@ -200,7 +201,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var latestVersion = await metadataResource.GetLatestVersion("not-found", true, false, NullLogger.Instance, CancellationToken.None);
+            var latestVersion = await metadataResource.GetLatestVersion("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Null(latestVersion);
@@ -223,7 +224,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var versions = await metadataResource.GetVersions("not-found", true, false, NullLogger.Instance, CancellationToken.None);
+            var versions = await metadataResource.GetVersions("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(0, versions.Count());
@@ -249,7 +250,7 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("xunit", new NuGetVersion("1.0.0-notfound"));
 
             // Act
-            var exist = await metadataResource.Exists(package, NullLogger.Instance, CancellationToken.None);
+            var exist = await metadataResource.Exists(package, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.False(exist);
@@ -272,7 +273,7 @@ namespace NuGet.Protocol.Tests
             var metadataResource = await repo.GetResourceAsync<MetadataResource>();
 
             // Act
-            var exist = await metadataResource.Exists("not-found", true, false, NullLogger.Instance, CancellationToken.None);
+            var exist = await metadataResource.Exists("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.False(exist);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV2FeedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
@@ -33,7 +34,7 @@ namespace NuGet.Protocol.Tests
             var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
 
             // Act
-            var metadata = await packageMetadataResource.GetMetadataAsync("WindowsAzure.Storage", true, false, NullLogger.Instance, CancellationToken.None);
+            var metadata = await packageMetadataResource.GetMetadataAsync("WindowsAzure.Storage", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
             var latestPackage = (PackageSearchMetadataV2Feed) metadata.OrderByDescending(e => e.Identity.Version, VersionComparer.VersionRelease).FirstOrDefault();
 
             // Assert
@@ -76,7 +77,7 @@ namespace NuGet.Protocol.Tests
             var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
 
             // Act
-            var metadata = (IEnumerable<PackageSearchMetadataV2Feed>) await packageMetadataResource.GetMetadataAsync("afine", true, false, NullLogger.Instance, CancellationToken.None);
+            var metadata = (IEnumerable<PackageSearchMetadataV2Feed>) await packageMetadataResource.GetMetadataAsync("afine", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             var first = metadata.ElementAt(0);
             var second = metadata.ElementAt(1);
@@ -101,7 +102,7 @@ namespace NuGet.Protocol.Tests
             var packageMetadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
 
             // Act
-            var metadata = await packageMetadataResource.GetMetadataAsync("not-found", true, false, NullLogger.Instance, CancellationToken.None);
+            var metadata = await packageMetadataResource.GetMetadataAsync("not-found", true, false, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal(0, metadata.Count());
@@ -125,7 +126,7 @@ namespace NuGet.Protocol.Tests
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("4.3.2-preview"));
 
             // Act
-            var metadata = await packageMetadataResource.GetMetadataAsync(packageIdentity, NullLogger.Instance, CancellationToken.None);
+            var metadata = await packageMetadataResource.GetMetadataAsync(packageIdentity, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Equal("WindowsAzure.Storage", metadata.Identity.Id);
@@ -152,7 +153,7 @@ namespace NuGet.Protocol.Tests
             var packageIdentity = new PackageIdentity("WindowsAzure.Storage", new NuGetVersion("0.0.0"));
 
             // Act
-            var metadata = await packageMetadataResource.GetMetadataAsync(packageIdentity, NullLogger.Instance, CancellationToken.None);
+            var metadata = await packageMetadataResource.GetMetadataAsync(packageIdentity, NullSourceCacheContext.Instance, NullLogger.Instance, CancellationToken.None);
 
             // Assert
             Assert.Null(metadata);

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PackageMetadataResourceV3Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -31,23 +32,26 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.9.0"));
 
             // Act
-            var result = (PackageSearchMetadataRegistration) await resource.GetMetadataAsync(package, Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = (PackageSearchMetadataRegistration)await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Equal("deepequal", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
-            Assert.Equal("0.9.0", result.Identity.Version.ToNormalizedString());
-            Assert.True(result.Authors.Contains("James Foster"));
-            Assert.Equal("An extensible deep comparison library for .NET", result.Description);
-            Assert.Null(result.IconUrl);
-            Assert.Null(result.LicenseUrl);
-            Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl.ToString());
-            Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json",
-                result.CatalogUri.ToString());
-            Assert.Equal(DateTimeOffset.Parse("2013-08-28T09:19:10.013Z"), result.Published);
-            Assert.False(result.RequireLicenseAcceptance);
-            Assert.Equal(result.Description, result.Summary);
-            Assert.Equal(string.Join(", ", "deepequal", "deep", "equal"), result.Tags);
-            Assert.Equal("DeepEqual", result.Title);
+                // Assert
+                Assert.Equal("deepequal", result.Identity.Id, StringComparer.OrdinalIgnoreCase);
+                Assert.Equal("0.9.0", result.Identity.Version.ToNormalizedString());
+                Assert.True(result.Authors.Contains("James Foster"));
+                Assert.Equal("An extensible deep comparison library for .NET", result.Description);
+                Assert.Null(result.IconUrl);
+                Assert.Null(result.LicenseUrl);
+                Assert.Equal("http://github.com/jamesfoster/DeepEqual", result.ProjectUrl.ToString());
+                Assert.Equal("https://api.nuget.org/v3/catalog0/data/2015.02.03.18.34.51/deepequal.0.9.0.json",
+                    result.CatalogUri.ToString());
+                Assert.Equal(DateTimeOffset.Parse("2013-08-28T09:19:10.013Z"), result.Published);
+                Assert.False(result.RequireLicenseAcceptance);
+                Assert.Equal(result.Description, result.Summary);
+                Assert.Equal(string.Join(", ", "deepequal", "deep", "equal"), result.Tags);
+                Assert.Equal("DeepEqual", result.Title);
+            }
         }
 
         [Fact]
@@ -63,13 +67,16 @@ namespace NuGet.Protocol.Tests
             var resource = await repo.GetResourceAsync<PackageMetadataResource>();
 
             // Act
-            var result = (IEnumerable<PackageSearchMetadataRegistration>) await resource.GetMetadataAsync("afine", true, true, Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = (IEnumerable<PackageSearchMetadataRegistration>)await resource.GetMetadataAsync("afine", true, true, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            var first = result.ElementAt(0);
-            var second = result.ElementAt(1);
+                var first = result.ElementAt(0);
+                var second = result.ElementAt(1);
 
-            // Assert
-            MetadataReferenceCacheTestUtility.AssertPackagesHaveSameReferences(first, second);
+                // Assert
+                MetadataReferenceCacheTestUtility.AssertPackagesHaveSameReferences(first, second);
+            }
         }
 
         [Fact]
@@ -87,10 +94,13 @@ namespace NuGet.Protocol.Tests
             var package = new PackageIdentity("deepequal", NuGetVersion.Parse("0.0.0"));
 
             // Act
-            var result = await resource.GetMetadataAsync(package, Common.NullLogger.Instance, CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var result = await resource.GetMetadataAsync(package, sourceCacheContext, Common.NullLogger.Instance, CancellationToken.None);
 
-            // Assert
-            Assert.Null(result);
+                // Assert
+                Assert.Null(result);
+            }
         }
     }
 }

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/PowershellAutoCompleteResourceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
 using NuGet.Protocol.VisualStudio;
@@ -53,18 +54,22 @@ namespace NuGet.Protocol.Tests
             Assert.NotNull(resource);
 
             // Act
-            var versions = await resource.VersionStartsWith(
-                "NuGet.Versioning",
-                "3.",
-                includePrerelease: true,
-                log: NullLogger.Instance,
-                token: CancellationToken.None);
+            using (var sourceCacheContext = new SourceCacheContext())
+            {
+                var versions = await resource.VersionStartsWith(
+                    "NuGet.Versioning",
+                    "3.",
+                    includePrerelease: true,
+                    sourceCacheContext: sourceCacheContext,
+                    log: NullLogger.Instance,
+                    token: CancellationToken.None);
 
-            // Assert
-            Assert.NotNull(versions);
-            Assert.Equal(2, versions.Count());
-            Assert.Contains(new NuGetVersion("3.5.0-rc1-final"), versions);
-            Assert.Contains(new NuGetVersion("3.5.0"), versions);
+                // Assert
+                Assert.NotNull(versions);
+                Assert.Equal(2, versions.Count());
+                Assert.Contains(new NuGetVersion("3.5.0-rc1-final"), versions);
+                Assert.Contains(new NuGetVersion("3.5.0"), versions);
+            }
         }
 
         [Theory]

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/RemoteRepositories/RemoteV3FindPackageByIdResourceTests.cs
@@ -641,6 +641,7 @@ namespace NuGet.Protocol.Tests
 
                 dependencyInfoResource.Setup(x => x.ResolvePackages(
                         It.Is<string>(id => id == packageIdentity.Id),
+                        It.IsAny<SourceCacheContext>(),
                         It.IsNotNull<ILogger>(),
                         It.IsAny<CancellationToken>()))
                     .ReturnsAsync(new[] { remoteSourceDependencyInfo });


### PR DESCRIPTION
We already have http cache working for packageReference based projects, this commit implements this http cache for packages.config based projects as well which will significantly improve install/ update performance.

I will try to get some numbers of improvements for some sample solutions.

Fixes: https://github.com/NuGet/Home/issues/5401

@rrelyea 