### PR TITLE
Fix issue where datetime was not configured to be culture invariant

### DIFF
--- a/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
+++ b/src/NuGet.Core/NuGet.Packaging/PackagesConfigWriter.cs
@@ -522,7 +522,7 @@ namespace NuGet.Packaging
                 var directorypath = Path.GetDirectoryName(fullPath);
 
                 var configFileCopyPath = Path.Combine(directorypath, 
-                    @"packages.config.old." + DateTime.Now.ToString("yyyyMMddHHmmss"));
+                    @"packages.config.old." + DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture));
 
                 // Delete configFileCopyPath if it already exists
                 FileUtility.Delete(configFileCopyPath);
@@ -550,7 +550,7 @@ namespace NuGet.Packaging
                     }
 
                     var configFileNewPath = Path.Combine(directorypath,
-                        @"packages.config.new." + DateTime.Now.ToString("yyyyMMddHHmmss"));
+                        @"packages.config.new." + DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture));
 
                     using (var tempConfigStream = File.Create(configFileNewPath))
                     {

--- a/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Packaging.Test/PackagesConfigWriterTests.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -51,6 +53,51 @@ namespace NuGet.Packaging.Test
 
             Assert.Equal("net45", packages[0].TargetFramework.GetShortFolderName());
             Assert.Equal("portable-net45+win8", packages[1].TargetFramework.GetShortFolderName());
+        }
+
+        [Fact]
+        public void PackagesConfigWriter_BasicWithDifferentCulture()
+        {
+            var calendar = new CultureInfo("he-IL");
+            calendar.DateTimeFormat.Calendar = new HebrewCalendar();
+            CultureInfo.CurrentCulture = calendar;
+            CultureInfo.CurrentUICulture = calendar;
+
+            // Arrange
+            using (var testFolder = TestDirectory.Create())
+            {
+                var path = Path.Combine(testFolder + "packages.config");
+
+                // Act
+                using (var writer = new PackagesConfigWriter(path, true))
+                {
+                    writer.WriteMinClientVersion(NuGetVersion.Parse("3.0.1"));
+
+                    writer.AddPackageEntry("packageB", NuGetVersion.Parse("2.0.0"), NuGetFramework.Parse("portable-net45+win8"));
+
+                    writer.AddPackageEntry("packageA", NuGetVersion.Parse("1.0.1"), NuGetFramework.Parse("net45"));
+                }
+
+                // Assert
+                var xml = XDocument.Load(path);
+
+                // Assert
+                Assert.Equal("utf-8", xml.Declaration.Encoding);
+
+                PackagesConfigReader reader = new PackagesConfigReader(xml);
+
+                Assert.Equal("3.0.1", reader.GetMinClientVersion().ToNormalizedString());
+
+                var packages = reader.GetPackages().ToArray();
+                Assert.Equal("packageA", packages[0].PackageIdentity.Id);
+                Assert.Equal("packageB", packages[1].PackageIdentity.Id);
+
+                Assert.Equal("1.0.1", packages[0].PackageIdentity.Version.ToNormalizedString());
+                Assert.Equal("2.0.0", packages[1].PackageIdentity.Version.ToNormalizedString());
+
+                Assert.Equal("net45", packages[0].TargetFramework.GetShortFolderName());
+                Assert.Equal("portable-net45+win8", packages[1].TargetFramework.GetShortFolderName());
+            }
         }
 
         [Fact]


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5976 
Regression: No  

## Fix
When installing a package in packages.config project, a datetime string for a temp file name is issued to write the updated packages.config.  This string was not culture invariant, therefore in some cultures that use characters not supported by paths in dates, installation would fail.
