### PR TITLE
Improve restore no-op performance

### DIFF
--- a/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
+++ b/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/NoOpRestoreUtilities.cs
@@ -176,16 +176,6 @@ namespace NuGet.Commands
                         {
                             found = true;
 
-                            // Cache sha512 values across all restores
-                            // If a full restore is done this same value will also be used later
-                            var sha512 = request.DependencyProviders.PackageFileCache.GetOrAddSha512(hashPath);
-
-                            if (!StringComparer.Ordinal.Equals(library.Sha512, sha512.Value))
-                            {
-                                // A package has changed
-                                return false;
-                            }
-
                             // Skip checking the rest of the package folders
                             break;
                         }

--- a/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
+++ b/test/NuGet.Core.Tests/NuGet.PackageManagement.Test/BuildIntegration/BuildIntegratedNuGetProjectTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -98,10 +98,7 @@ namespace NuGet.PackageManagement.Test
                 var resolver = new VersionFolderPathResolver(packagesFolder);
                 var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
 
-                using (var writer = new StreamWriter(hashPath))
-                {
-                    writer.Write("ANAWESOMELYWRONGHASH!!!");
-                }
+                File.Delete(hashPath);
 
                 var restoreSummaries = await DependencyGraphRestoreUtility.RestoreAsync(
                     solutionManager,


### PR DESCRIPTION
#Improve restore no-op performance by avoiding reading sha file and instead just check the existence of the file.

Name | Inc % | Inc
-- | -- | --
\|\|\|\|\|\|+ nuget.commands!NuGet.Commands.RestoreCommand+<ExecuteAsync>d__8.MoveNext() | 13.0 | 192
\|\|\|\|\|\|\|+ nuget.commands!NoOpRestoreUtilities.VerifyAssetsAndMSBuildFilesAndPackagesArePresent | 7.4 | 109
\|\|\|\|\|\|\|\|+ nuget.commands!NoOpRestoreUtilities.VerifyPackagesOnDisk | 7.0 | 104
\|\|\|\|\|\|\|\|\|+ mscorlib.ni!System.IO.File.ReadAllText(System.String) | 2.9 | 43
`\|\|\|\|\|\|\|\|\|+ mscorlib.ni!File.InternalExistsHelper | 2.8 | 41`
\|\|\|\|\|\|\|\|\|+ system.core.ni!System.Linq.Enumerable+WhereListIterator`1[System.__Canon].MoveNext() | 0.9 | 14
\|\|\|\|\|\|\|\|\|+ clr!ThePreStub | 0.1 | 1
\|\|\|\|\|\|\|\|+ clr!ThePreStub | 0.2 | 3

