### PR TITLE
Show disabled versions gray and don't let user select them

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -318,7 +318,7 @@ namespace NuGet.PackageManagement.UI
             get { return _selectedVersion; }
             set
             {
-                if (_selectedVersion != value)
+                if (_selectedVersion != value && value.IsValidVersion)
                 {
                     _selectedVersion = value;
 

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Xamls/ProjectView.xaml
@@ -99,10 +99,13 @@
       AutomationProperties.Name="{x:Static local:Resources.Label_Version}"
       ItemsSource="{Binding Path=Versions}"
       SelectedItem="{Binding Path=SelectedVersion}">
-
-        <ComboBox.ItemContainerStyle>
-            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}"> 
+      <ComboBox.ItemContainerStyle>
+            <Style TargetType="{x:Type ComboBoxItem}" BasedOn="{StaticResource ComboBoxItemStyle}">
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static local:Brushes.UIText}}" />
                 <Style.Triggers>
+                    <DataTrigger Binding="{Binding Path=IsValidVersion}" Value="false">
+                        <Setter Property="Foreground" Value="{x:Static SystemColors.GrayTextBrush}" />
+                    </DataTrigger>
                     <DataTrigger
                         Binding="{Binding Converter={StaticResource NotNullToBooleanConverter}}"
                         Value="True" >


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5948
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 

When a version in the versions list is blocked the item in the list should be disabled and grayed out. This PR adds the graying out to the combobox. Also ensures that a user could not select a version that is not valid.

![disabled](https://user-images.githubusercontent.com/2132567/30939729-5bb73984-a393-11e7-8a48-ea2c2e8386bc.PNG)


## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI color change, requires manual testing
Validation done:  
