### PR TITLE
Resolve relative RestoreConfigFile paths against MSBuildStartupDirectory

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets
@@ -878,7 +878,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
   -->
   <Target Name="_GetRestoreSettingsOverrides"
-          Returns="$(_RestorePackagesPathOverride);$(_GetRestoreSourcesOverride);$(_GetRestoreFallbackFoldersOverride)">
+          Returns="$(_RestorePackagesPathOverride);$(_RestoreSourcesOverride);$(_RestoreFallbackFoldersOverride)">
 
     <!-- RestorePackagesPathOverride -->
     <MsBuild


### PR DESCRIPTION
Relative paths for nuget.config should be resolved against the original working directory, and not the project directory which appears as the working directory when paths are resolved from an MSBuild task.

Cleaned up a few other things around the settings task which looked incorrect.

Fixes https://github.com/NuGet/Home/issues/5933