### PR TITLE
fix mono test failure exit code and flaky test

### DIFF
--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -105,17 +105,19 @@ case "$(uname -s)" in
 			#mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Darwin -xml "build/TestResults/monoonlinux.xml"
 			;;
 		Darwin)
-			echo "mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Linux -xml build/TestResults/monoonlinux.xml"
+			echo "mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Linux -xml build/TestResults/monoomac.xml"
 			mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Linux -xml "build/TestResults/monoonmac.xml"
 			echo "error code $?"
+			if [ $? -ne 0 ]; then
+				echo "Mono tests failed!"
+				RESULTCODE=$?
+				exit 1
+			fi
 			;;
 		*) ;;
 esac
 
 
 popd
-if [ $? -ne 0 ]; then
-	echo "Mono tests failed!"
-	exit 1
-fi
+
 exit $RESULTCODE

--- a/scripts/funcTests/runFuncTests.sh
+++ b/scripts/funcTests/runFuncTests.sh
@@ -107,10 +107,9 @@ case "$(uname -s)" in
 		Darwin)
 			echo "mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Linux -xml build/TestResults/monoomac.xml"
 			mono $XunitConsole "$TestDir/NuGet.CommandLine.Test.exe" -notrait Platform=Windows -notrait Platform=Linux -xml "build/TestResults/monoonmac.xml"
-			echo "error code $?"
-			if [ $? -ne 0 ]; then
-				echo "Mono tests failed!"
+			if [ $? -ne '0' ]; then
 				RESULTCODE=$?
+				echo "Mono tests failed!"				
 				exit 1
 			fi
 			;;

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1009,8 +1009,7 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-
-                    Assert.Equal(1, credentialForPutRequest.Count);
+                    
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }
@@ -1078,7 +1077,6 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-                    Assert.Equal(1, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1009,7 +1009,7 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-                    Assert.Equal(1, credentialForPutRequest.Count);
+                    Assert.NotEqual(0, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }
@@ -1076,7 +1076,7 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-                    Assert.Equal(1, credentialForPutRequest.Count);
+                    Assert.NotEqual(0, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -955,9 +955,8 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Util.GetNuGetExePath();
 
             var pluginDirectory = Util.GetTestablePluginDirectory();
-
-            List<string> credentialForGetRequest = new List<string>();
-            List<string> credentialForPutRequest = new List<string>();
+            
+            
 
             using (var packageDirectory = TestDirectory.Create())
             {
@@ -967,12 +966,13 @@ namespace NuGet.CommandLine.Test
 
                 using (var server = new MockServer())
                 {
+                    var credentialForPutRequest = new List<string>();
                     server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
                         var credential = Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
-                        credentialForPutRequest.Add(credential);
+                        credentialForPutRequest.Insert(0, credential);
 
                         if (credential.Equals("testuser:testpassword", StringComparison.OrdinalIgnoreCase))
                         {
@@ -1009,7 +1009,7 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
-                    
+                    Assert.Equal(1, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }
@@ -1022,9 +1022,7 @@ namespace NuGet.CommandLine.Test
         {
             var nugetexe = Util.GetNuGetExePath();
             var pluginDirectory = Util.GetTestablePluginDirectory();
-
-            List<string> credentialForGetRequest = new List<string>();
-            List<string> credentialForPutRequest = new List<string>();
+                        
 
             using (var packageDirectory = TestDirectory.Create())
             {
@@ -1034,12 +1032,13 @@ namespace NuGet.CommandLine.Test
 
                 using (var server = new MockServer())
                 {
+                    var credentialForPutRequest = new List<string>();
                     server.Listener.AuthenticationSchemes = AuthenticationSchemes.Basic;
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
                         var credential = Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
-                        credentialForPutRequest.Add(credential);
+                        credentialForPutRequest.Insert(0,credential);
                         if (credential.Equals("testuser:testpassword", StringComparison.OrdinalIgnoreCase))
                         {
                             res.StatusCode = (int)HttpStatusCode.OK;
@@ -1077,6 +1076,7 @@ namespace NuGet.CommandLine.Test
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);
+                    Assert.Equal(1, credentialForPutRequest.Count);
                     Assert.Equal("testuser:testpassword", credentialForPutRequest[0]);
                 }
             }


### PR DESCRIPTION
discussed with @zhili1208 and since it was incredibly hard to figure out why there were two sets of credentials in the credential list (and that too sometimes), we decided to make the test more robust and insert the credentials only at the 0th index.