### PR TITLE
IsPackable should default to false if IsTestProject AND PackageId empty

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/Pack.targets
@@ -21,14 +21,14 @@ Copyright (c) .NET Foundation. All rights reserved.
   <UsingTask TaskName="NuGet.Build.Tasks.GetProjectTargetFrameworksTask" AssemblyFile="$(NuGetPackTaskAssemblyFile)" />
 
   <PropertyGroup>
+    <IsPackable Condition="'$(IsPackable)'=='' AND '$(PackageId)' == '' AND '$(IsTestProject)'=='true'">false</IsPackable>
+    <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <PackageId Condition=" '$(PackageId)' == '' ">$(AssemblyName)</PackageId>
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
     <IncludeContentInPack Condition="'$(IncludeContentInPack)'==''">true</IncludeContentInPack>
     <GenerateNuspecDependsOn>_LoadPackInputItems; _GetTargetFrameworksOutput; _WalkEachTargetPerFramework; _GetPackageFiles; $(GenerateNuspecDependsOn)</GenerateNuspecDependsOn>
     <PackageDescription Condition="'$(PackageDescription)'==''">$(Description)</PackageDescription>
     <PackageDescription Condition="'$(PackageDescription)'==''">Package Description</PackageDescription>
-    <IsPackable Condition="'$(IsPackable)'=='' AND '$(IsTestProject)'=='true'">false</IsPackable>
-    <IsPackable Condition="'$(IsPackable)'==''">true</IsPackable>
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)'==''">true</IncludeBuildOutput>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == '' AND '$(IsTool)' == 'true'">tools</BuildOutputTargetFolder>
     <BuildOutputTargetFolder Condition="'$(BuildOutputTargetFolder)' == ''">lib</BuildOutputTargetFolder>


### PR DESCRIPTION
Building projects with xunit 2.3 results in IsTestProject being true (xunit 2.2 didn't).
By default now projects cannot be packed anymore (dotnet pack / msbuild /t:pack).
While this seems like an xunit issue, probably xunit is right in setting IsTestProject to true.

This might be useful to many projects containing ONLY tests, but not all are that way.

See: https://github.com/xunit/xunit/issues/1487

The workaround (in linked issue) explicitly setting IsPackable to true is ok, but I hereby suggest to implicitely set IsPackable to true if IsTestProject is false OR if there is an explicitly defined PackageId in csproj file.

If you reject this request (or anyway), I would be happy if someone could give some info/link what IsTestProject is about (other usages).