### PR TITLE
fix build number for build tools sku

### DIFF
--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=Microsoft.VisualStudio.NuGet.BuildTools
-        version=15.0.40400.$(BuildNumber)
+        version=15.0.40500.$(BuildNumber)
 
 folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet"
         file source="$(NuGetTargetsPath)"


### PR DESCRIPTION
just noticed that the version of the build tools sku is hardcoded as 15.0.40400.$(BuildNumber) - i have changed to 15.0.40500.$(BuildNumber) for now, but we should make this share the same logic as the vsixmanifest file.