### PR TITLE
Fix VS start-up time by lazy initializing NuGetPackage

### DIFF
--- a/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
+++ b/src/NuGet.Clients/NuGet.Console/PowerConsoleToolWindow.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
@@ -17,11 +18,13 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
 using NuGet.PackageManagement;
 using NuGet.PackageManagement.VisualStudio;
 using NuGet.VisualStudio;
 using NuGetConsole.Implementation.Console;
 using NuGetConsole.Implementation.PowerConsole;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole.Implementation
 {
@@ -32,6 +35,8 @@ namespace NuGetConsole.Implementation
     [SuppressMessage("Microsoft.VisualStudio.Threading.Analyzers", "VSTHRD010", Justification = "NuGet/Home#4833 Baseline")]
     public sealed class PowerConsoleToolWindow : ToolWindowPane, IOleCommandTarget, IPowerConsoleService
     {
+        private JoinableTask _loadTask;
+
         /// <summary>
         /// Get VS IComponentModel service.
         /// </summary>
@@ -103,31 +108,31 @@ namespace NuGetConsole.Implementation
         {
             base.Initialize();
 
-            OleMenuCommandService mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
             if (mcs != null)
             {
                 // Get list command for the Feed combo
-                CommandID sourcesListCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidSourcesList);
+                var sourcesListCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidSourcesList);
                 mcs.AddCommand(new OleMenuCommand(SourcesList_Exec, sourcesListCommandID));
 
                 // invoke command for the Feed combo
-                CommandID sourcesCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidSources);
+                var sourcesCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidSources);
                 mcs.AddCommand(new OleMenuCommand(Sources_Exec, sourcesCommandID));
 
                 // get default project command
-                CommandID projectsListCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidProjectsList);
+                var projectsListCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidProjectsList);
                 mcs.AddCommand(new OleMenuCommand(ProjectsList_Exec, projectsListCommandID));
 
                 // invoke command for the Default project combo
-                CommandID projectsCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidProjects);
+                var projectsCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidProjects);
                 mcs.AddCommand(new OleMenuCommand(Projects_Exec, projectsCommandID));
 
                 // clear console command
-                CommandID clearHostCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidClearHost);
+                var clearHostCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidClearHost);
                 mcs.AddCommand(new OleMenuCommand(ClearHost_Exec, clearHostCommandID));
 
                 // terminate command execution command
-                CommandID stopHostCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidStopHost);
+                var stopHostCommandID = new CommandID(GuidList.guidNuGetCmdSet, PkgCmdIDList.cmdidStopHost);
                 mcs.AddCommand(new OleMenuCommand(StopHost_Exec, stopHostCommandID));
             }
         }
@@ -138,36 +143,19 @@ namespace NuGetConsole.Implementation
             Justification = "We really don't want exceptions from the console to bring down VS")]
         public override void OnToolWindowCreated()
         {
+            base.OnToolWindowCreated();
+
             // Register key bindings to use in the editor
             var windowFrame = (IVsWindowFrame)Frame;
-            Guid cmdUi = VSConstants.GUID_TextEditorFactory;
+            var cmdUi = VSConstants.GUID_TextEditorFactory;
             windowFrame.SetGuidProperty((int)__VSFPROPID.VSFPROPID_InheritKeyBindings, ref cmdUi);
 
-            // refresh PMC UI to update default project name after solution load completed.
-            SolutionManager.SolutionOpened += (o, e) =>
-            {
-                VsUIShell.UpdateCommandUI(0);
-            };
-
-            // pause for a tiny moment to let the tool window open before initializing the host
-            var timer = new DispatcherTimer();
-            timer.Interval = TimeSpan.FromMilliseconds(10);
-            timer.Tick += (o, e) =>
+            // start a task when VS us idle and dont await it immediately
+            _loadTask = ThreadHelper.JoinableTaskFactory.StartOnIdle(
+                async () =>
                 {
-                    // all exceptions from the timer thread should be caught to avoid crashing VS
-                    try
-                    {
-                        LoadConsoleEditor();
-                        timer.Stop();
-                    }
-                    catch (Exception x)
-                    {
-                        ExceptionHelper.WriteErrorToActivityLog(x);
-                    }
-                };
-            timer.Start();
-
-            base.OnToolWindowCreated();
+                    await Task.Run(LoadConsoleEditorAsync);
+                });
         }
 
         protected override void OnClose()
@@ -187,16 +175,20 @@ namespace NuGetConsole.Implementation
         /// <returns></returns>
         protected override bool PreProcessMessage(ref Message m)
         {
-            IVsWindowPane vsWindowPane = VsTextView as IVsWindowPane;
-            if (vsWindowPane != null)
+            // Now, await for the _loadTask which was started in OnToolWindowCreated API
+            if (_loadTask != null && _loadTask.IsCompleted)
             {
-                MSG[] pMsg = new MSG[1];
-                pMsg[0].hwnd = m.HWnd;
-                pMsg[0].message = (uint)m.Msg;
-                pMsg[0].wParam = m.WParam;
-                pMsg[0].lParam = m.LParam;
+                var vsWindowPane = VsTextView as IVsWindowPane;
+                if (vsWindowPane != null)
+                {
+                    var pMsg = new MSG[1];
+                    pMsg[0].hwnd = m.HWnd;
+                    pMsg[0].message = (uint)m.Msg;
+                    pMsg[0].wParam = m.WParam;
+                    pMsg[0].lParam = m.LParam;
 
-                return vsWindowPane.TranslateAccelerator(pMsg) == 0;
+                    return vsWindowPane.TranslateAccelerator(pMsg) == 0;
+                }
             }
 
             return base.PreProcessMessage(ref m);
@@ -210,11 +202,11 @@ namespace NuGetConsole.Implementation
             // examine buttons within our toolbar
             if (pguidCmdGroup == GuidList.guidNuGetCmdSet)
             {
-                bool isEnabled = IsToolbarEnabled;
+                var isEnabled = IsToolbarEnabled;
 
                 if (isEnabled)
                 {
-                    bool isStopButton = (prgCmds[0].cmdID == 0x0600); // 0x0600 is the Command ID of the Stop button, defined in .vsct
+                    var isStopButton = (prgCmds[0].cmdID == 0x0600); // 0x0600 is the Command ID of the Stop button, defined in .vsct
 
                     // when command is executing: enable stop button and disable the rest
                     // when command is not executing: disable the stop button and enable the rest
@@ -233,11 +225,11 @@ namespace NuGetConsole.Implementation
                 return VSConstants.S_OK;
             }
 
-            int hr = OleCommandFilter.OLECMDERR_E_NOTSUPPORTED;
+            var hr = OleCommandFilter.OLECMDERR_E_NOTSUPPORTED;
 
             if (VsTextView != null)
             {
-                IOleCommandTarget cmdTarget = (IOleCommandTarget)VsTextView;
+                var cmdTarget = (IOleCommandTarget)VsTextView;
                 hr = cmdTarget.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
             }
 
@@ -245,7 +237,7 @@ namespace NuGetConsole.Implementation
                 ||
                 hr == OleCommandFilter.OLECMDERR_E_UNKNOWNGROUP)
             {
-                IOleCommandTarget target = GetService(typeof(IOleCommandTarget)) as IOleCommandTarget;
+                var target = GetService(typeof(IOleCommandTarget)) as IOleCommandTarget;
                 if (target != null)
                 {
                     hr = target.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText);
@@ -260,11 +252,11 @@ namespace NuGetConsole.Implementation
         /// </summary>
         int IOleCommandTarget.Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
         {
-            int hr = OleCommandFilter.OLECMDERR_E_NOTSUPPORTED;
+            var hr = OleCommandFilter.OLECMDERR_E_NOTSUPPORTED;
 
             if (VsTextView != null)
             {
-                IOleCommandTarget cmdTarget = (IOleCommandTarget)VsTextView;
+                var cmdTarget = (IOleCommandTarget)VsTextView;
                 hr = cmdTarget.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
             }
 
@@ -272,7 +264,7 @@ namespace NuGetConsole.Implementation
                 ||
                 hr == OleCommandFilter.OLECMDERR_E_UNKNOWNGROUP)
             {
-                IOleCommandTarget target = GetService(typeof(IOleCommandTarget)) as IOleCommandTarget;
+                var target = GetService(typeof(IOleCommandTarget)) as IOleCommandTarget;
                 if (target != null)
                 {
                     hr = target.Exec(ref pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
@@ -284,7 +276,7 @@ namespace NuGetConsole.Implementation
 
         private void SourcesList_Exec(object sender, EventArgs e)
         {
-            OleMenuCmdEventArgs args = e as OleMenuCmdEventArgs;
+            var args = e as OleMenuCmdEventArgs;
             if (args != null)
             {
                 if (args.InValue != null
@@ -301,13 +293,13 @@ namespace NuGetConsole.Implementation
         /// </summary>
         private void Sources_Exec(object sender, EventArgs e)
         {
-            OleMenuCmdEventArgs args = e as OleMenuCmdEventArgs;
+            var args = e as OleMenuCmdEventArgs;
             if (args != null)
             {
                 if (args.InValue != null
                     && args.InValue is int) // Selected a feed
                 {
-                    int index = (int)args.InValue;
+                    var index = (int)args.InValue;
                     if (index >= 0
                         && index < PowerConsoleWindow.PackageSources.Length)
                     {
@@ -316,7 +308,7 @@ namespace NuGetConsole.Implementation
                 }
                 else if (args.OutValue != IntPtr.Zero) // Query selected feed name
                 {
-                    string displayName = PowerConsoleWindow.ActivePackageSource ?? string.Empty;
+                    var displayName = PowerConsoleWindow.ActivePackageSource ?? string.Empty;
                     Marshal.GetNativeVariantForObject(displayName, args.OutValue);
                 }
             }
@@ -324,7 +316,7 @@ namespace NuGetConsole.Implementation
 
         private void ProjectsList_Exec(object sender, EventArgs e)
         {
-            OleMenuCmdEventArgs args = e as OleMenuCmdEventArgs;
+            var args = e as OleMenuCmdEventArgs;
             if (args != null)
             {
                 if (args.InValue != null
@@ -343,14 +335,14 @@ namespace NuGetConsole.Implementation
         /// </summary>
         private void Projects_Exec(object sender, EventArgs e)
         {
-            OleMenuCmdEventArgs args = e as OleMenuCmdEventArgs;
+            var args = e as OleMenuCmdEventArgs;
             if (args != null)
             {
                 if (args.InValue != null
                     && args.InValue is int)
                 {
                     // Selected a default projects
-                    int index = (int)args.InValue;
+                    var index = (int)args.InValue;
                     if (index >= 0
                         && index < PowerConsoleWindow.AvailableProjects.Length)
                     {
@@ -359,7 +351,7 @@ namespace NuGetConsole.Implementation
                 }
                 else if (args.OutValue != IntPtr.Zero)
                 {
-                    string displayName = PowerConsoleWindow.DefaultProject ?? string.Empty;
+                    var displayName = PowerConsoleWindow.DefaultProject ?? string.Empty;
                     Marshal.GetNativeVariantForObject(displayName, args.OutValue);
                 }
             }
@@ -389,23 +381,33 @@ namespace NuGetConsole.Implementation
             get { return PowerConsoleWindow.ActiveHostInfo; }
         }
 
-        private void LoadConsoleEditor()
+        private async Task LoadConsoleEditorAsync()
         {
-            if (WpfConsole != null)
+            try
             {
-                // allow the console to start writing output
-                WpfConsole.StartWritingOutput();
-
-                FrameworkElement consolePane = WpfConsole.Content as FrameworkElement;
-                ConsoleParentPane.AddConsoleEditor(consolePane);
-
-                // WPF doesn't handle input focus automatically in this scenario. We
-                // have to set the focus manually, otherwise the editor is displayed but
-                // not focused and not receiving keyboard inputs until clicked.
-                if (consolePane != null)
+                if (WpfConsole != null)
                 {
-                    PendingMoveFocus(consolePane);
+                    // allow the console to start writing output
+                    WpfConsole.StartWritingOutput();
+
+                    var consolePane = WpfConsole.Content as FrameworkElement;
+
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    ConsoleParentPane.AddConsoleEditor(consolePane);
+
+                    // WPF doesn't handle input focus automatically in this scenario. We
+                    // have to set the focus manually, otherwise the editor is displayed but
+                    // not focused and not receiving keyboard inputs until clicked.
+                    if (consolePane != null)
+                    {
+                        PendingMoveFocus(consolePane);
+                    }
                 }
+            }
+            catch (Exception x)
+            {
+                ExceptionHelper.WriteErrorToActivityLog(x);
             }
         }
 
@@ -573,12 +575,7 @@ namespace NuGetConsole.Implementation
             {
                 if (_consoleParentPane == null)
                 {
-                    _consoleParentPane = new ConsoleContainer(
-                        SolutionManager,
-                        ProductUpdateService,
-                        PackageRestoreManager,
-                        DeleteOnRestartManager,
-                        VsShell);
+                    _consoleParentPane = new ConsoleContainer(VsShell);
                 }
                 return _consoleParentPane;
             }
@@ -604,15 +601,15 @@ namespace NuGetConsole.Implementation
                 throw new NotSupportedException(Resources.PackageManagerConsoleBusy);
             }
 
-            if (!String.IsNullOrEmpty(command))
+            if (!string.IsNullOrEmpty(command))
             {
                 WpfConsole.SetExecutionMode(true);
                 // Cast the ToolWindowPane to PowerConsoleToolWindow
                 // Access the IHost from PowerConsoleToolWindow as follows PowerConsoleToolWindow.WpfConsole.Host
                 // Cast IHost to IAsyncHost
                 // Also, register for IAsyncHost.ExecutedEnd and return only when the command is completed
-                IPrivateWpfConsole powerShellConsole = (IPrivateWpfConsole)WpfConsole;
-                IHost host = powerShellConsole.Host;
+                var powerShellConsole = (IPrivateWpfConsole)WpfConsole;
+                var host = powerShellConsole.Host;
 
                 var asynchost = host as IAsyncHost;
                 if (asynchost != null)

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/NuGet.SolutionRestoreManager.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.legacy.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -129,6 +129,12 @@
       <Project>{24e62ab7-64e4-4975-9417-883559d1bc19}</Project>
       <Name>NuGet.Versioning</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime">
+      <Version>15.0.26606</Version>
+      <ExcludeAssets>all</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(BuildCommonDirectory)common.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/Console/IHost.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/Console/IHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -53,7 +53,7 @@ namespace NuGet.VisualStudio
 
         string ActivePackageSource { get; set; }
 
-        PackageManagementContext PackageManagementContext { get; set; }
+        PackageManagementContext PackageManagementContext { get; }
 
         string[] GetPackageSources();
 

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/NuGet.VisualStudio.Common.csproj
@@ -47,23 +47,23 @@
       <Private>False</Private>
     </Reference>
     <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="15.112.1" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Language.StandardClassification" Version="15.0.26606" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.112.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.112.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26606" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.15.0" Version="15.0.25123-Dev15Preview">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="15.0.691-master31907920" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26201" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.0.240" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.3.23" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.0.240" />
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
     <PackageReference Include="VSLangProj" Version="7.0.3300" />

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/PowerShellHost.cs
@@ -16,6 +16,9 @@ using System.Threading.Tasks;
 using System.Windows.Media;
 using EnvDTE;
 using Microsoft;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -25,6 +28,7 @@ using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.Protocol.Core.Types;
 using NuGet.VisualStudio;
+using Task = System.Threading.Tasks.Task;
 
 namespace NuGetConsole.Host.PowerShell.Implementation
 {
@@ -34,17 +38,20 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private static readonly TimeSpan ExecuteInitScriptsRetryDelay = TimeSpan.FromMilliseconds(400);
         private static readonly int MaxTasks = 16;
 
+        private Microsoft.VisualStudio.Threading.AsyncLazy<IVsMonitorSelection> _vsMonitorSelection;
+        private IVsMonitorSelection VsMonitorSelection => ThreadHelper.JoinableTaskFactory.Run(_vsMonitorSelection.GetValueAsync);
+
         private readonly AsyncSemaphore _initScriptsLock = new AsyncSemaphore(1);
         private readonly string _name;
         private readonly IRestoreEvents _restoreEvents;
         private readonly IRunspaceManager _runspaceManager;
         private readonly ISourceRepositoryProvider _sourceRepositoryProvider;
-        private readonly IVsSolutionManager _solutionManager;
-        private readonly ISettings _settings;
-        private readonly ISourceControlManagerProvider _sourceControlManagerProvider;
-        private readonly ICommonOperations _commonOperations;
-        private readonly IDeleteOnRestartManager _deleteOnRestartManager;
-        private readonly IScriptExecutor _scriptExecutor;
+        private readonly Lazy<IVsSolutionManager> _solutionManager;
+        private readonly Lazy<ISettings> _settings;
+        private readonly Lazy<ISourceControlManagerProvider> _sourceControlManagerProvider;
+        private readonly Lazy<ICommonOperations> _commonOperations;
+        private readonly Lazy<IDeleteOnRestartManager> _deleteOnRestartManager;
+        private readonly Lazy<IScriptExecutor> _scriptExecutor;
         private const string ActivePackageSourceKey = "activePackageSource";
         private const string SyncModeKey = "IsSyncMode";
         private const string PackageManagementContextKey = "PackageManagementContext";
@@ -53,7 +60,9 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         private const int ExecuteInitScriptsRetriesLimit = 50;
         private string _activePackageSource;
         private string[] _packageSources;
-        private readonly DTE _dte;
+        private readonly Lazy<DTE> _dte;
+
+        private uint _solutionExistsCookie;
 
         private IConsole _activeConsole;
         private NuGetPSHost _nugetHost;
@@ -93,16 +102,15 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             // TODO: Take these as ctor arguments
             _sourceRepositoryProvider = ServiceLocator.GetInstance<ISourceRepositoryProvider>();
-            _solutionManager = ServiceLocator.GetInstance<IVsSolutionManager>();
-            _settings = ServiceLocator.GetInstance<ISettings>();
-            _deleteOnRestartManager = ServiceLocator.GetInstance<IDeleteOnRestartManager>();
-            _scriptExecutor = ServiceLocator.GetInstance<IScriptExecutor>();
+            _solutionManager = new Lazy<IVsSolutionManager>(() => ServiceLocator.GetInstance<IVsSolutionManager>());
+            _settings = new Lazy<ISettings>(() => ServiceLocator.GetInstance<ISettings>());
+            _deleteOnRestartManager = new Lazy<IDeleteOnRestartManager>(() => ServiceLocator.GetInstance<IDeleteOnRestartManager>());
+            _scriptExecutor = new Lazy<IScriptExecutor>(() => ServiceLocator.GetInstance<IScriptExecutor>());
 
-            _dte = ServiceLocator.GetInstance<DTE>();
-            _sourceControlManagerProvider = ServiceLocator.GetInstanceSafe<ISourceControlManagerProvider>();
-            _commonOperations = ServiceLocator.GetInstanceSafe<ICommonOperations>();
-            PackageManagementContext = new PackageManagementContext(_sourceRepositoryProvider, _solutionManager,
-                _settings, _sourceControlManagerProvider, _commonOperations);
+            _dte = new Lazy<DTE>(() => ServiceLocator.GetInstance<DTE>());
+            _sourceControlManagerProvider = new Lazy<ISourceControlManagerProvider>(
+                () => ServiceLocator.GetInstanceSafe<ISourceControlManagerProvider>());
+            _commonOperations = new Lazy<ICommonOperations>(() => ServiceLocator.GetInstanceSafe<ICommonOperations>());
 
             _name = name;
             IsCommandEnabled = true;
@@ -111,6 +119,22 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
             _sourceRepositoryProvider.PackageSourceProvider.PackageSourcesChanged += PackageSourceProvider_PackageSourcesChanged;
             _restoreEvents.SolutionRestoreCompleted += RestoreEvents_SolutionRestoreCompleted;
+
+            _vsMonitorSelection = new Microsoft.VisualStudio.Threading.AsyncLazy<IVsMonitorSelection>(
+                async () =>
+                {
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    // get the UI context cookie for the debugging mode
+                    var vsMonitorSelection = ServiceLocator.GetGlobalService<IVsMonitorSelection, IVsMonitorSelection>();
+
+                    var guidCmdUI = VSConstants.UICONTEXT.SolutionExists_guid;
+                    vsMonitorSelection.GetCmdUIContextCookie(
+                        ref guidCmdUI, out _solutionExistsCookie);
+
+                    return vsMonitorSelection;
+                },
+                ThreadHelper.JoinableTaskFactory);
         }
 
         private void InitializeSources()
@@ -170,22 +194,22 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 if (_complexCommand == null)
                 {
                     _complexCommand = new ComplexCommand((allLines, lastLine) =>
+                    {
+                        Collection<PSParseError> errors;
+                        PSParser.Tokenize(allLines, out errors);
+
+                        // If there is a parse error token whose END is past input END, consider
+                        // it a multi-line command.
+                        if (errors.Count > 0)
                         {
-                            Collection<PSParseError> errors;
-                            PSParser.Tokenize(allLines, out errors);
-
-                            // If there is a parse error token whose END is past input END, consider
-                            // it a multi-line command.
-                            if (errors.Count > 0)
+                            if (errors.Any(e => (e.Token.Start + e.Token.Length) >= allLines.Length))
                             {
-                                if (errors.Any(e => (e.Token.Start + e.Token.Length) >= allLines.Length))
-                                {
-                                    return false;
-                                }
+                                return false;
                             }
+                        }
 
-                            return true;
-                        });
+                        return true;
+                    });
                 }
                 return _complexCommand;
             }
@@ -196,7 +220,18 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             get { return ComplexCommand.IsComplete ? EvaluatePrompt() : ">> "; }
         }
 
-        public PackageManagementContext PackageManagementContext { get; set; }
+        public PackageManagementContext PackageManagementContext
+        {
+            get
+            {
+                return new PackageManagementContext(
+                    _sourceRepositoryProvider,
+                    _solutionManager.Value,
+                    _settings.Value,
+                    _sourceControlManagerProvider.Value,
+                    _commonOperations.Value);
+            }
+        }
 
         public string ActivePackageSource
         {
@@ -208,11 +243,23 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         {
             get
             {
-                Assumes.Present(_solutionManager);
+                Assumes.Present(_solutionManager.Value);
 
                 return NuGetUIThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    var defaultProject = await _solutionManager.GetDefaultNuGetProjectAsync();
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                    var hr = VsMonitorSelection.IsCmdUIContextActive(
+                        _solutionExistsCookie, out var pfActive);
+
+                    if (!(ErrorHandler.Succeeded(hr) && pfActive > 0))
+                    {
+                        return null;
+                    }
+
+                    await TaskScheduler.Default;
+
+                    var defaultProject = await _solutionManager.Value.GetDefaultNuGetProjectAsync();
                     if (defaultProject == null)
                     {
                         return null;
@@ -265,73 +312,73 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         public void Initialize(IConsole console)
         {
             NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                ActiveConsole = console;
+                if (_initialized.HasValue)
                 {
-                    ActiveConsole = console;
-                    if (_initialized.HasValue)
+                    if (_initialized.Value
+                        && console.ShowDisclaimerHeader)
                     {
-                        if (_initialized.Value
-                            && console.ShowDisclaimerHeader)
+                        DisplayDisclaimerAndHelpText();
+                    }
+                }
+                else
+                {
+                    try
+                    {
+                        var result = _runspaceManager.GetRunspace(console, _name);
+                        Runspace = result.Item1;
+                        _nugetHost = result.Item2;
+
+                        _initialized = true;
+
+                        if (console.ShowDisclaimerHeader)
                         {
                             DisplayDisclaimerAndHelpText();
                         }
+
+                        UpdateWorkingDirectory();
+                        await ExecuteInitScriptsAsync();
+
+                        // check if PMC console is actually opened, then only hook to solution load/close events.
+                        if (console is IWpfConsole)
+                        {
+                            // Hook up solution events
+                            _solutionManager.Value.SolutionOpened += (_, __) => HandleSolutionOpened();
+                            _solutionManager.Value.SolutionClosed += (o, e) => UpdateWorkingDirectory();
+                        }
+                        _solutionManager.Value.NuGetProjectAdded += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
+                        _solutionManager.Value.NuGetProjectRenamed += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
+                        _solutionManager.Value.NuGetProjectUpdated += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
+                        _solutionManager.Value.NuGetProjectRemoved += (o, e) =>
+                        {
+                            UpdateWorkingDirectoryAndAvailableProjects();
+                            // When the previous default project has been removed, _solutionManager.DefaultNuGetProjectName becomes null
+                            if (_solutionManager.Value.DefaultNuGetProjectName == null)
+                            {
+                                // Change default project to the first one in the collection
+                                SetDefaultProjectIndex(0);
+                            }
+                        };
+                        // Set available private data on Host
+                        SetPrivateDataOnHost(false);
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        try
-                        {
-                            var result = _runspaceManager.GetRunspace(console, _name);
-                            Runspace = result.Item1;
-                            _nugetHost = result.Item2;
+                        // catch all exception as we don't want it to crash VS
+                        _initialized = false;
+                        IsCommandEnabled = false;
+                        ReportError(ex);
 
-                            _initialized = true;
-
-                            if (console.ShowDisclaimerHeader)
-                            {
-                                DisplayDisclaimerAndHelpText();
-                            }
-
-                            UpdateWorkingDirectory();
-                            await ExecuteInitScriptsAsync();
-
-                            // check if PMC console is actually opened, then only hook to solution load/close events.
-                            if (console is IWpfConsole)
-                            {
-                                // Hook up solution events
-                                _solutionManager.SolutionOpened += (_, __) => HandleSolutionOpened();
-                                _solutionManager.SolutionClosed += (o, e) => UpdateWorkingDirectory();
-                            }
-                            _solutionManager.NuGetProjectAdded += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
-                            _solutionManager.NuGetProjectRenamed += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
-                            _solutionManager.NuGetProjectUpdated += (o, e) => UpdateWorkingDirectoryAndAvailableProjects();
-                            _solutionManager.NuGetProjectRemoved += (o, e) =>
-                                {
-                                    UpdateWorkingDirectoryAndAvailableProjects();
-                                    // When the previous default project has been removed, _solutionManager.DefaultNuGetProjectName becomes null
-                                    if (_solutionManager.DefaultNuGetProjectName == null)
-                                    {
-                                        // Change default project to the first one in the collection
-                                        SetDefaultProjectIndex(0);
-                                    }
-                                };
-                            // Set available private data on Host
-                            SetPrivateDataOnHost(false);
-                        }
-                        catch (Exception ex)
-                        {
-                            // catch all exception as we don't want it to crash VS
-                            _initialized = false;
-                            IsCommandEnabled = false;
-                            ReportError(ex);
-
-                            ExceptionHelper.WriteErrorToActivityLog(ex);
-                        }
+                        ExceptionHelper.WriteErrorToActivityLog(ex);
                     }
-                });
+                }
+            });
         }
 
         private void HandleSolutionOpened()
         {
-            _scriptExecutor.Reset();
+            _scriptExecutor.Value.Reset();
 
             // Solution opened event is raised on the UI thread
             // Go off the UI thread before calling likely expensive call of ExecuteInitScriptsAsync
@@ -344,7 +391,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                 while (retries < ExecuteInitScriptsRetriesLimit)
                 {
-                    if (await _solutionManager.IsAllProjectsNominatedAsync())
+                    if (await _solutionManager.Value.IsAllProjectsNominatedAsync())
                     {
                         await ExecuteInitScriptsAsync();
                         break;
@@ -371,8 +418,8 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 if (Runspace.RunspaceAvailability == RunspaceAvailability.Available)
                 {
                     // if there is no solution open, we set the active directory to be user profile folder
-                    var targetDir = _solutionManager.IsSolutionOpen ?
-                        _solutionManager.SolutionDirectory :
+                    var targetDir = _solutionManager.Value.IsSolutionOpen ?
+                        _solutionManager.Value.SolutionDirectory :
                         Environment.GetEnvironmentVariable("USERPROFILE");
 
                     Runspace.ChangePSDirectory(targetDir);
@@ -386,7 +433,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             // Fix for Bug 1426 Disallow ExecuteInitScripts from being executed concurrently by multiple threads.
             using (await _initScriptsLock.EnterAsync())
             {
-                if (!_solutionManager.IsSolutionOpen)
+                if (!_solutionManager.Value.IsSolutionOpen)
                 {
                     return;
                 }
@@ -398,7 +445,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                 }
 
                 var latestRestore = _latestRestore;
-                var latestSolutionDirectory = _solutionManager.SolutionDirectory;
+                var latestSolutionDirectory = _solutionManager.Value.SolutionDirectory;
                 if (ShouldNoOpDueToRestore(latestRestore) &&
                     ShouldNoOpDueToSolutionDirectory(latestSolutionDirectory))
                 {
@@ -410,11 +457,11 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                 var packageManager = new NuGetPackageManager(
                     _sourceRepositoryProvider,
-                    _settings,
-                    _solutionManager,
-                    _deleteOnRestartManager);
+                    _settings.Value,
+                    _solutionManager.Value,
+                    _deleteOnRestartManager.Value);
 
-                var enumerator = new InstalledPackageEnumerator(_solutionManager, _settings);
+                var enumerator = new InstalledPackageEnumerator(_solutionManager.Value, _settings.Value);
                 var installedPackages = await enumerator.EnumeratePackagesAsync(packageManager, CancellationToken.None);
 
                 foreach (var installedPackage in installedPackages)
@@ -440,7 +487,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
                     var scriptPath = Path.Combine(toolsPath, PowerShellScripts.Init);
                     if (File.Exists(scriptPath) &&
-                        _scriptExecutor.TryMarkVisited(identity, PackageInitPS1State.FoundAndExecuted))
+                        _scriptExecutor.Value.TryMarkVisited(identity, PackageInitPS1State.FoundAndExecuted))
                     {
                         // always execute init script on a background thread
                         await TaskScheduler.Default;
@@ -456,7 +503,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
                     }
                 }
 
-                _scriptExecutor.TryMarkVisited(identity, PackageInitPS1State.NotFound);
+                _scriptExecutor.Value.TryMarkVisited(identity, PackageInitPS1State.NotFound);
             }
             catch (Exception ex)
             {
@@ -550,7 +597,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             // "All" aggregate source in a context of PS command means no particular source is preferred,
             // in that case all enabled sources will be picked for a command execution.
             SetPropertyValueOnHost(ActivePackageSourceKey, ActivePackageSource != AggregateSourceName ? ActivePackageSource : string.Empty);
-            SetPropertyValueOnHost(DTEKey, _dte);
+            SetPropertyValueOnHost(DTEKey, _dte.Value);
             SetPropertyValueOnHost(CancellationTokenKey, _token);
         }
 
@@ -558,7 +605,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
         {
             if (_nugetHost != null)
             {
-                PSPropertyInfo property = _nugetHost.PrivateData.Properties[propertyName];
+                var property = _nugetHost.PrivateData.Properties[propertyName];
                 if (property == null)
                 {
                     property = new PSNoteProperty(propertyName, value);
@@ -581,7 +628,7 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             WriteLine(Resources.Console_DisclaimerText);
             WriteLine();
 
-            WriteLine(String.Format(CultureInfo.CurrentCulture, Resources.PowerShellHostTitle, _nugetHost.Version));
+            WriteLine(string.Format(CultureInfo.CurrentCulture, Resources.PowerShellHostTitle, _nugetHost.Version));
             WriteLine();
 
             WriteLine(Resources.Console_HelpText);
@@ -665,63 +712,63 @@ namespace NuGetConsole.Host.PowerShell.Implementation
 
         public void SetDefaultProjectIndex(int selectedIndex)
         {
-            Debug.Assert(_solutionManager != null);
+            Debug.Assert(_solutionManager.Value != null);
 
             if (_projectSafeNames != null
                 && selectedIndex >= 0
                 && selectedIndex < _projectSafeNames.Length)
             {
-                _solutionManager.DefaultNuGetProjectName = _projectSafeNames[selectedIndex];
+                _solutionManager.Value.DefaultNuGetProjectName = _projectSafeNames[selectedIndex];
             }
             else
             {
-                _solutionManager.DefaultNuGetProjectName = null;
+                _solutionManager.Value.DefaultNuGetProjectName = null;
             }
         }
 
         public string[] GetAvailableProjects()
         {
-            Debug.Assert(_solutionManager != null);
+            Debug.Assert(_solutionManager.Value != null);
 
             return NuGetUIThreadHelper.JoinableTaskFactory.Run(async delegate
+            {
+                var displayNames = new List<string>();
+                var displayNameTasks = new List<Task<string>>();
+
+                // start a single task to get all project's safe name
+                var safeNamesTask = Task.Run(async () => await _solutionManager.Value.GetAllNuGetProjectSafeNameAsync());
+
+                var allProjects = await _solutionManager.Value.GetNuGetProjectsAsync();
+
+                foreach (var project in allProjects)
                 {
-                    var displayNames = new List<string>();
-                    var displayNameTasks = new List<Task<string>>();
-
-                    // start a single task to get all project's safe name
-                    var safeNamesTask = Task.Run(async () => await _solutionManager.GetAllNuGetProjectSafeNameAsync());
-
-                    var allProjects = await _solutionManager.GetNuGetProjectsAsync();
-
-                    foreach (var project in allProjects)
-                    {
-                        // Throttle and wait for a task to finish if we have hit the limit
-                        if (displayNameTasks.Count == MaxTasks)
-                        {
-                            var displayName = await CompleteTaskAsync(displayNameTasks);
-                            displayNames.Add(displayName);
-                        }
-
-                        var displayNameTask = Task.Run(async () => await GetDisplayNameAsync(project));
-                        displayNameTasks.Add(displayNameTask);
-                    }
-
-                    // wait until all the tasks to retrieve display names are completed
-                    while (displayNameTasks.Count > 0)
+                    // Throttle and wait for a task to finish if we have hit the limit
+                    if (displayNameTasks.Count == MaxTasks)
                     {
                         var displayName = await CompleteTaskAsync(displayNameTasks);
                         displayNames.Add(displayName);
                     }
 
-                    _projectSafeNames = (await safeNamesTask).ToArray();
-                    Array.Sort(displayNames.ToArray(), _projectSafeNames, StringComparer.CurrentCultureIgnoreCase);
-                    return _projectSafeNames;
-                });
+                    var displayNameTask = Task.Run(async () => await GetDisplayNameAsync(project));
+                    displayNameTasks.Add(displayNameTask);
+                }
+
+                // wait until all the tasks to retrieve display names are completed
+                while (displayNameTasks.Count > 0)
+                {
+                    var displayName = await CompleteTaskAsync(displayNameTasks);
+                    displayNames.Add(displayName);
+                }
+
+                _projectSafeNames = (await safeNamesTask).ToArray();
+                Array.Sort(displayNames.ToArray(), _projectSafeNames, StringComparer.CurrentCultureIgnoreCase);
+                return _projectSafeNames;
+            });
         }
 
         private async Task<string> GetDisplayNameAsync(NuGetProject nuGetProject)
         {
-            var vsProjectAdapter = await _solutionManager.GetVsProjectAdapterAsync(nuGetProject);
+            var vsProjectAdapter = await _solutionManager.Value.GetVsProjectAdapterAsync(nuGetProject);
 
             var name = vsProjectAdapter.CustomUniqueName;
             if (await IsWebSiteAsync(vsProjectAdapter))
@@ -764,14 +811,14 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             {
                 SetPrivateDataOnHost(isSync);
                 expansions = await Task.Run(() =>
-                    {
-                        var query = from s in Runspace.Invoke(
-                            @"$__pc_args=@();$input|%{$__pc_args+=$_};if(Test-Path Function:\TabExpansion2){(TabExpansion2 $__pc_args[0] $__pc_args[0].length).CompletionMatches|%{$_.CompletionText}}else{TabExpansion $__pc_args[0] $__pc_args[1]};Remove-Variable __pc_args -Scope 0;",
-                            new[] { line, lastWord },
-                            outputResults: false)
-                                    select (s == null ? null : s.ToString());
-                        return query.ToArray();
-                    }, _token);
+                {
+                    var query = from s in Runspace.Invoke(
+                        @"$__pc_args=@();$input|%{$__pc_args+=$_};if(Test-Path Function:\TabExpansion2){(TabExpansion2 $__pc_args[0] $__pc_args[0].length).CompletionMatches|%{$_.CompletionText}}else{TabExpansion $__pc_args[0] $__pc_args[1]};Remove-Variable __pc_args -Scope 0;",
+                        new[] { line, lastWord },
+                        outputResults: false)
+                                select (s == null ? null : s.ToString());
+                    return query.ToArray();
+                }, _token);
             }
             finally
             {
@@ -800,20 +847,20 @@ namespace NuGetConsole.Host.PowerShell.Implementation
             _token = token;
             SetPropertyValueOnHost(CancellationTokenKey, _token);
             var simpleExpansion = await Task.Run(() =>
+            {
+                var expansion = Runspace.Invoke(
+                    "$input|%{$__pc_args=$_}; _TabExpansionPath $__pc_args; Remove-Variable __pc_args -Scope 0",
+                    new object[] { line },
+                    outputResults: false).FirstOrDefault();
+                if (expansion != null)
                 {
-                    PSObject expansion = Runspace.Invoke(
-                        "$input|%{$__pc_args=$_}; _TabExpansionPath $__pc_args; Remove-Variable __pc_args -Scope 0",
-                        new object[] { line },
-                        outputResults: false).FirstOrDefault();
-                    if (expansion != null)
-                    {
-                        int replaceStart = (int)expansion.Properties["ReplaceStart"].Value;
-                        IList<string> paths = ((IEnumerable<object>)expansion.Properties["Paths"].Value).Select(o => o.ToString()).ToList();
-                        return new SimpleExpansion(replaceStart, line.Length - replaceStart, paths);
-                    }
+                    var replaceStart = (int)expansion.Properties["ReplaceStart"].Value;
+                    IList<string> paths = ((IEnumerable<object>)expansion.Properties["Paths"].Value).Select(o => o.ToString()).ToList();
+                    return new SimpleExpansion(replaceStart, line.Length - replaceStart, paths);
+                }
 
-                    return null;
-                }, token);
+                return null;
+            }, token);
 
             _token = CancellationToken.None;
             SetPropertyValueOnHost(CancellationTokenKey, _token);

--- a/src/NuGet.Clients/NuGetConsole.Host.PowerShell/UnsupportedHost.cs
+++ b/src/NuGet.Clients/NuGetConsole.Host.PowerShell/UnsupportedHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -70,7 +70,6 @@ namespace NuGetConsole.Host
         public PackageManagementContext PackageManagementContext
         {
             get { return null; }
-            set { }
         }
     }
 }

--- a/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
+++ b/test/NuGet.Clients.Tests/NuGet.SolutionRestoreManager.Test/NuGet.SolutionRestoreManager.Test.csproj
@@ -30,5 +30,11 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="15.0.26606">
+      <ExcludeAssets>All</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
   <Import Project="$(BuildCommonDirectory)common.targets" />
 </Project>


### PR DESCRIPTION
Since NuGetPackage was being loaded and initialized synchronously on VS start-up which delays VS load. This PR fixes this issue by lazy initializing NuGetPackage when the solution is actually loaded which is where it will actually be used. 

It improves VS start-up from ~1200ms to ~100ms in duration. and adding somewhere from ~5000ms to total VS Start-up time to ~500ms

Fixes internal bug# 497515

**Previous results:**
![image](https://user-images.githubusercontent.com/18219758/31406650-01b6c214-adb7-11e7-9581-1fb8dc1d5dba.png)

**New results:**
![image](https://user-images.githubusercontent.com/18219758/31406695-27cf98c2-adb7-11e7-807b-76ceb92ae481.png)

@rrelyea 