### PR TITLE
Loading CPS JTF for VisualC projects

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProjectProvider.cs
@@ -29,11 +29,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private readonly IVsProjectThreadingService _threadingService;
         private readonly AsyncLazy<IComponentModel> _componentModel;
 
-        // Reason it's lazy<object> is because we don't want to load any CPS assemblies untill
-        // we're really going to use any of CPS api. Which is why we also don't use nameof or typeof apis.
-        [Import("Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor")]
-        private Lazy<object> ProjectServiceAccessor { get; set; }
-
         public RuntimeTypeHandle ProjectType => typeof(LegacyPackageReferenceProject).TypeHandle;
 
         [ImportingConstructor]
@@ -156,9 +151,6 @@ namespace NuGet.PackageManagement.VisualStudio
         private INuGetProjectServices CreateCoreProjectSystemServices(
                 IVsProjectAdapter vsProjectAdapter, IComponentModel componentModel)
         {
-            // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as ProjectSystem.IProjectServiceAccessor);
-
             return new VsManagedLanguagesProjectSystemServices(vsProjectAdapter, componentModel);
         }
     }

--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProjectProvider.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/NetCorePackageReferenceProjectProvider.cs
@@ -30,11 +30,6 @@ namespace NuGet.PackageManagement.VisualStudio
 
         private readonly Lazy<IComponentModel> _componentModel;
 
-        // Reason it's lazy<object> is because we don't want to load any CPS assemblies untill
-        // we're really going to use any of CPS api. Which is why we also don't use nameof or typeof apis.
-        [Import("Microsoft.VisualStudio.ProjectSystem.IProjectServiceAccessor")]
-        private Lazy<object> ProjectServiceAccessor { get; set; }
-
         public RuntimeTypeHandle ProjectType => typeof(NetCorePackageReferenceProject).TypeHandle;
 
         [ImportingConstructor]
@@ -94,9 +89,6 @@ namespace NuGet.PackageManagement.VisualStudio
             {
                 return null;
             }
-
-            // Lazy load the CPS enabled JoinableTaskFactory for the UI.
-            NuGetUIThreadHelper.SetJoinableTaskFactoryFromService(ProjectServiceAccessor.Value as IProjectServiceAccessor);
 
             var projectNames = vsProject.ProjectNames;
             var fullProjectPath = vsProject.FullProjectPath;

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/VsHierarchyUtility.cs
@@ -108,6 +108,17 @@ namespace NuGet.VisualStudio
         }
 
         /// <summary>
+        /// Check for CPS capability in IVsHierarchy. All CPS projects will have CPS capability except VisualC projects.
+        /// So checking for VisualC explicitly with a OR flag.
+        /// </summary>
+        public static bool IsCPSCapabilityComplaint(IVsHierarchy hierarchy)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return hierarchy.IsCapabilityMatch("CPS | VisualC");
+        }
+
+        /// <summary>
         /// Gets the EnvDTE.Project instance from IVsHierarchy
         /// </summary>
         /// <param name="pHierarchy">pHierarchy is the IVsHierarchy instance from which the project instance is obtained</param>


### PR DESCRIPTION
Until now we were loading CPS JTF only when there is netcore sdk based project or PackageReference csproj, which was not the ideal way to do this. Besides this also ignore VisualC projects which are also CPS based.

So this change will fix the above issue by correctly loading CPS enabled JTF whenever there is a CPS based project irrespective of package management format.

Fixes https://github.com/NuGet/Home/issues/6025

@rrelyea 