### PR TITLE
Copy over the HTTP response content headers, since we wrap the original content

### DIFF
--- a/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
+++ b/src/NuGet.Core/NuGet.Protocol/HttpSource/HttpRetryHandler.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,7 +47,7 @@ namespace NuGet.Protocol
                 using (var requestMessage = request.RequestFactory())
                 {
                     var stopwatch = Stopwatch.StartNew();
-                    string requestUri = requestMessage.RequestUri.ToString();
+                    var requestUri = requestMessage.RequestUri.ToString();
                     
                     try
                     {
@@ -94,6 +93,14 @@ namespace NuGet.Protocol
                                 requestUri,
                                 networkStream,
                                 request.DownloadTimeout);
+
+                            // Copy over the content headers since we are replacing the HttpContent instance associated
+                            // with the response message.
+                            foreach (var header in response.Content.Headers)
+                            {
+                                newContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                            }
+
                             response.Content = newContent;
                         }
 

--- a/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.FuncTests/NuGet.Core.FuncTest/HttpRetryHandlerTests.cs
@@ -1,11 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -20,6 +18,27 @@ namespace NuGet.Core.FuncTest
     public class HttpRetryHandlerTests
     {
         private const string TestUrl = "https://test.local/test.json";
+
+        [Fact]
+        public async Task HttpRetryHandler_ReturnsContentHeaders()
+        {
+            // Arrange
+            var retryHandler = new HttpRetryHandler();
+            using (var httpClient = new HttpClient())
+            {
+                var request = new HttpRetryHandlerRequest(
+                    httpClient,
+                    () => new HttpRequestMessage(HttpMethod.Get, "https://api.nuget.org/v3/index.json"));
+                var log = new TestLogger();
+
+                // Act
+                using (var actualResponse = await retryHandler.SendAsync(request, log, CancellationToken.None))
+                {
+                    // Assert
+                    Assert.NotEmpty(actualResponse.Content.Headers);
+                }
+            }
+        }
 
         [Fact]
         public async Task HttpRetryHandler_AppliesTimeoutToRequestsIndividually()

--- a/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.Protocol.Tests/HttpSource/HttpRetryHandlerTests.cs
@@ -1,17 +1,16 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Common;
-using NuGet.Test.Server;
 using NuGet.Test.Utility;
 using Test.Utility;
 using Xunit;
@@ -24,6 +23,46 @@ namespace NuGet.Protocol.Tests
         private const string TestUrl = "https://test.local/test.json";
         private static readonly TimeSpan SmallTimeout = TimeSpan.FromMilliseconds(50);
         private static readonly TimeSpan LargeTimeout = TimeSpan.FromSeconds(5);
+
+        [Fact]
+        public async Task HttpRetryHandler_ReturnsContentHeaders()
+        {
+            // Arrange
+            Func<HttpRequestMessage, HttpResponseMessage> handler = requestMessage =>
+            {
+                var stringContent = new StringContent("Plain text document.", Encoding.UTF8, "text/plain");
+                stringContent.Headers.TryAddWithoutValidation("X-Content-ID", "49f47c14-c21f-4c1d-9e13-4f5fcf5f8013");
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = stringContent,
+                };
+                response.Headers.TryAddWithoutValidation("X-Message-Header", "This isn't on the content.");
+                return response;
+            };
+
+            var retryHandler = new HttpRetryHandler();
+            var testHandler = new HttpRetryTestHandler(handler);
+            var httpClient = new HttpClient(testHandler);
+            var request = new HttpRetryHandlerRequest(
+                httpClient,
+                () => new HttpRequestMessage(HttpMethod.Get, TestUrl));
+            var log = new TestLogger();
+
+            // Act
+            var actualResponse = await retryHandler.SendAsync(request, log, CancellationToken.None);
+
+            // Assert
+            var actualHeaders = actualResponse
+                .Content
+                .Headers
+                .OrderBy(x => x.Key)
+                .ToDictionary(x => x.Key, x => x.Value);
+            Assert.Equal(
+                new List<string> { "Content-Type", "X-Content-ID" },
+                actualHeaders.Keys.OrderBy(x => x).ToList());
+            Assert.Equal(actualHeaders["Content-Type"], new[] { "text/plain; charset=utf-8" });
+            Assert.Equal(actualHeaders["X-Content-ID"], new[] { "49f47c14-c21f-4c1d-9e13-4f5fcf5f8013" });
+        }
 
         [Fact]
         public async Task HttpRetryHandler_DifferentRequestInstanceEachTime()


### PR DESCRIPTION
Fix https://github.com/NuGet/Home/issues/6112.
