### PR TITLE
fix swix authoring

### DIFF
--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -4,23 +4,23 @@ package name=Microsoft.VisualStudio.NuGet.BuildTools
         version=15.0.40500.$(BuildNumber)
 
 folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet"
-        file source="$(NuGetTargetsPath)"
-        file source="$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll"
-        file source="$(ReferenceOutputPath)Newtonsoft.Json.dll"
-        file source="$(ReferenceOutputPath)NuGet.Build.Tasks.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Commands.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Common.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Configuration.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Frameworks.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.LibraryModel.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.PackageManagement.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Packaging.Core.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Packaging.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.ProjectModel.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Protocol.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Resolver.dll vs.file.ngenArchitecture=all"
-        file source="$(ReferenceOutputPath)NuGet.Versioning.dll vs.file.ngenArchitecture=all"
+        file source=$(NuGetTargetsPath)
+        file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
+        file source=$(ReferenceOutputPath)Newtonsoft.Json.dll
+        file source=$(ReferenceOutputPath)NuGet.Build.Tasks.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Commands.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Common.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Configuration.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.DependencyResolver.Core.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Frameworks.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.LibraryModel.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.PackageManagement.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Packaging.Core.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Packaging.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.ProjectModel.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Protocol.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Resolver.dll vs.file.ngenArchitecture=all
+        file source=$(ReferenceOutputPath)NuGet.Versioning.dll vs.file.ngenArchitecture=all
 
 folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs"
         file source="$(XmlTransformPath)cs\Microsoft.Web.XmlTransform.resources.dll"

--- a/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
+++ b/setup/Microsoft.VisualStudio.NuGet.BuildTools.swr
@@ -3,7 +3,7 @@ use vs
 package name=Microsoft.VisualStudio.NuGet.BuildTools
         version=15.0.40500.$(BuildNumber)
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet 
         file source=$(NuGetTargetsPath)
         file source=$(ReferenceOutputPath)Microsoft.Web.XmlTransform.dll
         file source=$(ReferenceOutputPath)Newtonsoft.Json.dll
@@ -22,223 +22,223 @@ folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet"
         file source=$(ReferenceOutputPath)NuGet.Resolver.dll vs.file.ngenArchitecture=all
         file source=$(ReferenceOutputPath)NuGet.Versioning.dll vs.file.ngenArchitecture=all
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs"
-        file source="$(XmlTransformPath)cs\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)cs\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\cs 
+        file source=$(XmlTransformPath)cs\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)cs\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\de"
-        file source="$(XmlTransformPath)de\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)de\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\de 
+        file source=$(XmlTransformPath)de\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)de\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\es"
-        file source="$(XmlTransformPath)es\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)es\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\es 
+        file source=$(XmlTransformPath)es\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)es\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\fr"
-        file source="$(XmlTransformPath)fr\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)fr\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\fr 
+        file source=$(XmlTransformPath)fr\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)fr\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\it"
-        file source="$(XmlTransformPath)it\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)it\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\it 
+        file source=$(XmlTransformPath)it\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)it\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ja"
-        file source="$(XmlTransformPath)ja\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)ja\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ja 
+        file source=$(XmlTransformPath)ja\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)ja\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ko"
-        file source="$(XmlTransformPath)ko\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)ko\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ko 
+        file source=$(XmlTransformPath)ko\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)ko\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pl"
-        file source="$(XmlTransformPath)pl\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)pl\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pl 
+        file source=$(XmlTransformPath)pl\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)pl\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pt-BR"
-        file source="$(XmlTransformPath)pt-BR\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)pt-BR\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\pt-BR 
+        file source=$(XmlTransformPath)pt-BR\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)pt-BR\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ru"
-        file source="$(XmlTransformPath)ru\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)ru\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\ru 
+        file source=$(XmlTransformPath)ru\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)ru\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\tr"
-        file source="$(XmlTransformPath)tr\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)tr\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\tr 
+        file source=$(XmlTransformPath)tr\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)tr\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hans"
-        file source="$(XmlTransformPath)zh-Hans\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hans\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hans 
+        file source=$(XmlTransformPath)zh-Hans\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hans\NuGet.Versioning.resources.dll
 
-folder "InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hant"
-        file source="$(XmlTransformPath)zh-Hant\Microsoft.Web.XmlTransform.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Build.Tasks.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Commands.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Common.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Configuration.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.DependencyResolver.Core.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Frameworks.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.LibraryModel.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.PackageManagement.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Packaging.Core.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Packaging.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.ProjectModel.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Protocol.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Resolver.resources.dll"
-        file source="$(ReferenceOutputPath)zh-Hant\NuGet.Versioning.resources.dll"
+folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\zh-Hant 
+        file source=$(XmlTransformPath)zh-Hant\Microsoft.Web.XmlTransform.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Build.Tasks.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Commands.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Common.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Configuration.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.DependencyResolver.Core.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Frameworks.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.LibraryModel.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.PackageManagement.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Packaging.Core.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Packaging.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.ProjectModel.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Protocol.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Resolver.resources.dll
+        file source=$(ReferenceOutputPath)zh-Hant\NuGet.Versioning.resources.dll


### PR DESCRIPTION
#Build fails with error like:
```
2017-09-22T01:01:52.5356948Z Build:
2017-09-22T01:01:52.5356948Z   E:\A\_work\31\a\MicroBuild\Plugins\MicroBuild.Plugins.SwixBuild.1.0.147\build\..\tools\bin\swc.exe -arch neutral -ext E:\A\_work\31\a\MicroBuild\Plugins\MicroBuild.Plugins.SwixBuild.1.0.147\build\..\tools\VsixSwixExtension.dll -o E:\A\_work\31\s\artifacts\Microsoft.VisualStudio.NuGet.BuildTools\15.0\bin\release\Microsoft.VisualStudio.NuGet.BuildTools.vsix -d ReferenceOutputPath=E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\ -d NuGetTargetsPath=E:\A\_work\31\s\src\NuGet.Core\NuGet.Build.Tasks\NuGet.targets -d XmlTransformPath=E:\A\_work\31\s\artifacts\Microsoft.Web.Xdt.2.1.1\lib\net40\ -d BuildNumber=7947 -d Chip=AnyCPU -d MicrosoftPackageNamePrefix=Microsoft. -d "MicrosoftPublisher=CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" -d "VSDefaultProgramPath=Software\Microsoft\VisualStudio_[InstanceId]\Capabilities" -d VsDdeApplication=VisualStudio.15.0 -d Lang=enu -d Codepage=1252 -d Culture=en -d LangCountry=en-US -d LCID=1033 Microsoft.VisualStudio.NuGet.BuildTools.swr E:\A\_work\31\a\MicroBuild\Plugins\MicroBuild.Plugins.SwixBuild.1.0.147\build\..\tools\VsixExternalFolders.swr -t vsix 
2017-09-22T01:01:53.0315662Z ##[error]setup\Microsoft.VisualStudio.NuGet.BuildTools.swr(10,8): Error SWIX1108: Could not find file at path: E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\NuGet.Build.Tasks.dll vs.file.ngenArchitecture=all.
2017-09-22T01:01:53.0345624Z E:\A\_work\31\s\setup\Microsoft.VisualStudio.NuGet.BuildTools.swr(10,8): error SWIX1108: Could not find file at path: E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\NuGet.Build.Tasks.dll vs.file.ngenArchitecture=all. [E:\A\_work\31\s\setup\Microsoft.VisualStudio.NuGet.BuildTools.swixproj]
2017-09-22T01:01:53.0345624Z ##[error]setup\Microsoft.VisualStudio.NuGet.BuildTools.swr(11,8): Error SWIX1108: Could not find file at path: E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\NuGet.Commands.dll vs.file.ngenArchitecture=all.
2017-09-22T01:01:53.0355627Z E:\A\_work\31\s\setup\Microsoft.VisualStudio.NuGet.BuildTools.swr(11,8): error SWIX1108: Could not find file at path: E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\NuGet.Commands.dll vs.file.ngenArchitecture=all. [E:\A\_work\31\s\setup\Microsoft.VisualStudio.NuGet.BuildTools.swixproj]
2017-09-22T01:01:53.0355627Z ##[error]setup\Microsoft.VisualStudio.NuGet.BuildTools.swr(12,8): Error SWIX1108: Could not find file at path: E:\A\_work\31\s\artifacts\NuGet.VisualStudio.Client\15.0\bin\release\NuGet.Common.dll vs.file.ngenArchitecture=all.

```

The attribute vs.file.ngenArchitecture=all needs to be outisde the quotes like in : 

https://github.com/Microsoft/msbuild/blob/master/setup/files.swr#L14