### PR TITLE
Remove re-use of LockFileLibrary items

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/LockFileBuilder.cs
@@ -110,45 +110,19 @@ namespace NuGet.Commands
                     // Packages
                     var packageInfo = NuGetv3LocalRepositoryUtility.GetPackage(localRepositories, library.Name, library.Version);
 
-                    if (packageInfo == null)
+                    // Add the library if it was resolved, unresolved packages are not added to the assets file.
+                    if (packageInfo != null)
                     {
-                        continue;
+                        var package = packageInfo.Package;
+                        var resolver = packageInfo.Repository.PathResolver;
+
+                        var sha512 = File.ReadAllText(resolver.GetHashPath(package.Id, package.Version));
+                        var path = PathUtility.GetPathWithForwardSlashes(
+                            resolver.GetPackageDirectory(package.Id, package.Version));
+
+                        // Create a new lock file library
+                        lockFile.Libraries.Add(CreateLockFileLibrary(package, sha512, path));
                     }
-
-                    var package = packageInfo.Package;
-                    var resolver = packageInfo.Repository.PathResolver;
-
-                    LockFileLibrary previousLibrary = null;
-                    if (previousLibraries?.TryGetValue(Tuple.Create(package.Id, package.Version), out previousLibrary) == true)
-                    {
-                        // We mutate this previous library so we must take a clone of it. This is
-                        // important because later, when deciding whether the lock file has changed,
-                        // we compare the new lock file to the previous (in-memory) lock file.
-                        previousLibrary = previousLibrary.Clone();
-                    }
-
-                    var sha512 = File.ReadAllText(resolver.GetHashPath(package.Id, package.Version));
-                    var path = PathUtility.GetPathWithForwardSlashes(
-                        resolver.GetPackageDirectory(package.Id, package.Version));
-
-                    var lockFileLib = previousLibrary;
-
-                    // If we have the same library in the lock file already, use that.
-                    if (previousLibrary == null ||
-                        previousLibrary.Sha512 != sha512 ||
-                        previousLibrary.Path != path)
-                    {
-                        // The existing library did not match, create a new one.
-                        lockFileLib = CreateLockFileLibrary(
-                            package,
-                            sha512,
-                            path);
-                    }
-
-                    lockFile.Libraries.Add(lockFileLib);
-
-                    var packageIdentity = new PackageIdentity(lockFileLib.Name, lockFileLib.Version);
-                    context.PackageFileCache.TryAdd(packageIdentity, lockFileLib.Files);
                 }
             }
 

--- a/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
+++ b/test/NuGet.Clients.Tests/NuGet.CommandLine.Test/RestoreNETCoreTest.cs
@@ -20,6 +20,51 @@ namespace NuGet.CommandLine.Test
     public class RestoreNetCoreTest
     {
         [Fact]
+        public void RestoreNetCore_ModifyFilesInPackageVerifyRestoreUpdates()
+        {
+            // Arrange
+            using (var pathContext = new SimpleTestPathContext())
+            {
+                // Set up solution, project, and packages
+                var solution = new SimpleTestSolutionContext(pathContext.SolutionRoot);
+
+                var projectA = SimpleTestProjectContext.CreateNETCore(
+                    "a",
+                    pathContext.SolutionRoot,
+                    NuGetFramework.Parse("net45"));
+
+                var pkgX = new SimpleTestPackageContext("x", "1.0.0");
+                pkgX.AddFile("lib/net45/x.dll");
+
+                // Add y to the project
+                projectA.AddPackageToAllFrameworks(pkgX);
+
+                solution.Projects.Add(projectA);
+                solution.Create(pathContext.SolutionRoot);
+
+                SimpleTestPackageUtility.CreatePackages(pathContext.PackageSource, pkgX);
+
+                // Location where the package will be installed
+                var pathResolver = new VersionFolderPathResolver(pathContext.UserPackagesFolder);
+                var xPath = pathResolver.GetInstallPath("x", NuGetVersion.Parse("1.0.0"));
+
+                // First restore
+                var r = Util.RestoreSolution(pathContext);
+                r.Success.Should().BeTrue();
+
+                // Modify files in package
+                File.WriteAllText(Path.Combine(xPath, "lib", "net45", "test.txt"), "test");
+
+                // Second restore with force
+                r = Util.RestoreSolution(pathContext, 0, "-Force");
+
+                // Assert
+                r.Success.Should().BeTrue();
+                projectA.AssetsFile.GetLibrary("x", NuGetVersion.Parse("1.0.0")).Files.Should().Contain("lib/net45/test.txt");
+            }
+        }
+
+        [Fact]
         public void RestoreNetCore_AddExternalTargetVerifyTargetUsed()
         {
             // Arrange


### PR DESCRIPTION
Read the list of package files from disk instead of from the previous assets file. This is done to avoid persisting bad data between restores.

This change is for **4.5.0**, the full fix is here: https://github.com/NuGet/NuGet.Client/pull/1759 which contains additional perf improvements. For 4.5.0 this is the safest and smallest fix, perf is negligible here since this code is avoided when a noop happens now. The previous reason for re-using libraries was to noop part of the lock file creation.

Fixes NuGet/Home#5995

## Bug
Link: NuGet/Home#5995
Regression: No
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: Restore reads the existing assets file and takes the package file list from there for the next restore. When a restore is done against a partial package the bad file list is persisted between restores, even when -Force is used. This change removes the re-use of file lists from old packages, this optimization is no longer needed now that restore can noop without rebuilding the assets file.

## Testing/Validation
Tests Added: Yes
Reason for not adding tests:  
Validation done: tests
