### PR TITLE
Fixing VsSolutionRestoreService.ToPackageSpec to have same project name in PackageSpec and RestoreMetadata

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/Projects/LegacyPackageReferenceProject.cs
@@ -322,9 +322,11 @@ namespace NuGet.PackageManagement.VisualStudio
             // In legacy CSProj, we only have one target framework per project
             var tfis = new TargetFrameworkInformation[] { projectTfi };
 
+            var projectName = _projectName ?? _projectUniqueName;
+
             return new PackageSpec(tfis)
             {
-                Name = _projectName ?? _projectUniqueName,
+                Name = projectName,
                 Version = new NuGetVersion(_vsProjectAdapter.Version),
                 Authors = new string[] { },
                 Owners = new string[] { },
@@ -337,7 +339,7 @@ namespace NuGet.PackageManagement.VisualStudio
                     ProjectStyle = ProjectStyle.PackageReference,
                     OutputPath = GetBaseIntermediatePath(),
                     ProjectPath = _projectFullPath,
-                    ProjectName = _projectName ?? _projectUniqueName,
+                    ProjectName = projectName,
                     ProjectUniqueName = _projectFullPath,
                     OriginalTargetFrameworks = tfis
                         .Select(tfi => tfi.FrameworkName.GetShortFolderName())

--- a/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
+++ b/src/NuGet.Clients/NuGet.SolutionRestoreManager/VsSolutionRestoreService.cs
@@ -250,14 +250,17 @@ namespace NuGet.SolutionRestoreManager
                         Path.Combine(
                             projectDirectory,
                             projectRestoreInfo.BaseIntermediatePath));
+
+            var projectName = GetPackageId(projectNames, projectRestoreInfo.TargetFrameworks);
+
             var packageSpec = new PackageSpec(tfis)
             {
-                Name = GetPackageId(projectNames, projectRestoreInfo.TargetFrameworks),
+                Name = projectName,
                 Version = GetPackageVersion(projectRestoreInfo.TargetFrameworks),
                 FilePath = projectFullPath,
                 RestoreMetadata = new ProjectRestoreMetadata
                 {
-                    ProjectName = projectNames.ShortName,
+                    ProjectName = projectName,
                     ProjectUniqueName = projectFullPath,
                     ProjectPath = projectFullPath,
                     OutputPath = outputPath,

--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/SpecValidationUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -326,6 +326,20 @@ namespace NuGet.Commands
                     CultureInfo.CurrentCulture,
                     Strings.MissingRequiredProperty,
                     nameof(spec.RestoreMetadata.ProjectName));
+
+                throw RestoreSpecException.Create(message, files);
+            }
+
+            // spec.name and spec.RestoreMetadata.ProjectName should be the same
+            if (!string.Equals(spec.Name, spec.RestoreMetadata.ProjectName, StringComparison.Ordinal))
+            {
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    Strings.NonMatchingProperties,
+                    nameof(spec.Name),
+                    spec.Name,
+                    nameof(spec.RestoreMetadata.ProjectName),
+                    spec.RestoreMetadata.ProjectName);
 
                 throw RestoreSpecException.Create(message, files);
             }

--- a/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Commands/Strings.Designer.cs
@@ -1116,6 +1116,15 @@ namespace NuGet.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Properties &apos;{0}&apos;:&apos;{1}&apos; and &apos;{2}&apos;:&apos;{3}&apos; do not match..
+        /// </summary>
+        internal static string NonMatchingProperties {
+            get {
+                return ResourceManager.GetString("NonMatchingProperties", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to http://docs.nuget.org/.
         /// </summary>
         internal static string NuGetDocs {

--- a/src/NuGet.Core/NuGet.Commands/Strings.resx
+++ b/src/NuGet.Core/NuGet.Commands/Strings.resx
@@ -603,4 +603,11 @@ For more information, visit http://docs.nuget.org/docs/reference/command-line-re
   <data name="Warning_VersionAboveUpperBound" xml:space="preserve">
     <value>Detected package version outside of dependency constraint: {0} requires {1} but version {2} was resolved.</value>
   </data>
+  <data name="NonMatchingProperties" xml:space="preserve">
+    <value>Properties '{0}':'{1}' and '{2}':'{3}' do not match.</value>
+    <comment>0 - first property name
+1 - first property value
+2 - second property name
+3 - second property value</comment>
+  </data>
 </root>

--- a/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Commands.Test/SpecValidationUtilityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -233,6 +233,43 @@ namespace NuGet.Commands.Test
 
             // Act && Assert
             AssertError(spec, "Missing required property 'FilePath'");
+        }
+
+        [Fact]
+        public void SpecValidationUtility_VerifyProjectMetadata_SameNameAsSpecName()
+        {
+            // Arrange
+            var spec = new DependencyGraphSpec();
+            spec.AddRestore("a");
+
+            var targetFramework1 = new TargetFrameworkInformation()
+            {
+                FrameworkName = NuGetFramework.Parse("net45")
+            };
+
+            var info = new[] { targetFramework1 };
+
+            var project = new PackageSpec(info)
+            {
+                RestoreMetadata = new ProjectRestoreMetadata(),
+                Name = "a",
+                FilePath = Path.Combine(Directory.GetCurrentDirectory(), "project.json")
+            };
+
+            project.RestoreMetadata.ProjectUniqueName = "some_other_path";
+            project.RestoreMetadata.ProjectName = "some_other_name";
+            project.RestoreMetadata.ProjectPath = Path.Combine(Directory.GetCurrentDirectory(), "a.csproj");
+            project.RestoreMetadata.ProjectStyle = ProjectStyle.Unknown;
+
+            targetFramework1.Dependencies.Add(new LibraryDependency()
+            {
+                LibraryRange = new LibraryRange("x", VersionRange.Parse("1.0.0"), LibraryDependencyTarget.PackageProjectExternal)
+            });
+
+            spec.AddProject(project);
+
+            // Act && Assert
+            AssertError(spec, $"Properties '{nameof(project.Name)}':'{project.Name}' and '{nameof(project.RestoreMetadata.ProjectName)}':'{project.RestoreMetadata.ProjectName}' do not match.");
         }
 
         [Fact]

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegratedTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -149,7 +149,7 @@ namespace NuGet.Test
                         {
                             RestoreMetadata = new ProjectRestoreMetadata()
                             {
-                                ProjectName = "myproj",
+                                ProjectName = myProjPath,
                                 ProjectUniqueName = myProjPath,
                                 ProjectStyle = ProjectStyle.Unknown,
                                 ProjectPath = myProjPath
@@ -292,7 +292,7 @@ namespace NuGet.Test
                         {
                             RestoreMetadata = new ProjectRestoreMetadata()
                             {
-                                ProjectName = "myproj",
+                                ProjectName = myProjPath,
                                 ProjectUniqueName = myProjPath,
                                 ProjectStyle = ProjectStyle.Unknown,
                                 ProjectPath = myProjPath


### PR DESCRIPTION
## Bug
Link: https://github.com/NuGet/Home/issues/6020
Regression: Yes

## Fix
Details: In 15.4 we introduced transitive no warn which used the Package spec and the restore metadata to traverse the dependency graph. This exposed a bug in `VsSolutionRestoreService.ToPackageSpec` where, if the project had an `AssemblyName` different from the project file name, the `PackageSpec.Name` and `PackageSpec.RestoreMetadata.ProjectName` were being assigned different values. This caused transitive no warn to throw a key not found exception.

## Testing/Validation
Tests Added: Yes
Validation done:  manual validation done on a project that was failing.
