### PR TITLE
Pack.targets fix

### DIFF
--- a/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
+++ b/src/NuGet.Core/NuGet.Build.Tasks.Pack/NuGet.Build.Tasks.Pack.targets
@@ -138,7 +138,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <Delete Files="@(_PackageFilesToDelete)"/>
   </Target>
 
-  <Target Name="_CalculateInputsOutputsForPack">
+  <Target Name="_CalculateInputsOutputsForPack" DependsOnTargets="_GetOutputItemsFromPack">
     <PropertyGroup Condition="$(ContinuePackingAfterGeneratingNuspec) == '' ">
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
     </PropertyGroup>
@@ -169,18 +169,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <NuGetPackInput Include="@(_TargetPathsToSymbols->'%(FinalOutputPath)')"/>
       <NuGetPackInput Include="@(_SourceFiles)"/>
       <NuGetPackInput Include="@(_References)"/>
-      <NuGetPackOutput Include="$(RestoreOutputAbsolutePath)$(PackageId).$(PackageVersion).nuspec"/>
-
-      <NuGetPackOutput Include="$(PackageOutputAbsolutePath)$(PackageId).$(PackageVersion).nupkg"
-                       Condition="'$(ContinuePackingAfterGeneratingNuspec)' == 'true'"/>
-
-      <NuGetPackOutput Include="$(PackageOutputAbsolutePath)$(PackageId).$(PackageVersion).symbols.nupkg"
-                       Condition="'$(IncludeSource)' == 'true'
-                               OR '$(IncludeSymbols)' == 'true'"/>
-
-      <NuGetPackOutput Include="$(RestoreOutputAbsolutePath)$(PackageId).$(PackageVersion).symbols.nuspec"
-                       Condition="'$(IncludeSource)' == 'true'
-                             OR '$(IncludeSymbols)' == 'true'"/>
+      <NuGetPackOutput Include="@(_OutputPackItems)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Bug
Fixes: NuGet/Home#6099
Regression: Probably not
If Regression then when did it last work:  N/A
If Regression then how are we preventing it in future:  N/A

## Fix
Details: The nuspec path for incremental build was wrong. Fixed it.

## Testing/Validation
Tests Added: No  
Reason for not adding tests: Not sure if targets should have tests
Validation done: None