### PR TITLE
add signature issues to verification flow

### DIFF
--- a/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
+++ b/src/NuGet.Core/NuGet.Common/Errors/NuGetLogCode.cs
@@ -21,6 +21,7 @@ namespace NuGet.Common
     ///         
     /// Groups:
     /// 1000 - Restore
+    /// 3000 - Signing
     /// 
     /// Sub groups:
     /// error/warning - Reason
@@ -186,5 +187,35 @@ namespace NuGet.Common
         /// Feed error converted to a warning when ignoreFailedSources is true.
         /// </summary>
         NU1801 = 1801,
+
+        /// <summary>
+        /// Undefined signature error
+        /// </summary>
+        NU3000 = 3000,
+
+        /// <summary>
+        /// Invalid Input error
+        /// </summary>
+        NU3001 = 3001,
+
+        /// <summary>
+        /// Invalid package error
+        /// </summary>
+        NU3002 = 3002,
+
+        /// <summary>
+        /// Undefined signature warning
+        /// </summary>
+        NU3500 = 3500,
+
+        /// <summary>
+        /// Untrusted root warning
+        /// </summary>
+        NU3501 = 3501,
+
+        /// <summary>
+        /// Signature information unavailable warning
+        /// </summary>
+        NU3502 = 3502,
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureIssue.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureIssue.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Common;
+
+namespace NuGet.Packaging.Signing
+{
+    public class SignatureIssue : IEquatable<SignatureIssue>
+    {
+        public bool Fatal { get; }
+
+        public string Message { get; }
+
+        public NuGetLogCode Code { get; }
+
+        private SignatureIssue(bool fatal, NuGetLogCode code, string message)
+        {
+            Fatal = fatal;
+            Code = code;
+            Message = message;
+        }
+
+        public static SignatureIssue InvalidInputError(string message)
+        {
+            return new SignatureIssue(true, NuGetLogCode.NU3001, message);
+        }
+
+        public static SignatureIssue InvalidPackageError(string message)
+        {
+            return new SignatureIssue(true, NuGetLogCode.NU3002, message);
+        }
+
+        public static SignatureIssue UntrustedRootWarning(string message)
+        {
+            return new SignatureIssue(false, NuGetLogCode.NU3501, message);
+        }
+
+        public static SignatureIssue SignatureInformationUnavailableWarning(string message)
+        {
+            return new SignatureIssue(false, NuGetLogCode.NU3502, message);
+        }
+
+        public override string ToString()
+        {
+            var issueType = Fatal ? "ERROR" : "WARNING";
+
+            return $"{issueType}: NU{Code} {Message}";
+        }
+
+        public bool Equals(SignatureIssue other)
+        {
+            return other != null &&
+                Equals(Fatal, other.Fatal) &&
+                Equals(Code, other.Code) &&
+                string.Equals(Message, other.Message, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/NuGet.Core/NuGet.Packaging/Signing/SignatureIssue.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/SignatureIssue.cs
@@ -41,11 +41,13 @@ namespace NuGet.Packaging.Signing
             return new SignatureIssue(false, NuGetLogCode.NU3502, message);
         }
 
-        public override string ToString()
+        public ILogMessage ToLogMessage()
         {
-            var issueType = Fatal ? "ERROR" : "WARNING";
-
-            return $"{issueType}: NU{Code} {Message}";
+            if (Fatal)
+            {
+                return LogMessage.CreateError(Code, Message);
+            }
+            return LogMessage.CreateWarning(Code, Message);
         }
 
         public bool Equals(SignatureIssue other)

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationResult.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignatureVerificationResult.cs
@@ -30,13 +30,41 @@ namespace NuGet.Packaging.Signing
         public X509Chain Chain { get; }
 
         /// <summary>
+        /// List of issues found in the verification process
+        /// </summary>
+        public IEnumerable<SignatureIssue> Issues { get; }
+
+        /// <summary>
         /// SignatureVerificationResult
         /// </summary>
-        public SignatureVerificationResult(SignatureVerificationStatus trust, Signature signature, X509Chain chain)
+        public SignatureVerificationResult(SignatureVerificationStatus trust, Signature signature, X509Chain chain, IEnumerable<SignatureIssue> issues)
         {
             Trust = trust;
             Signature = signature ?? throw new ArgumentNullException(nameof(signature));
             Chain = chain ?? throw new ArgumentNullException(nameof(chain));
+            Issues = issues ?? new List<SignatureIssue>();
+        }
+
+        /// <summary>
+        /// Creates a SignatureVerificationResult for an unsigned package
+        /// </summary>
+        /// <param name="trust">Verification status</param>
+        /// <param name="issues">List of issues with the verification result</param>
+        /// <returns></returns>
+        public static SignatureVerificationResult UnsignedPackageResult(SignatureVerificationStatus trust, IEnumerable<SignatureIssue> issues)
+        {
+            return new SignatureVerificationResult(trust, issues);
+        }
+
+        /// <summary>
+        /// SignatureVerificationResult
+        /// </summary>
+        private SignatureVerificationResult(SignatureVerificationStatus trust, IEnumerable<SignatureIssue> issues)
+        {
+            Trust = trust;
+            Issues = issues ?? new List<SignatureIssue>();
+            Signature = null;
+            Chain = null;
         }
     }
 }

--- a/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifier.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Signing/Verification/SignedPackageVerifier.cs
@@ -53,6 +53,10 @@ namespace NuGet.Packaging.Signing
                 // An unsigned package is valid only if unsigned packages are allowed.
                 valid = true;
             }
+            else
+            {
+                trustResults.Add(SignatureVerificationResult.UnsignedPackageResult(SignatureVerificationStatus.Invalid, new List<SignatureIssue>{ SignatureIssue.InvalidInputError(Strings.ErrorPackageNotSigned) }));
+            }
 
             return new VerifySignaturesResult(valid, trustResults);
         }

--- a/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.Designer.cs
@@ -125,6 +125,33 @@ namespace NuGet.Packaging {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Package is not signed..
+        /// </summary>
+        internal static string ErrorPackageNotSigned {
+            get {
+                return ResourceManager.GetString("ErrorPackageNotSigned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Package contents might have been tampered..
+        /// </summary>
+        internal static string ErrorPackageTampered {
+            get {
+                return ResourceManager.GetString("ErrorPackageTampered", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Signing certificate chains to an untrusted root..
+        /// </summary>
+        internal static string ErrorSigningCertUntrustedRoot {
+            get {
+                return ResourceManager.GetString("ErrorSigningCertUntrustedRoot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unable to delete temporary file &apos;{0}&apos;. Error: &apos;{1}&apos;..
         /// </summary>
         internal static string ErrorUnableToDeleteFile {

--- a/src/NuGet.Core/NuGet.Packaging/Strings.resx
+++ b/src/NuGet.Core/NuGet.Packaging/Strings.resx
@@ -208,4 +208,13 @@
     <comment>{0} is the invalid path.
 {1} is the package ID and version.</comment>
   </data>
+  <data name="ErrorPackageNotSigned" xml:space="preserve">
+    <value>Package is not signed.</value>
+  </data>
+  <data name="ErrorPackageTampered" xml:space="preserve">
+    <value>Package contents might have been tampered.</value>
+  </data>
+  <data name="ErrorSigningCertUntrustedRoot" xml:space="preserve">
+    <value>Signing certificate chains to an untrusted root.</value>
+  </data>
 </root>


### PR DESCRIPTION
Clients that consume the API need a way of getting more information about the signature results.