### PR TITLE
Fix tools cross-client no-op

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -117,7 +117,7 @@ namespace NuGet.Build.Tasks
                 packageProperties.Add("TargetFrameworks", ToolFramework);
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), packageProperties));
-                 
+
                 // Add restore spec to ensure this is executed during restore
                 var restoreProperties = new Dictionary<string, string>();
                 restoreProperties.Add("ProjectUniqueName", uniqueName);

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -93,7 +93,11 @@ namespace NuGet.Build.Tasks
                 var properties = new Dictionary<string, string>();
                 properties.Add("Type", "ProjectSpec");
                 properties.Add("ProjectPath", ProjectPath);
-                properties.Add("ProjectName", $"DotnetCliToolReference-{msbuildItem.ItemSpec}");
+                properties.TryGetValue("Version", out string value);
+                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : VersionRange.All);
+                properties.Add("ProjectUniqueName", uniqueName);
+                properties.Add("ProjectName", uniqueName);
+
                 BuildTasksUtility.AddPropertyIfExists(properties, "Sources", RestoreSources);
                 BuildTasksUtility.AddPropertyIfExists(properties, "FallbackFolders", RestoreFallbackFolders);
                 BuildTasksUtility.AddPropertyIfExists(properties, "ConfigFilePaths", RestoreConfigFilePaths);
@@ -101,10 +105,6 @@ namespace NuGet.Build.Tasks
                 properties.Add("TargetFrameworks", ToolFramework);
                 properties.Add("ProjectStyle", ProjectStyle.DotnetCliTool.ToString());
                 BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
-
-                properties.TryGetValue("Version", out string value);
-                var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : VersionRange.All);
-                properties.Add("ProjectUniqueName", uniqueName);
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
 
@@ -117,7 +117,7 @@ namespace NuGet.Build.Tasks
                 packageProperties.Add("TargetFrameworks", ToolFramework);
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), packageProperties));
-
+                 
                 // Add restore spec to ensure this is executed during restore
                 var restoreProperties = new Dictionary<string, string>();
                 restoreProperties.Add("ProjectUniqueName", uniqueName);

--- a/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
+++ b/src/NuGet.Core/NuGet.Build.Tasks/GetRestoreDotnetCliToolsTask.cs
@@ -93,6 +93,7 @@ namespace NuGet.Build.Tasks
                 var properties = new Dictionary<string, string>();
                 properties.Add("Type", "ProjectSpec");
                 properties.Add("ProjectPath", ProjectPath);
+                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
                 properties.TryGetValue("Version", out string value);
                 var uniqueName = ToolRestoreUtility.GetUniqueName(msbuildItem.ItemSpec, ToolFramework, value != null ? VersionRange.Parse(value) : VersionRange.All);
                 properties.Add("ProjectUniqueName", uniqueName);
@@ -104,7 +105,6 @@ namespace NuGet.Build.Tasks
                 BuildTasksUtility.AddPropertyIfExists(properties, "PackagesPath", RestorePackagesPath);
                 properties.Add("TargetFrameworks", ToolFramework);
                 properties.Add("ProjectStyle", ProjectStyle.DotnetCliTool.ToString());
-                BuildTasksUtility.CopyPropertyIfExists(msbuildItem, properties, "Version");
 
                 entries.Add(new TaskItem(Guid.NewGuid().ToString(), properties));
 

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -22,7 +22,8 @@ namespace NuGet.Commands
         public static PackageSpec GetSpec(string projectFilePath, string id, VersionRange versionRange, NuGetFramework framework, string packagesPath, IList<string> fallbackFolders, IList<PackageSource> sources, WarningProperties projectWideWarningProperties)
 
         {
-            var name = GetUniqueName(id, framework.GetShortFolderName(), versionRange);
+            var frameworkShortFolderName = framework.GetShortFolderName();
+            var name = GetUniqueName(id, frameworkShortFolderName, versionRange);
 
             return new PackageSpec()
             {
@@ -53,7 +54,7 @@ namespace NuGet.Commands
                     FallbackFolders = fallbackFolders,
                     Sources = sources,
                     OriginalTargetFrameworks = {
-                        framework.GetShortFolderName()
+                        frameworkShortFolderName
                     },
                     TargetFrameworks =
                     {

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -52,6 +52,17 @@ namespace NuGet.Commands
                     PackagesPath = packagesPath,
                     FallbackFolders = fallbackFolders,
                     Sources = sources,
+                    OriginalTargetFrameworks = {
+                        framework.Framework
+                    },
+                    TargetFrameworks =
+                    {
+                        new ProjectRestoreMetadataFrameworkInfo
+                        {
+                            FrameworkName = framework,
+                            ProjectReferences = { }
+                        }
+                    },
                     ProjectWideWarningProperties = projectWideWarningProperties
                 }
             };
@@ -59,9 +70,9 @@ namespace NuGet.Commands
 
         public static string GetUniqueName(string id, string framework, VersionRange versionRange)
         {
-            return $"{id}-{framework}-{versionRange.ToNormalizedString()}".ToLowerInvariant(); 
+            return $"{id}-{framework}-{versionRange.ToNormalizedString()}".ToLowerInvariant();
         }
-        
+
         /// <summary>
         /// Only one output can win per packages folder/version range. Between colliding requests take
         /// the intersection of the inputs used.

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/ToolRestoreUtility.cs
@@ -22,7 +22,7 @@ namespace NuGet.Commands
         public static PackageSpec GetSpec(string projectFilePath, string id, VersionRange versionRange, NuGetFramework framework, string packagesPath, IList<string> fallbackFolders, IList<PackageSource> sources, WarningProperties projectWideWarningProperties)
 
         {
-            var name = GetUniqueName(id, framework.Framework, versionRange);
+            var name = GetUniqueName(id, framework.GetShortFolderName(), versionRange);
 
             return new PackageSpec()
             {
@@ -53,7 +53,7 @@ namespace NuGet.Commands
                     FallbackFolders = fallbackFolders,
                     Sources = sources,
                     OriginalTargetFrameworks = {
-                        framework.Framework
+                        framework.GetShortFolderName()
                     },
                     TargetFrameworks =
                     {

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -317,13 +317,36 @@ function Set-ProjectJsonLockFile {
     return $lockFileFormat.Write($projectJsonLockFilePath, $LockFile)
 }
 
-function Get-ProjectCacheFilePath {
+function Get-ProjectToolsCacheFilePath {
     param(
         [parameter(Mandatory = $true)]
         $Project
     )
-        return CacheFilePathFromProjectPath $Project.FullName
+    $node = Get-ToolsReference $Project.FullName
+
+    $includeValue = $node.Attributes['Include'].Value
+    $versionValue = $node.Attributes['Version'].Value
+
+    return "$($home)\packages\.tools\$($includeValue)\$($versionValue)\netcoreapp1.0\$($includeValue).tools.nuget.cache"      
 }
+
+function Get-ToolsReference {
+    param(
+        [parameter(Mandatory = $true)]
+        $projectPath
+    )
+    $doc = [xml](Get-Content $projectPath)
+    $ns = New-Object System.Xml.XmlNamespaceManager($doc.NameTable)
+    $ns.AddNamespace("ns", $doc.DocumentElement.NamespaceURI)
+    $node = $doc.SelectSingleNode("//ns:DotNetCliToolReference",$ns)
+    return $node
+
+    $includeValue = $node.Attributes['Include'].Value
+    $versionValue = $node.Attributes['Version'].Value
+    Write-Host $includeValue
+    Write-Host $versionValue
+}
+
 
 function Get-CacheFilePathFromProjectPath {
         param(
@@ -337,6 +360,15 @@ function Get-CacheFilePathFromProjectPath {
 
     return $projectCacheFilePath
 }
+
+function Get-ProjectCacheFilePath {
+    param(
+        [parameter(Mandatory = $true)]
+        $Project
+    )
+        return CacheFilePathFromProjectPath $Project.FullName
+}
+
 
 
 function Get-ProjectJsonLockFilePath {

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -340,11 +340,6 @@ function Get-ToolsReference {
     $ns.AddNamespace("ns", $doc.DocumentElement.NamespaceURI)
     $node = $doc.SelectSingleNode("//ns:DotNetCliToolReference",$ns)
     return $node
-
-    $includeValue = $node.Attributes['Include'].Value
-    $versionValue = $node.Attributes['Version'].Value
-    Write-Host $includeValue
-    Write-Host $versionValue
 }
 
 

--- a/test/EndToEnd/nuget.assert.ps1
+++ b/test/EndToEnd/nuget.assert.ps1
@@ -327,7 +327,7 @@ function Get-ProjectToolsCacheFilePath {
     $includeValue = $node.Attributes['Include'].Value
     $versionValue = $node.Attributes['Version'].Value
 
-    return "$($home)\packages\.tools\$($includeValue)\$($versionValue)\netcoreapp1.0\$($includeValue).tools.nuget.cache"      
+    return "$($home)\.nuget\packages\.tools\$($includeValue)\$($versionValue)\netcoreapp1.0\$($includeValue).nuget.cache"      
 }
 
 function Get-ToolsReference {

--- a/test/EndToEnd/tests/NetCoreProjectTest.ps1
+++ b/test/EndToEnd/tests/NetCoreProjectTest.ps1
@@ -801,3 +801,24 @@ function Test-NetCoreVSandMSBuildNoOp {
     #Assert
     Assert-True ($MsBuildRestoreTimestamp -eq $VSRestoreTimestamp)
 }
+
+function Test-NetCoreToolsVSandMSBuildNoOp {
+    
+    # Arrange
+    $project = New-NetCoreWebApp10 ConsoleApp
+    Assert-NetCoreProjectCreation $project
+
+    $ToolsCacheFile = Get-ProjectToolsCacheFilePath $project
+    
+    #Act
+    $VSRestoreTimestamp =( [datetime](Get-ItemProperty -Path $ToolsCacheFile -Name LastWriteTime).lastwritetime).Ticks
+    
+    $MSBuildExe = Get-MSBuildExe
+    
+    & "$MSBuildExe" /t:restore
+
+    $MsBuildRestoreTimestamp =( [datetime](Get-ItemProperty -Path $ToolsCacheFile -Name LastWriteTime).lastwritetime).Ticks
+
+    #Assert
+    Assert-True ($MsBuildRestoreTimestamp -eq $VSRestoreTimestamp)
+}

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -1414,8 +1414,10 @@ namespace NuGet.CommandLine.Test
                 Assert.False(File.Exists(path), r2.Item2);
                 Assert.False(File.Exists(cacheFile), r2.Item2);
                 Assert.DoesNotContain("NU1603", r2.Item2);
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have not changed. No further actions are required to complete the restore.", r2.Item2);
-
+                for (var i = 1; i <= testCount; i++)
+                {
+                    Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[{i}.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                }
                 // Each project should have its own tool verion
                 Assert.Equal(testCount, Directory.GetDirectories(zPath).Length);
             }
@@ -1729,8 +1731,8 @@ namespace NuGet.CommandLine.Test
                 Assert.Equal(1, Directory.GetDirectories(zPath).Length);
                 // This is expected because all the projects keep overwriting the cache file for the tool.
 
-                Assert.Contains("The restore inputs for 'DotnetCliToolReference-z' have changed. Continuing restore.", r2.Item2);
-                var count = Regex.Matches(r2.Item2, ("The restore inputs for 'DotnetCliToolReference-z' have changed. Continuing restore.")).Count;
+                Assert.Contains(@"have changed. Continuing restore.", r2.Item2);
+                var count = Regex.Matches(r2.Item2, (@"have changed. Continuing restore.")).Count;
                 Assert.True(count == 9 || count == 10, $"{ count } needs to be 9 or 10 in \n: { r2.Item2 }");
             }
         }
@@ -1867,7 +1869,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(cachePath));
                 // This is expected, because despite the fact that both projects resolve to the same tool, the version range they request is different so they will keep overwriting each other
                 // Basically, it is impossible for both tools to no-op.
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have changed. Continuing restore.", r2.Item2);
+                Assert.Contains($"Writing tool lock file to disk", r2.Item2);
                 r = Util.RestoreSolution(pathContext);
 
             }
@@ -1948,7 +1950,7 @@ namespace NuGet.CommandLine.Test
                 Assert.True(File.Exists(cachePath));
                 // This is a more complex scenario, since when we dedup 2.0.0 and 2.0.* we only look for 2.0.*...if 2.0.0 package exists, the 2.0.* would resolve to 2.0.0 so both cases would be covered
                 // The issue is ofc when you have 2.5 package in your local, and a package with 2.0.0 was added remotely. Then we re-download
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[2.0.*, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
             }
         }
 
@@ -2047,7 +2049,7 @@ namespace NuGet.CommandLine.Test
                 // The issue is ofc when you have 2.5 package in your local, and a package with 2.0.0 was added remotely. Then we won't redownload
                 Assert.False(File.Exists(assetsPath20));
                 Assert.False(File.Exists(cachePath20));
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[2.0.*, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
                 r = Util.RestoreSolution(pathContext);
             }
         }
@@ -2114,7 +2116,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore", r2.Item2);
 
                 r = Util.RestoreSolution(pathContext);
 
@@ -2249,7 +2251,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-z' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'z-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
 
                 r = Util.RestoreSolution(pathContext);
             }
@@ -2372,7 +2374,7 @@ namespace NuGet.CommandLine.Test
                 // Assert
                 Assert.True(File.Exists(assetsPath));
                 Assert.True(File.Exists(cachePath));
-                Assert.Contains($"The restore inputs for 'DotnetCliToolReference-x' have not changed. No further actions are required to complete the restore.", r2.Item2);
+                Assert.Contains($"The restore inputs for 'x-netcoreapp1.0-[1.0.0, )' have not changed. No further actions are required to complete the restore.", r2.Item2);
                 Assert.Contains($"The restore inputs for 'a' have not changed. No further actions are required to complete the restore.", r2.Item2);
                 Assert.Contains($"The restore inputs for 'b' have not changed. No further actions are required to complete the restore.", r2.Item2);
 


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5911
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Align the dg spec creation among both msbuild and vs tools restore to populate the same elements, add E2E tests  

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done:  Tests + Manual validation
