### PR TITLE
removing SkipVS14 flag from build.ps1 and updating the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This repo contains the following clients:
   * [NuGet CLI](https://docs.nuget.org/ndocs/tools/nuget.exe-cli-reference)
-  * [NuGet Package Manager for Visual Studio 2015/2017](https://docs.nuget.org/ndocs/tools/package-manager-ui)
+  * [NuGet Package Manager for Visual Studio 2017](https://docs.nuget.org/ndocs/tools/package-manager-ui)
   * [PowerShell CmdLets](https://docs.nuget.org/ndocs/tools/powershell-reference)
 
 ## Build Status
@@ -27,8 +27,6 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
     - .NET desktop development
     - Desktop development with C++
     - Visual Studio extension development.
-- [Visual Studio 2015 Update 3](https://go.microsoft.com/fwlink/?LinkId=691129)
-  with Visual Studio Extensibility Tools
 - [Windows 10 SDK](https://dev.windows.com/en-US/downloads/windows-10-sdk)
 - Git
 - Windows Powershell v3.0+
@@ -62,11 +60,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 > In case you have build issues try cleaning the local repository using `git clean -xdf` and retry steps 3 and 4.
 
 #### Notable `build.ps1` switches
-- `-SkipVS14` - skips building binaries targeting Visual Studio "14" (released as Visual Studio 2015)
 - `-SkipVS15` - skips building binaries targeting Visual Studio "15" (released as Visual Studio 2017)
-
-> Note that if only one of Visual Studio 2015 (VS14) or Visual Studio 2017 (VS15) is installed, neither of the above switches is necessary - the script will build according to the installed version.
-
+- `-SkipUnitTest` - skips running unit tests.
 - `-Fast` - runs minimal incremental build. Skips end-to-end packaging step.
 
 > Reveal all script parameters and switches by running

--- a/build.ps1
+++ b/build.ps1
@@ -17,9 +17,6 @@ Path to a code signing certificate for delay-sigining (optional)
 .PARAMETER NuGetPFXPath
 Path to a code signing certificate for delay-sigining (optional)
 
-.PARAMETER SkipVS14
-Skips building binaries targeting Visual Studio "14" (released as Visual Studio 2015)
-
 .PARAMETER SkipVS15
 Skips building binaries targeting Visual Studio "15"
 
@@ -38,8 +35,8 @@ To run full clean build, e.g after switching branches
 Fast incremental build
 
 .EXAMPLE
-.\build.ps1 -s14 -s15
-To build core projects only
+.\build.ps1 -s15
+To only run unit tests
 
 .EXAMPLE
 .\build.ps1 -v -ea Stop
@@ -59,8 +56,6 @@ param (
     [string]$MSPFXPath,
     [Alias('nugetpfx')]
     [string]$NuGetPFXPath,
-    [Alias('s14')]
-    [switch]$SkipVS14,
     [Alias('s15')]
     [switch]$SkipVS15,
     [Alias('su')]
@@ -92,11 +87,6 @@ Trace-Log "Build #$BuildNumber started at $startTime"
 Test-BuildEnvironment -CI:$CI
 
 # Adjust version skipping if only one version installed - if VS15 is not installed, no need to specify SkipVS15
-if (-not $SkipVS14 -and -not $VS14Installed) {
-    Warning-Log "VS14 build is requested but it appears not to be installed."
-    $SkipVS14 = $True
-}
-
 if (-not $SkipVS15 -and -not $VS15Installed) {
     Warning-Log "VS15 build is requested but it appears not to be installed."
     $SkipVS15 = $True


### PR DESCRIPTION
## Bug
Link: None
Regression: No  

## Fix
Details: As part of https://github.com/NuGet/NuGet.Client/commit/47d8bcb2146a2c01ccb6dc503768f458793f261a I removed the dev14 builds from build.ps1. This change removes the flag and updates the readme file to reflect the change.

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Engineering Fix
Validation done:  CI builds fine.
