### PR TITLE
Fixing Help string for NuGet PMC to match the title in Tools/Options

### DIFF
--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -10070,7 +10070,7 @@ namespace NuGet.CommandLine {
         
         /// <summary>
         ///   Looks up a localized string similar to Restoring NuGet packages...
-        ///To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck &apos;{0}&apos;..
+        ///To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the NuGet Package Manager node and uncheck &apos;{0}&apos;..
         /// </summary>
         public static string RestoreCommandPackageRestoreOptOutMessage {
             get {

--- a/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -492,7 +492,7 @@
   </data>
   <data name="RestoreCommandPackageRestoreOptOutMessage" xml:space="preserve">
     <value>Restoring NuGet packages...
-To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck '{0}'.</value>
+To prevent NuGet from downloading packages during build, open the Visual Studio Options dialog, click on the NuGet Package Manager node and uncheck '{0}'.</value>
   </data>
   <data name="ProjectRestoreCommandNoPackagesConfigOrProjectJson" xml:space="preserve">
     <value>Nothing to do. This project does not specify any packages for NuGet to restore.</value>

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more NuGet packages need to be restored but couldn&apos;t be because consent has not been granted. To give consent, open the Visual Studio Options dialog, click on the Package Manager node and check &apos;Allow NuGet to download missing packages during build.&apos; You can also give consent by setting the environment variable &apos;EnableNuGetPackageRestore&apos; to &apos;true&apos;.
+        ///   Looks up a localized string similar to One or more NuGet packages need to be restored but couldn&apos;t be because consent has not been granted. To give consent, open the Visual Studio Options dialog, click on the NuGet Package Manager node and check &apos;Allow NuGet to download missing packages during build.&apos; You can also give consent by setting the environment variable &apos;EnableNuGetPackageRestore&apos; to &apos;true&apos;.
         ///
         ///Missing packages: {0}.
         /// </summary>
@@ -126,7 +126,7 @@ namespace NuGet.SolutionRestoreManager {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the Package Manager node and check &apos;Allow NuGet to download missing packages during build.&apos; You can also enable it by setting the environment variable &apos;EnableNuGetPackageRestore&apos; to &apos;true&apos;..
+        ///   Looks up a localized string similar to NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the NuGet Package Manager node and check &apos;Allow NuGet to download missing packages during build.&apos; You can also enable it by setting the environment variable &apos;EnableNuGetPackageRestore&apos; to &apos;true&apos;..
         /// </summary>
         internal static string PackageRefNotRestoredBecauseOfNoConsent {
             get {
@@ -181,7 +181,7 @@ namespace NuGet.SolutionRestoreManager {
         
         /// <summary>
         ///   Looks up a localized string similar to Restoring NuGet packages...
-        ///To prevent NuGet from restoring packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck &apos;Allow NuGet to download missing packages during build.&apos;.
+        ///To prevent NuGet from restoring packages during build, open the Visual Studio Options dialog, click on the NuGet Package Manager node and uncheck &apos;Allow NuGet to download missing packages during build.&apos;.
         /// </summary>
         internal static string PackageRestoreOptOutMessage {
             get {

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -136,12 +136,12 @@
     <value>Time Elapsed: {0}</value>
   </data>
   <data name="PackageNotRestoredBecauseOfNoConsent" xml:space="preserve">
-    <value>One or more NuGet packages need to be restored but couldn't be because consent has not been granted. To give consent, open the Visual Studio Options dialog, click on the Package Manager node and check 'Allow NuGet to download missing packages during build.' You can also give consent by setting the environment variable 'EnableNuGetPackageRestore' to 'true'.
+    <value>One or more NuGet packages need to be restored but couldn't be because consent has not been granted. To give consent, open the Visual Studio Options dialog, click on the NuGet Package Manager node and check 'Allow NuGet to download missing packages during build.' You can also give consent by setting the environment variable 'EnableNuGetPackageRestore' to 'true'.
 
 Missing packages: {0}</value>
   </data>
   <data name="PackageRefNotRestoredBecauseOfNoConsent" xml:space="preserve">
-    <value>NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the Package Manager node and check 'Allow NuGet to download missing packages during build.' You can also enable it by setting the environment variable 'EnableNuGetPackageRestore' to 'true'.</value>
+    <value>NuGet restore is currently disabled. To enable it, open the Visual Studio Options dialog, click on the NuGet Package Manager node and check 'Allow NuGet to download missing packages during build.' You can also enable it by setting the environment variable 'EnableNuGetPackageRestore' to 'true'.</value>
   </data>
   <data name="PackageRestoreCanceled" xml:space="preserve">
     <value>NuGet package restore canceled.</value>
@@ -160,7 +160,7 @@ Missing packages: {0}</value>
   </data>
   <data name="PackageRestoreOptOutMessage" xml:space="preserve">
     <value>Restoring NuGet packages...
-To prevent NuGet from restoring packages during build, open the Visual Studio Options dialog, click on the Package Manager node and uncheck 'Allow NuGet to download missing packages during build.'</value>
+To prevent NuGet from restoring packages during build, open the Visual Studio Options dialog, click on the NuGet Package Manager node and uncheck 'Allow NuGet to download missing packages during build.'</value>
   </data>
   <data name="RelativeGlobalPackagesFolder" xml:space="preserve">
     <value>'globalPackagesFolder' from nuget.config file or the environment variable is '{0}', a relative path and the solution is not saved. Please save your solution or configure a 'globalPackagesFolder' which is a full path.</value>


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5844
Regression: No  

## Fix
Details: The fix corrects the text in PM Console to match the settings in VS.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  String update
Validation done:  Locally installed the vsix and launched PMC
