### PR TITLE
Fix error logging in E2E tests

### DIFF
--- a/scripts/e2etests/NuGetFunctionalTestUtils.ps1
+++ b/scripts/e2etests/NuGetFunctionalTestUtils.ps1
@@ -97,7 +97,7 @@ function RealTimeLogResults
 
     $log = Join-Path $currentBinFolder.FullName "log.txt"
     $testResults = Join-Path $currentBinFolder.FullName "Realtimeresults.txt"
-
+    $lastLogLine = ""
     While ($currentTestTime -le $EachTestTimoutInSecs)
     {
         Start-Sleep 1
@@ -134,7 +134,8 @@ function RealTimeLogResults
             else
             {                               
                 $logContent = Get-Content $log
-                Write-Host $logContent[$currentTestId] " and current test time is ${currentTestTime}" 
+                $lastLogLine = $logContent[$currentTestId]
+                Write-Host $lastLogLine " and current test time is ${currentTestTime}" 
             }
 
             $logContent = Get-Content $log
@@ -169,18 +170,18 @@ function RealTimeLogResults
 
     if ($currentTestTime -gt $EachTestTimoutInSecs)
     {
-        $logLastLine = (Get-Content $log)[-1] -split " "
-        $currentTestName = $logLastLine[2].Replace("...", "") 
+        $logLineEntries = $lastLogLine -split " "
+        $currentTestName = $logLineEntries[2].Replace("...", "") 
         $resultRow = "Failed $currentTestName 600000 Test timed out"
-        $resultRow >> $RealTimeResultsFile
+        $resultRow >> $testResults
         $errorMessage = 'Run Failed - Results.html did not get created. ' `
         + 'This indicates that the tests did not finish running. It could be that the VS crashed or a test timed out. Please investigate.'
         CopyResultsToCI $NuGetDropPath $RunCounter $testResults
-        if($env:CI)
-        {
-            # Running into some hangs, so comment it out for now.
-            #Get-ScreenCapture -OfWindow -OutputPath $env:EndToEndResultsDropPath
-        }
+        # if($env:CI)
+        # {
+        ## Running into some hangs, so comment it out for now.
+        #     Get-ScreenCapture -OfWindow -OutputPath $env:EndToEndResultsDropPath
+        # }
         
         Write-Error $errorMessage
         return $null

--- a/scripts/e2etests/NuGetFunctionalTestUtils.ps1
+++ b/scripts/e2etests/NuGetFunctionalTestUtils.ps1
@@ -169,12 +169,17 @@ function RealTimeLogResults
 
     if ($currentTestTime -gt $EachTestTimoutInSecs)
     {
+        $logLastLine = (Get-Content $log)[-1] -split " "
+        $currentTestName = $logLastLine[2].Replace("...", "") 
+        $resultRow = "Failed $currentTestName 600000 Test timed out"
+        $resultRow >> $RealTimeResultsFile
         $errorMessage = 'Run Failed - Results.html did not get created. ' `
         + 'This indicates that the tests did not finish running. It could be that the VS crashed or a test timed out. Please investigate.'
         CopyResultsToCI $NuGetDropPath $RunCounter $testResults
         if($env:CI)
         {
-            Get-ScreenCapture -OfWindow -OutputPath $env:EndToEndResultsDropPath
+            # Running into some hangs, so comment it out for now.
+            #Get-ScreenCapture -OfWindow -OutputPath $env:EndToEndResultsDropPath
         }
         
         Write-Error $errorMessage

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -479,21 +479,15 @@ function Get-TextResultRow
     )
 
     $status = 'Passed'
-    $errorMessage = $($Result.Error)
 
     if($Result.Skipped) {
         $status = 'Skipped'
     }
     elseif($Result.Error) {
         $status = 'Failed'
-        $errorMessageArray = Get-Content $errorMessage
-        if($errorMessageArray.Length -gt 1)
-        {
-            $errorMessage = [string]::Join(" ", $errorMessageArray)
-        }
     }
 
-    $row = "$status $($Result.Test) $([math]::Round($Result.Time.TotalMilliseconds)) $errorMessage "
+    $row = "$status $($Result.Test) $([math]::Round($Result.Time.TotalMilliseconds)) $($Result.Error) "
 
     return $row
 }
@@ -506,6 +500,12 @@ function Append-TextResult
     )
 
     $row = Get-TextResultRow $Result
+    $numLines = $row | Measure-Object -Line
+    if($numLines.Lines -gt 1)
+    {
+        $rowArray = $row.Split([environment]::NewLine)
+        $row = [string]::Join(" ", $rowArray)
+    }
     $row >> $Path
 }
 

--- a/test/EndToEnd/NuGet.Tests.psm1
+++ b/test/EndToEnd/NuGet.Tests.psm1
@@ -479,15 +479,21 @@ function Get-TextResultRow
     )
 
     $status = 'Passed'
+    $errorMessage = $($Result.Error)
 
     if($Result.Skipped) {
         $status = 'Skipped'
     }
     elseif($Result.Error) {
         $status = 'Failed'
+        $errorMessageArray = Get-Content $errorMessage
+        if($errorMessageArray.Length -gt 1)
+        {
+            $errorMessage = [string]::Join(" ", $errorMessageArray)
+        }
     }
 
-    $row = "$status $($Result.Test) $([math]::Round($Result.Time.TotalMilliseconds)) $($Result.Error) "
+    $row = "$status $($Result.Test) $([math]::Round($Result.Time.TotalMilliseconds)) $errorMessage "
 
     return $row
 }


### PR DESCRIPTION
- Disabling screen capture temporarily as it's running into a hang on some machines.
- Also logs the test into the error file which times out.
- Fixing error logging in cases where the error message in itself spans across more than one line, which breaks the assumptions about parsing the results file.

This fixes the parsing issue by replacing the new line with a space and collapsing everything into a single line.