### PR TITLE
Handle null versions gracefully in the UI

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.UI/Models/DetailControlModel.cs
@@ -154,7 +154,11 @@ namespace NuGet.PackageManagement.UI
                 return;
             }
 
-            _allPackageVersions = versions.Select(v => v.Version).ToList();
+            // Get the list of available versions, ignoring null versions
+            _allPackageVersions = versions
+                .Where(v => v?.Version != null)
+                .Select(v => v.Version)
+                .ToList();
 
             // hook event handler for dependency behavior changed
             Options.SelectedChanged += DependencyBehavior_SelectedChanged;


### PR DESCRIPTION
This fixes a watson issue where null versions were throwing when checked against allowedVersion.

The fix is to ignore null versions when creating the list of versions to display in the NuGet UI, there is no reason to have them. This works for all sources/types as this is the central point where they are read in for the version list.

The source of these null versions is unclear since there are many different providers for them. It is likely due to bad local packages, or bad data on a feeds. There isn't much that can be done about this without blocking all valid versions, so filtering out bad data from the options which can be installed seems like the correct behavior here.
