### PR TITLE
Fix error reporting in package download

### DIFF
--- a/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
+++ b/src/NuGet.Core/NuGet.PackageManagement/PackageDownloader.cs
@@ -180,7 +180,16 @@ namespace NuGet.PackageManagement
 
                 foreach (var task in failedTasks)
                 {
-                    var message = ExceptionUtilities.DisplayMessage(task.Exception);
+                    string message;
+
+                    if (task.Exception == null)
+                    {
+                        message = task.Status.ToString();
+                    }
+                    else
+                    {
+                        message = ExceptionUtilities.DisplayMessage(task.Exception);
+                    }
 
                     errors.AppendLine($"  {tasksLookup[task].PackageSource.Source}: {message}");
                 }


### PR DESCRIPTION
Resolve NuGet/Home#6096.

This bug has been around for a while, but it only surfaces in a multifeed environment when the overall package download fails and at least one package download task is canceled.  When we try to report details for each failed task, the reporting fails because an exception is not available.