### PR TITLE
Fix default version range for null or empty dependency version in registration

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/RegistrationUtility.cs
@@ -1,25 +1,28 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Common;
 using NuGet.Versioning;
 
 namespace NuGet.Protocol
 {
-    internal static class Utils
+    public static class RegistrationUtility
     {
         public static VersionRange CreateVersionRange(string stringToParse)
         {
-            var range = VersionRange.Parse(string.IsNullOrEmpty(stringToParse) ? "[0.0.0-alpha,)" : stringToParse);
+            if (string.IsNullOrEmpty(stringToParse))
+            {
+                return VersionRange.All;
+            }
+
+            var range = VersionRange.Parse(stringToParse);
+
             return new VersionRange(range.MinVersion, range.IsMinInclusive, range.MaxVersion, range.IsMaxInclusive);
         }
 

--- a/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
+++ b/src/NuGet.Core/NuGet.Protocol/DependencyInfo/ResolverMetadataClient.cs
@@ -33,7 +33,7 @@ namespace NuGet.Protocol
             ILogger log,
             CancellationToken token)
         {
-            var ranges = await Utils.LoadRanges(httpClient, registrationUri, range, log, token);
+            var ranges = await RegistrationUtility.LoadRanges(httpClient, registrationUri, range, log, token);
 
             var results = new HashSet<RemoteSourceDependencyInfo>();
             foreach (var rangeObj in ranges)
@@ -93,7 +93,7 @@ namespace NuGet.Protocol
                         foreach (JObject dependencyObj in dependenciesObj)
                         {
                             var dependencyId = dependencyObj.Value<string>("id");
-                            var dependencyRange = Utils.CreateVersionRange(dependencyObj.Value<string>("range"));
+                            var dependencyRange = RegistrationUtility.CreateVersionRange(dependencyObj.Value<string>("range"));
 
                             groupDependencies.Add(new PackageDependency(dependencyId, dependencyRange));
                         }

--- a/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
+++ b/src/NuGet.Core/NuGet.Protocol/Resources/RegistrationResourceV3.cs
@@ -119,7 +119,7 @@ namespace NuGet.Protocol
 
             var registrationUri = GetUri(packageId);
 
-            var ranges = await Utils.LoadRanges(_client, registrationUri, range, log, token);
+            var ranges = await RegistrationUtility.LoadRanges(_client, registrationUri, range, log, token);
 
             foreach (var rangeObj in ranges)
             {

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfo/RegistrationUtilityTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/DependencyInfo/RegistrationUtilityTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using NuGet.Versioning;
+using Xunit;
+
+namespace NuGet.Protocol.Tests
+{
+    public class RegistrationUtilityTests
+    {
+        [Theory]
+        [InlineData("", "(, )")]
+        [InlineData(null, "(, )")]
+        [InlineData("1.0.0", "[1.0.0, )")]
+        [InlineData("1.0.0-*", "[1.0.0-0, )")]
+        [InlineData("1.0.*", "[1.0.0, )")]
+        [InlineData("[1.0.0,2.0.0]", "[1.0.0, 2.0.0]")]
+        public void CreateVersionRange_AcceptsValidAndEmpty(string input, string expectedString)
+        {
+            // Arrange
+            var expected = VersionRange.Parse(expectedString);
+
+            // Act
+            var actual = RegistrationUtility.CreateVersionRange(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData(" \t \n ")]
+        [InlineData("[15.106.0.preview]")]
+        public void CreateVersionRange_RejectsInvalid(string input)
+        {
+            var exception = Assert.Throws<ArgumentException>(
+                () => RegistrationUtility.CreateVersionRange(input));
+            Assert.Equal($"'{input}' is not a valid version string.", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Currently, we use `[0.0.0-alpha,)` which seems arbitrary and does not align with:

https://github.com/NuGet/NuGet.Client/blob/ceb01f8696f29c8fc2c871180c1e552bd98ac154/src/NuGet.Core/NuGet.Packaging.Core/PackageDependency.cs#L64

Aligns with https://github.com/NuGet/NuGet.Services.Metadata/pull/253.