### PR TITLE
Fix flaky e2e test

### DIFF
--- a/test/EndToEnd/ProjectTemplates/NetCoreWebApplication1.0.zip/WebApplication.csproj
+++ b/test/EndToEnd/ProjectTemplates/NetCoreWebApplication1.0.zip/WebApplication.csproj
@@ -19,5 +19,8 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />
   </ItemGroup>
+  <PropertyGroup>
+    <DotnetCliToolTargetFramework>netcoreapp2.0</DotnetCliToolTargetFramework>
+  </PropertyGroup>  
 
 </Project>


### PR DESCRIPTION
## Bug
Link:   
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: This test was flaky as tools were being restore wrt to a value supplied by the dotnet SDK. 
I am now overwriting this value so that we get consistent results regardless of the machine's setup. 

Basically the SDK sets the DotnetCliToolTargetFramework value..newer SDKs set it while older ones do not. 
If the value is not set it defaults to netcoreapp1.0.

I am overwriting this value in order to get consistent results among different machines and different SDK installations. 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  
Validation done:  
