### PR TITLE
Fix apex tests failures

### DIFF
--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -24,6 +24,7 @@ namespace NuGet.Console.TestContract
 
         private bool EnsureInitilizeConsole()
         {
+            _wpfConsole.Dispatcher.Start();
             var stopwatch = Stopwatch.StartNew();
             var timeout = TimeSpan.FromSeconds(5);
             do

--- a/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Console.TestContract/ApexTestConsole.cs
@@ -26,7 +26,7 @@ namespace NuGet.Console.TestContract
         {
             _wpfConsole.Dispatcher.Start();
             var stopwatch = Stopwatch.StartNew();
-            var timeout = TimeSpan.FromSeconds(5);
+            var timeout = TimeSpan.FromMinutes(5);
             do
             {
                 if (_wpfConsole.Dispatcher.IsStartCompleted && _wpfConsole.Host != null) { return true; }
@@ -40,7 +40,7 @@ namespace NuGet.Console.TestContract
         {
             _wpfConsole.Clear();
             var command = $"Get-Package {packageId} -ProjectName {projectName}";
-            if (WaitForActionComplete(() => RunCommand(command), TimeSpan.FromSeconds(5)))
+            if (WaitForActionComplete(() => RunCommand(command), TimeSpan.FromMinutes(5)))
             {
                 var snapshot = (_wpfConsole.Content as IWpfTextViewHost).TextView.TextBuffer.CurrentSnapshot;
                 for (var i = 0; i < snapshot.LineCount; i++)

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexBaseTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/ApexBaseTestClass.cs
@@ -33,6 +33,8 @@ namespace NuGet.Tests.Apex
 
         public abstract void EnsureVisualStudioHost();
 
+        public abstract void CloseVisualStudioHost();
+
         public virtual NuGetApexTestService GetNuGetTestService()
         {
             EnsureVisualStudioHost();
@@ -41,6 +43,7 @@ namespace NuGet.Tests.Apex
 
         public virtual void Dispose()
         {
+            CloseVisualStudioHost();
             //test cleanup
         }
     }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
@@ -188,7 +188,7 @@ namespace NuGet.Tests.Apex
                     window.Show();
                     return true;
                 }
-                found = UIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fFindFirst, powerConsoleToolWindowGUID, out window);
+                found = UIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, powerConsoleToolWindowGUID, out window);
 
                 System.Threading.Thread.Sleep(100);
             }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetApexTestService.cs
@@ -179,7 +179,7 @@ namespace NuGet.Tests.Apex
             IVsWindowFrame window = null;
             var powerConsoleToolWindowGUID = new Guid("0AD07096-BBA9-4900-A651-0598D26F6D24");
             var stopwatch = Stopwatch.StartNew();
-            var timeout = TimeSpan.FromSeconds(10);
+            var timeout = TimeSpan.FromMinutes(5);
 
             var found = UIShell.FindToolWindow((uint)__VSFINDTOOLWIN.FTW_fForceCreate, powerConsoleToolWindowGUID, out window);
             do

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/NuGetConsoleTestExtension.cs
@@ -9,7 +9,7 @@ namespace NuGet.Tests.Apex
     public class NuGetConsoleTestExtension : NuGetBaseTestExtension<object, NuGetConsoleTestExtensionVerifier>
     {
         private ApexTestConsole _pmConsole;
-        private TimeSpan _timeout = TimeSpan.FromSeconds(5);
+        private TimeSpan _timeout = TimeSpan.FromMinutes(5);
 
         public string _projectName { get; set; }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Apex/SharedVisualStudioHostTestClass.cs
@@ -45,6 +45,11 @@ namespace NuGet.Tests.Apex
             _hostFixture.Value.EnsureHost();
         }
 
+        public override void CloseVisualStudioHost()
+        {
+            VisualStudio.Stop();
+        }
+
         public IOperations Operations
         {
             get

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Fixtures/VisualStudioHostFixture.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/Fixtures/VisualStudioHostFixture.cs
@@ -43,7 +43,7 @@ namespace NuGet.Tests.Apex
                     // VSO 178569: Access to DTE during shutdown may throw a variety of COM exceptions
                     // if inaccessible.
                 }
-                catch (Exception filterException)
+                catch (Exception)
                 {
                     //this.Logger.WriteException(EntryType.Warning, filterException, "Could not to tear down the message filter.");
                 }

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -4,6 +4,7 @@
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.Test.Utility;
 using Xunit;
+using System.Threading;
 
 namespace NuGet.Tests.Apex
 {
@@ -21,12 +22,11 @@ namespace NuGet.Tests.Apex
             {
                 // Arrange
                 EnsureVisualStudioHost();
-                var dte = VisualStudio.Dte;
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                dte.ExecuteCommand("View.PackageManagerConsole");
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -41,7 +41,6 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
-                solutionService.Close();
             }
         }
 
@@ -52,12 +51,11 @@ namespace NuGet.Tests.Apex
             {
                 // Arrange
                 EnsureVisualStudioHost();
-                var dte = VisualStudio.Dte;
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                dte.ExecuteCommand("View.PackageManagerConsole");
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                OpenNuGetPMC();
 
                 var nugetTestService = GetNuGetTestService();
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
@@ -70,7 +68,6 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
-                solutionService.Close();
             }
         }
 
@@ -81,12 +78,11 @@ namespace NuGet.Tests.Apex
             {
                 // Arrange
                 EnsureVisualStudioHost();
-                var dte = VisualStudio.Dte;
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                dte.ExecuteCommand("View.PackageManagerConsole");
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
@@ -104,7 +100,6 @@ namespace NuGet.Tests.Apex
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
-                solutionService.Close();
             }
         }
 
@@ -115,12 +110,11 @@ namespace NuGet.Tests.Apex
             {
                 // Arrange
                 EnsureVisualStudioHost();
-                var dte = VisualStudio.Dte;
                 var solutionService = VisualStudio.Get<SolutionService>();
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
-                dte.ExecuteCommand("View.PackageManagerConsole");
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
+                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -141,8 +135,17 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
 
                 nugetConsole.Clear();
-                solutionService.Close();
             }
+        }
+
+        private void OpenNuGetPMC()
+        {
+            var dte = VisualStudio.Dte;
+            dte.ExecuteCommand("View.PackageManagerConsole");
+            // We need to wait for the tool window to be initialized
+            // Because it is started on idle there is no way to make sure it
+            // has been initialized, so just pause for 10 seconds.
+            Thread.Sleep(10000);
         }
 
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -41,6 +41,7 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
+                solutionService.Save();
             }
         }
 
@@ -68,6 +69,7 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
+                solutionService.Save();
             }
         }
 
@@ -100,6 +102,7 @@ namespace NuGet.Tests.Apex
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
+                solutionService.Save();
             }
         }
 
@@ -135,6 +138,7 @@ namespace NuGet.Tests.Apex
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
 
                 nugetConsole.Clear();
+                solutionService.Save();
             }
         }
 

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.Test.Utility;
 using Xunit;
-using System.Diagnostics;
 
 namespace NuGet.Tests.Apex
 {

--- a/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
+++ b/test/NuGet.Tests.Apex/NuGet.Tests.Apex/NuGetIVsApiTests/NuGetConsoleTestCase.cs
@@ -4,7 +4,7 @@
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using NuGet.Test.Utility;
 using Xunit;
-using System.Threading;
+using System.Diagnostics;
 
 namespace NuGet.Tests.Apex
 {
@@ -26,18 +26,17 @@ namespace NuGet.Tests.Apex
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
                 CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
                 var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
-
-                Assert.True(nugetTestService.Verify.PackageIsInstalled(project.UniqueName, packageName));
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
@@ -56,16 +55,16 @@ namespace NuGet.Tests.Apex
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-                OpenNuGetPMC();
 
                 var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
 
                 var packageName = "newtonsoft.json";
                 var packageVersion = "9.0.1";
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json");
 
-                nugetTestService.Verify.PackageIsInstalled(project.UniqueName, packageName);
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion, "https://api.nuget.org/v3/index.json"));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
@@ -84,21 +83,20 @@ namespace NuGet.Tests.Apex
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion = "1.0.0";
                 CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion);
 
                 var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.Name);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion);
-                nugetTestService.Verify.PackageIsInstalled(project.UniqueName, packageName);
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
-                nugetConsole.UninstallPackageFromPMC(packageName);
-                nugetTestService.Verify.PackageIsNotInstalled(project.UniqueName, packageName);
+                Assert.True(nugetConsole.UninstallPackageFromPMC(packageName));
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion));
 
                 nugetConsole.Clear();
@@ -117,7 +115,6 @@ namespace NuGet.Tests.Apex
 
                 solutionService.CreateEmptySolution("TestSolution", pathContext.SolutionRoot);
                 var project = solutionService.AddProject(ProjectLanguage.CSharp, ProjectTemplate.ClassLibrary, ProjectTargetFramework.V46, "TestProject");
-                OpenNuGetPMC();
 
                 var packageName = "TestPackage";
                 var packageVersion1 = "1.0.0";
@@ -126,14 +123,14 @@ namespace NuGet.Tests.Apex
                 CreatePackageInSource(pathContext.PackageSource, packageName, packageVersion2);
 
                 var nugetTestService = GetNuGetTestService();
+                Assert.True(nugetTestService.EnsurePackageManagerConsoleIsOpen());
+
                 var nugetConsole = nugetTestService.GetPackageManagerConsole(project.UniqueName);
 
-                nugetConsole.InstallPackageFromPMC(packageName, packageVersion1);
-                nugetTestService.Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion1);
+                Assert.True(nugetConsole.InstallPackageFromPMC(packageName, packageVersion1));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
 
-                nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2);
-                nugetTestService.Verify.PackageIsInstalled(project.UniqueName, packageName, packageVersion2);
+                Assert.True(nugetConsole.UpdatePackageFromPMC(packageName, packageVersion2));
                 Assert.False(nugetConsole.IsPackageInstalled(packageName, packageVersion1));
                 Assert.True(nugetConsole.IsPackageInstalled(packageName, packageVersion2));
 
@@ -141,17 +138,6 @@ namespace NuGet.Tests.Apex
                 solutionService.Save();
             }
         }
-
-        private void OpenNuGetPMC()
-        {
-            var dte = VisualStudio.Dte;
-            dte.ExecuteCommand("View.PackageManagerConsole");
-            // We need to wait for the tool window to be initialized
-            // Because it is started on idle there is no way to make sure it
-            // has been initialized, so just pause for 10 seconds.
-            Thread.Sleep(10000);
-        }
-
 
         private static void CreatePackageInSource(string packageSource, string packageName, string packageVersion)
         {


### PR DESCRIPTION
Changes done include:
- Make each test case close the VS instance. Even though this makes it slower, we ensure independence from each other and make sure that each test case starts with a clean state.
- Add a waiting time when opening PMC. PMC was recently changed to be started on idle, therefore there is no way to ensure PMC has been initialized. Ensuring PMC is open before running every command by forcing the start of the window and the dispatcher.
- Save every solution before closing VS. This will make sure we don't see the save as dialog that made tests fail