### PR TITLE
Fixed circular dependency for EnsureInitializeAsync under LSL mode

### DIFF
--- a/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.PackageManagement.VisualStudio/IDE/VSSolutionManager.cs
@@ -296,77 +296,6 @@ namespace NuGet.PackageManagement.VisualStudio
             }
         }
 
-        public async Task<KeyValuePair<bool, bool>> CheckSolutionUIPreConditionsAsync()
-        {
-            // Do NOT initialize VSSolutionManager through this API (by calling EnsureInitializeAsync)
-            // This checks all the pre-conditions before showing NuGet manager UI at solution level
-            // without initializing full VSSolutionManager, otherwise it will create hang issues.
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await EnsureInitializeAsync();
-
-            bool? isSolutionAvailable = null;
-            var DoesNuGetSupportsAnyProject = false;
-
-            if (!IsSolutionOpen)
-            {
-                // Solution is not open. return immediately with false
-                return new KeyValuePair<bool, bool>(false, false);
-            }
-
-            if (!DoesSolutionRequireAnInitialSaveAs())
-            {
-                // Solution is open and 'Save As' is not required. So solution is available to operate but
-                // we also need to check if solution has any supported NuGet project.
-                isSolutionAvailable = true;
-            }
-
-            // read all deferred projects and check for packages.config based projects
-            var deferredProjects = await GetDeferredProjectsAsync();
-
-            foreach (var project in deferredProjects)
-            {
-                var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForDeferredProjectAsync(project);
-
-                // project is supported in NuGet, then set DoesNuGetSupportsAnyProject
-                if (vsProjectAdapter.IsSupported)
-                {
-                    DoesNuGetSupportsAnyProject = true;
-
-                    if (isSolutionAvailable == true)
-                    {
-                        // solution is available and also has NuGet supported project, so we don't need to go further.
-                        break;
-                    }
-
-                    // construct packages.config file path and check if it exists
-                    var packagesConfigFilePath = Path.Combine(Path.GetDirectoryName(vsProjectAdapter.FullProjectPath), "packages.config");
-                    var DoesPackagesConfigFileExist = await _vsProjectAdapterProvider.EntityExistsAsync(packagesConfigFilePath);
-
-                    if (DoesPackagesConfigFileExist)
-                    {
-                        if (isSolutionAvailable != true)
-                        {
-                            // if there is any project with packages.config and solution is also required to be saved then solution is not available.
-                            isSolutionAvailable = false;
-
-                            // we got the final result for both the conditions so we can break now.
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Finally, solution is open and not saved. And, only contains project.json based projects.
-            // Check if globalPackagesFolder is a full path. If so, solution is available.
-            if (isSolutionAvailable == null)
-            {
-                var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(_settings.Value);
-                isSolutionAvailable = Path.IsPathRooted(globalPackagesFolder);
-            }
-
-            return new KeyValuePair<bool, bool>(isSolutionAvailable == true, DoesNuGetSupportsAnyProject);
-        }
-
         public async Task<bool> IsSolutionAvailableAsync()
         {
             await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -416,34 +345,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 .Where(EnvDTEProjectUtility.IsSupported)
                 .Any();
 
-            if (isSupported)
-            {
-                return true;
-            }
-
-            var deferredProjects = await GetDeferredProjectsAsync();
-
-            foreach (var project in deferredProjects)
-            {
-                try
-                {
-                    var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForDeferredProjectAsync(project);
-
-                    if (vsProjectAdapter.IsSupported)
-                    {
-                        // as soon as we find a supported project, we returns without checking for all the projects.
-                        return true;
-                    }
-                }
-                catch (Exception e)
-                {
-                    // Ignore failed projects.
-                    _logger.LogWarning($"The project {project} failed to initialize as a NuGet project.");
-                    _logger.LogError(e.ToString());
-                }
-            }
-
-            return false;
+            return isSupported;
         }
 
         public void EnsureSolutionIsLoaded()
@@ -483,80 +385,6 @@ namespace NuGet.PackageManagement.VisualStudio
                     return Path.GetDirectoryName(solutionFilePath);
                 });
             }
-        }
-
-        private async Task<bool> IsSolutionDPLEnabledAsync()
-        {
-#if VS14
-            // for Dev14 always return false since DPL not exists there.
-            return await Task.FromResult(false);
-#else
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await EnsureInitializeAsync();
-
-            var vsSolution7 = _vsSolution as IVsSolution7;
-
-            if (vsSolution7 != null && vsSolution7.IsSolutionLoadDeferred())
-            {
-                return true;
-            }
-
-            return false;
-#endif
-        }
-
-        public async Task<bool> SolutionHasDeferredProjectsAsync()
-        {
-#if VS14
-            // for Dev14 always return false since DPL not exists there.
-            return await Task.FromResult(false);
-#else
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await EnsureInitializeAsync();
-
-            // check if solution is DPL enabled or not. 
-            if (!await IsSolutionDPLEnabledAsync())
-            {
-                return false;
-            }
-
-            // Get deferred projects count of current solution
-            var value = GetVSSolutionProperty((int)(__VSPROPID7.VSPROPID_DeferredProjectCount));
-            return (int)value != 0;
-#endif
-        }
-
-        public async Task<IEnumerable<IVsHierarchy>> GetDeferredProjectsAsync()
-        {
-#if VS14
-            // Not applicable for Dev14 so always return empty list.
-            return await Task.FromResult(Enumerable.Empty<IVsHierarchy>());
-#else
-            await NuGetUIThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            await EnsureInitializeAsync();
-
-            var projectIVsHierarchys = new List<IVsHierarchy>();
-
-            IEnumHierarchies enumHierarchies;
-            var guid = Guid.Empty;
-
-            var hr = _vsSolution.GetProjectEnum((uint)__VSENUMPROJFLAGS3.EPF_DEFERRED, ref guid, out enumHierarchies);
-            ErrorHandler.ThrowOnFailure(hr);
-
-            // Loop all projects found
-            if (enumHierarchies != null)
-            {
-                // Loop projects found
-                var hierarchy = new IVsHierarchy[1];
-                uint fetched = 0;
-                while (enumHierarchies.Next(1, hierarchy, out fetched) == VSConstants.S_OK && fetched == 1)
-                {
-                    projectIVsHierarchys.Add(hierarchy[0]);
-                }
-            }
-
-            return projectIVsHierarchys;
-#endif
         }
 
         private async Task<string> GetSolutionFilePathAsync()
@@ -809,26 +637,6 @@ namespace NuGet.PackageManagement.VisualStudio
                 {
                     try
                     {
-                        var deferredProjects = await GetDeferredProjectsAsync();
-
-                        foreach (var project in deferredProjects)
-                        {
-                            try
-                            {
-                                var vsProjectAdapter = await _vsProjectAdapterProvider.CreateAdapterForDeferredProjectAsync(project);
-                                await AddVsProjectAdapterToCacheAsync(vsProjectAdapter);
-                            }
-                            catch (Exception e)
-                            {
-                                // Ignore failed projects.
-                                _logger.LogWarning($"The project {project} failed to initialize as a NuGet project.");
-                                _logger.LogError(e.ToString());
-                            }
-
-                            // Consider that the cache is initialized only when there are any projects to add.
-                            _cacheInitialized = true;
-                        }
-
                         var dte = _serviceProvider.GetDTE();
 
                         var supportedProjects = EnvDTESolutionUtility
@@ -874,7 +682,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 return;
             }
 
-            _projectSystemCache.TryGetProjectNameByShortName(vsProjectAdapter.ProjectName, out ProjectNames oldProjectName);
+            _projectSystemCache.TryGetProjectNameByShortName(vsProjectAdapter.ProjectName, out var oldProjectName);
 
             // Create the NuGet project first. If this throws we bail out and do not change the cache.
             var nuGetProject = await CreateNuGetProjectAsync(vsProjectAdapter);
@@ -996,7 +804,7 @@ namespace NuGet.PackageManagement.VisualStudio
                 var referencedProjects = await vsProjectAdapter.GetReferencedProjectsAsync();
                 foreach (var projectProjectPath in referencedProjects)
                 {
-                    var result = _projectSystemCache.TryGetVsProjectAdapter(projectProjectPath, out IVsProjectAdapter vsReferencedProject);
+                    var result = _projectSystemCache.TryGetVsProjectAdapter(projectProjectPath, out var vsReferencedProject);
                     if (result)
                     {
                         AddDependentProject(dependentProjectsDictionary, vsReferencedProject, vsProjectAdapter);
@@ -1014,7 +822,7 @@ namespace NuGet.PackageManagement.VisualStudio
         {
             var uniqueName = vsProjectAdapter.UniqueName;
 
-            if (!dependentProjectsDictionary.TryGetValue(uniqueName, out List<IVsProjectAdapter> dependentProjects))
+            if (!dependentProjectsDictionary.TryGetValue(uniqueName, out var dependentProjects))
             {
                 dependentProjects = new List<IVsProjectAdapter>();
                 dependentProjectsDictionary[uniqueName] = dependentProjects;

--- a/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
+++ b/src/NuGet.Clients/NuGet.Tools/NuGetPackage.cs
@@ -609,42 +609,17 @@ namespace NuGetVSExtension
                 (uint)_VSRDTFLAGS.RDT_DontAddToMRU |
                 (uint)_VSRDTFLAGS.RDT_DontSaveAs;
 
-            if (await SolutionManager.Value.SolutionHasDeferredProjectsAsync() && !SolutionManager.Value.IsInitialized)
+            // when VSSolutionManager is already initialized, then use the existing APIs to check pre-conditions.
+            if (!await SolutionManager.Value.IsSolutionAvailableAsync())
             {
-                // when VSSolutionManager is not yet initialized, then do a quick pre-condition checks without initializing it fully
-                // which might take some time so we'll initialize it after showing the manager ui window.
-                var preCheckResult = await SolutionManager.Value.CheckSolutionUIPreConditionsAsync();
-
-                // key represent if solution is available or not.
-                if (!preCheckResult.Key)
-                {
-                    throw new InvalidOperationException(Resources.SolutionIsNotSaved);
-                }
-
-                // value represent if there is any project in the solution which NuGet supports.
-                if (!preCheckResult.Value)
-                {
-                    // NOTE: The menu 'Manage NuGet Packages For Solution' will be disabled in this case.
-                    // But, it is possible, that, before NuGetPackage is loaded in VS, the menu is enabled and used.
-                    // For once, this message will be shown. Once the package is loaded, the menu will get disabled as appropriate
-                    MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
-                    return null;
-                }
+                throw new InvalidOperationException(Resources.SolutionIsNotSaved);
             }
-            else
-            {
-                // when VSSolutionManager is already initialized, then use the existing APIs to check pre-conditions.
-                if (!await SolutionManager.Value.IsSolutionAvailableAsync())
-                {
-                    throw new InvalidOperationException(Resources.SolutionIsNotSaved);
-                }
 
-                var projects = await SolutionManager.Value.GetNuGetProjectsAsync();
-                if (!projects.Any())
-                {
-                    MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
-                    return null;
-                }
+            var projects = await SolutionManager.Value.GetNuGetProjectsAsync();
+            if (!projects.Any())
+            {
+                MessageHelper.ShowWarningMessage(Resources.NoSupportedProjectsInSolution, Resources.ErrorDialogBoxTitle);
+                return null;
             }
 
             // pass empty array of NuGetProject

--- a/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
+++ b/src/NuGet.Clients/NuGet.VisualStudio.Common/IDE/IVsSolutionManager.cs
@@ -85,17 +85,5 @@ namespace NuGet.PackageManagement.VisualStudio
         /// Return collection of safe name for all supported projects in solution.
         /// </summary>
         Task<IEnumerable<string>> GetAllNuGetProjectSafeNameAsync();
-
-        /// <summary>
-        /// Check for all the pre-conditions before showing manager ui at solution level. And
-        /// return KeyValuePair, where key represents if solution is available to work. And
-        /// value represents if solution has any project which NuGet supports.
-        /// </summary>
-        Task<KeyValuePair<bool, bool>> CheckSolutionUIPreConditionsAsync();
-
-        /// <summary>
-        /// Returns true if solution has any deferred project.
-        /// </summary>
-        Task<bool> SolutionHasDeferredProjectsAsync();
     }
 }


### PR DESCRIPTION
Because of the recent change of moving ctor out of MEF initialization, it introduced circular dependency as defined below. So this PR fixes this issue.

EnsureInitializeAsync -> EnsureNuGetAndVsProjectAdapterCacheAsync -> GetDeferredProjectsAsync -> EnsureInitializeAsync

@rrelyea 