### PR TITLE
Increasing the SematicVersionDate to 2017-10-12

### DIFF
--- a/build/common.ps1
+++ b/build/common.ps1
@@ -415,15 +415,9 @@ Function Set-DelaySigning {
 }
 
 Function Get-BuildNumber() {
-    $SemanticVersionDate = '2017-10-12'
-    try {
-        [uint16](((Get-Date) - (Get-Date $SemanticVersionDate)).TotalMinutes / 5)
-    }
-    catch {
-        # Build number is a 16-bit integer. The limitation is imposed by VERSIONINFO.
-        # https://msdn.microsoft.com/en-gb/library/aa381058.aspx
-        Error-Log "Build number is out of range! Consider advancing SemanticVersionDate." -Fatal
-    }
+    # This build number is only used for local private builds.
+    # Return 0 since we no longer have package references between core and client solutions.
+    [uint16](0)
 }
 
 Function Format-BuildNumber([int]$BuildNumber) {

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -415,7 +415,7 @@ Function Set-DelaySigning {
 }
 
 Function Get-BuildNumber() {
-    $SemanticVersionDate = '2017-02-27'
+    $SemanticVersionDate = '2017-10-12'
     try {
         [uint16](((Get-Date) - (Get-Date $SemanticVersionDate)).TotalMinutes / 5)
     }

--- a/build/common.ps1
+++ b/build/common.ps1
@@ -415,9 +415,15 @@ Function Set-DelaySigning {
 }
 
 Function Get-BuildNumber() {
-    # This build number is only used for local private builds.
-    # Return 0 since we no longer have package references between core and client solutions.
-    [uint16](0)
+    $SemanticVersionDate = '2017-10-12'
+    try {
+        [uint16](((Get-Date) - (Get-Date $SemanticVersionDate)).TotalMinutes / 5)
+    }
+    catch {
+        # Build number is a 16-bit integer. The limitation is imposed by VERSIONINFO.
+        # https://msdn.microsoft.com/en-gb/library/aa381058.aspx
+        Error-Log "Build number is out of range! Consider advancing SemanticVersionDate." -Fatal
+    }
 }
 
 Function Format-BuildNumber([int]$BuildNumber) {


### PR DESCRIPTION
## Bug
Link: NA
Regression: No

## Fix
Details: Currently we have a Date being used to generate increment version numbers. Due to limitations in the size of `uint16`, that overflows periodically. I have updated the build version date to 10/12/2017.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Engineering fix
Validation done:  Builds locally and waiting on CI to run through before merging.
