### PR TITLE
change cert 25 to 67 since 25 is deprecated

### DIFF
--- a/build/sign.proj
+++ b/build/sign.proj
@@ -27,7 +27,7 @@
       </FilesToSign>
       <FilesToSign Include="$(ArtifactsDirectory)Microsoft.Web.Xdt.2.1.1\lib\net40\**\Microsoft.Web.XmlTransform.resources.dll">
         <Authenticode>Microsoft</Authenticode>
-        <StrongName>25</StrongName>
+        <StrongName>67</StrongName>
       </FilesToSign>
     </ItemGroup>
     <MSBuild

--- a/build/sign.targets
+++ b/build/sign.targets
@@ -3,7 +3,7 @@
   <!-- Use NuGet SNK by default for all projects except API.Test. -->
   <PropertyGroup>
     <StrongNameKey>$(NUGET_PFX_PATH)</StrongNameKey>
-    <DefaultStrongNameCert>25</DefaultStrongNameCert>
+    <DefaultStrongNameCert>67</DefaultStrongNameCert>
   </PropertyGroup>
 
   <!-- Use MSFT SNK for all NuGet.Core test and source projects and since we do not own MSFT SNK we can only delay sign the assemblies. -->


### PR DESCRIPTION
Fixes: https://github.com/NuGet/Client.Engineering/issues/83
Have an email thread with whole team CC'd for context of this change. Both these certs have the same public key , so this shouldn't break anyone.