### PR TITLE
catch setting exception in Option UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Options/GeneralOptionControl.cs
@@ -100,6 +100,12 @@ namespace NuGet.Options
                 MessageHelper.ShowErrorMessage(Resources.ShowError_ConfigUnauthorizedAccess, Resources.ErrorDialogBoxTitle);
                 return false;
             }
+            catch (Exception ex)
+            {
+                MessageHelper.ShowErrorMessage(Resources.ShowError_ApplySettingFailed, Resources.ErrorDialogBoxTitle);
+                ActivityLog.LogError(NuGetUI.LogEntrySource, ex.ToString());
+                return false;
+            }
 
             return true;
         }

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.Designer.cs
@@ -1053,6 +1053,15 @@ namespace NuGet.PackageManagement.UI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Applying setting failed..
+        /// </summary>
+        public static string ShowError_ApplySettingFailed {
+            get {
+                return ResourceManager.GetString("ShowError_ApplySettingFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to NuGet.Config is malformed, Please check NuGet.Config.
         /// </summary>
         public static string ShowError_ConfigInvalidOperation {

--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Resources.resx
@@ -684,4 +684,7 @@ Please see https://aka.ms/troubleshoot_nuget_cache for more help.</value>
   <data name="RefreshButtonLabel" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="ShowError_ApplySettingFailed" xml:space="preserve">
+    <value>Applying setting failed.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Bug
Link: VSTS Watson issue 490438  
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Catch exception in option UI

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  UI change
Validation done:  
