### PR TITLE
Turning off vs14 build in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -117,14 +117,10 @@ Invoke-BuildStep 'Set delay signing options' {
 -ev +BuildErrors
 
 if($SkipUnitTest){
-    $VS14Target = "BuildVS14";
-    $VS14Message = "Running Build for VS 14.0";
     $VS15Target = "BuildVS15;Pack";
     $VS15Message = "Running Build for VS 15.0"
 }
 else {
-    $VS14Target = "RunVS14";
-    $VS14Message = "Running Build and Unit tests for VS 14.0";
     $VS15Target = "RunVS15";
     $VS15Message = "Running Build, Pack, Core unit tests, and Unit tests for VS 15.0";
 }
@@ -159,47 +155,6 @@ Invoke-BuildStep $VS15Message {
 } `
 -skip:$SkipVS15 `
 -ev +BuildErrors
-
-Invoke-BuildStep 'Running Restore for VS 14.0' {
-
-    # Restore for VS 14.0
-    Trace-Log ". `"$MSBuildExe`" build\build.proj /t:RestoreVS14 /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:RestoreVS14 /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
-
-    if (-not $?)
-    {
-        Write-Error "Failed - Running Restore for VS 14.0"
-        exit 1
-    }
-} `
--skip:$SkipVS14 `
--ev +BuildErrors
-
-
-Invoke-BuildStep $VS14Message {
-
-    # Build and (If not $SkipUnitTest) Run Unit tests for VS 14.0
-    Trace-Log ". `"$MSBuildExe`" build\build.proj /t:$VS14Target /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1"
-    & $MSBuildExe build\build.proj /t:$VS14Target /p:Configuration=$Configuration /p:ReleaseLabel=$ReleaseLabel /p:BuildNumber=$BuildNumber /v:m /m:1
-
-    if (-not $?)
-    {
-        Write-Error "Failed - $VS14Message"
-        exit 1
-    }
-} `
--skip:$SkipVS14 `
--ev +BuildErrors
-
-Invoke-BuildStep 'Publishing the VS14 EndToEnd test package' {
-        param($Configuration)
-        $EndToEndScript = Join-Path $PSScriptRoot scripts\cibuild\CreateEndToEndTestPackage.ps1 -Resolve
-        $OutDir = Join-Path $Artifacts VS14
-        & $EndToEndScript -c $Configuration -tv 14 -out $OutDir
-    } `
-    -args $Configuration `
-    -skip:($Fast -or $SkipVS14) `
-    -ev +BuildErrors
 
 Invoke-BuildStep 'Publishing the VS15 EndToEnd test package' {
         param($Configuration)


### PR DESCRIPTION
## Bug
Link: None
Regression: Yes

## Fix
Details: We no longer plan on shipping a build for dev14 from current dev branch. Commit https://github.com/NuGet/NuGet.Client/commit/8ca1ae85a871866b21cf853121cb6b6e79b5dd2f broke the build for dev14 by using `IProjectServiceAccessor` which is not available for dev14. I have remove the code to build dev14 from our build script.   

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Engineering fix
Validation done:  CI is passing fine.
