### PR TITLE
Call DTE.Project.FullName instead of DTE.Project.Properties item

### DIFF
--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -51,7 +51,7 @@ namespace NuGet.VisualStudio
             // FullName
             var fullName = GetPotentialFullPathOrNull(envDTEProject.FullName);
 
-            if (fullName != null)
+            if (!string.IsNullOrEmpty(fullName))
             {
                 return fullName;
             }
@@ -59,7 +59,7 @@ namespace NuGet.VisualStudio
             // FullPath
             var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
 
-            if (fullPath != null)
+            if (!string.IsNullOrEmpty(fullPath))
             {
                 return fullPath;
             }
@@ -92,32 +92,29 @@ namespace NuGet.VisualStudio
             // until we can find one containing the full path.
 
             // FullName
-            if (!String.IsNullOrEmpty(envDTEProject.FullName))
+            var fullName = GetPotentialFullPathOrNull(envDTEProject.FullName);
+
+            if (!string.IsNullOrEmpty(fullName))
             {
-                return Path.GetDirectoryName(envDTEProject.FullName);
+                return Path.GetDirectoryName(fullName);
             }
 
             // C++ projects do not have FullPath property, but do have ProjectDirectory one.
-            string projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
+            var projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
 
-            if (!String.IsNullOrEmpty(projectDirectory))
+            if (!string.IsNullOrEmpty(projectDirectory))
             {
                 return projectDirectory;
             }
 
             // FullPath
-            string fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
+            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
 
             if (!String.IsNullOrEmpty(fullPath))
             {
                 // Some Project System implementations (JS metro app) return the project 
                 // file as FullPath. We only need the parent directory
-                if (File.Exists(fullPath))
-                {
                     return Path.GetDirectoryName(fullPath);
-                }
-
-                return fullPath;
             }
 
             Debug.Fail("Unable to find the project path");

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -48,20 +48,20 @@ namespace NuGet.VisualStudio
                 return Path.Combine(solutionDirectory, envDTEProject.UniqueName);
             }
 
-            // FullPath
-            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
-
-            if (fullPath != null)
-            {
-                return fullPath;
-            }
-
             // FullName
             var fullName = GetPotentialFullPathOrNull(envDTEProject.FullName);
 
             if (fullName != null)
             {
                 return fullName;
+            }
+
+            // FullPath
+            var fullPath = GetPotentialFullPathOrNull(GetPropertyValue<string>(envDTEProject, FullPath));
+
+            if (fullPath != null)
+            {
+                return fullPath;
             }
 
             return null;
@@ -91,6 +91,20 @@ namespace NuGet.VisualStudio
             // for start up scenarios such as VS Templates. In these cases we need to fallback 
             // until we can find one containing the full path.
 
+            // FullName
+            if (!String.IsNullOrEmpty(envDTEProject.FullName))
+            {
+                return Path.GetDirectoryName(envDTEProject.FullName);
+            }
+
+            // C++ projects do not have FullPath property, but do have ProjectDirectory one.
+            string projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
+
+            if (!String.IsNullOrEmpty(projectDirectory))
+            {
+                return projectDirectory;
+            }
+
             // FullPath
             string fullPath = GetPropertyValue<string>(envDTEProject, FullPath);
 
@@ -104,20 +118,6 @@ namespace NuGet.VisualStudio
                 }
 
                 return fullPath;
-            }
-
-            // C++ projects do not have FullPath property, but do have ProjectDirectory one.
-            string projectDirectory = GetPropertyValue<string>(envDTEProject, ProjectDirectory);
-
-            if (!String.IsNullOrEmpty(projectDirectory))
-            {
-                return projectDirectory;
-            }
-
-            // FullName
-            if (!String.IsNullOrEmpty(envDTEProject.FullName))
-            {
-                return Path.GetDirectoryName(envDTEProject.FullName);
             }
 
             Debug.Fail("Unable to find the project path");

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/EnvDTEProjectInfoUtility.cs
@@ -114,7 +114,7 @@ namespace NuGet.VisualStudio
             {
                 // Some Project System implementations (JS metro app) return the project 
                 // file as FullPath. We only need the parent directory
-                    return Path.GetDirectoryName(fullPath);
+                return Path.GetDirectoryName(fullPath);
             }
 
             Debug.Fail("Unable to find the project path");


### PR DESCRIPTION
## Bug
Fixes: Only partially addresses internal issue 504715 
Related issue here: https://github.com/NuGet/Home/issues/6120
Regression: No  
If Regression then when did it last work:   
If Regression then how are we preventing it in future:   

## Fix
Details: 
Per @lifengl's suggestion in an e-mail thread.

```
But instead of calling DTE.Project.Properties.Item(“FullPath”), which maps to a msbuild property, maybe you can try to use DTE.Project.FullName, which is the full path of the project file.  FullName is implemented directly inside CPS, and will return a value immediately, instead of accessing the msbuild model.
```

Earlier we had the properties call, then the project.fullName call. 

Those 2 calls' ordering has been switched. 

The delay is in GetFullProjectPath but since GetFullPath has the same call order I have changed it there as well. 

//cc 

@lifengl Can you please take a look as well? 

## Testing/Validation
Tests Added: No  
Reason for not adding tests:  Perf improvement, existing infrastructure should catch any potential bugs
Validation done:  Manual + automated tests. 
