### PR TITLE
Changing the PR template to use fixes keyword to allow github to close the related issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Bug
-Link: Link_to_issue  
+Fixes: Link_to_issue  
 Regression: Yes/No  
 If Regression then when did it last work:   
 If Regression then how are we preventing it in future:   


### PR DESCRIPTION
Relevant doc - https://help.github.com/articles/closing-issues-using-keywords/

## Bug
Link: NA
Regression: No  

## Fix
Details: Fixing the template to allow github to close issues when the PR is merged.  

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  engineering fix
Validation done:  None
