### PR TITLE
increase netcore restore wait time

### DIFF
--- a/test/EndToEnd/vs.ps1
+++ b/test/EndToEnd/vs.ps1
@@ -68,7 +68,7 @@ function Wait-OnNetCoreRestoreCompletion{
      param(
         [parameter(Mandatory = $true)]
         $Project,
-        [int]$TimoutSeconds = 20
+        [int]$TimoutSeconds = 30
     )
 
     $NetCoreLockFilePath = Get-NetCoreLockFilePath $Project


### PR DESCRIPTION
## Bug
Link: 
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: NetStandard E2E tests are failing due to restore timeout, since the time is machine dependent, I'll increase it. 
Let's start off with 30 and go from there. 

## Testing/Validation
Tests Added: Yes/No  
Reason for not adding tests:  
Validation done:  
