### PR TITLE
Fixing string formatting in add package command

### DIFF
--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -41,7 +41,9 @@ namespace NuGet.CommandLine.XPlat
             var dgSpec = ReadProjectDependencyGraph(packageReferenceArgs);
             if (dgSpec == null)
             {
-                throw new Exception(Strings.Error_NoDgSpec);
+                packageReferenceArgs.Logger.LogDebug(Strings.Error_NoDgSpec);
+
+                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoDgSpec));
             }
             packageReferenceArgs.Logger.LogDebug("Project Dependency Graph Read");
 
@@ -57,13 +59,25 @@ namespace NuGet.CommandLine.XPlat
             // Throw otherwise since we cannot proceed further.
             if (!matchingPackageSpecs.Any())
             {
-                packageReferenceArgs.Logger.LogDebug(Strings.Error_NoMatchingSpecs);
-                throw new Exception(Strings.Error_NoProjectFound);
+                packageReferenceArgs.Logger.LogDebug(string.Format(Strings.Error_NoMatchingSpecs,
+                    packageReferenceArgs.PackageDependency.Id,
+                    packageReferenceArgs.ProjectPath));
+
+                throw new Exception(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_NoMatchingSpecs,
+                    packageReferenceArgs.PackageDependency.Id,
+                    packageReferenceArgs.ProjectPath));
             }
             else if (matchingPackageSpecs.Count() > 1)
             {
-                packageReferenceArgs.Logger.LogDebug(Strings.Error_MultipleMatchingSpecs);
-                throw new Exception(Strings.Error_MultipleProjectsFound);
+                packageReferenceArgs.Logger.LogDebug(string.Format(Strings.Error_MultipleMatchingSpecs,
+                    packageReferenceArgs.PackageDependency.Id,
+                    packageReferenceArgs.ProjectPath));
+
+                throw new Exception(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_MultipleMatchingSpecs,
+                    packageReferenceArgs.PackageDependency.Id,
+                    packageReferenceArgs.ProjectPath));
             }
 
             // Parse the user specified frameworks once to avoid re-do's

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -44,7 +44,7 @@ namespace NuGet.CommandLine.XPlat
                 // Logging non localized error on debug stream.
                 packageReferenceArgs.Logger.LogDebug(Strings.Error_NoDgSpec);
 
-                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoDgSpec));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoDgSpec));
             }
             packageReferenceArgs.Logger.LogDebug("Project Dependency Graph Read");
 

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Commands/PackageReferenceCommands/AddPackageReferenceCommandRunner.cs
@@ -41,6 +41,7 @@ namespace NuGet.CommandLine.XPlat
             var dgSpec = ReadProjectDependencyGraph(packageReferenceArgs);
             if (dgSpec == null)
             {
+                // Logging non localized error on debug stream.
                 packageReferenceArgs.Logger.LogDebug(Strings.Error_NoDgSpec);
 
                 throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_NoDgSpec));
@@ -57,25 +58,10 @@ namespace NuGet.CommandLine.XPlat
 
             // This ensures that the DG specs generated in previous steps contain exactly 1 project with the same path as the project requesting add package.
             // Throw otherwise since we cannot proceed further.
-            if (!matchingPackageSpecs.Any())
+            if (matchingPackageSpecs.Length != 1)
             {
-                packageReferenceArgs.Logger.LogDebug(string.Format(Strings.Error_NoMatchingSpecs,
-                    packageReferenceArgs.PackageDependency.Id,
-                    packageReferenceArgs.ProjectPath));
-
-                throw new Exception(string.Format(CultureInfo.CurrentCulture,
-                    Strings.Error_NoMatchingSpecs,
-                    packageReferenceArgs.PackageDependency.Id,
-                    packageReferenceArgs.ProjectPath));
-            }
-            else if (matchingPackageSpecs.Count() > 1)
-            {
-                packageReferenceArgs.Logger.LogDebug(string.Format(Strings.Error_MultipleMatchingSpecs,
-                    packageReferenceArgs.PackageDependency.Id,
-                    packageReferenceArgs.ProjectPath));
-
-                throw new Exception(string.Format(CultureInfo.CurrentCulture,
-                    Strings.Error_MultipleMatchingSpecs,
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                    Strings.Error_UnsupportedProject,
                     packageReferenceArgs.PackageDependency.Id,
                     packageReferenceArgs.ProjectPath));
             }

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -341,7 +341,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. The project does not support adding package reference through add package command..
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. The project does not support adding package references through add package command..
         /// </summary>
         internal static string Error_UnsupportedProject {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -20,7 +20,7 @@ namespace NuGet.CommandLine.XPlat {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -341,7 +341,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But no project was found at the project path &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But no project was found at the project path &apos;{1}&apos;..
         /// </summary>
         internal static string Error_NoProjectFound {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -305,24 +305,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Multiple matching package specs found when attempting to add package &apos;{0}&apos; to project &apos;{1}&apos;. Number of matching package specs found are  &apos;{2}&apos;..
-        /// </summary>
-        internal static string Error_MultipleMatchingSpecs {
-            get {
-                return ResourceManager.GetString("Error_MultipleMatchingSpecs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But multiple projects were found at the project path &apos;{1}&apos;..
-        /// </summary>
-        internal static string Error_MultipleProjectsFound {
-            get {
-                return ResourceManager.GetString("Error_MultipleProjectsFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to None or invalid DgSpec was passed to NuGet add package command..
         /// </summary>
         internal static string Error_NoDgSpec {
@@ -341,15 +323,6 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. dotnet add package command supports adding package to one project at a time. But no project was found at the project path &apos;{1}&apos;..
-        /// </summary>
-        internal static string Error_NoProjectFound {
-            get {
-                return ResourceManager.GetString("Error_NoProjectFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to {0} package. Argument &apos;{1}&apos; not provided..
         /// </summary>
         internal static string Error_PkgMissingArgument {
@@ -364,6 +337,15 @@ namespace NuGet.CommandLine.XPlat {
         internal static string Error_PkgMissingOrInvalidProjectFile {
             get {
                 return ResourceManager.GetString("Error_PkgMissingOrInvalidProjectFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. The project does not support adding package reference through add package command..
+        /// </summary>
+        internal static string Error_UnsupportedProject {
+            get {
+                return ResourceManager.GetString("Error_UnsupportedProject", resourceCulture);
             }
         }
         

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.Designer.cs
@@ -341,7 +341,7 @@ namespace NuGet.CommandLine.XPlat {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. The project does not support adding package references through add package command..
+        ///   Looks up a localized string similar to Error while adding package &apos;{0}&apos; to project &apos;{1}&apos;. The project does not support adding package references through the add package command..
         /// </summary>
         internal static string Error_UnsupportedProject {
             get {

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -464,7 +464,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {1} - Project path</comment>
   </data>
   <data name="Error_UnsupportedProject" xml:space="preserve">
-    <value>Error while adding package '{0}' to project '{1}'. The project does not support adding package reference through add package command.</value>
+    <value>Error while adding package '{0}' to project '{1}'. The project does not support adding package references through add package command.</value>
     <comment>{0} - Package Id
 {1} - Project path</comment>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -462,7 +462,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <value>Multiple matching package specs found when attempting to add package '{0}' to project '{1}'. Number of matching package specs found are  '{2}'.</value>
     <comment>{0} - Package ID
 {1} - Project path
-{2} -  NUmber of matching package specs found</comment>
+{2} -  Number of matching package specs found</comment>
   </data>
   <data name="Error_NoMatchingSpecs" xml:space="preserve">
     <value>No matching package specs found when attempting to add package '{0}' to project '{1}'.</value>
@@ -475,7 +475,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {1} - Project path</comment>
   </data>
   <data name="Error_NoProjectFound" xml:space="preserve">
-    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But no project was found at the project path '{0}'.</value>
+    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But no project was found at the project path '{1}'.</value>
     <comment>{0} - Package Id
 {1} - Project path</comment>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -464,7 +464,7 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
 {1} - Project path</comment>
   </data>
   <data name="Error_UnsupportedProject" xml:space="preserve">
-    <value>Error while adding package '{0}' to project '{1}'. The project does not support adding package references through add package command.</value>
+    <value>Error while adding package '{0}' to project '{1}'. The project does not support adding package references through the add package command.</value>
     <comment>{0} - Package Id
 {1} - Project path</comment>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Strings.resx
@@ -458,24 +458,13 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
     <comment>{0} - Operation Name
 {1} - project file path</comment>
   </data>
-  <data name="Error_MultipleMatchingSpecs" xml:space="preserve">
-    <value>Multiple matching package specs found when attempting to add package '{0}' to project '{1}'. Number of matching package specs found are  '{2}'.</value>
-    <comment>{0} - Package ID
-{1} - Project path
-{2} -  Number of matching package specs found</comment>
-  </data>
   <data name="Error_NoMatchingSpecs" xml:space="preserve">
     <value>No matching package specs found when attempting to add package '{0}' to project '{1}'.</value>
     <comment>{0} - Package ID
 {1} - Project path</comment>
   </data>
-  <data name="Error_MultipleProjectsFound" xml:space="preserve">
-    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But multiple projects were found at the project path '{1}'.</value>
-    <comment>{0} - Package Id
-{1} - Project path</comment>
-  </data>
-  <data name="Error_NoProjectFound" xml:space="preserve">
-    <value>Error while adding package '{0}' to project '{1}'. dotnet add package command supports adding package to one project at a time. But no project was found at the project path '{1}'.</value>
+  <data name="Error_UnsupportedProject" xml:space="preserve">
+    <value>Error while adding package '{0}' to project '{1}'. The project does not support adding package reference through add package command.</value>
     <comment>{0} - Package Id
 {1} - Project path</comment>
   </data>

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -40,7 +40,7 @@ namespace NuGet.CommandLine.XPlat
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
             {
-                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
             }
             return new Project(projectRootElement);
         }
@@ -56,7 +56,7 @@ namespace NuGet.CommandLine.XPlat
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
             {
-                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
             }
             return new Project(projectRootElement, globalProperties, toolsVersion: null);
         }
@@ -250,7 +250,7 @@ namespace NuGet.CommandLine.XPlat
                         importedPackageReference.UnevaluatedInclude,
                         importedPackageReference.Xml.ContainingProject.FullPath));
                 }
-                throw new Exception(string.Format(CultureInfo.CurrentCulture,
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
                     Strings.Error_AddPkgFailOnImportEdit,
                     operationType,
                     packageDependency.Id,

--- a/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
+++ b/src/NuGet.Core/NuGet.CommandLine.XPlat/Utility/MSBuildAPIUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -27,11 +27,7 @@ namespace NuGet.CommandLine.XPlat
 
         public MSBuildAPIUtility(ILogger logger)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-            Logger = logger;
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         /// <summary>
@@ -44,7 +40,7 @@ namespace NuGet.CommandLine.XPlat
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
             {
-                throw new Exception(Strings.Error_MsBuildUnableToOpenProject);
+                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
             }
             return new Project(projectRootElement);
         }
@@ -60,7 +56,7 @@ namespace NuGet.CommandLine.XPlat
             var projectRootElement = TryOpenProjectRootElement(projectCSProjPath);
             if (projectCSProjPath == null)
             {
-                throw new Exception(Strings.Error_MsBuildUnableToOpenProject);
+                throw new Exception(string.Format(CultureInfo.CurrentCulture, Strings.Error_MsBuildUnableToOpenProject, projectCSProjPath));
             }
             return new Project(projectRootElement, globalProperties, toolsVersion: null);
         }


### PR DESCRIPTION
## Bug
Link: Internal email
Regression: No  

## Fix
Details: In an internal email, I saw that some exception messages in dotnet add command were not correctly formatted. This PR adds culture and right params to those exceptions.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Changes to string formatting
Validation done:  Local testing with dotnet.exe
