### PR TITLE
Exclude frameworks with invalid assets from compat suggestions

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/CompatibilityChecker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -243,17 +243,21 @@ namespace NuGet.Commands
             {
                 foreach (var group in contentItems.FindItemGroups(pattern))
                 {
-                    object tfmObj = null;
-                    object ridObj = null;
-                    group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.RuntimeIdentifier, out ridObj);
-                    group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out tfmObj);
-
-                    var tfm = tfmObj as NuGetFramework;
-
-                    // RID specific items should be ignored here since they are only used in the runtime assem check
-                    if (ridObj == null && tfm?.IsSpecificFramework == true)
+                    // lib/net45/subfolder/a.dll will be returned as a group with zero items since sub
+                    // folders are not allowed. Completely empty groups are not compatible, a group with
+                    // _._ would contain _._ as an item.
+                    if (group.Items.Count > 0)
                     {
-                        available.Add(tfm);
+                        group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.RuntimeIdentifier, out var ridObj);
+                        group.Properties.TryGetValue(ManagedCodeConventions.PropertyNames.TargetFrameworkMoniker, out var tfmObj);
+
+                        var tfm = tfmObj as NuGetFramework;
+
+                        // RID specific items should be ignored here since they are only used in the runtime assembly check
+                        if (ridObj == null && tfm?.IsSpecificFramework == true)
+                        {
+                            available.Add(tfm);
+                        }
                     }
                 }
             }

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/CompatilibityCheckerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -247,6 +247,74 @@ namespace NuGet.Commands.Test
                 var issue = result.CompatibilityCheckResults.SelectMany(check => check.Issues).Single();
 
                 Assert.Equal(@"Package packageA 1.0.0 is not compatible with netstandard1.0 (.NETStandard,Version=v1.0). Package packageA 1.0.0 does not support any target frameworks.".Replace("\n", Environment.NewLine), issue.Format());
+            }
+        }
+
+        [Fact]
+        public async Task CompatilibityChecker_PackageCompatibility_VerifyAvailableFrameworksIgnoresInvalidAssets()
+        {
+            // Arrange
+            var sources = new List<PackageSource>();
+
+            var project1Json = @"
+            {
+              ""version"": ""1.0.0"",
+              ""description"": """",
+              ""authors"": [ ""author"" ],
+              ""tags"": [ """" ],
+              ""projectUrl"": """",
+              ""licenseUrl"": """",
+              ""frameworks"": {
+                ""netstandard1.0"": {
+                    ""dependencies"": {
+                        ""packageA"": {
+                            ""version"": ""1.0.0""
+                        }
+                    }
+                }
+              }
+            }";
+
+            using (var workingDir = TestDirectory.Create())
+            {
+                var packagesDir = new DirectoryInfo(Path.Combine(workingDir, "globalPackages"));
+                var packageSource = new DirectoryInfo(Path.Combine(workingDir, "packageSource"));
+                var project1 = new DirectoryInfo(Path.Combine(workingDir, "projects", "project1"));
+                packagesDir.Create();
+                packageSource.Create();
+                project1.Create();
+                sources.Add(new PackageSource(packageSource.FullName));
+
+                File.WriteAllText(Path.Combine(project1.FullName, "project.json"), project1Json);
+
+                var specPath1 = Path.Combine(project1.FullName, "project.json");
+                var spec1 = JsonPackageSpecReader.GetPackageSpec(project1Json, "project1", specPath1);
+
+                var logger = new TestLogger();
+                var request = new TestRestoreRequest(spec1, sources, packagesDir.FullName, logger);
+
+                request.LockFilePath = Path.Combine(project1.FullName, "project.lock.json");
+
+                var packageA = new SimpleTestPackageContext("packageA");
+                packageA.AddFile("lib/netstandard1.1/valid.dll");
+                packageA.AddFile("lib/netstandard1.0/x86/invalid.dll");
+
+                SimpleTestPackageUtility.CreatePackages(packageSource.FullName, packageA);
+
+                // Act
+                var command = new RestoreCommand(request);
+                var result = await command.ExecuteAsync();
+                await result.CommitAsync(logger, CancellationToken.None);
+
+                // Assert
+                Assert.False(result.Success, logger.ShowErrors());
+
+                // Verify both libraries were installed
+                Assert.Equal(1, result.LockFile.Libraries.Count);
+
+                var issue = result.CompatibilityCheckResults.SelectMany(check => check.Issues).Single();
+
+                Assert.Equal("Package packageA 1.0.0 is not compatible with netstandard1.0 (.NETStandard,Version=v1.0). Package packageA 1.0.0 supports: netstandard1.1 (.NETStandard,Version=v1.1)", issue.Format());
             }
         }
 


### PR DESCRIPTION
Exclude frameworks with invalid assets from compat suggestions

A package fails the compat check displays a message containing a list of compatible frameworks as a suggestion to the user. Groups that do not contain any valid items should be excluded from this set since they do not count as compatible items.

Example: `lib/net45/blah/a.dll` was being ignored when creating the assets file, but counted as a valid net45 group later when diagnosing what the package could be compatible with. This change puts the get all frameworks logic in sync with the logic used to find the assets.

Fixes https://github.com/NuGet/Home/issues/4259
