### PR TITLE
ignore unsupport project in VS restore

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/ProjectServices/VsManagedLanguagesProjectSystemServices.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -136,7 +136,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
             var references = AsVSProject4.References
                 .Cast<Reference6>()
-                .Where(r => r.SourceProject != null)
+                .Where(r => r.SourceProject != null && EnvDTEProjectUtility.IsSupported(r.SourceProject))
                 .Select(reference =>
                 {
                     Array metadataElements;

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -155,6 +155,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 project.RestoreMetadata.Sources = VSRestoreSettingsUtilities.GetSources(settings, originalProject);
                 project.RestoreMetadata.FallbackFolders = VSRestoreSettingsUtilities.GetFallbackFolders(settings, originalProject);
                 project.RestoreMetadata.ConfigFilePaths = GetConfigFilePaths(settings);
+                IgnoreUnsupportProjectReference(project);
                 projects.Add(project);
             }
 
@@ -177,6 +178,24 @@ namespace NuGet.PackageManagement.VisualStudio
         private IList<string> GetConfigFilePaths(ISettings settings)
         {
             return SettingsUtility.GetConfigFilePaths(settings).ToList();
+        }
+
+        private void IgnoreUnsupportProjectReference(PackageSpec project)
+        {
+            foreach (var frameworkInfo in project.RestoreMetadata.TargetFrameworks)
+            {
+                var projectReferences = new List<ProjectRestoreReference>();
+
+                foreach (var projectReference in frameworkInfo.ProjectReferences)
+                {
+                    if (_projectSystemCache.ContainsKey(projectReference.ProjectUniqueName))
+                    {
+                        projectReferences.Add(projectReference);
+                    }
+                }
+
+                frameworkInfo.ProjectReferences = projectReferences;
+            }
         }
 
         #endregion

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProject.cs
@@ -188,7 +188,7 @@ namespace NuGet.PackageManagement.VisualStudio
 
                 foreach (var projectReference in frameworkInfo.ProjectReferences)
                 {
-                    if (_projectSystemCache.ContainsKey(projectReference.ProjectUniqueName))
+                    if (SupportedProjectTypes.IsSupportedProjectExtension(projectReference.ProjectPath))
                     {
                         projectReferences.Add(projectReference);
                     }

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/SupportedProjectTypes.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/SupportedProjectTypes.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using NuGet.VisualStudio;
 
@@ -55,6 +56,14 @@ namespace NuGet.VisualStudio
                 VsProjectTypes.CppProjectTypeGuid,
             };
 
+        private static readonly HashSet<string> _unsupportedProjectExtension = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".metaproj",
+            ".shproj",
+            ".vcxitems",
+            ".sqlproj"
+        };
+
         public static bool IsSupported(string projectKind)
         {
             return _supportedProjectTypes.Contains(projectKind);
@@ -73,6 +82,11 @@ namespace NuGet.VisualStudio
         public static bool IsSupportedForAddingReferences(string projectKind)
         {
             return !_unsupportedProjectTypesForAddingReferences.Contains(projectKind, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public static bool IsSupportedProjectExtension(string projectPath)
+        {
+            return !_unsupportedProjectExtension.Contains(Path.GetExtension(projectPath));
         }
     }
 }


### PR DESCRIPTION
Remove unsupport project references from packageSpec For net core project and legacyRef project
https://github.com/NuGet/Home/issues/5928