### PR TITLE
Fix PluginCredentialProvider to use AbsoluteUri instead of ToString() to handle spaces correctly

### DIFF
--- a/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
+++ b/src/NuGet.Clients/NuGet.Credentials/PluginCredentialProvider.cs
@@ -102,7 +102,7 @@ namespace NuGet.Credentials
             {
                 var request = new PluginCredentialRequest
                 {
-                    Uri = uri.ToString(),
+                    Uri = uri.AbsoluteUri,
                     IsRetry = isRetry,
                     NonInteractive = nonInteractive,
                     Verbosity = _verbosity

--- a/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginCredentialProviderTests.cs
+++ b/test/NuGet.Clients.Tests/NuGet.Credentials.Test/PluginCredentialProviderTests.cs
@@ -572,5 +572,63 @@ namespace NuGet.Credentials.Test
 
             Assert.StartsWith("PluginCredentialProvider_provider.exe_", provider.Id);
         }
+
+        [Fact]
+        public async Task EncodesSpacesWhenUriWithSpaces()
+        {
+            // Arrange
+            var mockProvider = CreateMockProvider(verbosity: "Normal");
+            var uri = new Uri("http://host/path with spaces/index.json");
+            var proxy = null as IWebProxy;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
+            var isRetry = false;
+            var nonInteractive = false;
+
+            // Act
+            var result = await mockProvider.Object.GetAsync(
+                uri,
+                proxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
+                CancellationToken.None);
+
+            // Assert
+            mockProvider.Verify(x => x.Execute(
+                It.Is<ProcessStartInfo>(p => p.Arguments == "-uri http://host/path%20with%20spaces/index.json"),
+                It.IsAny<CancellationToken>(),
+                out _testStdOut));
+        }
+
+        [Fact]
+        public async Task EncodesSpacesWhenUriWithEncodedSpaces()
+        {
+            // Arrange
+            var mockProvider = CreateMockProvider(verbosity: "Normal");
+            var uri = new Uri("http://host/path%20with%20spaces/index.json");
+            var proxy = null as IWebProxy;
+            var type = CredentialRequestType.Unauthorized;
+            var message = null as string;
+            var isRetry = false;
+            var nonInteractive = false;
+
+            // Act
+            var result = await mockProvider.Object.GetAsync(
+                uri,
+                proxy,
+                type,
+                message,
+                isRetry,
+                nonInteractive,
+                CancellationToken.None);
+
+            // Assert
+            mockProvider.Verify(x => x.Execute(
+                It.Is<ProcessStartInfo>(p => p.Arguments == "-uri http://host/path%20with%20spaces/index.json"),
+                It.IsAny<CancellationToken>(),
+                out _testStdOut));
+        }
     }
 }


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/5982
Regression: **No**  

## Fix
Details: Use uri.AbsoluteUri instead of uri.ToString(), as the .NET Uri class converts even encoded spaces into literal spaces when ToString is used, therefore producing an invalid uri.

## Testing/Validation
Tests Added: **Yes**/No  
Reason for not adding tests:  
Validation done:  Manual testing against VSTS feeds with spaces in URL
